### PR TITLE
refactor(phase_scan): redesign YAML schema with polymorphic scan types

### DIFF
--- a/examples/configs/eu151_jz_scan.yaml
+++ b/examples/configs/eu151_jz_scan.yaml
@@ -1,0 +1,43 @@
+# Eu151 Jz-constrained ground state scan.
+# Finds ground states with specific total angular momentum J_z = L_z + S_z
+# via bisection on rotating_frame_omega. Relevant for magnetic vortex
+# and polar-core vortex states from EdH effect.
+
+phase_scan:
+  name: "Eu151 Jz-constrained scan"
+
+  system:
+    atom: Eu151
+    grid:
+      n_points: [32, 32]
+      box_size: [12.0, 12.0]
+    interactions:
+      c_total: 4689.0
+      c1_ratio: 0.0
+    ddi:
+      enabled: true
+      c_dd: 7647.0
+
+  ground_state:
+    dt: 0.005
+    n_steps: 5000
+    tol: 1.0e-8
+    initial_state: polar
+    zeeman:
+      p: 0.39
+      q: 0.0
+    potential:
+      type: harmonic
+      omega: [1.0, 1.0]
+
+  scan:
+    type: constrained_jz
+    target_values: [0.0, 1.0, 2.0, 4.0, 6.0]
+    tolerance: 0.05
+    max_iter: 15
+    omega_range: [-10.0, 10.0]
+
+  output:
+    dir: results/eu151_jz_scan
+    csv: true
+    save_psi: false

--- a/examples/configs/eu151_phase_scan_1d.yaml
+++ b/examples/configs/eu151_phase_scan_1d.yaml
@@ -1,0 +1,52 @@
+# Eu151 1D phase scan: c1_ratio sweep with multistart ITP.
+# Scans c1_ratio from ferromagnetic to antiferromagnetic regime.
+
+phase_scan:
+  name: "Eu151 1D c1_ratio scan"
+
+  system:
+    atom: Eu151
+    grid:
+      n_points: 32
+      box_size: 8.0
+    interactions:
+      c_total: 4689.0
+      c1_ratio: 0.0
+    ddi:
+      enabled: false
+
+  ground_state:
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-8
+    initial_state: polar
+    zeeman:
+      p: 0.39
+      q: 0.0
+    potential:
+      type: harmonic
+      omega: [1.0]
+
+  scan:
+    type: parameter
+    axes:
+      - parameter: c1_ratio
+        values:
+          from: -0.01389
+          to: 0.02778
+          n_points: 10
+
+  strategy:
+    continuation:
+      enabled: true
+      n_steps: 1000
+      energy_jump_threshold: 0.1
+    multistart:
+      enabled: true
+      initial_states: [polar, ferromagnetic, uniform, antiferromagnetic]
+      n_random: 0
+
+  output:
+    dir: results/eu151_phase_scan_1d
+    csv: true
+    save_psi: false

--- a/examples/configs/eu151_phase_scan_2d.yaml
+++ b/examples/configs/eu151_phase_scan_2d.yaml
@@ -1,0 +1,53 @@
+# Eu151 2D phase diagram: c1_ratio x quadratic Zeeman q.
+# Uses continuation from neighboring points for efficiency.
+
+phase_scan:
+  name: "Eu151 2D c1_ratio x q"
+
+  system:
+    atom: Eu151
+    grid:
+      n_points: 32
+      box_size: 8.0
+    interactions:
+      c_total: 4689.0
+      c1_ratio: 0.0
+    ddi:
+      enabled: false
+
+  ground_state:
+    dt: 0.005
+    n_steps: 5000
+    tol: 1.0e-8
+    initial_state: polar
+    zeeman:
+      p: 0.39
+      q: 0.0
+    potential:
+      type: harmonic
+      omega: [1.0]
+
+  scan:
+    type: parameter
+    axes:
+      - parameter: c1_ratio
+        values:
+          from: -0.01389
+          to: 0.02778
+          n_points: 9
+      - parameter: zeeman_q
+        values:
+          from: -0.5
+          to: 2.0
+          n_points: 9
+
+  strategy:
+    continuation:
+      enabled: true
+      n_steps: 1500
+      energy_jump_threshold: 0.1
+
+  output:
+    dir: results/eu151_phase_scan_2d
+    csv: true
+    save_psi: false

--- a/examples/configs/eu151_quasi2d_scan.yaml
+++ b/examples/configs/eu151_quasi2d_scan.yaml
@@ -1,0 +1,52 @@
+# Eu151 quasi-2D DDI scan.
+# Uses z-integrated DDI kernel for ~100x speedup over full 3D.
+# Suitable for pancake trap geometries (omega_z >> omega_perp).
+
+phase_scan:
+  name: "Eu151 quasi-2D DDI scan"
+
+  system:
+    atom: Eu151
+    grid:
+      n_points: [64, 64]
+      box_size: [12.0, 12.0]
+    interactions:
+      c_total: 4689.0
+      c1_ratio: 0.0
+    ddi:
+      enabled: true
+      c_dd: 7647.0
+      quasi_2d: true
+      l_z: 0.847          # 1/sqrt(130/110) = a_ho_z / a_ho_perp
+
+  ground_state:
+    dt: 0.005
+    n_steps: 5000
+    tol: 1.0e-8
+    initial_state: polar
+    zeeman:
+      p: 0.39
+      q: 0.0
+    potential:
+      type: harmonic
+      omega: [1.0, 1.0]
+
+  scan:
+    type: parameter
+    axes:
+      - parameter: c1_ratio
+        values:
+          from: -0.01389
+          to: 0.02778
+          n_points: 10
+
+  strategy:
+    continuation:
+      enabled: true
+      n_steps: 1000
+      energy_jump_threshold: 0.1
+
+  output:
+    dir: results/eu151_quasi2d_scan
+    csv: true
+    save_psi: false

--- a/examples/configs/eu151_stability_scan.yaml
+++ b/examples/configs/eu151_stability_scan.yaml
@@ -1,0 +1,55 @@
+# Eu151 stability analysis: c1_ratio sweep with post-GS perturbation.
+# For each point: find ground state, then perturb-and-evolve to measure
+# growth rate and dominant unstable k-mode (roton/EdH instability).
+
+phase_scan:
+  name: "Eu151 stability scan"
+
+  system:
+    atom: Eu151
+    grid:
+      n_points: 32
+      box_size: 8.0
+    interactions:
+      c_total: 4689.0
+      c1_ratio: 0.0
+    ddi:
+      enabled: false
+
+  ground_state:
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-8
+    initial_state: polar
+    zeeman:
+      p: 0.0
+      q: 0.0
+    potential:
+      type: harmonic
+      omega: [1.0]
+
+  scan:
+    type: parameter
+    axes:
+      - parameter: c1_ratio
+        values:
+          from: -0.01389
+          to: 0.02778
+          n_points: 8
+
+  strategy:
+    continuation:
+      enabled: true
+      n_steps: 1000
+      energy_jump_threshold: 0.1
+
+  stability:
+    enabled: true
+    perturbation: 1.0e-4
+    n_steps: 300
+    sample_every: 10
+
+  output:
+    dir: results/eu151_stability_scan
+    csv: true
+    save_psi: false

--- a/src/SpinorBEC.jl
+++ b/src/SpinorBEC.jl
@@ -54,6 +54,7 @@ include("adaptive.jl")
 include("yoshida.jl")
 include("experiment.jl")
 include("experiment_runner.jl")
+include("phase_scan.jl")
 include("io.jl")
 include("unitful_support.jl")
 
@@ -172,6 +173,12 @@ export ConstantValue, LinearRamp, RampOrConstant, interpolate_value
 export PotentialConfig, PhaseConfig, GroundStateConfig, DDIConfig
 export SystemConfig, ExperimentConfig, ExperimentResult
 export load_experiment, load_experiment_from_string, run_experiment, seed_noise
+
+# Phase scan
+export SweepValues, SweepAxis, ContinuationConfig, ScanStabilityConfig, ScanOutputConfig
+export MultiStartConfig, ScanStrategyConfig, AbstractScanSpec, ParameterScan, ConstrainedJzScan
+export ScanGroundStateConfig, PhaseScanConfig
+export load_phase_scan, load_phase_scan_from_string, run_phase_scan
 
 # Units
 export Units

--- a/src/experiment.jl
+++ b/src/experiment.jl
@@ -45,9 +45,12 @@ struct DDIConfig
     enabled::Bool
     c_dd::Union{Nothing,Float64}
     secular::Bool
+    quasi_2d::Bool
+    l_z::Float64
 end
 
-DDIConfig() = DDIConfig(false, nothing, false)
+DDIConfig() = DDIConfig(false, nothing, false, false, 0.0)
+DDIConfig(enabled, c_dd, secular) = DDIConfig(enabled, c_dd, secular, false, 0.0)
 
 struct SystemConfig
     atom_name::Symbol
@@ -135,7 +138,9 @@ function _parse_system(d::Dict)
         enabled = get(dd, "enabled", false)
         c_dd = haskey(dd, "c_dd") ? Float64(dd["c_dd"]) : nothing
         secular = Bool(get(dd, "secular", false))
-        DDIConfig(enabled, c_dd, secular)
+        quasi_2d = Bool(get(dd, "quasi_2d", false))
+        l_z = Float64(get(dd, "l_z", 0.0))
+        DDIConfig(enabled, c_dd, secular, quasi_2d, l_z)
     else
         DDIConfig()
     end
@@ -246,4 +251,157 @@ function _parse_c_extra(inter::Dict, ::Int)
         haskey(inter, "c$n") && (c_extra[n - 1] = Float64(inter["c$n"]))
     end
     c_extra
+end
+
+# --- Phase Scan Configuration ---
+
+struct ScanGroundStateConfig
+    dt::Float64
+    n_steps::Int
+    tol::Float64
+    initial_state::Symbol
+    zeeman::ZeemanParams
+    potential::PotentialConfig
+    target_magnetization::Union{Nothing,Float64}
+    rotating_frame_omega::Float64
+end
+
+struct PhaseScanConfig
+    name::String
+    system::SystemConfig
+    ground_state::ScanGroundStateConfig
+    c_total::Float64
+    scan::AbstractScanSpec
+    strategy::ScanStrategyConfig
+    stability::ScanStabilityConfig
+    output::ScanOutputConfig
+end
+
+function load_phase_scan(path::String)
+    data = YAML.load_file(path)
+    ps_data = get(data, "phase_scan", data)
+    _parse_phase_scan(ps_data)
+end
+
+function load_phase_scan_from_string(yaml_str::String)
+    data = YAML.load(yaml_str)
+    ps_data = get(data, "phase_scan", data)
+    _parse_phase_scan(ps_data)
+end
+
+function _parse_phase_scan(d::Dict)
+    name = get(d, "name", "unnamed scan")
+    system = _parse_system(d["system"])
+    gs = _parse_scan_ground_state(d["ground_state"])
+
+    F = resolve_atom(system.atom_name).F
+    ip = system.interactions
+    c_total = ip.c0 + F^2 * ip.c1
+
+    scan_d = d["scan"]
+    scan_type = Symbol(scan_d["type"])
+    scan = if scan_type == :parameter
+        _parse_parameter_scan(scan_d)
+    elseif scan_type == :constrained_jz
+        _parse_constrained_jz_scan(scan_d)
+    else
+        throw(ArgumentError("Unknown scan type: $scan_type. Supported: parameter, constrained_jz"))
+    end
+
+    strategy = haskey(d, "strategy") ? _parse_strategy(d["strategy"]) : ScanStrategyConfig()
+
+    stab = haskey(d, "stability") ? _parse_scan_stability(d["stability"]) : ScanStabilityConfig()
+    output = haskey(d, "output") ? _parse_scan_output(d["output"]) : ScanOutputConfig()
+
+    PhaseScanConfig(name, system, gs, c_total, scan, strategy, stab, output)
+end
+
+function _parse_scan_ground_state(d::Dict)
+    dt = Float64(d["dt"])
+    n_steps = Int(d["n_steps"])
+    tol = Float64(d["tol"])
+    initial_state = Symbol(get(d, "initial_state", "polar"))
+
+    z = get(d, "zeeman", Dict())
+    zeeman = ZeemanParams(Float64(get(z, "p", 0.0)), Float64(get(z, "q", 0.0)))
+
+    pot = _parse_potential_config(get(d, "potential", Dict("type" => "none")))
+
+    target_mag = let v = get(d, "target_magnetization", nothing)
+        v === nothing ? nothing : Float64(v)
+    end
+
+    rotating_frame_omega = Float64(get(d, "rotating_frame_omega", 0.0))
+
+    ScanGroundStateConfig(dt, n_steps, tol, initial_state, zeeman, pot,
+                          target_mag, rotating_frame_omega)
+end
+
+function _parse_parameter_scan(d::Dict)
+    axes_data = d["axes"]
+    axes = SweepAxis[_parse_sweep_axis(a) for a in axes_data]
+    ParameterScan(axes)
+end
+
+function _parse_constrained_jz_scan(d::Dict)
+    target_values = Float64[Float64(v) for v in d["target_values"]]
+    tolerance = Float64(get(d, "tolerance", 0.05))
+    max_iter = Int(get(d, "max_iter", 15))
+    omega_range = if haskey(d, "omega_range")
+        r = d["omega_range"]
+        (Float64(r[1]), Float64(r[2]))
+    else
+        (-10.0, 10.0)
+    end
+    ConstrainedJzScan(target_values, tolerance, max_iter, omega_range)
+end
+
+function _parse_strategy(d::Dict)
+    cont = haskey(d, "continuation") ? _parse_continuation(d["continuation"]) : ContinuationConfig()
+    ms = haskey(d, "multistart") ? _parse_multistart(d["multistart"]) : MultiStartConfig()
+    ScanStrategyConfig(cont, ms)
+end
+
+function _parse_multistart(d::Dict)
+    enabled = Bool(get(d, "enabled", false))
+    states = if haskey(d, "initial_states")
+        Symbol[Symbol(s) for s in d["initial_states"]]
+    else
+        Symbol[:polar, :ferromagnetic, :uniform, :antiferromagnetic]
+    end
+    n_random = Int(get(d, "n_random", 0))
+    MultiStartConfig(enabled, states, n_random)
+end
+
+function _parse_sweep_axis(d::Dict)
+    param = Symbol(d["parameter"])
+    vals = d["values"]
+    values = if vals isa Dict
+        SweepValues(Float64(vals["from"]), Float64(vals["to"]), Int(vals["n_points"]))
+    else
+        Float64[Float64(v) for v in vals]
+    end
+    SweepAxis(param, values)
+end
+
+function _parse_continuation(d::Dict)
+    enabled = Bool(get(d, "enabled", true))
+    n_steps = Int(get(d, "n_steps", 1000))
+    threshold = Float64(get(d, "energy_jump_threshold", 0.1))
+    ContinuationConfig(enabled, n_steps, threshold)
+end
+
+function _parse_scan_stability(d::Dict)
+    enabled = Bool(get(d, "enabled", false))
+    perturbation = Float64(get(d, "perturbation", 1e-4))
+    n_steps = Int(get(d, "n_steps", 300))
+    sample_every = Int(get(d, "sample_every", 10))
+    ScanStabilityConfig(enabled, perturbation, n_steps, sample_every)
+end
+
+function _parse_scan_output(d::Dict)
+    dir = String(get(d, "dir", "results"))
+    csv = Bool(get(d, "csv", true))
+    save_psi = Bool(get(d, "save_psi", false))
+    ScanOutputConfig(dir, csv, save_psi)
 end

--- a/src/phase_scan.jl
+++ b/src/phase_scan.jl
@@ -1,0 +1,324 @@
+# --- Phase Scan Runner ---
+
+function _sweep_values(sv::SweepValues)
+    range(sv.from, sv.to; length=sv.n_points)
+end
+
+_sweep_values(v::Vector{Float64}) = v
+
+function _base_sweep_state(config::PhaseScanConfig)
+    (interactions=config.system.interactions,
+     zeeman=config.ground_state.zeeman,
+     c_dd_override=nothing,
+     rotating_frame_omega=config.ground_state.rotating_frame_omega)
+end
+
+function _apply_sweep_param(state::NamedTuple, param::Symbol, value::Float64;
+                            c_total::Float64, F::Int)
+    if param == :c1_ratio
+        ip = interaction_params_from_constraint(;
+            c_total, c1_ratio=value, F, c_extra=copy(state.interactions.c_extra))
+        merge(state, (interactions=ip,))
+    elseif param == :zeeman_p
+        merge(state, (zeeman=ZeemanParams(value, state.zeeman.q),))
+    elseif param == :zeeman_q
+        merge(state, (zeeman=ZeemanParams(state.zeeman.p, value),))
+    elseif param == :c_dd
+        merge(state, (c_dd_override=value,))
+    elseif param == :rotating_frame_omega
+        merge(state, (rotating_frame_omega=value,))
+    else
+        throw(ArgumentError(
+            "Unknown sweep parameter: $param. " *
+            "Supported: c1_ratio, zeeman_p, zeeman_q, c_dd, rotating_frame_omega"))
+    end
+end
+
+function _run_single_point(config::PhaseScanConfig, state::NamedTuple,
+                           grid, atom, sm, potential, ndim;
+                           prev_psi=nothing, force_multistart::Bool=false)
+    gs = config.ground_state
+    sys = config.system
+    strategy = config.strategy
+    c_dd_val = state.c_dd_override !== nothing ? state.c_dd_override :
+               (sys.ddi.c_dd === nothing ? NaN : sys.ddi.c_dd)
+
+    use_continuation = strategy.continuation.enabled && prev_psi !== nothing && !force_multistart
+    n_steps = use_continuation ? strategy.continuation.n_steps : gs.n_steps
+
+    gs_kwargs = (;
+        enable_ddi=sys.ddi.enabled, c_dd=c_dd_val,
+        secular_ddi=sys.ddi.secular,
+        quasi_2d_ddi=sys.ddi.quasi_2d, l_z_ddi=sys.ddi.l_z,
+        fft_flags=FFTW.ESTIMATE,
+        target_magnetization=gs.target_magnetization,
+        rotating_frame_omega=state.rotating_frame_omega,
+    )
+
+    result = if (strategy.multistart.enabled && !use_continuation) || force_multistart
+        find_ground_state_multistart(;
+            grid, atom, interactions=state.interactions,
+            zeeman=state.zeeman, potential,
+            dt=gs.dt, n_steps=gs.n_steps, tol=gs.tol,
+            initial_states=strategy.multistart.initial_states,
+            n_random=strategy.multistart.n_random,
+            gs_kwargs...)
+    else
+        psi_init = use_continuation ? copy(prev_psi) : nothing
+        find_ground_state(;
+            grid, atom, interactions=state.interactions,
+            zeeman=state.zeeman, potential,
+            dt=gs.dt, n_steps, tol=gs.tol,
+            initial_state=gs.initial_state, psi_init,
+            gs_kwargs...)
+    end
+
+    ws = result.workspace
+    psi = ws.state.psi
+    phase_info = classify_phase_detailed(psi, atom.F, grid, sm)
+
+    stab_result = if config.stability.enabled
+        analyze_stability(ws;
+            perturbation=config.stability.perturbation,
+            n_steps=config.stability.n_steps,
+            sample_every=config.stability.sample_every,
+        )
+    else
+        nothing
+    end
+
+    (energy=result.energy, converged=result.converged,
+     phase_info=phase_info, psi=copy(psi), stability=stab_result)
+end
+
+function _open_csv(dir, filename)
+    open(joinpath(dir, filename), "w")
+end
+
+function _write_csv(io, values)
+    row = join(values, ",")
+    if io !== nothing
+        println(io, row)
+        flush(io)
+    end
+    row
+end
+
+function run_phase_scan(config::PhaseScanConfig; verbose::Bool=true)
+    sys = config.system
+    atom = resolve_atom(sys.atom_name)
+    ndim = length(sys.grid_n_points)
+    grid_cfg = GridConfig(NTuple{ndim,Int}(sys.grid_n_points),
+                          NTuple{ndim,Float64}(sys.grid_box_size))
+    grid = make_grid(grid_cfg)
+    sm = spin_matrices(atom.F)
+    potential = _build_potential(config.ground_state.potential, ndim)
+
+    verbose && println("Phase scan: $(config.name)")
+
+    if config.output.csv
+        mkpath(config.output.dir)
+    end
+
+    _run_scan(config, config.scan, grid, atom, sm, potential, ndim; verbose)
+end
+
+# --- Parameter scan (1D/2D unified via axes count) ---
+
+function _run_scan(config::PhaseScanConfig, scan::ParameterScan,
+                   grid, atom, sm, potential, ndim; verbose::Bool=true)
+    n_axes = length(scan.axes)
+    if n_axes == 1
+        _run_parameter_1d(config, scan, grid, atom, sm, potential, ndim; verbose)
+    elseif n_axes == 2
+        _run_parameter_2d(config, scan, grid, atom, sm, potential, ndim; verbose)
+    else
+        throw(ArgumentError("ParameterScan supports 1 or 2 axes, got $n_axes"))
+    end
+end
+
+function _run_parameter_1d(config::PhaseScanConfig, scan::ParameterScan,
+                           grid, atom, sm, potential, ndim; verbose::Bool=true)
+    axis = scan.axes[1]
+    values = collect(_sweep_values(axis.values))
+    F = atom.F
+    c_total = config.c_total
+    strategy = config.strategy
+    base_state = _base_sweep_state(config)
+
+    verbose && println("  1D sweep: $(axis.parameter), $(length(values)) points")
+
+    io = config.output.csv ? _open_csv(config.output.dir, "scan_1d.csv") : nothing
+
+    cols = Any[axis.parameter, :phase, :point_group, :energy,
+               :spin_order, :nematic_order, :biaxiality, :converged]
+    config.stability.enabled && append!(cols, [:growth_rate, :unstable, :k_peak])
+    header = _write_csv(io, cols)
+    verbose && println(header)
+
+    results = NamedTuple[]
+    prev_psi = nothing
+    prev_energy = NaN
+
+    for (i, val) in enumerate(values)
+        state = _apply_sweep_param(base_state, axis.parameter, val; c_total, F)
+
+        r = _run_single_point(config, state, grid, atom, sm, potential, ndim; prev_psi)
+
+        if strategy.continuation.enabled && !isnan(prev_energy) &&
+           abs(r.energy - prev_energy) / max(abs(prev_energy), 1e-30) > strategy.continuation.energy_jump_threshold
+            r = _run_single_point(config, state, grid, atom, sm, potential, ndim;
+                                  prev_psi=nothing,
+                                  force_multistart=strategy.multistart.enabled)
+        end
+
+        info = r.phase_info
+        row_vals = Any[
+            round(val; sigdigits=6), info.phase, info.point_group,
+            round(r.energy; sigdigits=8), round(info.spin_order; sigdigits=4),
+            round(info.nematic_order; sigdigits=4), round(info.biaxiality; sigdigits=4),
+            r.converged]
+        if config.stability.enabled && r.stability !== nothing
+            append!(row_vals, [round(r.stability.growth_rate; sigdigits=4),
+                               r.stability.unstable, round(r.stability.k_peak; sigdigits=4)])
+        end
+
+        row = _write_csv(io, row_vals)
+        verbose && println(row)
+
+        push!(results, (param=val, energy=r.energy, converged=r.converged,
+                        phase_info=info, stability=r.stability))
+
+        if config.output.save_psi
+            JLD2.jldsave(joinpath(config.output.dir, "psi_$(i).jld2"); psi=r.psi)
+        end
+
+        prev_psi = r.psi
+        prev_energy = r.energy
+    end
+
+    io !== nothing && close(io)
+    results
+end
+
+function _run_parameter_2d(config::PhaseScanConfig, scan::ParameterScan,
+                           grid, atom, sm, potential, ndim; verbose::Bool=true)
+    ax1 = scan.axes[1]
+    ax2 = scan.axes[2]
+    vals1 = collect(_sweep_values(ax1.values))
+    vals2 = collect(_sweep_values(ax2.values))
+    n1, n2 = length(vals1), length(vals2)
+    F = atom.F
+    c_total = config.c_total
+    strategy = config.strategy
+    base_state = _base_sweep_state(config)
+
+    verbose && println("  2D sweep: $(ax1.parameter) ($n1) × $(ax2.parameter) ($n2)")
+
+    io = config.output.csv ? _open_csv(config.output.dir, "scan_2d.csv") : nothing
+    cols = Any[ax1.parameter, ax2.parameter, :phase, :point_group, :energy,
+               :spin_order, :nematic_order, :biaxiality, :converged]
+    header = _write_csv(io, cols)
+    verbose && println(header)
+
+    results = Matrix{NamedTuple}(undef, n1, n2)
+    prev_row_psi = nothing
+
+    for (j, v2) in enumerate(vals2)
+        prev_psi = prev_row_psi
+        prev_energy = NaN
+
+        for (i, v1) in enumerate(vals1)
+            state = _apply_sweep_param(base_state, ax1.parameter, v1; c_total, F)
+            state = _apply_sweep_param(state, ax2.parameter, v2; c_total, F)
+
+            r = _run_single_point(config, state, grid, atom, sm, potential, ndim; prev_psi)
+
+            if strategy.continuation.enabled && !isnan(prev_energy) &&
+               abs(r.energy - prev_energy) / max(abs(prev_energy), 1e-30) > strategy.continuation.energy_jump_threshold
+                r = _run_single_point(config, state, grid, atom, sm, potential, ndim;
+                                      prev_psi=nothing,
+                                      force_multistart=strategy.multistart.enabled)
+            end
+
+            info = r.phase_info
+            row_vals = Any[
+                round(v1; sigdigits=6), round(v2; sigdigits=6),
+                info.phase, info.point_group, round(r.energy; sigdigits=8),
+                round(info.spin_order; sigdigits=4), round(info.nematic_order; sigdigits=4),
+                round(info.biaxiality; sigdigits=4), r.converged]
+            row = _write_csv(io, row_vals)
+            verbose && println(row)
+
+            results[i, j] = (param1=v1, param2=v2, energy=r.energy, converged=r.converged,
+                             phase_info=info)
+
+            prev_psi = r.psi
+            prev_energy = r.energy
+            i == 1 && (prev_row_psi = r.psi)
+        end
+    end
+
+    io !== nothing && close(io)
+    results
+end
+
+# --- Constrained Jz scan ---
+
+function _run_scan(config::PhaseScanConfig, scan::ConstrainedJzScan,
+                   grid, atom, sm, potential, ndim; verbose::Bool=true)
+    verbose && println("  Jz scan: $(length(scan.target_values)) targets")
+
+    io = config.output.csv ? _open_csv(config.output.dir, "scan_jz.csv") : nothing
+    cols = [:target_Jz, :actual_Jz, :omega, :energy, :phase, :point_group,
+            :spin_order, :converged]
+    header = _write_csv(io, cols)
+    verbose && println(header)
+
+    gs = config.ground_state
+    sys = config.system
+    c_dd_val = sys.ddi.c_dd === nothing ? NaN : sys.ddi.c_dd
+
+    results = NamedTuple[]
+
+    for jz_target in scan.target_values
+        r = find_ground_state(;
+            grid, atom, interactions=sys.interactions,
+            zeeman=gs.zeeman, potential,
+            dt=gs.dt, n_steps=gs.n_steps, tol=gs.tol,
+            initial_state=gs.initial_state,
+            enable_ddi=sys.ddi.enabled, c_dd=c_dd_val,
+            secular_ddi=sys.ddi.secular,
+            quasi_2d_ddi=sys.ddi.quasi_2d, l_z_ddi=sys.ddi.l_z,
+            fft_flags=FFTW.ESTIMATE,
+            target_magnetization=gs.target_magnetization,
+            rotating_frame_omega=gs.rotating_frame_omega,
+            target_Jz=jz_target,
+            Jz_tol=scan.tolerance,
+            Jz_max_iter=scan.max_iter,
+            Jz_omega_range=scan.omega_range,
+        )
+
+        psi = r.workspace.state.psi
+        info = classify_phase_detailed(psi, atom.F, grid, sm)
+
+        row_vals = Any[
+            round(jz_target; digits=2), round(r.Jz; digits=4),
+            round(r.omega; sigdigits=4), round(r.energy; sigdigits=8),
+            info.phase, info.point_group, round(info.spin_order; sigdigits=4),
+            r.converged]
+        row = _write_csv(io, row_vals)
+        verbose && println(row)
+
+        push!(results, (target_Jz=jz_target, actual_Jz=r.Jz, omega=r.omega,
+                        energy=r.energy, converged=r.converged, phase_info=info))
+
+        if config.output.save_psi
+            JLD2.jldsave(joinpath(config.output.dir, "psi_jz_$(round(jz_target; digits=2)).jld2");
+                         psi=copy(psi))
+        end
+    end
+
+    io !== nothing && close(io)
+    results
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -396,6 +396,90 @@ struct BdGResult
     unstable::Bool
 end
 
+# --- Phase Scan Types ---
+
+struct SweepValues
+    from::Float64
+    to::Float64
+    n_points::Int
+
+    function SweepValues(from::Float64, to::Float64, n_points::Int)
+        n_points >= 2 || throw(ArgumentError("n_points must be >= 2"))
+        new(from, to, n_points)
+    end
+end
+
+struct SweepAxis
+    parameter::Symbol
+    values::Union{SweepValues,Vector{Float64}}
+end
+
+struct ContinuationConfig
+    enabled::Bool
+    n_steps::Int
+    energy_jump_threshold::Float64
+
+    function ContinuationConfig(enabled::Bool, n_steps::Int, energy_jump_threshold::Float64)
+        n_steps > 0 || throw(ArgumentError("n_steps must be positive"))
+        energy_jump_threshold > 0 || throw(ArgumentError("energy_jump_threshold must be positive"))
+        new(enabled, n_steps, energy_jump_threshold)
+    end
+end
+
+ContinuationConfig() = ContinuationConfig(true, 1000, 0.1)
+
+struct MultiStartConfig
+    enabled::Bool
+    initial_states::Vector{Symbol}
+    n_random::Int
+end
+
+MultiStartConfig() = MultiStartConfig(false, [:polar, :ferromagnetic, :uniform, :antiferromagnetic], 0)
+
+struct ScanStrategyConfig
+    continuation::ContinuationConfig
+    multistart::MultiStartConfig
+end
+
+ScanStrategyConfig() = ScanStrategyConfig(ContinuationConfig(), MultiStartConfig())
+
+abstract type AbstractScanSpec end
+
+struct ParameterScan <: AbstractScanSpec
+    axes::Vector{SweepAxis}
+end
+
+struct ConstrainedJzScan <: AbstractScanSpec
+    target_values::Vector{Float64}
+    tolerance::Float64
+    max_iter::Int
+    omega_range::Tuple{Float64,Float64}
+end
+
+struct ScanStabilityConfig
+    enabled::Bool
+    perturbation::Float64
+    n_steps::Int
+    sample_every::Int
+
+    function ScanStabilityConfig(enabled::Bool, perturbation::Float64, n_steps::Int, sample_every::Int)
+        perturbation > 0 || throw(ArgumentError("perturbation must be positive"))
+        n_steps > 0 || throw(ArgumentError("n_steps must be positive"))
+        sample_every > 0 || throw(ArgumentError("sample_every must be positive"))
+        new(enabled, perturbation, n_steps, sample_every)
+    end
+end
+
+ScanStabilityConfig() = ScanStabilityConfig(false, 1e-4, 300, 10)
+
+struct ScanOutputConfig
+    dir::String
+    csv::Bool
+    save_psi::Bool
+end
+
+ScanOutputConfig() = ScanOutputConfig("results", true, false)
+
 # --- Workspace ---
 
 struct Workspace{N,A,P,IP,SM<:SpinMatrices,ZEE,DDI,DDIB,RAM,LOSS,DDIP,BK,TC,CC}

--- a/test/test_phase_scan.jl
+++ b/test/test_phase_scan.jl
@@ -1,0 +1,474 @@
+using FFTW
+
+@testset "Phase Scan" begin
+    @testset "YAML parsing - 1D parameter scan" begin
+        yaml = """
+        phase_scan:
+          name: "test 1D"
+          system:
+            atom: Rb87
+            grid:
+              n_points: 8
+              box_size: 6.0
+            interactions:
+              c0: 100.0
+              c1: -5.0
+          ground_state:
+            dt: 0.01
+            n_steps: 100
+            tol: 1e-6
+            initial_state: polar
+            zeeman:
+              p: 0.0
+              q: 0.0
+            potential:
+              type: harmonic
+              omega: [1.0]
+          scan:
+            type: parameter
+            axes:
+              - parameter: c1_ratio
+                values:
+                  from: -0.01
+                  to: 0.03
+                  n_points: 5
+          strategy:
+            continuation:
+              enabled: true
+              n_steps: 50
+              energy_jump_threshold: 0.2
+          output:
+            dir: /tmp/test_phase_scan
+            csv: true
+            save_psi: false
+        """
+        config = load_phase_scan_from_string(yaml)
+        @test config.name == "test 1D"
+        @test config.scan isa ParameterScan
+        @test length(config.scan.axes) == 1
+        @test config.scan.axes[1].parameter == :c1_ratio
+        @test config.scan.axes[1].values isa SweepValues
+        @test config.scan.axes[1].values.n_points == 5
+        @test config.strategy.continuation.enabled == true
+        @test config.strategy.continuation.n_steps == 50
+        @test config.stability.enabled == false
+        @test config.output.dir == "/tmp/test_phase_scan"
+        @test config.ground_state.rotating_frame_omega == 0.0
+    end
+
+    @testset "YAML parsing - 2D parameter scan" begin
+        yaml = """
+        phase_scan:
+          name: "test 2D"
+          system:
+            atom: Rb87
+            grid:
+              n_points: 8
+              box_size: 6.0
+            interactions:
+              c0: 100.0
+              c1: -5.0
+          ground_state:
+            dt: 0.01
+            n_steps: 100
+            tol: 1e-6
+            potential:
+              type: harmonic
+              omega: [1.0]
+          scan:
+            type: parameter
+            axes:
+              - parameter: c1_ratio
+                values:
+                  from: -0.01
+                  to: 0.03
+                  n_points: 3
+              - parameter: zeeman_q
+                values: [0.0, 1.0, 2.0]
+          output:
+            dir: /tmp/test_phase_scan_2d
+            csv: false
+        """
+        config = load_phase_scan_from_string(yaml)
+        @test config.scan isa ParameterScan
+        @test length(config.scan.axes) == 2
+        @test config.scan.axes[1].parameter == :c1_ratio
+        @test config.scan.axes[2].parameter == :zeeman_q
+        @test config.scan.axes[2].values isa Vector{Float64}
+        @test length(config.scan.axes[2].values) == 3
+    end
+
+    @testset "YAML parsing - constrained Jz scan" begin
+        yaml = """
+        phase_scan:
+          name: "test Jz"
+          system:
+            atom: Rb87
+            grid:
+              n_points: [8, 8]
+              box_size: [6.0, 6.0]
+            interactions:
+              c0: 100.0
+              c1: -5.0
+          ground_state:
+            dt: 0.01
+            n_steps: 100
+            tol: 1e-6
+            potential:
+              type: harmonic
+              omega: [1.0, 1.0]
+          scan:
+            type: constrained_jz
+            target_values: [0.0, 1.0, 2.0]
+            tolerance: 0.1
+            max_iter: 5
+            omega_range: [-5.0, 5.0]
+        """
+        config = load_phase_scan_from_string(yaml)
+        @test config.scan isa ConstrainedJzScan
+        @test length(config.scan.target_values) == 3
+        @test config.scan.tolerance == 0.1
+        @test config.scan.max_iter == 5
+        @test config.scan.omega_range == (-5.0, 5.0)
+    end
+
+    @testset "YAML parsing - stability" begin
+        yaml = """
+        phase_scan:
+          name: "test stability"
+          system:
+            atom: Rb87
+            grid:
+              n_points: 8
+              box_size: 6.0
+            interactions:
+              c0: 100.0
+              c1: -5.0
+          ground_state:
+            dt: 0.01
+            n_steps: 100
+            tol: 1e-6
+            potential:
+              type: harmonic
+              omega: [1.0]
+          scan:
+            type: parameter
+            axes:
+              - parameter: c1_ratio
+                values: [-0.01, 0.0, 0.01]
+          stability:
+            enabled: true
+            perturbation: 1.0e-3
+            n_steps: 50
+            sample_every: 5
+        """
+        config = load_phase_scan_from_string(yaml)
+        @test config.stability.enabled == true
+        @test config.stability.perturbation == 1e-3
+        @test config.stability.n_steps == 50
+        @test config.stability.sample_every == 5
+    end
+
+    @testset "YAML parsing - multistart in strategy" begin
+        yaml = """
+        phase_scan:
+          name: "test multistart"
+          system:
+            atom: Rb87
+            grid:
+              n_points: 8
+              box_size: 6.0
+            interactions:
+              c0: 100.0
+              c1: -5.0
+          ground_state:
+            dt: 0.01
+            n_steps: 100
+            tol: 1e-6
+            potential:
+              type: harmonic
+              omega: [1.0]
+            target_magnetization: 0.5
+          scan:
+            type: parameter
+            axes:
+              - parameter: zeeman_p
+                values: [0.0, 1.0]
+          strategy:
+            multistart:
+              enabled: true
+              initial_states: [polar, ferromagnetic]
+              n_random: 2
+        """
+        config = load_phase_scan_from_string(yaml)
+        @test config.strategy.multistart.enabled == true
+        @test config.strategy.multistart.initial_states == [:polar, :ferromagnetic]
+        @test config.strategy.multistart.n_random == 2
+        @test config.ground_state.target_magnetization == 0.5
+    end
+
+    @testset "YAML parsing - quasi_2d DDI" begin
+        yaml = """
+        phase_scan:
+          name: "test quasi-2d"
+          system:
+            atom: Eu151
+            grid:
+              n_points: [8, 8]
+              box_size: [6.0, 6.0]
+            interactions:
+              c_total: 4689.0
+              c1_ratio: 0.0
+            ddi:
+              enabled: true
+              c_dd: 7647.0
+              quasi_2d: true
+              l_z: 0.847
+          ground_state:
+            dt: 0.01
+            n_steps: 100
+            tol: 1e-6
+            potential:
+              type: harmonic
+              omega: [1.0, 1.0]
+          scan:
+            type: parameter
+            axes:
+              - parameter: c1_ratio
+                values: [0.0, 0.01]
+        """
+        config = load_phase_scan_from_string(yaml)
+        @test config.system.ddi.enabled == true
+        @test config.system.ddi.quasi_2d == true
+        @test config.system.ddi.l_z ≈ 0.847
+    end
+
+    @testset "YAML parsing - rotating_frame_omega" begin
+        yaml = """
+        phase_scan:
+          name: "test rotating"
+          system:
+            atom: Rb87
+            grid:
+              n_points: [8, 8]
+              box_size: [6.0, 6.0]
+            interactions:
+              c0: 100.0
+              c1: -5.0
+          ground_state:
+            dt: 0.01
+            n_steps: 100
+            tol: 1e-6
+            rotating_frame_omega: 0.5
+            potential:
+              type: harmonic
+              omega: [1.0, 1.0]
+          scan:
+            type: parameter
+            axes:
+              - parameter: rotating_frame_omega
+                values: [0.0, 0.5, 1.0]
+        """
+        config = load_phase_scan_from_string(yaml)
+        @test config.ground_state.rotating_frame_omega == 0.5
+        @test config.scan.axes[1].parameter == :rotating_frame_omega
+    end
+
+    @testset "YAML parsing - default strategy" begin
+        yaml = """
+        phase_scan:
+          name: "test defaults"
+          system:
+            atom: Rb87
+            grid:
+              n_points: 8
+              box_size: 6.0
+            interactions:
+              c0: 100.0
+              c1: -5.0
+          ground_state:
+            dt: 0.01
+            n_steps: 100
+            tol: 1e-6
+            potential:
+              type: harmonic
+              omega: [1.0]
+          scan:
+            type: parameter
+            axes:
+              - parameter: c1_ratio
+                values: [0.0, 0.01]
+        """
+        config = load_phase_scan_from_string(yaml)
+        @test config.strategy.continuation.enabled == true
+        @test config.strategy.continuation.n_steps == 1000
+        @test config.strategy.multistart.enabled == false
+    end
+
+    @testset "YAML parsing - constrained_jz defaults" begin
+        yaml = """
+        phase_scan:
+          name: "test Jz defaults"
+          system:
+            atom: Rb87
+            grid:
+              n_points: [8, 8]
+              box_size: [6.0, 6.0]
+            interactions:
+              c0: 100.0
+              c1: -5.0
+          ground_state:
+            dt: 0.01
+            n_steps: 100
+            tol: 1e-6
+            potential:
+              type: harmonic
+              omega: [1.0, 1.0]
+          scan:
+            type: constrained_jz
+            target_values: [0.0, 1.0]
+        """
+        config = load_phase_scan_from_string(yaml)
+        @test config.scan isa ConstrainedJzScan
+        @test config.scan.tolerance == 0.05
+        @test config.scan.max_iter == 15
+        @test config.scan.omega_range == (-10.0, 10.0)
+    end
+
+    @testset "_sweep_values" begin
+        sv = SweepValues(0.0, 1.0, 5)
+        vals = collect(SpinorBEC._sweep_values(sv))
+        @test length(vals) == 5
+        @test vals[1] ≈ 0.0
+        @test vals[end] ≈ 1.0
+
+        v = [1.0, 2.0, 3.0]
+        @test SpinorBEC._sweep_values(v) === v
+    end
+
+    @testset "_apply_sweep_param" begin
+        # Rb87: F=1, c_total = c0 + F^2*c1 = 100 + 1*(-5) = 95
+        state = (interactions=InteractionParams(100.0, -5.0),
+                 zeeman=ZeemanParams(1.0, 0.5),
+                 c_dd_override=nothing,
+                 rotating_frame_omega=0.0)
+
+        r = SpinorBEC._apply_sweep_param(state, :zeeman_p, 2.0; c_total=95.0, F=1)
+        @test r.zeeman.p == 2.0
+        @test r.zeeman.q == 0.5
+        @test r.interactions === state.interactions
+
+        r = SpinorBEC._apply_sweep_param(state, :zeeman_q, 3.0; c_total=95.0, F=1)
+        @test r.zeeman.p == 1.0
+        @test r.zeeman.q == 3.0
+
+        r = SpinorBEC._apply_sweep_param(state, :c_dd, 500.0; c_total=95.0, F=1)
+        @test r.c_dd_override == 500.0
+        @test r.interactions === state.interactions
+
+        r = SpinorBEC._apply_sweep_param(state, :c1_ratio, 0.0; c_total=95.0, F=1)
+        @test r.interactions.c0 ≈ 95.0
+        @test r.interactions.c1 ≈ 0.0
+
+        r = SpinorBEC._apply_sweep_param(state, :rotating_frame_omega, 1.5; c_total=95.0, F=1)
+        @test r.rotating_frame_omega == 1.5
+        @test r.interactions === state.interactions
+
+        @test_throws ArgumentError SpinorBEC._apply_sweep_param(
+            state, :unknown, 1.0; c_total=95.0, F=1)
+    end
+
+    @testset "_apply_sweep_param chaining (2D)" begin
+        state = (interactions=InteractionParams(100.0, -5.0),
+                 zeeman=ZeemanParams(1.0, 0.5),
+                 c_dd_override=nothing,
+                 rotating_frame_omega=0.0)
+
+        s1 = SpinorBEC._apply_sweep_param(state, :c1_ratio, 0.0; c_total=95.0, F=1)
+        s2 = SpinorBEC._apply_sweep_param(s1, :zeeman_q, 2.0; c_total=95.0, F=1)
+
+        @test s2.interactions.c0 ≈ 95.0
+        @test s2.interactions.c1 ≈ 0.0
+        @test s2.zeeman.p == 1.0
+        @test s2.zeeman.q == 2.0
+        @test s2.rotating_frame_omega == 0.0
+    end
+
+    @testset "Tiny 1D scan" begin
+        yaml = """
+        phase_scan:
+          name: "tiny scan"
+          system:
+            atom: Rb87
+            grid:
+              n_points: 8
+              box_size: 6.0
+            interactions:
+              c0: 10.0
+              c1: -1.0
+          ground_state:
+            dt: 0.01
+            n_steps: 50
+            tol: 1e-4
+            potential:
+              type: harmonic
+              omega: [1.0]
+          scan:
+            type: parameter
+            axes:
+              - parameter: zeeman_q
+                values: [0.0, 0.5, 1.0]
+          strategy:
+            continuation:
+              enabled: false
+              n_steps: 30
+              energy_jump_threshold: 0.5
+          output:
+            dir: /tmp/test_tiny_scan
+            csv: true
+            save_psi: false
+        """
+        config = load_phase_scan_from_string(yaml)
+        results = run_phase_scan(config; verbose=false)
+
+        @test length(results) == 3
+        for r in results
+            @test haskey(r, :energy)
+            @test haskey(r, :phase_info)
+            @test isfinite(r.energy)
+        end
+
+        csv_path = "/tmp/test_tiny_scan/scan_1d.csv"
+        @test isfile(csv_path)
+        lines = readlines(csv_path)
+        @test length(lines) == 4  # header + 3 data rows
+        @test startswith(lines[1], "zeeman_q,")
+
+        rm("/tmp/test_tiny_scan"; recursive=true, force=true)
+    end
+
+    @testset "Type constructors" begin
+        @test_throws ArgumentError SweepValues(0.0, 1.0, 1)
+        @test_throws ArgumentError ContinuationConfig(true, 0, 0.1)
+        @test_throws ArgumentError ContinuationConfig(true, 100, -0.1)
+        @test_throws ArgumentError ScanStabilityConfig(true, -1.0, 300, 10)
+
+        c = ContinuationConfig()
+        @test c.enabled == true
+        @test c.n_steps == 1000
+
+        s = ScanStabilityConfig()
+        @test s.enabled == false
+
+        o = ScanOutputConfig()
+        @test o.dir == "results"
+
+        ms = MultiStartConfig()
+        @test ms.enabled == false
+        @test ms.n_random == 0
+
+        st = ScanStrategyConfig()
+        @test st.continuation.enabled == true
+        @test st.multistart.enabled == false
+    end
+end


### PR DESCRIPTION
Replace the monolithic PhaseScanConfig god-struct with clean separation of concerns:

- Add AbstractScanSpec with ParameterScan and ConstrainedJzScan subtypes (1D/2D unified by axes count, Jz scan with clean snake_case fields)
- Extract MultiStartConfig and ScanStrategyConfig from ground_state (search strategy != solver config)
- Move continuation from sweep to strategy (execution strategy != scan def)
- Use method dispatch in phase_scan.jl instead of if/else on sweep_type
- Update all 5 YAML configs and tests to new schema

Before: sweep.type: sweep_1d|sweep_2d|jz_scan, Jz_tol, Jz_max_iter
After:  scan.type: parameter|constrained_jz, tolerance, max_iter

Assisted-by: Claude Opus 4.6 (model: claude-opus-4-6)