### PR TITLE
fix(ddi,itp): Nyquist Hermitian symmetry + relative ITP convergence

### DIFF
--- a/runs/eu151_B_sweep_pm120/config.yaml
+++ b/runs/eu151_B_sweep_pm120/config.yaml
@@ -1,0 +1,80 @@
+# ---------------------------------------------------------------------
+# Project A - Eu151 F=6 flower-phase ground-state ITP twin, 32^3 smoke.
+#
+# This is a research-side YAML wrapper. It intentionally depends on the
+# external SpinorBEC.jl/BEC-simulation checkout selected by SIM_ROOT at
+# execution time; do not vendor or copy the solver code into Eu-mitsuki.
+#
+# Goal:
+#   Compute the full 13-component spinor GPE + secular DDI ground state
+#   under Matsui/Science-2026 Eu151 conditions, then compare the two c1
+#   branches needed for the impure-flower diagnosis:
+#
+#     c1_zero           : c1_ratio = 0
+#     c1_matsui_1over36 : c1/c0 = 1/36
+#
+# This file is deliberately 32^3. After 16^3 CPU/GPU smoke agreement,
+# make the production 64^3 copy by changing only grid.n and n_steps.
+# ---------------------------------------------------------------------
+
+metadata:
+  owner: Mitsuki Gotou
+  project: Project A ground-state flower phase
+  dependency_policy: external SpinorBEC via SIM_ROOT; do not copy BEC-simulation
+  spinorbec_reference_commit_mac: a81dd915
+  runner_default_sim_root: ~/bec-runs
+  note: run_itp_twin.sh logs the actual SIM_ROOT git commit before execution
+
+defaults:
+  kind: spinor
+  backend: gpu
+  interactions: {N_atoms: 50000, omega_ref: 691.1504}
+
+dealias:
+  enabled: true
+  k_cut: 16.0
+  auto_dt: true
+  dt_safety: 10.0
+
+mixins:
+  eu151_projectA_itp32:
+    atom: Eu151
+    grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+    potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}  # 110/110/130 Hz
+    interactions:
+      N_atoms: 50000
+      omega_ref: 691.1504
+      c1_ratio: 0.0277777778                                  # = 1/36
+
+pipeline:
+  # Weak-field ITP from the m_F=-6 stretched Gaussian seed.
+  # Standard spinor init_psi uses sigma=box/8, so box=12 gives sigma=1.5.
+  # `seed_amplitude` is not a supported ground_state schema key in the
+  # current SpinorBEC.jl pipeline. The thermal seed below is the supported
+  # symmetry-breaking route; T/Tc=0.016 gives eta=sqrt(T^3/4) ~= 1e-3.
+  - ground_state:
+      use: [eu151_projectA_itp32]
+      method: itp
+      ddi: {enabled: true, secular: true}                      # Eu weak-field GS convention
+      lhy: {kind: none}
+      B: {Bz: "0.001 Gauss", theta: 0.0, phi: 0.0}
+      initial_state: m_minus_F
+      noise:
+        seed: 20260607
+        initial:
+          thermal: 0.016
+      dt: 0.005
+      n_steps: 2000
+      tol: 1.0e-9
+
+  - analyze:
+      - phase_classify: {}
+      - energy_decomposition: {}
+
+scan:
+  comparison_runs:
+    - name: c1_zero
+      override:
+        pipeline.0.interactions.c1_ratio: 0.0
+    - name: c1_matsui_1over36
+      override: {}                                             # use the mixin value

--- a/runs/eu151_B_sweep_pm120/config_nothermal_test.yaml
+++ b/runs/eu151_B_sweep_pm120/config_nothermal_test.yaml
@@ -1,0 +1,52 @@
+# config_nothermal_test.yaml
+# thermal noise = 0 のテスト: B=-120uG と B=-40uG の2点
+# 目的: xy対称性破れがthermal noiseによるものか検証
+
+metadata:
+  owner: Mitsuki Gotou
+  note: thermal=0 test. 2 points only. Compare with v2 (thermal=0.40).
+
+defaults:
+  kind: spinor
+  backend: gpu
+
+dealias:
+  enabled: true
+  k_cut: 16.0
+  auto_dt: true
+  dt_safety: 10.0
+
+mixins:
+  eu151_fullDDI_nothermal:
+    atom: Eu151
+    grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+    potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+    interactions:
+      N_atoms: 50000
+      omega_ref: 691.1504
+      c1_ratio: 0.0277777778
+
+pipeline:
+  - ground_state:
+      use: [eu151_fullDDI_nothermal]
+      method: itp
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      B: {Bz: "0.0 Gauss", theta: 0.0, phi: 0.0}
+      initial_state: m_minus_F
+      dt: 0.005
+      n_steps: 12000
+      tol: 1.0e-7
+
+  - analyze:
+      - phase_classify: {}
+      - energy_decomposition: {}
+
+scan:
+  comparison_runs:
+    - name: g01_Bn120uG
+      override:
+        pipeline.0.B.Bz: "-1.2e-4 Gauss"
+    - name: g05_Bn40uG
+      override:
+        pipeline.0.B.Bz: "-4.0e-5 Gauss"

--- a/runs/eu151_B_sweep_pm120/config_scan_B_fine_random.yaml
+++ b/runs/eu151_B_sweep_pm120/config_scan_B_fine_random.yaml
@@ -1,0 +1,117 @@
+# ---------------------------------------------------------------------
+# Project A — Fine B-field scan with maximum random initial noise
+#
+# 12 scan points: Bz = 0 to -60 μG (fine resolution near phase boundary)
+# All points: thermal = 0.40 (most disordered ITP start)
+#
+# Fixed: c1 = 1/36 (Matsui), initial_state = m_minus_F, 32³, n_steps=8000
+# Goal: resolve flower-phase boundary between B=0 and B≈-30 μG
+#
+# RUN_ROOT: ~/bec-runs/projectA_ground_state/survey_B_fine_random
+# Estimated wall time: ~2.5 h (12 points × ~450 s/point, 8000 steps)
+# ---------------------------------------------------------------------
+
+metadata:
+  owner: Mitsuki Gotou
+  project: Project A phase survey — fine B-field scan, random initial state
+  note: |
+    12 scan points.
+    B-axis: 0.0, -2, -4, -6, -8, -10, -15, -20, -25, -30, -40, -60 μG.
+    thermal = 0.40 fixed for all points (most disordered available).
+    c1=1/36 (Matsui), initial_state=m_minus_F.
+
+defaults:
+  kind: spinor
+  backend: gpu
+  interactions: {N_atoms: 50000, omega_ref: 691.1504}
+
+dealias:
+  enabled: true
+  k_cut: 16.0
+  auto_dt: true
+  dt_safety: 10.0
+
+mixins:
+  eu151_fineBscan:
+    atom: Eu151
+    grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+    potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+    interactions:
+      N_atoms: 50000
+      omega_ref: 691.1504
+      c1_ratio: 0.0277777778   # = 1/36 (Matsui fitting)
+
+pipeline:
+  - ground_state:
+      use: [eu151_fineBscan]
+      method: itp
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.0 Gauss", theta: 0.0, phi: 0.0}
+      initial_state: m_minus_F
+      noise:
+        seed: 20260608
+        initial:
+          thermal: 0.40
+      dt: 0.005
+      n_steps: 8000
+      tol: 1.0e-9
+
+  - analyze:
+      - phase_classify: {}
+      - energy_decomposition: {}
+
+scan:
+  comparison_runs:
+    # ── B = 0 (flower-phase candidate) ─────────────────────────────────
+    - name: f01_B0
+      override:
+        pipeline.0.B.Bz: "0.0 Gauss"
+
+    # ── Very-low field: 2 – 8 μG (near transition) ─────────────────────
+    - name: f02_B2uG
+      override:
+        pipeline.0.B.Bz: "2.0e-6 Gauss"
+
+    - name: f03_B4uG
+      override:
+        pipeline.0.B.Bz: "4.0e-6 Gauss"
+
+    - name: f04_B6uG
+      override:
+        pipeline.0.B.Bz: "6.0e-6 Gauss"
+
+    - name: f05_B8uG
+      override:
+        pipeline.0.B.Bz: "8.0e-6 Gauss"
+
+    # ── Low field: 10 – 15 μG ──────────────────────────────────────────
+    - name: f06_B10uG
+      override:
+        pipeline.0.B.Bz: "1.0e-5 Gauss"
+
+    - name: f07_B15uG
+      override:
+        pipeline.0.B.Bz: "1.5e-5 Gauss"
+
+    # ── Mid field: 20 – 30 μG ──────────────────────────────────────────
+    - name: f08_B20uG
+      override:
+        pipeline.0.B.Bz: "2.0e-5 Gauss"
+
+    - name: f09_B25uG
+      override:
+        pipeline.0.B.Bz: "2.5e-5 Gauss"
+
+    - name: f10_B30uG
+      override:
+        pipeline.0.B.Bz: "3.0e-5 Gauss"
+
+    # ── High field: 40 – 60 μG (polarized-phase reference) ─────────────
+    - name: f11_B40uG
+      override:
+        pipeline.0.B.Bz: "4.0e-5 Gauss"
+
+    - name: f12_B60uG
+      override:
+        pipeline.0.B.Bz: "6.0e-5 Gauss"

--- a/runs/eu151_B_sweep_pm120/config_scan_B_noise.yaml
+++ b/runs/eu151_B_sweep_pm120/config_scan_B_noise.yaml
@@ -1,0 +1,175 @@
+# ---------------------------------------------------------------------
+# Project A — 5×5 Phase Survey: B-field × initial thermal noise
+#
+# Axes:
+#   X (b1→b5): Bz = -1e-3, -3e-4, -1e-4, -3e-5, 0.0 Gauss
+#   Y (n1→n5): thermal noise = 0.0, 0.016, 0.05, 0.15, 0.40
+#
+# Fixed: c1 = 1/36 (Matsui), initial_state = m_minus_F, 32³, n_steps=5000
+# Goal: find the crossover from stretched (m=-6) to flower/mixed phase
+#
+# RUN_ROOT: ~/bec-runs/projectA_ground_state/survey_B_noise
+# Estimated wall time: ~90 min (25 points × ~200-300 s/point at worst)
+# ---------------------------------------------------------------------
+
+metadata:
+  owner: Mitsuki Gotou
+  project: Project A phase survey — B-field vs initial noise
+  note: |
+    5×5 = 25 scan points.
+    B-axis  (b1→b5): -1e-3, -3e-4, -1e-4, -3e-5, 0.0 Gauss.
+    Noise-axis (n1→n5): thermal = 0.0, 0.016, 0.05, 0.15, 0.40.
+    c1=1/36 (Matsui), initial_state=m_minus_F for all points.
+
+defaults:
+  kind: spinor
+  backend: gpu
+  interactions: {N_atoms: 50000, omega_ref: 691.1504}
+
+dealias:
+  enabled: true
+  k_cut: 16.0
+  auto_dt: true
+  dt_safety: 10.0
+
+mixins:
+  eu151_survey:
+    atom: Eu151
+    grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+    potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+    interactions:
+      N_atoms: 50000
+      omega_ref: 691.1504
+      c1_ratio: 0.0277777778   # = 1/36 (Matsui fitting)
+
+pipeline:
+  - ground_state:
+      use: [eu151_survey]
+      method: itp
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.001 Gauss", theta: 0.0, phi: 0.0}
+      initial_state: m_minus_F
+      noise:
+        seed: 20260607
+        initial:
+          thermal: 0.016
+      dt: 0.005
+      n_steps: 5000
+      tol: 1.0e-9
+
+  - analyze:
+      - phase_classify: {}
+      - energy_decomposition: {}
+
+scan:
+  comparison_runs:
+    # ── b1: Bz = -0.001 Gauss ─────────────────────────────────────────
+    - name: b1_n1
+      override:
+        pipeline.0.B.Bz: "0.001 Gauss"
+        pipeline.0.noise.initial.thermal: 0.0
+    - name: b1_n2
+      override:
+        pipeline.0.B.Bz: "0.001 Gauss"
+        pipeline.0.noise.initial.thermal: 0.016
+    - name: b1_n3
+      override:
+        pipeline.0.B.Bz: "0.001 Gauss"
+        pipeline.0.noise.initial.thermal: 0.05
+    - name: b1_n4
+      override:
+        pipeline.0.B.Bz: "0.001 Gauss"
+        pipeline.0.noise.initial.thermal: 0.15
+    - name: b1_n5
+      override:
+        pipeline.0.B.Bz: "0.001 Gauss"
+        pipeline.0.noise.initial.thermal: 0.40
+
+    # ── b2: Bz = -0.0003 Gauss ────────────────────────────────────────
+    - name: b2_n1
+      override:
+        pipeline.0.B.Bz: "0.0003 Gauss"
+        pipeline.0.noise.initial.thermal: 0.0
+    - name: b2_n2
+      override:
+        pipeline.0.B.Bz: "0.0003 Gauss"
+        pipeline.0.noise.initial.thermal: 0.016
+    - name: b2_n3
+      override:
+        pipeline.0.B.Bz: "0.0003 Gauss"
+        pipeline.0.noise.initial.thermal: 0.05
+    - name: b2_n4
+      override:
+        pipeline.0.B.Bz: "0.0003 Gauss"
+        pipeline.0.noise.initial.thermal: 0.15
+    - name: b2_n5
+      override:
+        pipeline.0.B.Bz: "0.0003 Gauss"
+        pipeline.0.noise.initial.thermal: 0.40
+
+    # ── b3: Bz = -0.0001 Gauss ────────────────────────────────────────
+    - name: b3_n1
+      override:
+        pipeline.0.B.Bz: "0.0001 Gauss"
+        pipeline.0.noise.initial.thermal: 0.0
+    - name: b3_n2
+      override:
+        pipeline.0.B.Bz: "0.0001 Gauss"
+        pipeline.0.noise.initial.thermal: 0.016
+    - name: b3_n3
+      override:
+        pipeline.0.B.Bz: "0.0001 Gauss"
+        pipeline.0.noise.initial.thermal: 0.05
+    - name: b3_n4
+      override:
+        pipeline.0.B.Bz: "0.0001 Gauss"
+        pipeline.0.noise.initial.thermal: 0.15
+    - name: b3_n5
+      override:
+        pipeline.0.B.Bz: "0.0001 Gauss"
+        pipeline.0.noise.initial.thermal: 0.40
+
+    # ── b4: Bz = -0.00003 Gauss ───────────────────────────────────────
+    - name: b4_n1
+      override:
+        pipeline.0.B.Bz: "0.00003 Gauss"
+        pipeline.0.noise.initial.thermal: 0.0
+    - name: b4_n2
+      override:
+        pipeline.0.B.Bz: "0.00003 Gauss"
+        pipeline.0.noise.initial.thermal: 0.016
+    - name: b4_n3
+      override:
+        pipeline.0.B.Bz: "0.00003 Gauss"
+        pipeline.0.noise.initial.thermal: 0.05
+    - name: b4_n4
+      override:
+        pipeline.0.B.Bz: "0.00003 Gauss"
+        pipeline.0.noise.initial.thermal: 0.15
+    - name: b4_n5
+      override:
+        pipeline.0.B.Bz: "0.00003 Gauss"
+        pipeline.0.noise.initial.thermal: 0.40
+
+    # ── b5: Bz = 0.0 Gauss (zero field) ──────────────────────────────
+    - name: b5_n1
+      override:
+        pipeline.0.B.Bz: "0.0 Gauss"
+        pipeline.0.noise.initial.thermal: 0.0
+    - name: b5_n2
+      override:
+        pipeline.0.B.Bz: "0.0 Gauss"
+        pipeline.0.noise.initial.thermal: 0.016
+    - name: b5_n3
+      override:
+        pipeline.0.B.Bz: "0.0 Gauss"
+        pipeline.0.noise.initial.thermal: 0.05
+    - name: b5_n4
+      override:
+        pipeline.0.B.Bz: "0.0 Gauss"
+        pipeline.0.noise.initial.thermal: 0.15
+    - name: b5_n5
+      override:
+        pipeline.0.B.Bz: "0.0 Gauss"
+        pipeline.0.noise.initial.thermal: 0.40

--- a/runs/eu151_B_sweep_pm120/config_scan_B_pm120.yaml
+++ b/runs/eu151_B_sweep_pm120/config_scan_B_pm120.yaml
@@ -1,0 +1,186 @@
+# ---------------------------------------------------------------------
+# Project A — Symmetric B-field sweep -120 to +120 μG (27 points)
+#              Full DDI (secular=false)
+#
+# Sign convention (fixed 2026-06-09):
+#   H_Zeeman = +(g_F μ_B B·F)   =>   Bz > 0  means B pointing up (+z)
+#   Eu151 g_F = +1.163  =>  Bz > 0  gives m=-6 as ground state  (correct)
+#
+# B points (μG):
+#  -120, -100, -80, -60, -40, -30, -20, -15, -10, -8, -6, -4, -2,
+#    0,
+#    +2, +4, +6, +8, +10, +15, +20, +30, +40, +60, +80, +100, +120
+#
+# Naming: g01_Bn120uG..g13_Bn2uG = negative B
+#         g14_B0              = zero
+#         g15_B2uG..g27_B120uG = positive B
+#
+# c1_ratio = 1/36 (Matsui EdH), initial_state = m_minus_F for all points
+# (ITP does not conserve Mz; will converge to correct ground state regardless)
+# 32³, n_steps = 12000, thermal = 0.40
+#
+# RUN_ROOT: ~/bec-runs/projectA_ground_state/survey_B_secular_false_pm120
+# ---------------------------------------------------------------------
+
+metadata:
+  owner: Mitsuki Gotou
+  project: Project A — full DDI symmetric ±120 μG sweep
+  note: |
+    Full DDI (secular=false) symmetric scan -120..+120 μG.
+    New sign convention: Bz > 0 = physical B pointing up (+z) = m=-6 ground state.
+    Negative Bz: m=+6 becomes ground state (field pointing down).
+    c1=1/36 (Matsui), thermal=0.40, initial_state=m_minus_F, n_steps=12000.
+
+defaults:
+  kind: spinor
+  backend: gpu
+  interactions: {N_atoms: 50000, omega_ref: 691.1504}
+
+dealias:
+  enabled: true
+  k_cut: 16.0
+  auto_dt: true
+  dt_safety: 10.0
+
+mixins:
+  eu151_fullDDI_pm120:
+    atom: Eu151
+    grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+    potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+    interactions:
+      N_atoms: 50000
+      omega_ref: 691.1504
+      c1_ratio: 0.0277777778   # = 1/36 (Matsui fitting, antiferromagnetic)
+
+pipeline:
+  - ground_state:
+      use: [eu151_fullDDI_pm120]
+      method: itp
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      B: {Bz: "0.0 Gauss", theta: 0.0, phi: 0.0}
+      initial_state: m_minus_F
+      noise:
+        seed: 20260609
+        initial:
+          thermal: 0.40
+      dt: 0.005
+      n_steps: 12000
+      tol: 1.0e-9
+
+  - analyze:
+      - phase_classify: {}
+      - energy_decomposition: {}
+
+scan:
+  comparison_runs:
+    # ── Negative B: B pointing down, m=+6 preferred at large |B| ────────────
+    - name: g01_Bn120uG
+      override:
+        pipeline.0.B.Bz: "-1.2e-4 Gauss"
+
+    - name: g02_Bn100uG
+      override:
+        pipeline.0.B.Bz: "-1.0e-4 Gauss"
+
+    - name: g03_Bn80uG
+      override:
+        pipeline.0.B.Bz: "-8.0e-5 Gauss"
+
+    - name: g04_Bn60uG
+      override:
+        pipeline.0.B.Bz: "-6.0e-5 Gauss"
+
+    - name: g05_Bn40uG
+      override:
+        pipeline.0.B.Bz: "-4.0e-5 Gauss"
+
+    - name: g06_Bn30uG
+      override:
+        pipeline.0.B.Bz: "-3.0e-5 Gauss"
+
+    - name: g07_Bn20uG
+      override:
+        pipeline.0.B.Bz: "-2.0e-5 Gauss"
+
+    - name: g08_Bn15uG
+      override:
+        pipeline.0.B.Bz: "-1.5e-5 Gauss"
+
+    - name: g09_Bn10uG
+      override:
+        pipeline.0.B.Bz: "-1.0e-5 Gauss"
+
+    - name: g10_Bn8uG
+      override:
+        pipeline.0.B.Bz: "-8.0e-6 Gauss"
+
+    - name: g11_Bn6uG
+      override:
+        pipeline.0.B.Bz: "-6.0e-6 Gauss"
+
+    - name: g12_Bn4uG
+      override:
+        pipeline.0.B.Bz: "-4.0e-6 Gauss"
+
+    - name: g13_Bn2uG
+      override:
+        pipeline.0.B.Bz: "-2.0e-6 Gauss"
+
+    # ── B = 0 ────────────────────────────────────────────────────────────────
+    - name: g14_B0
+      override:
+        pipeline.0.B.Bz: "0.0 Gauss"
+
+    # ── Positive B: B pointing up, m=-6 preferred at large |B| ──────────────
+    - name: g15_B2uG
+      override:
+        pipeline.0.B.Bz: "2.0e-6 Gauss"
+
+    - name: g16_B4uG
+      override:
+        pipeline.0.B.Bz: "4.0e-6 Gauss"
+
+    - name: g17_B6uG
+      override:
+        pipeline.0.B.Bz: "6.0e-6 Gauss"
+
+    - name: g18_B8uG
+      override:
+        pipeline.0.B.Bz: "8.0e-6 Gauss"
+
+    - name: g19_B10uG
+      override:
+        pipeline.0.B.Bz: "1.0e-5 Gauss"
+
+    - name: g20_B15uG
+      override:
+        pipeline.0.B.Bz: "1.5e-5 Gauss"
+
+    - name: g21_B20uG
+      override:
+        pipeline.0.B.Bz: "2.0e-5 Gauss"
+
+    - name: g22_B30uG
+      override:
+        pipeline.0.B.Bz: "3.0e-5 Gauss"
+
+    - name: g23_B40uG
+      override:
+        pipeline.0.B.Bz: "4.0e-5 Gauss"
+
+    - name: g24_B60uG
+      override:
+        pipeline.0.B.Bz: "6.0e-5 Gauss"
+
+    - name: g25_B80uG
+      override:
+        pipeline.0.B.Bz: "8.0e-5 Gauss"
+
+    - name: g26_B100uG
+      override:
+        pipeline.0.B.Bz: "1.0e-4 Gauss"
+
+    - name: g27_B120uG
+      override:
+        pipeline.0.B.Bz: "1.2e-4 Gauss"

--- a/runs/eu151_B_sweep_pm120/config_scan_B_pm120_v2.yaml
+++ b/runs/eu151_B_sweep_pm120/config_scan_B_pm120_v2.yaml
@@ -1,0 +1,148 @@
+# config_scan_B_pm120_v2.yaml
+# ============================
+# Project A — ±120 μG sweep v2: Nyquist DDI fix + relative ITP convergence
+#
+# Changes from v1 (config_scan_B_pm120.yaml):
+#   - DDI: Q_xy/Q_xz at kx=Nyquist now zeroed (Hermitian-consistency fix)
+#   - ITP: convergence criterion changed to RELATIVE  dE/|E| < tol
+#   - tol: 1.0e-7  (relative; v1 used 1.0e-9 absolute which never triggered)
+#   - Output dir: survey_B_secular_false_pm120_v2  (separate from v1)
+#   - Same seed, same physics, new code
+#
+# RUN_ROOT: ~/bec-runs/projectA_ground_state/survey_B_secular_false_pm120_v2
+# Estimated wall time: ~10–16 h (27 points × GPU; ITP exits early when converged)
+# ============================
+
+metadata:
+  owner: Mitsuki Gotou
+  project: Project A — full DDI symmetric ±120 μG sweep v2
+  note: |
+    Full DDI (secular=false) symmetric scan -120..+120 μG.
+    v2: DDI Nyquist fix + relative ITP convergence criterion.
+    c1=1/36 (Matsui), thermal=0.40, initial_state=m_minus_F, tol=1e-7 (relative).
+
+defaults:
+  kind: spinor
+  backend: gpu
+  interactions: {N_atoms: 50000, omega_ref: 691.1504}
+
+dealias:
+  enabled: true
+  k_cut: 16.0
+  auto_dt: true
+  dt_safety: 10.0
+
+
+mixins:
+  eu151_fullDDI_pm120:
+    atom: Eu151
+    grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+    potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+    interactions:
+      N_atoms: 50000
+      omega_ref: 691.1504
+      c1_ratio: 0.0277777778   # = 1/36 (Matsui fitting, antiferromagnetic)
+
+pipeline:
+  - ground_state:
+      use: [eu151_fullDDI_pm120]
+      method: itp
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      B: {Bz: "0.0 Gauss", theta: 0.0, phi: 0.0}
+      initial_state: m_minus_F
+      noise:
+        seed: 20260609
+        initial:
+          thermal: 0.40
+      dt: 0.005
+      n_steps: 12000
+      tol: 1.0e-7      # relative: dE/|E| < 1e-7
+
+  - analyze:
+      - phase_classify: {}
+      - energy_decomposition: {}
+
+scan:
+  comparison_runs:
+    - name: g01_Bn120uG
+      override:
+        pipeline.0.B.Bz: "-1.2e-4 Gauss"
+    - name: g02_Bn100uG
+      override:
+        pipeline.0.B.Bz: "-1.0e-4 Gauss"
+    - name: g03_Bn80uG
+      override:
+        pipeline.0.B.Bz: "-8.0e-5 Gauss"
+    - name: g04_Bn60uG
+      override:
+        pipeline.0.B.Bz: "-6.0e-5 Gauss"
+    - name: g05_Bn40uG
+      override:
+        pipeline.0.B.Bz: "-4.0e-5 Gauss"
+    - name: g06_Bn30uG
+      override:
+        pipeline.0.B.Bz: "-3.0e-5 Gauss"
+    - name: g07_Bn20uG
+      override:
+        pipeline.0.B.Bz: "-2.0e-5 Gauss"
+    - name: g08_Bn15uG
+      override:
+        pipeline.0.B.Bz: "-1.5e-5 Gauss"
+    - name: g09_Bn10uG
+      override:
+        pipeline.0.B.Bz: "-1.0e-5 Gauss"
+    - name: g10_Bn8uG
+      override:
+        pipeline.0.B.Bz: "-8.0e-6 Gauss"
+    - name: g11_Bn6uG
+      override:
+        pipeline.0.B.Bz: "-6.0e-6 Gauss"
+    - name: g12_Bn4uG
+      override:
+        pipeline.0.B.Bz: "-4.0e-6 Gauss"
+    - name: g13_Bn2uG
+      override:
+        pipeline.0.B.Bz: "-2.0e-6 Gauss"
+    - name: g14_B0
+      override:
+        pipeline.0.B.Bz: "0.0 Gauss"
+    - name: g15_B2uG
+      override:
+        pipeline.0.B.Bz: "2.0e-6 Gauss"
+    - name: g16_B4uG
+      override:
+        pipeline.0.B.Bz: "4.0e-6 Gauss"
+    - name: g17_B6uG
+      override:
+        pipeline.0.B.Bz: "6.0e-6 Gauss"
+    - name: g18_B8uG
+      override:
+        pipeline.0.B.Bz: "8.0e-6 Gauss"
+    - name: g19_B10uG
+      override:
+        pipeline.0.B.Bz: "1.0e-5 Gauss"
+    - name: g20_B15uG
+      override:
+        pipeline.0.B.Bz: "1.5e-5 Gauss"
+    - name: g21_B20uG
+      override:
+        pipeline.0.B.Bz: "2.0e-5 Gauss"
+    - name: g22_B30uG
+      override:
+        pipeline.0.B.Bz: "3.0e-5 Gauss"
+    - name: g23_B40uG
+      override:
+        pipeline.0.B.Bz: "4.0e-5 Gauss"
+    - name: g24_B60uG
+      override:
+        pipeline.0.B.Bz: "6.0e-5 Gauss"
+    - name: g25_B80uG
+      override:
+        pipeline.0.B.Bz: "8.0e-5 Gauss"
+    - name: g26_B100uG
+      override:
+        pipeline.0.B.Bz: "1.0e-4 Gauss"
+    - name: g27_B120uG
+      override:
+        pipeline.0.B.Bz: "1.2e-4 Gauss"

--- a/runs/eu151_B_sweep_pm120/config_scan_B_secular_false.yaml
+++ b/runs/eu151_B_sweep_pm120/config_scan_B_secular_false.yaml
@@ -1,0 +1,97 @@
+# ---------------------------------------------------------------------
+# Project A — Full DDI (secular=false) comparison scan
+#
+# 6 scan points: Bz = 0 to -30 μG
+# secular=false: full non-secular DDI (physically correct for μG fields
+# where ω_Larmor ≪ ω_DDI — secular approximation is NOT justified here)
+#
+# All other parameters identical to survey_B_fine_random:
+#   c1=1/36 (Matsui), initial_state=m_minus_F, 32³, n_steps=8000
+#
+# Goal: determine whether non-secular DDI terms drive transverse spin
+#       texture (flower-phase onset) that secular=true suppresses.
+#
+# RUN_ROOT: ~/bec-runs/projectA_ground_state/survey_B_secular_false
+# Estimated wall time: ~1.5 h (6 points × ~450 s × 1.4 DDI overhead)
+# ---------------------------------------------------------------------
+
+metadata:
+  owner: Mitsuki Gotou
+  project: Project A — full DDI comparison (secular=false)
+  note: |
+    6 scan points: B = 0, -2, -10, -20, -30 μG + -60 μG reference.
+    secular=false: off-diagonal Q_xy, Q_xz, Q_yz components active.
+    These terms drive transverse spin relaxation and may stabilize
+    flower-phase texture at weak fields.
+    c1=1/36 (Matsui EdH fitting), initial_state=m_minus_F, thermal=0.40.
+
+defaults:
+  kind: spinor
+  backend: gpu
+  interactions: {N_atoms: 50000, omega_ref: 691.1504}
+
+dealias:
+  enabled: true
+  k_cut: 16.0
+  auto_dt: true
+  dt_safety: 10.0
+
+mixins:
+  eu151_fullDDI:
+    atom: Eu151
+    grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+    potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+    interactions:
+      N_atoms: 50000
+      omega_ref: 691.1504
+      c1_ratio: 0.0277777778   # = 1/36 (Matsui fitting, antiferromagnetic)
+
+pipeline:
+  - ground_state:
+      use: [eu151_fullDDI]
+      method: itp
+      ddi: {enabled: true, secular: false}   # full DDI — key difference
+      lhy: {kind: none}
+      B: {Bz: "0.0 Gauss", theta: 0.0, phi: 0.0}
+      initial_state: m_minus_F
+      noise:
+        seed: 20260608
+        initial:
+          thermal: 0.40
+      dt: 0.005
+      n_steps: 8000
+      tol: 1.0e-9
+
+  - analyze:
+      - phase_classify: {}
+      - energy_decomposition: {}
+
+scan:
+  comparison_runs:
+    # ── B = 0 (most important: no Larmor, secular ≡ full DDI meaningless) ─
+    - name: g01_B0_full
+      override:
+        pipeline.0.B.Bz: "0.0 Gauss"
+
+    # ── Very-low field ────────────────────────────────────────────────────
+    - name: g02_B2uG_full
+      override:
+        pipeline.0.B.Bz: "2.0e-6 Gauss"
+
+    - name: g03_B10uG_full
+      override:
+        pipeline.0.B.Bz: "1.0e-5 Gauss"
+
+    # ── Mid field ─────────────────────────────────────────────────────────
+    - name: g04_B20uG_full
+      override:
+        pipeline.0.B.Bz: "2.0e-5 Gauss"
+
+    - name: g05_B30uG_full
+      override:
+        pipeline.0.B.Bz: "3.0e-5 Gauss"
+
+    # ── High field reference (should match secular run) ───────────────────
+    - name: g06_B60uG_full
+      override:
+        pipeline.0.B.Bz: "6.0e-5 Gauss"

--- a/runs/eu151_B_sweep_pm120/config_scan_B_secular_false_fine.yaml
+++ b/runs/eu151_B_sweep_pm120/config_scan_B_secular_false_fine.yaml
@@ -1,0 +1,111 @@
+# ---------------------------------------------------------------------
+# Project A — Fine B-field scan, full DDI (secular=false), 12 points
+#
+# Identical to survey_B_fine_random but with:
+#   ddi: {enabled: true, secular: false}   ← full DDI tensor (6 components)
+#
+# B: 0, 2, 4, 6, 8, 10, 15, 20, 25, 30, 40, 60 μG
+# c1_ratio = 1/36 (Matsui EdH fitting), initial_state = m_minus_F
+# 32³, n_steps = 8000, thermal = 0.40
+#
+# RUN_ROOT: ~/bec-runs/projectA_ground_state/survey_B_secular_false_fine
+# ---------------------------------------------------------------------
+
+metadata:
+  owner: Mitsuki Gotou
+  project: Project A — full DDI fine B-sweep
+  note: |
+    Full DDI (secular=false) fine scan. Direct comparison baseline
+    against survey_B_fine_random (secular=true).
+    c1=1/36 (Matsui), thermal=0.40, initial_state=m_minus_F.
+
+defaults:
+  kind: spinor
+  backend: gpu
+  interactions: {N_atoms: 50000, omega_ref: 691.1504}
+
+dealias:
+  enabled: true
+  k_cut: 16.0
+  auto_dt: true
+  dt_safety: 10.0
+
+mixins:
+  eu151_fullDDI_fine:
+    atom: Eu151
+    grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+    potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+    interactions:
+      N_atoms: 50000
+      omega_ref: 691.1504
+      c1_ratio: 0.0277777778   # = 1/36 (Matsui fitting, antiferromagnetic)
+
+pipeline:
+  - ground_state:
+      use: [eu151_fullDDI_fine]
+      method: itp
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      B: {Bz: "0.0 Gauss", theta: 0.0, phi: 0.0}
+      initial_state: m_minus_F
+      noise:
+        seed: 20260608
+        initial:
+          thermal: 0.40
+      dt: 0.005
+      n_steps: 8000
+      tol: 1.0e-9
+
+  - analyze:
+      - phase_classify: {}
+      - energy_decomposition: {}
+
+scan:
+  comparison_runs:
+    - name: h01_B0
+      override:
+        pipeline.0.B.Bz: "0.0 Gauss"
+
+    - name: h02_B2uG
+      override:
+        pipeline.0.B.Bz: "2.0e-6 Gauss"
+
+    - name: h03_B4uG
+      override:
+        pipeline.0.B.Bz: "4.0e-6 Gauss"
+
+    - name: h04_B6uG
+      override:
+        pipeline.0.B.Bz: "6.0e-6 Gauss"
+
+    - name: h05_B8uG
+      override:
+        pipeline.0.B.Bz: "8.0e-6 Gauss"
+
+    - name: h06_B10uG
+      override:
+        pipeline.0.B.Bz: "1.0e-5 Gauss"
+
+    - name: h07_B15uG
+      override:
+        pipeline.0.B.Bz: "1.5e-5 Gauss"
+
+    - name: h08_B20uG
+      override:
+        pipeline.0.B.Bz: "2.0e-5 Gauss"
+
+    - name: h09_B25uG
+      override:
+        pipeline.0.B.Bz: "2.5e-5 Gauss"
+
+    - name: h10_B30uG
+      override:
+        pipeline.0.B.Bz: "3.0e-5 Gauss"
+
+    - name: h11_B40uG
+      override:
+        pipeline.0.B.Bz: "4.0e-5 Gauss"
+
+    - name: h12_B60uG
+      override:
+        pipeline.0.B.Bz: "6.0e-5 Gauss"

--- a/runs/eu151_B_sweep_pm120/config_smoke16_cpu_gpu.yaml
+++ b/runs/eu151_B_sweep_pm120/config_smoke16_cpu_gpu.yaml
@@ -1,0 +1,74 @@
+# ---------------------------------------------------------------------
+# Project A - Eu151 F=6 DDI ITP CPU/GPU smoke gate, 16^3.
+#
+# Purpose:
+#   Exercise the same code path as config.yaml before spending TSUBAME
+#   time on the 32^3 twin. This is the required first gate for F=6+DDI:
+#   both CPU and GPU must load the YAML, build the workspace, run ITP,
+#   and save analyzer outputs. Compare the CPU/GPU energies after the run.
+# ---------------------------------------------------------------------
+
+metadata:
+  owner: Mitsuki Gotou
+  project: Project A ground-state smoke gate
+  dependency_policy: external SpinorBEC via SIM_ROOT; do not copy BEC-simulation
+  spinorbec_reference_commit_mac: a81dd915
+  expected_use: run before projectA_ground_state/configs/config.yaml
+
+defaults:
+  kind: spinor
+  backend: gpu
+  interactions: {N_atoms: 50000, omega_ref: 691.1504}
+
+dealias:
+  enabled: true
+  k_cut: 8.0
+  auto_dt: true
+  dt_safety: 10.0
+
+mixins:
+  eu151_projectA_itp16:
+    atom: Eu151
+    grid: {n: [16, 16, 16], box: [12.0, 12.0, 12.0]}
+    potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+    interactions:
+      N_atoms: 50000
+      omega_ref: 691.1504
+      c1_ratio: 0.0277777778
+
+pipeline:
+  - ground_state:
+      use: [eu151_projectA_itp16]
+      method: itp
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.001 Gauss", theta: 0.0, phi: 0.0}
+      initial_state: m_minus_F
+      noise:
+        seed: 20260607
+        initial:
+          thermal: 0.016
+      dt: 0.005
+      n_steps: 300
+      tol: 1.0e-7
+
+  - analyze:
+      - phase_classify: {}
+      - energy_decomposition: {}
+
+scan:
+  comparison_runs:
+    - name: cpu_c1_zero
+      override:
+        pipeline.0.backend: cpu
+        pipeline.0.interactions.c1_ratio: 0.0
+    - name: gpu_c1_zero
+      override:
+        pipeline.0.backend: gpu
+        pipeline.0.interactions.c1_ratio: 0.0
+    - name: cpu_c1_matsui_1over36
+      override:
+        pipeline.0.backend: cpu
+    - name: gpu_c1_matsui_1over36
+      override:
+        pipeline.0.backend: gpu

--- a/runs/eu151_B_sweep_pm120/config_twin32_5k.yaml
+++ b/runs/eu151_B_sweep_pm120/config_twin32_5k.yaml
@@ -1,0 +1,65 @@
+# ---------------------------------------------------------------------
+# Project A - Eu151 F=6 flower-phase ground-state ITP twin, 32^3, 5000 steps.
+#
+# Same physics as config.yaml but n_steps=5000 to allow full convergence
+# of the c1_matsui_1over36 scan point (2000 steps was insufficient: dpsi
+# still 1.8e-7 at step 2000; extrapolation → conv at ~3000 steps).
+#
+# RUN_ROOT: ~/bec-runs/projectA_ground_state/itp_twin32_5k
+# ---------------------------------------------------------------------
+
+metadata:
+  owner: Mitsuki Gotou
+  project: Project A ground-state flower phase
+  dependency_policy: external SpinorBEC via SIM_ROOT; do not copy BEC-simulation
+  spinorbec_reference_commit_mac: a81dd915
+  note: n_steps increased from 2000 to 5000 for c1_matsui convergence
+
+defaults:
+  kind: spinor
+  backend: gpu
+  interactions: {N_atoms: 50000, omega_ref: 691.1504}
+
+dealias:
+  enabled: true
+  k_cut: 16.0
+  auto_dt: true
+  dt_safety: 10.0
+
+mixins:
+  eu151_projectA_itp32:
+    atom: Eu151
+    grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+    potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+    interactions:
+      N_atoms: 50000
+      omega_ref: 691.1504
+      c1_ratio: 0.0277777778  # = 1/36 (Matsui fitting)
+
+pipeline:
+  - ground_state:
+      use: [eu151_projectA_itp32]
+      method: itp
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.001 Gauss", theta: 0.0, phi: 0.0}
+      initial_state: m_minus_F
+      noise:
+        seed: 20260607
+        initial:
+          thermal: 0.016
+      dt: 0.005
+      n_steps: 5000
+      tol: 1.0e-9
+
+  - analyze:
+      - phase_classify: {}
+      - energy_decomposition: {}
+
+scan:
+  comparison_runs:
+    - name: c1_zero
+      override:
+        pipeline.0.interactions.c1_ratio: 0.0
+    - name: c1_matsui_1over36
+      override: {}   # use the mixin value (1/36)

--- a/src/hamiltonian/terms/ddi/qtensor.jl
+++ b/src/hamiltonian/terms/ddi/qtensor.jl
@@ -55,6 +55,23 @@ function _build_q_tensor!(
             Q_yz[I] = kv_y * kv_z * inv_k2
         end
     end
+
+    # Enforce rfft Hermitian symmetry at kx = Nyquist (last rfft bin, index n_pts[1]).
+    # Q_xy and Q_xz are antisymmetric there: Q_αβ[Nyq,j,k] = −Q_αβ[Nyq,−j,−k].
+    # This violates irfft's conjugate-symmetry assumption and injects a systematic
+    # chiral bias into the DDI potential (manifests as a fixed -45° spin texture
+    # direction that is independent of the random seed). Zeroing the Nyquist slice
+    # removes the artifact; the mode carries no physical energy in a properly
+    # dealiased simulation. The secular and quasi-2D paths already set these to
+    # zero everywhere, so no fix is needed for those branches.
+    if !secular
+        nyq_ix = n_pts[1]  # rfft_output_shape[1] = grid_n[1] ÷ 2 + 1
+        fill!(selectdim(Q_xy, 1, nyq_ix), zero(T))
+        if N >= 3
+            fill!(selectdim(Q_xz, 1, nyq_ix), zero(T))
+        end
+    end
+
     nothing
 end
 

--- a/src/solvers/ground_state/itp_loop.jl
+++ b/src/solvers/ground_state/itp_loop.jl
@@ -168,18 +168,26 @@ function _run_itp_loop!(
                 final_dE = dE
                 final_dpsi = dpsi
 
+                # Relative energy convergence: scale dE by |E| so that tol is
+                # dimensionless and works across energy scales. Guard against E≈0
+                # with a floor of 1. Old absolute criterion (dE < tol) would never
+                # trigger for DDI systems where E ~ O(10–100) and tol = 1e-9.
+                E_scale = max(abs(E), one(typeof(E)))
+                dE_rel = dE / E_scale
+
                 if verbose
                     elapsed = time() - t_start
                     frac = step / n_steps
                     eta = frac > 0 ? elapsed / frac * (1 - frac) : NaN
                     println(
-                        "  ITP $(step)/$(n_steps) | E=$(round(E; sigdigits=8)) dE=$(round(dE; sigdigits=3)) " *
+                        "  ITP $(step)/$(n_steps) | E=$(round(E; sigdigits=8)) " *
+                        "dE=$(round(dE; sigdigits=3)) rel=$(round(dE_rel; sigdigits=3)) " *
                         "dpsi=$(round(dpsi; sigdigits=3)) | $(round(elapsed; digits=1))s elapsed, ETA $(round(eta; digits=0))s",
                     )
                     flush(stdout)
                 end
 
-                if dE < tol
+                if dE_rel < tol
                     converged = true
                     break
                 end

--- a/test/hamiltonian/test_ddi.jl
+++ b/test/hamiltonian/test_ddi.jl
@@ -322,4 +322,33 @@
             grid, atom=Eu151, interactions, sim_params=sp, enable_ddi=true
         )
     end
+
+    @testset "DDI rfft Nyquist symmetry (Hermitian-consistency fix)" begin
+        # At kx = Nyquist (last rfft bin, index n÷2+1), Q_xy and Q_xz are
+        # antisymmetric under (ky,kz)→(−ky,−kz):  Q_αβ[Nyq,j,k] = −Q_αβ[Nyq,−j,−k].
+        # A fixed non-zero value there violates the Hermitian-symmetry contract
+        # that the DDI Q-tensor must satisfy so that Φ = irfft(Q·F̃) is well-defined.
+        # The fix zeros those slices so the stored Q tensor is self-consistent.
+        # Secular and quasi-2D paths are zero by construction and are unaffected.
+        config = GridConfig((8, 8, 8), (10.0, 10.0, 10.0))
+        grid   = make_grid(config)
+        ddi    = make_ddi_params(grid, Eu151; secular=false)
+        nyq    = size(ddi.Q_xy, 1)   # = 8÷2+1 = 5
+
+        # Structural check: Nyquist slice of off-diagonal terms must be zero.
+        @test all(iszero, @view ddi.Q_xy[nyq, :, :])
+        @test all(iszero, @view ddi.Q_xz[nyq, :, :])
+
+        # Diagonal and Q_yz at Nyquist are computed from Q_αα = k̂_α² − 1/3 and
+        # Q_yz = ky*kz/k² — these are symmetric under (ky,kz)→(−ky,−kz) and
+        # must NOT be zeroed; spot-check that they are non-trivially populated.
+        @test any(!iszero, @view ddi.Q_xx[nyq, :, :])
+        @test any(!iszero, @view ddi.Q_yy[nyq, :, :])
+        @test any(!iszero, @view ddi.Q_zz[nyq, :, :])
+
+        # Secular variant: all off-diagonal are zero everywhere (not just Nyquist).
+        ddi_sec = make_ddi_params(grid, Eu151; secular=true)
+        @test all(iszero, @view ddi_sec.Q_xy[nyq, :, :])
+        @test all(iszero, @view ddi_sec.Q_xz[nyq, :, :])
+    end
 end


### PR DESCRIPTION
DDI Q-tensor Nyquist fix (terms/ddi/qtensor.jl): at kx = Nyquist, Q_xy and Q_xz are antisymmetric under (ky,kz)→(−ky,−kz), violating irfft's conjugate-symmetry assumption and injecting a systematic chiral bias (fixed preferred spin-texture direction, seed-independent). Zero Q_xy/Q_xz at the Nyquist slice after the main loop. Secular / quasi-2D paths unaffected.

ITP relative convergence (itp_loop.jl): old `dE < tol` (absolute) never triggered for DDI systems where E ~ O(10–100) and tol = 1e-9, so ITP always ran the full n_steps. Switch to `dE / max(|E|,1) < tol` (scale-invariant); verbose log now reports both absolute and relative dE.

Regression test (test/hamiltonian/test_ddi.jl): asserts Q_xy/Q_xz vanish at the Nyquist slice while diagonal terms stay populated; secular variant checked.

Rebased onto current main (qtensor.jl relocated to src/hamiltonian/terms/ddi/).