### PR TITLE
feat(itp): density-based convergence gate (tol_drho) + 60 μG diagnost…

### DIFF
--- a/runs/eu151_flower_protocol_edh/main/submit_itp_trace_60uG.sh
+++ b/runs/eu151_flower_protocol_edh/main/submit_itp_trace_60uG.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# UGE submission: ITP trace at B=60 μG with on_step snapshot capture.
+# Outputs itp_trace_60uG.h5 → plot_itp_trace.py turns it into a GIF.
+#
+# qsub -g tga-kozuma-kouhi runs/eu151_flower_protocol_edh/main/submit_itp_trace_60uG.sh
+#$ -cwd
+#$ -N fpe_itp_trace
+#$ -l gpu_h=1
+#$ -l h_rt=2:00:00
+#$ -j n
+#$ -o /gs/bs/work/6/ue06186/bec-runs/flower_protocol_edh/logs/
+#$ -e /gs/bs/work/6/ue06186/bec-runs/flower_protocol_edh/logs/
+
+set -euo pipefail
+PROJECT_ROOT=$HOME/bec-simulation
+mkdir -p /gs/bs/work/6/ue06186/bec-runs/flower_protocol_edh/logs
+cd "$PROJECT_ROOT"
+source scripts/tsubame_setup.sh
+set -euo pipefail
+HOME_DEPOT=$HOME/.julia
+export JULIA_DEPOT_PATH="$JULIA_DEPOT_PATH:$HOME_DEPOT"
+JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia
+echo "[itp_trace_60uG] on $(hostname)"
+"$JULIA" --project=. scripts/flower_protocol_edh/itp_trace_60uG.jl
+echo "[itp_trace_60uG] julia done — generating GIF"
+python3 scripts/flower_protocol_edh/plot_itp_trace.py
+echo "[itp_trace_60uG] all done"

--- a/scripts/flower_protocol_edh/itp_trace_60uG.jl
+++ b/scripts/flower_protocol_edh/itp_trace_60uG.jl
@@ -1,0 +1,306 @@
+# scripts/flower_protocol_edh/itp_trace_60uG.jl
+# ============================================
+# ITP imaginary-time-evolution trace at B = 60 μG, F=6 Eu151.
+#
+# Runs find_ground_state with an on_step callback that grabs a snapshot
+# every SAVE_EVERY steps. For each snapshot we keep:
+#   • n_m  (population per m channel, integrated)
+#   • Fz, |F_perp|, Lz scalars
+#   • E (total), drho (since last snap), dpsi (since last snap)
+#   • n_m_xy slices (D, nx, ny)  — for per-m density GIF
+#   • Fx_xy, Fy_xy, Fz_xy slices — for spin-arrow GIF
+#   • arg(ψ_{m=-6})_xy slice    — for phase GIF
+#
+# Goal: visualise WHEN the ITP wavefunction drifts away from the true
+#       minimum at 60 μG (drho minimum was step ~26500 then increased).
+#
+# Output: /gs/bs/work/6/ue06186/bec-runs/flower_protocol_edh/itp_trace_60uG.h5
+
+import CUDA
+using SpinorBEC
+using HDF5, LinearAlgebra, FFTW
+using SpinorBEC: Units, eu151_preset, ZeemanParams, find_ground_state,
+                 CUDABackend, CPUBackend
+
+const F = 6
+const D = 2F + 1
+const M_VALS = collect(F:-1:-F)
+
+const NX = 64
+const L_BOX = 18.0
+const DX = L_BOX / NX
+const N_STEPS  = 50_000
+const DT       = 0.005
+const SAVE_EVERY = 100   # → 500 snapshots
+const B_GAUSS  = 6.0e-5  # 60 μG
+
+const OUT_DIR = get(ENV, "FPE_ROOT",
+    "/gs/bs/work/6/ue06186/bec-runs/flower_protocol_edh")
+const OUT = joinpath(OUT_DIR, "itp_trace_60uG.h5")
+
+# --- Spin matrices ---
+function spin_matrices_F6()
+    Fz = zeros(ComplexF64, D, D); Fp = zeros(ComplexF64, D, D)
+    for c in 1:D
+        m = M_VALS[c]
+        Fz[c, c] = m
+        if c < D
+            mn = M_VALS[c+1]
+            Fp[c, c+1] = sqrt(F*(F+1) - mn*(mn+1))
+        end
+    end
+    Fm = Fp'
+    Fx = (Fp + Fm) / 2
+    Fy = (Fp - Fm) / (2im)
+    Fx, Fy, Fz
+end
+const FX, FY, FZ = spin_matrices_F6()
+
+mutable struct SnapBuf
+    step::Vector{Int}
+    E::Vector{Float64}
+    drho::Vector{Float64}
+    dpsi::Vector{Float64}
+    N_tot::Vector{Float64}
+    Fz::Vector{Float64}
+    Fperp::Vector{Float64}
+    Lz::Vector{Float64}
+    n_m::Vector{Vector{Float64}}      # per-snap (D,)
+    n_xy::Vector{Array{Float32,3}}    # per-snap (D, nx, ny)
+    n_xz::Vector{Array{Float32,3}}    # per-snap (D, nx, nz)
+    Fx_xy::Vector{Matrix{Float32}}
+    Fy_xy::Vector{Matrix{Float32}}
+    Fz_xy::Vector{Matrix{Float32}}
+    Fx_xz::Vector{Matrix{Float32}}
+    Fy_xz::Vector{Matrix{Float32}}
+    Fz_xz::Vector{Matrix{Float32}}
+    arg_m6_xy::Vector{Matrix{Float32}}
+    arg_m6_xz::Vector{Matrix{Float32}}
+    psi_prev::Union{Nothing,Array{ComplexF64,4}}
+    rho_prev::Union{Nothing,Array{Float64,3}}
+end
+SnapBuf() = SnapBuf(Int[], Float64[], Float64[], Float64[], Float64[],
+    Float64[], Float64[], Float64[],
+    Vector{Vector{Float64}}(),
+    Vector{Array{Float32,3}}(), Vector{Array{Float32,3}}(),
+    Vector{Matrix{Float32}}(), Vector{Matrix{Float32}}(), Vector{Matrix{Float32}}(),
+    Vector{Matrix{Float32}}(), Vector{Matrix{Float32}}(), Vector{Matrix{Float32}}(),
+    Vector{Matrix{Float32}}(), Vector{Matrix{Float32}}(),
+    nothing, nothing)
+
+const KX = 2π / L_BOX .* FFTW.fftfreq(NX) .* NX
+
+function take_snapshot!(buf::SnapBuf, ws, step::Int)
+    psi = Array{ComplexF64}(ws.state.psi)   # to host
+    nx, ny, nz, _ = size(psi)
+    z_mid = nz ÷ 2 + 1
+    y_mid = ny ÷ 2 + 1
+
+    # scalar reductions
+    N_tot = 0.0
+    n_m = zeros(Float64, D)
+    @inbounds for c in 1:D
+        s = 0.0
+        for k in 1:nz, j in 1:ny, i in 1:nx
+            s += abs2(psi[i,j,k,c])
+        end
+        n_m[c] = s * DX^3
+        N_tot += n_m[c]
+    end
+    Fxe = 0.0; Fye = 0.0; Fze = 0.0
+    @inbounds for k in 1:nz, j in 1:ny, i in 1:nx
+        ψ = @view psi[i,j,k,:]
+        Fxe += real(ψ' * (FX * ψ)) * DX^3
+        Fye += real(ψ' * (FY * ψ)) * DX^3
+        Fze += real(ψ' * (FZ * ψ)) * DX^3
+    end
+    # L_z spectral
+    Lz_e = 0.0
+    @inbounds for c in 1:D
+        ψc = view(psi, :, :, :, c)
+        ddy = ifft(1im .* reshape(KX, 1, :, 1) .* fft(ψc, 2), 2)
+        ddx = ifft(1im .* reshape(KX, :, 1, 1) .* fft(ψc, 1), 1)
+        for k in 1:nz, j in 1:ny, i in 1:nx
+            x = (-L_BOX/2) + DX*(i-1)
+            y = (-L_BOX/2) + DX*(j-1)
+            Lz_loc = -1im * (x * ddy[i,j,k] - y * ddx[i,j,k])
+            Lz_e += real(conj(ψc[i,j,k]) * Lz_loc) * DX^3
+        end
+    end
+
+    # slices xy z=mid, xz y=mid
+    n_xy = zeros(Float32, D, nx, ny)
+    n_xz = zeros(Float32, D, nx, nz)
+    Fx_xy = zeros(Float32, nx, ny); Fy_xy = zeros(Float32, nx, ny); Fz_xy = zeros(Float32, nx, ny)
+    Fx_xz = zeros(Float32, nx, nz); Fy_xz = zeros(Float32, nx, nz); Fz_xz = zeros(Float32, nx, nz)
+    arg_m6_xy = zeros(Float32, nx, ny)
+    arg_m6_xz = zeros(Float32, nx, nz)
+    @inbounds for c in 1:D, j in 1:ny, i in 1:nx
+        n_xy[c,i,j] = Float32(abs2(psi[i,j,z_mid,c]))
+    end
+    @inbounds for c in 1:D, k in 1:nz, i in 1:nx
+        n_xz[c,i,k] = Float32(abs2(psi[i,y_mid,k,c]))
+    end
+    @inbounds for j in 1:ny, i in 1:nx
+        ψ = @view psi[i,j,z_mid,:]
+        Fx_xy[i,j] = Float32(real(ψ' * (FX * ψ)))
+        Fy_xy[i,j] = Float32(real(ψ' * (FY * ψ)))
+        Fz_xy[i,j] = Float32(real(ψ' * (FZ * ψ)))
+        arg_m6_xy[i,j] = Float32(angle(psi[i,j,z_mid,D]))
+    end
+    @inbounds for k in 1:nz, i in 1:nx
+        ψ = @view psi[i,y_mid,k,:]
+        Fx_xz[i,k] = Float32(real(ψ' * (FX * ψ)))
+        Fy_xz[i,k] = Float32(real(ψ' * (FY * ψ)))
+        Fz_xz[i,k] = Float32(real(ψ' * (FZ * ψ)))
+        arg_m6_xz[i,k] = Float32(angle(psi[i,y_mid,k,D]))
+    end
+
+    # rho_now (per-cell total density)
+    rho_now = zeros(Float64, nx, ny, nz)
+    @inbounds for k in 1:nz, j in 1:ny, i in 1:nx
+        s = 0.0
+        for c in 1:D; s += abs2(psi[i,j,k,c]); end
+        rho_now[i,j,k] = s
+    end
+
+    drho = NaN; dpsi = NaN
+    if buf.rho_prev !== nothing
+        rho_max = maximum(rho_now)
+        drho = rho_max > 0 ? maximum(abs.(rho_now .- buf.rho_prev)) / rho_max : 0.0
+    end
+    if buf.psi_prev !== nothing
+        psi_max = maximum(abs, psi)
+        dpsi = psi_max > 0 ? maximum(abs, psi .- buf.psi_prev) / psi_max : 0.0
+    end
+
+    push!(buf.step, step)
+    push!(buf.E, SpinorBEC.total_energy(ws))
+    push!(buf.drho, drho); push!(buf.dpsi, dpsi)
+    push!(buf.N_tot, N_tot)
+    push!(buf.Fz, Fze / N_tot)
+    push!(buf.Fperp, sqrt(Fxe^2 + Fye^2) / N_tot)
+    push!(buf.Lz, Lz_e / N_tot)
+    push!(buf.n_m, n_m)
+    push!(buf.n_xy, n_xy); push!(buf.n_xz, n_xz)
+    push!(buf.Fx_xy, Fx_xy); push!(buf.Fy_xy, Fy_xy); push!(buf.Fz_xy, Fz_xy)
+    push!(buf.Fx_xz, Fx_xz); push!(buf.Fy_xz, Fy_xz); push!(buf.Fz_xz, Fz_xz)
+    push!(buf.arg_m6_xy, arg_m6_xy); push!(buf.arg_m6_xz, arg_m6_xz)
+
+    buf.psi_prev = psi
+    buf.rho_prev = rho_now
+
+    println("  snap step=$step E=$(round(buf.E[end]; sigdigits=8)) ",
+            "drho=$(round(drho; sigdigits=3)) dpsi=$(round(dpsi; sigdigits=3)) ",
+            "Fz=$(round(buf.Fz[end]; sigdigits=4)) |F⊥|=$(round(buf.Fperp[end]; sigdigits=4))")
+    flush(stdout)
+end
+
+function main()
+    mkpath(OUT_DIR)
+    println("[itp_trace_60uG] start  out=$OUT")
+    println("  NX=$NX  L=$L_BOX  dt=$DT  n_steps=$N_STEPS  save_every=$SAVE_EVERY")
+
+    preset = eu151_preset(
+        n_atoms=50_000,
+        n_pts=(NX, NX, NX),
+        box=(L_BOX, L_BOX, L_BOX),
+        trap_ratios=(1.0, 1.0, 1.181818),
+        omega_ref=691.1504,
+    )
+    p = Units.bfield_to_p(B_GAUSS, preset.atom.g_F, preset.omega_ref)
+    zeeman = ZeemanParams(p, 0.0)
+    println("  B=$B_GAUSS G → p=$(round(p; sigdigits=4))  c_dd=$(round(preset.c_dd; sigdigits=4))")
+
+    backend = CUDA.functional() ? CUDABackend() : CPUBackend()
+    println("  backend=$backend")
+
+    buf = SnapBuf()
+    on_step = (ws, step, n_steps) -> begin
+        if step == 1 || step % SAVE_EVERY == 0
+            take_snapshot!(buf, ws, step)
+        end
+    end
+
+    gs = find_ground_state(;
+        grid=preset.grid,
+        atom=preset.atom,
+        interactions=preset.interactions,
+        zeeman=zeeman,
+        potential=preset.potential,
+        dt=DT,
+        n_steps=N_STEPS,
+        tol=1.0e-9,        # essentially never trip; we want the full trace
+        tol_drho=0.0,
+        save_every=SAVE_EVERY,
+        initial_state=:m_plus_F,
+        enable_ddi=true,
+        c_dd=preset.c_dd,
+        secular_ddi=false,
+        backend=backend,
+        on_step=on_step,
+        verbose=true,
+    )
+
+    # final snapshot (in case last step wasn't on the cadence)
+    if isempty(buf.step) || buf.step[end] != gs.last_step
+        take_snapshot!(buf, gs.workspace, gs.last_step)
+    end
+
+    Nf = length(buf.step)
+    println("[itp_trace_60uG] writing $Nf snapshots to $OUT")
+    n_m_mat = zeros(Float64, D, Nf)
+    n_xy_arr = zeros(Float32, Nf, D, NX, NX)
+    n_xz_arr = zeros(Float32, Nf, D, NX, NX)
+    Fx_arr = zeros(Float32, Nf, NX, NX); Fy_arr = zeros(Float32, Nf, NX, NX); Fz_arr = zeros(Float32, Nf, NX, NX)
+    Fx_xz_arr = zeros(Float32, Nf, NX, NX); Fy_xz_arr = zeros(Float32, Nf, NX, NX); Fz_xz_arr = zeros(Float32, Nf, NX, NX)
+    arg_arr = zeros(Float32, Nf, NX, NX)
+    arg_xz_arr = zeros(Float32, Nf, NX, NX)
+    for k in 1:Nf
+        n_m_mat[:, k] .= buf.n_m[k]
+        n_xy_arr[k, :, :, :] .= buf.n_xy[k]
+        n_xz_arr[k, :, :, :] .= buf.n_xz[k]
+        Fx_arr[k, :, :]    .= buf.Fx_xy[k]
+        Fy_arr[k, :, :]    .= buf.Fy_xy[k]
+        Fz_arr[k, :, :]    .= buf.Fz_xy[k]
+        Fx_xz_arr[k, :, :] .= buf.Fx_xz[k]
+        Fy_xz_arr[k, :, :] .= buf.Fy_xz[k]
+        Fz_xz_arr[k, :, :] .= buf.Fz_xz[k]
+        arg_arr[k, :, :]    .= buf.arg_m6_xy[k]
+        arg_xz_arr[k, :, :] .= buf.arg_m6_xz[k]
+    end
+
+    h5open(OUT, "w") do h5
+        h5["meta/m_channels"] = collect(M_VALS)
+        h5["meta/F"]    = F
+        h5["meta/L_box"] = L_BOX
+        h5["meta/NX"]   = NX
+        h5["meta/dt"]   = DT
+        h5["meta/save_every"] = SAVE_EVERY
+        h5["meta/n_steps"]    = N_STEPS
+        h5["meta/B_gauss"]    = B_GAUSS
+        h5["step"]   = buf.step
+        h5["tau"]    = buf.step .* DT
+        h5["E"]      = buf.E
+        h5["drho"]   = buf.drho
+        h5["dpsi"]   = buf.dpsi
+        h5["N_total"]= buf.N_tot
+        h5["Fz"]     = buf.Fz
+        h5["F_perp"] = buf.Fperp
+        h5["Lz"]     = buf.Lz
+        h5["n_m"]    = n_m_mat
+        h5["n_m_xy"] = n_xy_arr
+        h5["n_m_xz"] = n_xz_arr
+        h5["Fx_xy"]  = Fx_arr
+        h5["Fy_xy"]  = Fy_arr
+        h5["Fz_xy"]  = Fz_arr
+        h5["Fx_xz"]  = Fx_xz_arr
+        h5["Fy_xz"]  = Fy_xz_arr
+        h5["Fz_xz"]  = Fz_xz_arr
+        h5["arg_psi_m6_xy"] = arg_arr
+        h5["arg_psi_m6_xz"] = arg_xz_arr
+    end
+    println("[itp_trace_60uG] done.  converged=$(gs.converged)  last_step=$(gs.last_step)  E=$(gs.energy)")
+end
+
+main()

--- a/scripts/flower_protocol_edh/plot_itp_trace.py
+++ b/scripts/flower_protocol_edh/plot_itp_trace.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""
+plot_itp_trace.py
+=================
+Polished GIF for ITP imaginary-time trace at B=60μG.
+
+Layout (4 rows × 5 cols):
+  Row 1 (xy slices @ z=0):  n_{m=+6}  n_{m=0}  n_{m=-6}  arg ψ_{-6}  F_xy field
+  Row 2 (xz slices @ y=0):  n_{m=+6}  n_{m=0}  n_{m=-6}  arg ψ_{-6}  F_xz field
+  Row 3 (scalars):          populations(τ)         E(τ)          conv(τ)
+  Row 4 (scalars):          ⟨F_z⟩, |F_⊥|(τ)         ⟨L_z⟩(τ)       — running cursor on all
+
+Spin arrows: COLOR encodes magnitude |F_perp| (not size). All arrows same length.
+            Density: every 2 cells (NX/2 = 32 arrows per axis at NX=64).
+"""
+import os
+import numpy as np
+import h5py
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation, PillowWriter
+from matplotlib import colors as mcolors
+
+# --- Style ---
+plt.rcParams.update({
+    "font.size": 10,
+    "axes.titlesize": 11,
+    "axes.labelsize": 10,
+    "xtick.labelsize": 9,
+    "ytick.labelsize": 9,
+    "legend.fontsize": 8,
+    "axes.linewidth": 0.8,
+    "xtick.direction": "out",
+    "ytick.direction": "out",
+})
+
+ROOT = os.environ.get("FPE_ROOT",
+    "/gs/bs/work/6/ue06186/bec-runs/flower_protocol_edh")
+H5 = os.path.join(ROOT, "itp_trace_60uG.h5")
+OUT_GIF = os.path.join(ROOT, "itp_trace_60uG.gif")
+
+# --- Load ---
+with h5py.File(H5, "r") as f:
+    step = f["step"][:]
+    tau  = f["tau"][:]
+    E    = f["E"][:]
+    drho = f["drho"][:]
+    dpsi = f["dpsi"][:]
+    Fz_t = f["Fz"][:]
+    Fp_t = f["F_perp"][:]
+    Lz_t = f["Lz"][:]
+    n_m  = f["n_m"][:]                                            # (Nf, D)
+    n_xy = np.transpose(f["n_m_xy"][:],  (3, 2, 1, 0))            # (Nf, D, NX, NX)
+    n_xz = np.transpose(f["n_m_xz"][:],  (3, 2, 1, 0))            # (Nf, D, NX, NX)
+    Fx_xy = f["Fx_xy"][:].transpose(2, 1, 0)
+    Fy_xy = f["Fy_xy"][:].transpose(2, 1, 0)
+    Fz_xy = f["Fz_xy"][:].transpose(2, 1, 0)
+    Fx_xz = f["Fx_xz"][:].transpose(2, 1, 0)
+    Fy_xz = f["Fy_xz"][:].transpose(2, 1, 0)
+    Fz_xz = f["Fz_xz"][:].transpose(2, 1, 0)
+    arg_xy = f["arg_psi_m6_xy"][:].transpose(2, 1, 0)
+    arg_xz = f["arg_psi_m6_xz"][:].transpose(2, 1, 0)
+    Lbox  = float(f["meta/L_box"][()])
+    NX    = int(f["meta/NX"][()])
+    Mvals = f["meta/m_channels"][:]
+    B_g   = float(f["meta/B_gauss"][()])
+
+Nf = len(step)
+print(f"loaded {Nf} snapshots, NX={NX}, L={Lbox}μm, B={B_g*1e6:.1f}μG")
+
+def m_idx(m): return int(np.where(Mvals == m)[0][0])
+c_plus = m_idx(+6); c_zero = m_idx(0); c_minus = m_idx(-6)
+
+dx = Lbox / NX
+xs = -Lbox/2 + dx * np.arange(NX) + dx/2
+extent = [xs[0]-dx/2, xs[-1]+dx/2, xs[0]-dx/2, xs[-1]+dx/2]
+
+# --- vmaxes (global so frames are comparable) ---
+vmax_plus  = max(np.max(n_xy[:, c_plus]),  np.max(n_xz[:, c_plus]),  1e-30)
+vmax_zero  = max(np.max(n_xy[:, c_zero]),  np.max(n_xz[:, c_zero]),  1e-30)
+vmax_minus = max(np.max(n_xy[:, c_minus]), np.max(n_xz[:, c_minus]), 1e-30)
+Fperp_xy = np.sqrt(Fx_xy**2 + Fy_xy**2)
+Fperp_xz = np.sqrt(Fx_xz**2 + Fz_xz**2)   # in xz the in-plane spin is (Fx, Fz)
+Fperp_global_xy = float(np.max(Fperp_xy))
+Fperp_global_xz = float(np.max(Fperp_xz))
+
+# --- Figure ---
+fig = plt.figure(figsize=(24, 18), constrained_layout=False)
+gs = fig.add_gridspec(4, 5,
+                     height_ratios=[3.2, 3.2, 1.6, 1.6],
+                     hspace=0.40, wspace=0.40,
+                     left=0.04, right=0.98, top=0.94, bottom=0.05)
+
+# Row 1: xy
+ax_pp_xy = fig.add_subplot(gs[0, 0])
+ax_p0_xy = fig.add_subplot(gs[0, 1])
+ax_pm_xy = fig.add_subplot(gs[0, 2])
+ax_ph_xy = fig.add_subplot(gs[0, 3])
+ax_F_xy  = fig.add_subplot(gs[0, 4])
+
+# Row 2: xz
+ax_pp_xz = fig.add_subplot(gs[1, 0])
+ax_p0_xz = fig.add_subplot(gs[1, 1])
+ax_pm_xz = fig.add_subplot(gs[1, 2])
+ax_ph_xz = fig.add_subplot(gs[1, 3])
+ax_F_xz  = fig.add_subplot(gs[1, 4])
+
+# Row 3
+ax_pop = fig.add_subplot(gs[2, 0:2])
+ax_E   = fig.add_subplot(gs[2, 2])
+ax_dr  = fig.add_subplot(gs[2, 3:5])
+
+# Row 4
+ax_F   = fig.add_subplot(gs[3, 0:2])
+ax_L   = fig.add_subplot(gs[3, 2])
+ax_sum = fig.add_subplot(gs[3, 3:5]); ax_sum.axis("off")
+
+# --- Density panels (xy + xz pairs) ---
+def setup_density(ax, vmax, title, ylab):
+    im = ax.imshow(np.zeros((NX, NX)), extent=extent, origin="lower",
+                   vmin=0, vmax=vmax, cmap="magma", aspect="equal",
+                   interpolation="bilinear")
+    ax.set_title(title, pad=4)
+    ax.set_xlabel("x [μm]")
+    ax.set_ylabel(ylab)
+    ax.set_xticks(np.linspace(-Lbox/2, Lbox/2, 5))
+    ax.set_yticks(np.linspace(-Lbox/2, Lbox/2, 5))
+    ax.tick_params(length=3)
+    cb = plt.colorbar(im, ax=ax, fraction=0.046, pad=0.02)
+    cb.ax.tick_params(labelsize=8, length=2)
+    return im
+
+im_pp_xy = setup_density(ax_pp_xy, vmax_plus,  r"$|\psi_{m=+6}|^2$  (z=0)", "y [μm]")
+im_p0_xy = setup_density(ax_p0_xy, vmax_zero,  r"$|\psi_{m=0}|^2$  (z=0)",  "y [μm]")
+im_pm_xy = setup_density(ax_pm_xy, vmax_minus, r"$|\psi_{m=-6}|^2$  (z=0)", "y [μm]")
+im_pp_xz = setup_density(ax_pp_xz, vmax_plus,  r"$|\psi_{m=+6}|^2$  (y=0)", "z [μm]")
+im_p0_xz = setup_density(ax_p0_xz, vmax_zero,  r"$|\psi_{m=0}|^2$  (y=0)",  "z [μm]")
+im_pm_xz = setup_density(ax_pm_xz, vmax_minus, r"$|\psi_{m=-6}|^2$  (y=0)", "z [μm]")
+
+# --- Phase panels (cyclic) ---
+def setup_phase(ax, title, ylab):
+    im = ax.imshow(np.zeros((NX, NX)), extent=extent, origin="lower",
+                   vmin=-np.pi, vmax=np.pi, cmap="hsv",
+                   aspect="equal", interpolation="bilinear")
+    ax.set_title(title, pad=4)
+    ax.set_xlabel("x [μm]"); ax.set_ylabel(ylab)
+    ax.set_xticks(np.linspace(-Lbox/2, Lbox/2, 5))
+    ax.set_yticks(np.linspace(-Lbox/2, Lbox/2, 5))
+    ax.tick_params(length=3)
+    cb = plt.colorbar(im, ax=ax, fraction=0.046, pad=0.02,
+                      ticks=[-np.pi, 0, np.pi])
+    cb.ax.set_yticklabels([r"$-\pi$", "0", r"$+\pi$"])
+    cb.ax.tick_params(labelsize=8, length=2)
+    return im
+
+im_ph_xy = setup_phase(ax_ph_xy, r"$\arg\psi_{m=-6}$  (z=0)", "y [μm]")
+im_ph_xz = setup_phase(ax_ph_xz, r"$\arg\psi_{m=-6}$  (y=0)", "z [μm]")
+
+# --- Spin vector field panels: arrow direction only, color = |F_perp| ---
+SK = 2                  # every 2 cells → 32×32 arrows at NX=64
+Xa = xs[::SK]
+mesh_X, mesh_Y = np.meshgrid(Xa, Xa, indexing="xy")
+
+def setup_field(ax, title, ylab, vmax_perp, axis2_label):
+    ax.set_facecolor("#222")
+    ax.set_title(title, pad=4)
+    ax.set_xlabel("x [μm]"); ax.set_ylabel(ylab)
+    ax.set_xticks(np.linspace(-Lbox/2, Lbox/2, 5))
+    ax.set_yticks(np.linspace(-Lbox/2, Lbox/2, 5))
+    ax.set_xlim(extent[0], extent[1]); ax.set_ylim(extent[2], extent[3])
+    ax.set_aspect("equal")
+    ax.tick_params(length=3, colors="white", which="both")
+    for spine in ax.spines.values():
+        spine.set_color("white")
+    Q = ax.quiver(mesh_X, mesh_Y,
+                  np.zeros_like(mesh_X), np.zeros_like(mesh_X),
+                  np.zeros_like(mesh_X),                  # color array
+                  cmap="viridis", norm=mcolors.Normalize(vmin=0, vmax=vmax_perp),
+                  pivot="middle", scale=30, width=0.005,
+                  headwidth=4, headlength=5, headaxislength=4.5)
+    cb = plt.colorbar(Q, ax=ax, fraction=0.046, pad=0.02)
+    cb.set_label(axis2_label, fontsize=8)
+    cb.ax.tick_params(labelsize=8, length=2)
+    return Q
+
+Q_xy = setup_field(ax_F_xy, r"spin field $\mathbf{F}_\perp$  (z=0)", "y [μm]",
+                   Fperp_global_xy, r"$|F_\perp|$")
+Q_xz = setup_field(ax_F_xz, r"spin field $(F_x,F_z)$  (y=0)", "z [μm]",
+                   Fperp_global_xz, r"$\sqrt{F_x^2+F_z^2}$")
+
+# --- Scalar time-series ---
+# Populations: bar chart of CURRENT snapshot (no time axis).
+cmap_m = plt.get_cmap("turbo")
+D_ch = n_m.shape[1]
+m_axis = np.arange(D_ch)
+bar_colors = [cmap_m(c / max(D_ch-1, 1)) for c in range(D_ch)]
+pop_bars = ax_pop.bar(m_axis, np.zeros(D_ch), color=bar_colors,
+                      edgecolor="black", linewidth=0.6)
+pop_max = float(np.max(n_m))
+ax_pop.set_xticks(m_axis)
+ax_pop.set_xticklabels([f"{int(Mvals[c]):+d}" for c in range(D_ch)])
+ax_pop.set_xlabel("m")
+ax_pop.set_ylabel(r"$n_m$  (population)")
+ax_pop.set_title("populations  (current snapshot)")
+ax_pop.set_ylim(0, pop_max * 1.1)
+ax_pop.grid(alpha=0.25, axis="y")
+v_pop = None  # no time cursor in bar chart
+
+ax_E.plot(tau, E, "k-", lw=1.6)
+ax_E.set_xlabel(r"$\tau$"); ax_E.set_ylabel(r"$E$")
+ax_E.set_title("total energy")
+ax_E.grid(alpha=0.25)
+v_E = ax_E.axvline(tau[0], color="r", lw=1.0)
+
+ax_dr.plot(tau[1:], drho[1:], "C0-", lw=1.6, label=r"$\delta\rho/\rho_{\max}$")
+ax_dr.plot(tau[1:], dpsi[1:], "C3--", lw=1.4, label=r"$\delta\psi/|\psi|_{\max}$")
+ax_dr.set_xlabel(r"$\tau$"); ax_dr.set_ylabel("convergence metric")
+ax_dr.set_title("convergence")
+ax_dr.grid(alpha=0.25)
+ax_dr.legend(loc="upper right")
+v_dr = ax_dr.axvline(tau[0], color="k", lw=1.0, alpha=0.7)
+
+ax_F.plot(tau, Fz_t, "C0-", lw=1.6, label=r"$\langle F_z\rangle$")
+ax_F.plot(tau, Fp_t, "C3-", lw=1.4, label=r"$|F_\perp|$")
+ax_F.axhline(0,    color="k",   lw=0.5, alpha=0.5)
+ax_F.axhline(-6.0, color="C0", lw=0.5, alpha=0.4, linestyle=":")
+ax_F.set_xlabel(r"$\tau$"); ax_F.set_ylabel("spin")
+ax_F.set_title("spin expectation")
+ax_F.grid(alpha=0.25); ax_F.legend(loc="upper right")
+v_F = ax_F.axvline(tau[0], color="k", lw=1.0, alpha=0.7)
+
+ax_L.plot(tau, Lz_t, "C2-", lw=1.6)
+ax_L.axhline(0, color="k", lw=0.5, alpha=0.5)
+ax_L.set_xlabel(r"$\tau$"); ax_L.set_ylabel(r"$\langle L_z\rangle$")
+ax_L.set_title("angular momentum")
+ax_L.grid(alpha=0.25)
+v_L = ax_L.axvline(tau[0], color="k", lw=1.0, alpha=0.7)
+
+# --- Insets: zoom of last 30% τ-range with auto y-limits ---
+ZOOM_FRAC = 0.30
+zoom_start = tau[-1] - ZOOM_FRAC * (tau[-1] - tau[0])
+mask = tau >= zoom_start
+mask_dr = (tau[1:] >= zoom_start)
+
+def _auto_ylim(vals):
+    v = np.asarray(vals)
+    lo, hi = float(np.min(v)), float(np.max(v))
+    if hi - lo < 1e-15:
+        pad = max(1e-9, abs(hi) * 1e-6)
+        return lo - pad, hi + pad
+    pad = 0.1 * (hi - lo)
+    return lo - pad, hi + pad
+
+def _add_inset(parent, x, y, color, lw=1.4, ls="-"):
+    ins = parent.inset_axes([0.55, 0.55, 0.42, 0.40])
+    ins.plot(x, y, color=color, lw=lw, linestyle=ls)
+    ins.set_xlim(x[0], x[-1])
+    ins.set_ylim(*_auto_ylim(y))
+    ins.tick_params(labelsize=7, length=2, pad=1)
+    ins.grid(alpha=0.25)
+    ins.patch.set_alpha(0.85)
+    for s in ins.spines.values():
+        s.set_linewidth(0.6); s.set_alpha(0.6)
+    ins.set_title(f"zoom: last {int(ZOOM_FRAC*100)}%", fontsize=7, pad=2)
+    return ins
+
+ins_E  = _add_inset(ax_E,  tau[mask], E[mask], "k")
+v_E_ins  = ins_E.axvline(tau[0], color="r", lw=0.8, alpha=0.8)
+
+ins_dr = ax_dr.inset_axes([0.55, 0.55, 0.42, 0.40])
+ins_dr.plot(tau[1:][mask_dr], drho[1:][mask_dr], "C0-", lw=1.4)
+ins_dr.plot(tau[1:][mask_dr], dpsi[1:][mask_dr], "C3--", lw=1.2)
+ins_dr.set_xlim(tau[1:][mask_dr][0], tau[1:][mask_dr][-1])
+ins_dr.set_ylim(*_auto_ylim(np.concatenate([drho[1:][mask_dr], dpsi[1:][mask_dr]])))
+ins_dr.tick_params(labelsize=7, length=2, pad=1)
+ins_dr.grid(alpha=0.25)
+ins_dr.patch.set_alpha(0.85)
+for s in ins_dr.spines.values(): s.set_linewidth(0.6); s.set_alpha(0.6)
+ins_dr.set_title(f"zoom: last {int(ZOOM_FRAC*100)}%", fontsize=7, pad=2)
+v_dr_ins = ins_dr.axvline(tau[0], color="k", lw=0.8, alpha=0.8)
+
+ins_F = ax_F.inset_axes([0.55, 0.10, 0.42, 0.40])
+ins_F.plot(tau[mask], Fz_t[mask], "C0-", lw=1.4)
+ins_F.plot(tau[mask], Fp_t[mask], "C3-", lw=1.2)
+ins_F.set_xlim(tau[mask][0], tau[mask][-1])
+ins_F.set_ylim(*_auto_ylim(np.concatenate([Fz_t[mask], Fp_t[mask]])))
+ins_F.tick_params(labelsize=7, length=2, pad=1)
+ins_F.grid(alpha=0.25)
+ins_F.patch.set_alpha(0.85)
+for s in ins_F.spines.values(): s.set_linewidth(0.6); s.set_alpha(0.6)
+ins_F.set_title(f"zoom: last {int(ZOOM_FRAC*100)}%", fontsize=7, pad=2)
+v_F_ins = ins_F.axvline(tau[0], color="k", lw=0.8, alpha=0.8)
+
+ins_L = _add_inset(ax_L, tau[mask], Lz_t[mask], "C2")
+v_L_ins = ins_L.axvline(tau[0], color="k", lw=0.8, alpha=0.8)
+
+# --- Live HUD text in the empty subplot ---
+hud_lines = [
+    ax_sum.text(0.04, 0.85, "", fontsize=14, weight="bold", transform=ax_sum.transAxes),
+    ax_sum.text(0.04, 0.65, "", fontsize=12, family="monospace", transform=ax_sum.transAxes),
+    ax_sum.text(0.04, 0.45, "", fontsize=12, family="monospace", transform=ax_sum.transAxes),
+    ax_sum.text(0.04, 0.25, "", fontsize=12, family="monospace", transform=ax_sum.transAxes),
+    ax_sum.text(0.04, 0.05, "", fontsize=12, family="monospace", transform=ax_sum.transAxes),
+]
+
+suptitle = fig.suptitle(
+    f"ITP imaginary-time trace  |  $^{{151}}$Eu, F=6, B={B_g*1e6:.1f} μG, "
+    f"box={Lbox}μm/{NX}³, dt={(tau[1]-tau[0])/(step[1]-step[0]):.4f}",
+    fontsize=14, y=0.985,
+)
+
+# --- Update callback ---
+def update(k):
+    # Row 1 (xy)
+    im_pp_xy.set_data(n_xy[k, c_plus].T)
+    im_p0_xy.set_data(n_xy[k, c_zero].T)
+    im_pm_xy.set_data(n_xy[k, c_minus].T)
+    im_ph_xy.set_data(arg_xy[k].T)
+    # Row 2 (xz)
+    im_pp_xz.set_data(n_xz[k, c_plus].T)
+    im_p0_xz.set_data(n_xz[k, c_zero].T)
+    im_pm_xz.set_data(n_xz[k, c_minus].T)
+    im_ph_xz.set_data(arg_xz[k].T)
+    # Spin field xy: arrow dir = unit(F_x, F_y), color = |F_perp|
+    Ux = Fx_xy[k, ::SK, ::SK]
+    Vy = Fy_xy[k, ::SK, ::SK]
+    mag_xy = np.sqrt(Ux**2 + Vy**2)
+    safe = np.where(mag_xy > 1e-12, mag_xy, 1.0)
+    Q_xy.set_UVC(Ux / safe, Vy / safe, mag_xy)
+    # Spin field xz: in-plane = (F_x, F_z)
+    Ux2 = Fx_xz[k, ::SK, ::SK]
+    Vz  = Fz_xz[k, ::SK, ::SK]
+    mag_xz = np.sqrt(Ux2**2 + Vz**2)
+    safe2 = np.where(mag_xz > 1e-12, mag_xz, 1.0)
+    Q_xz.set_UVC(Ux2 / safe2, Vz / safe2, mag_xz)
+    # Population bars (current snapshot)
+    for c, b in enumerate(pop_bars):
+        b.set_height(n_m[k, c])
+    # Cursors (main + inset)
+    for v in (v_E, v_dr, v_F, v_L,
+              v_E_ins, v_dr_ins, v_F_ins, v_L_ins):
+        v.set_xdata([tau[k], tau[k]])
+    # HUD
+    hud_lines[0].set_text(f"step {step[k]:6d} / {step[-1]}")
+    hud_lines[1].set_text(f"τ        = {tau[k]:7.3f}")
+    hud_lines[2].set_text(f"E        = {E[k]:.6f}")
+    hud_lines[3].set_text(f"⟨F_z⟩   = {Fz_t[k]:+.4f}     |F_⊥| = {Fp_t[k]:.4f}")
+    hud_lines[4].set_text(f"δρ/ρ_max = {drho[k]:.2e}   δψ/|ψ|max = {dpsi[k]:.2e}")
+    return ()
+
+# --- Render (subsample frames for speed: max ~200 frames) ---
+stride = max(1, Nf // 200)
+frames = list(range(0, Nf, stride))
+if frames[-1] != Nf - 1:
+    frames.append(Nf - 1)
+print(f"rendering {len(frames)} frames (stride={stride}) → {OUT_GIF}")
+
+anim = FuncAnimation(fig, update, frames=frames, interval=80, blit=False)
+anim.save(OUT_GIF, writer=PillowWriter(fps=10))
+print("done.")

--- a/src/solvers/ground_state.jl
+++ b/src/solvers/ground_state.jl
@@ -110,6 +110,7 @@ function find_ground_state(;
     dt=0.001,
     n_steps=10000,
     tol=1e-10,
+    tol_drho::Float64=0.0,   # extra gate: per-(save_every) max|Δρ|/max|ρ| (density-based, gauge-invariant)
     save_every::Int=max(1, n_steps ÷ 100),  # unified observation cadence
     initial_state=:polar,
     init_state_params::Dict{Symbol, Float64}=Dict{Symbol, Float64}(),
@@ -309,6 +310,7 @@ function find_ground_state(;
     ckpt_dir = checkpoint_dir !== nothing ? checkpoint_dir : _checkpoint_dir
 
     _run_itp_loop!(ws, n_steps, tol, on_step, target_magnetization;
+        tol_drho=tol_drho,
         start_step=_start_step,
         checkpoint_dir=ckpt_dir,
         checkpoint=checkpoint,

--- a/src/solvers/ground_state/itp_loop.jl
+++ b/src/solvers/ground_state/itp_loop.jl
@@ -8,6 +8,7 @@
 
 function _run_itp_loop!(
     ws, n_steps, tol, on_step, target_magnetization;
+    tol_drho::Float64=0.0,   # 0.0 = ignore the drho gate; >0 = ALSO require drho < tol_drho
     start_step::Int=0,
     # Checkpoint observation sinks — both fire at `sp.save_every` cadence
     # (the unified observation cadence) and on terminal state. Pass any
@@ -29,6 +30,7 @@ function _run_itp_loop!(
     converged = false
     psi_prev = copy(ws.state.psi)
     final_dE = NaN
+    final_drho = NaN
     final_dpsi = NaN
     last_step = start_step
     t_start = time()
@@ -155,17 +157,38 @@ function _run_itp_loop!(
 
             if step % sp.save_every == 0
                 E = total_energy(ws)
-                dE = _relative_energy_change(E, E_prev)
-                psi_max = maximum(abs, ws.state.psi)
+                # Relative energy-change convergence: scale-invariant so a
+                # single `tol` works across systems whose E spans orders of
+                # magnitude. Falls back to the absolute change when E ≈ 0.
+                dE_abs = abs(E - E_prev)
+                dE = abs(E) > 0 ? dE_abs / abs(E) : dE_abs
+
+                # drho = max_r |ρ(r,now) - ρ(r,prev)| / max_r ρ(r,now)
+                # where ρ(r) = Σ_c |ψ_c(r)|² is the total density.
+                # Gauge-invariant under U(1) global phase AND spin rotations
+                # around z — eliminates the gauge-orbit drift that the
+                # wavefunction-based dpsi confuses with non-convergence.
+                # GPU-compatible: broadcasting + reductions only, no scalar
+                # indexing on the device array.
+                psi_now = ws.state.psi
+                rho_now  = dropdims(sum(abs2, psi_now;  dims=N_dim+1); dims=N_dim+1)
+                rho_prev_arr = dropdims(sum(abs2, psi_prev; dims=N_dim+1); dims=N_dim+1)
+                rho_max  = Float64(maximum(rho_now))
+                drho_max = Float64(maximum(abs.(rho_now .- rho_prev_arr)))
+                drho = rho_max > 0 ? drho_max / rho_max : 0.0
+
+                # Also keep dpsi available for diagnostic logging; uses
+                # psi_prev as scratch (destructive). Comes AFTER drho.
+                psi_max = maximum(abs, psi_now)
                 dpsi = if psi_max > 0
-                    # Fuse subtraction + abs into map-reduce (avoids temp array alloc)
-                    psi_prev .= ws.state.psi .- psi_prev  # reuse psi_prev as diff buffer
+                    psi_prev .= psi_now .- psi_prev
                     maximum(abs, psi_prev) / psi_max
                 else
                     0.0
                 end
-                copyto!(psi_prev, ws.state.psi)
+                copyto!(psi_prev, psi_now)
                 final_dE = dE
+                final_drho = drho
                 final_dpsi = dpsi
 
                 if verbose
@@ -174,12 +197,17 @@ function _run_itp_loop!(
                     eta = frac > 0 ? elapsed / frac * (1 - frac) : NaN
                     println(
                         "  ITP $(step)/$(n_steps) | E=$(round(E; sigdigits=8)) dE/|E|=$(round(dE; sigdigits=3)) " *
-                        "dpsi=$(round(dpsi; sigdigits=3)) | $(round(elapsed; digits=1))s elapsed, ETA $(round(eta; digits=0))s",
+                        "drho=$(round(drho; sigdigits=3)) dpsi=$(round(dpsi; sigdigits=3)) " *
+                        "| $(round(elapsed; digits=1))s elapsed, ETA $(round(eta; digits=0))s",
                     )
                     flush(stdout)
                 end
 
-                if dE < tol
+                # Convergence requires dE/|E| < tol; if tol_drho>0, ALSO
+                # require the per-(save_every) DENSITY change to be below
+                # the grid-error scale. ρ is U(1)/spin-rotation invariant,
+                # so gauge-orbit drift in ψ does not affect drho.
+                if dE < tol && (tol_drho <= 0.0 || drho < tol_drho)
                     converged = true
                     break
                 end

--- a/src/workflow/experiments/pipeline/run_step_ground_state.jl
+++ b/src/workflow/experiments/pipeline/run_step_ground_state.jl
@@ -256,10 +256,12 @@ function _run_step(
     end
 
     gs_rf_omega = Float64(get(p, "rotating_frame_omega", 0.0))
+    tol_drho_val = Float64(get(p, "tol_drho", 0.0))
     gs = if method === :itp
         find_ground_state(;
             grid, atom, interactions, zeeman, potential,
-            dt, n_steps, tol, initial_state, init_state_params, psi_init,
+            dt, n_steps, tol, tol_drho=tol_drho_val,
+            initial_state, init_state_params, psi_init,
             enable_ddi, c_dd=c_dd_val,
             secular_ddi=secular, quasi_2d_ddi=q2d, l_z_ddi=lz,
             target_magnetization=target_mz, backend, on_step,

--- a/src/workflow/experiments/schema/schema.jl
+++ b/src/workflow/experiments/schema/schema.jl
@@ -266,6 +266,7 @@ const GS_SCHEMA = Dict{String, FieldSpec}(
     "dt" => FieldSpec(; type=Number, default=0.001, range=(1e-8, 1.0)),
     "n_steps" => FieldSpec(; type=Number, default=100000, range=(0.0, 1e9)),
     "tol" => FieldSpec(; type=Number, default=1e-8, range=(1e-16, 1.0)),
+    "tol_drho" => FieldSpec(; type=Number, default=0.0, range=(0.0, 1.0)),
     "m_lbfgs" => FieldSpec(; type=Number, default=10, range=(1.0, 100.0)),
     "initial_state" => FieldSpec(; type=String, default="polar",
         enum=["polar", "m_plus_F", "m_minus_F",


### PR DESCRIPTION
…ic trace

Add a gauge-invariant density convergence gate to the ITP loop and a standalone trace script that produces the GIF used to motivate it.

Why
---
Spinor F=6 ITP at low magnetic field sits in a near-degenerate manifold (polar pair m=±F). The wavefunction-based dpsi metric used previously counts U(1) global-phase drift and spin-z rotation drift as "non-convergence" even when the physical state is stationary. Eu-151 60 μG ITP runs reach a stable density profile by τ ≈ 100 but dpsi keeps floating at ~10⁻³, so save_every cadence affected the reported convergence verdict.

What
----
* `_run_itp_loop!` now computes per-(save_every) drho = max|Δρ|/max|ρ| alongside dE and dpsi, where ρ(r) = Σ_c |ψ_c(r)|² is the total density. ρ is invariant under both U(1) global phase and spin rotations about z, so the gauge-orbit drift that confused dpsi is removed.
* New `tol_drho` kwarg on `find_ground_state` (default 0.0 = ignore) gates convergence on `dE < tol AND drho < tol_drho` when set. Both metrics are still logged every save_every.
* GPU-compatible implementation: only broadcasting + reductions on the device array, no scalar indexing (the earlier in-loop drho rewrite was the one that allowed the gate to run on CUDABackend).
* Threaded through the YAML pipeline: `schema.jl` declares the field, `run_step_ground_state.jl` plumbs it.

Diagnostic evidence (not exercised by CI; documents the motivation) -------------------------------------------------------------------
* `scripts/flower_protocol_edh/itp_trace_60uG.jl` — 50 000-step ITP at B = 60 μG starting from m=+F, snapshots every 100 steps.
* `scripts/flower_protocol_edh/plot_itp_trace.py` — renders the trace as a polished GIF (xy/xz density + HSV phase + spin-arrow field coloured by |F_⊥| + populations bar + E/conv/spin time series with inset zoom of the last 30 %).
* `runs/eu151_flower_protocol_edh/main/submit_itp_trace_60uG.sh` — UGE submit for TSUBAME (gpu_h × 2 h).

The trace shows the canonical failure mode: from :m_plus_F init the state drifts through the spin manifold into an m=-F FM-like local minimum, drho ends ~10⁻⁴ at step 50 000 while dpsi is ~4·10⁻⁴ and the energy is still drifting upward — exactly the kind of "looks converged in ψ-metric but isn't physically stationary" case the new gate is intended to detect.