### PR TITLE
fix(integrator): imaginary-time + GPU-safe batched kinetic-phase update

### DIFF
--- a/src/hamiltonian/integrator/propagators.jl
+++ b/src/hamiltonian/integrator/propagators.jl
@@ -429,20 +429,36 @@ function _make_coriolis_cache(psi, backend::AbstractBackend=CPUBackend(); flags=
     CoriolisCache(fwd1, inv1, fwd2, inv2)
 end
 
-function _update_batched_kinetic_phase!(cache::BatchedKineticCache, k_squared, dt)
+function _update_batched_kinetic_phase!(
+    cache::BatchedKineticCache, k_squared, dt, imaginary_time::Bool
+)
     kp = cache.kinetic_phase_bc
     ndim = ndims(kp) - 1
     n_pts = ntuple(d -> size(kp, d), ndim)
     RT = eltype(k_squared)
     half = RT(0.5)
     dt_t = RT(dt)
+    # Imaginary time: exp(-½k²dt) (decaying); real time: cis(-½k²dt) (phase).
+    # The earlier always-cis form silently turned the kinetic substep into a
+    # real-time rotation during ITP (e.g. split_step_midpoint! used for an
+    # imaginary-time ground state), so the high-k modes did not decay.
     if kp isa Array
         @inbounds for I in CartesianIndices(n_pts)
-            kp[I, 1] = cis(-half * k_squared[I] * dt_t)
+            arg = -half * k_squared[I] * dt_t
+            kp[I, 1] = imaginary_time ? complex(exp(arg)) : cis(arg)
         end
     else
+        # GPU: `k_squared` is a host Array — broadcasting it into a device
+        # kernel is illegal (non-bitstype). Move it to a device array that
+        # matches `kp` first, then build the phase on-device.
+        k_sq_dev = similar(kp, RT, size(k_squared))
+        copyto!(k_sq_dev, k_squared)
         kp_view = selectdim(kp, ndim + 1, 1)
-        kp_view .= cis.(-half .* k_squared .* dt_t)
+        if imaginary_time
+            kp_view .= exp.(-half .* k_sq_dev .* dt_t)
+        else
+            kp_view .= cis.(-half .* k_sq_dev .* dt_t)
+        end
     end
     nothing
 end

--- a/src/hamiltonian/integrator/split_step.jl
+++ b/src/hamiltonian/integrator/split_step.jl
@@ -292,7 +292,7 @@ function split_step_midpoint!(ws::Workspace{N}; dt::Float64=ws.sim_params.dt) wh
     )
     # Always-update-on-entry semantics: the batched kinetic phase cache is
     # synced to the dt passed in. Costs O(N^ndim) elementwise cis per call.
-    _update_batched_kinetic_phase!(ws.batched_kinetic, ws.grid.k_squared, dt)
+    _update_batched_kinetic_phase!(ws.batched_kinetic, ws.grid.k_squared, dt, it)
     @timeit_debug TIMER "kinetic" apply_step!(
         KineticTerm(), ws.state.psi, 0.0, false, ws
     )

--- a/src/hamiltonian/integrator/split_step_composers.jl
+++ b/src/hamiltonian/integrator/split_step_composers.jl
@@ -93,7 +93,9 @@ function _strang_core!(
     omega = ws.sim_params.rotating_frame_omega
     _half_potential_step!(ws, dt / 2, n_comp, N, false; t_eval=t_base + dt / 4, t_start=t_base)
     apply_step!(CoriolisTerm(omega), ws.state.psi, dt / 2, false, ws)
-    _update_batched_kinetic_phase!(ws.batched_kinetic, ws.grid.k_squared, dt)
+    _update_batched_kinetic_phase!(
+        ws.batched_kinetic, ws.grid.k_squared, dt, ws.sim_params.imaginary_time
+    )
     apply_step!(KineticTerm(), ws.state.psi, 0.0, false, ws)
     apply_step!(CoriolisTerm(omega), ws.state.psi, dt / 2, false, ws)
     _half_potential_step!(
@@ -123,7 +125,9 @@ function _yoshida_core!(
     )
 
     apply_step!(CoriolisTerm(omega), ws.state.psi, w1 * dt / 2, false, ws)
-    _update_batched_kinetic_phase!(ws.batched_kinetic, ws.grid.k_squared, w1 * dt)
+    _update_batched_kinetic_phase!(
+        ws.batched_kinetic, ws.grid.k_squared, w1 * dt, ws.sim_params.imaginary_time
+    )
     apply_step!(KineticTerm(), ws.state.psi, 0.0, false, ws)
     apply_step!(CoriolisTerm(omega), ws.state.psi, w1 * dt / 2, false, ws)
 
@@ -132,7 +136,9 @@ function _yoshida_core!(
     _half_potential_step!(ws, wm * dt, n_comp, N, false; t_eval=t_v2 + wm * dt / 2, t_start=t_v2)
 
     apply_step!(CoriolisTerm(omega), ws.state.psi, w0 * dt / 2, false, ws)
-    _update_batched_kinetic_phase!(ws.batched_kinetic, ws.grid.k_squared, w0 * dt)
+    _update_batched_kinetic_phase!(
+        ws.batched_kinetic, ws.grid.k_squared, w0 * dt, ws.sim_params.imaginary_time
+    )
     apply_step!(KineticTerm(), ws.state.psi, 0.0, false, ws)
     apply_step!(CoriolisTerm(omega), ws.state.psi, w0 * dt / 2, false, ws)
 
@@ -142,7 +148,9 @@ function _yoshida_core!(
     _half_potential_step!(ws, wm * dt, n_comp, N, false; t_eval=t_v3 + wm * dt / 2, t_start=t_v3)
 
     apply_step!(CoriolisTerm(omega), ws.state.psi, w1 * dt / 2, false, ws)
-    _update_batched_kinetic_phase!(ws.batched_kinetic, ws.grid.k_squared, w1 * dt)
+    _update_batched_kinetic_phase!(
+        ws.batched_kinetic, ws.grid.k_squared, w1 * dt, ws.sim_params.imaginary_time
+    )
     apply_step!(KineticTerm(), ws.state.psi, 0.0, false, ws)
     apply_step!(CoriolisTerm(omega), ws.state.psi, w1 * dt / 2, false, ws)
 
@@ -188,7 +196,9 @@ function _aba_step!(
 
     for i in 1:Sk
         apply_step!(CoriolisTerm(omega), ws.state.psi, b[i] * dt / 2, false, ws)
-        _update_batched_kinetic_phase!(ws.batched_kinetic, ws.grid.k_squared, b[i] * dt)
+        _update_batched_kinetic_phase!(
+            ws.batched_kinetic, ws.grid.k_squared, b[i] * dt, ws.sim_params.imaginary_time
+        )
         apply_step!(KineticTerm(), ws.state.psi, 0.0, false, ws)
         apply_step!(CoriolisTerm(omega), ws.state.psi, b[i] * dt / 2, false, ws)
 

--- a/src/solvers/adaptive.jl
+++ b/src/solvers/adaptive.jl
@@ -114,7 +114,9 @@ function _adaptive_step_change_loop!(
         may_reject = !is_clamped && dt_step > adaptive.dt_min * 1.01
 
         if dt_step != current_kinetic_dt
-            _update_batched_kinetic_phase!(bk, ws.grid.k_squared, dt_step)
+            _update_batched_kinetic_phase!(
+                bk, ws.grid.k_squared, dt_step, ws.sim_params.imaginary_time
+            )
             current_kinetic_dt = dt_step
         end
 
@@ -289,13 +291,13 @@ function _adaptive_richardson_loop!(
 
         psi_saved .= ws.state.psi
 
-        _update_batched_kinetic_phase!(bk, ws.grid.k_squared, dt_step)
+        _update_batched_kinetic_phase!(bk, ws.grid.k_squared, dt_step, ws.sim_params.imaginary_time)
         _full_strang_step!(ws, dt_step, n_comp, bk)
         psi_full .= ws.state.psi
 
         ws.state.psi .= psi_saved
         dt_half = dt_step / 2
-        _update_batched_kinetic_phase!(bk, ws.grid.k_squared, dt_half)
+        _update_batched_kinetic_phase!(bk, ws.grid.k_squared, dt_half, ws.sim_params.imaginary_time)
         _full_strang_step!(ws, dt_half, n_comp, bk)
         _full_strang_step!(ws, dt_half, n_comp, bk)
 


### PR DESCRIPTION
## What

`_update_batched_kinetic_phase!` (used by `split_step_midpoint!`, the Yoshida/MPS composers, and adaptive dt) had two bugs for imaginary-time and/or GPU runs:

1. **Always real-time phase.** It always used `cis(-half*k^2*dt)` with no `imaginary_time` branch. In imaginary time the kinetic substep became a real-time rotation, so high-k modes never decayed — midpoint "ITP" was not actually imaginary time.
2. **GPU crash.** The GPU branch broadcast the host `k_squared` `Array` into a device kernel (non-bitstype), crashing midpoint / composers / adaptive on CUDA.

## Fix

- Add `imaginary_time::Bool` (`exp` for IT, `cis` for RT).
- On GPU, `copyto!` `k_squared` into a device array before building the phase.
- All 9 call sites pass their `imaginary_time`. Real-time behaviour unchanged.

## Verification

CPU 24³ Eu F=6 (c0/c1/DDI): midpoint ITP now descends in imaginary time (E 35.9 → 6.749). GPU branch not yet re-verified vs CPU.

## NOTE

This does **not** fix the ITP→RTP breathing. That is FP/thread-count sensitivity of the ITP stall point on the 60 µG near-degenerate manifold (cure: LBFGS), not an order or propagator-correctness issue.

Assisted-by: Claude Code (model: claude-opus-4-8)