### PR TITLE
refactor(lhy): flatten LHY collision-avoidance submodules into SpinorBEC

### DIFF
--- a/src/analysis/canonical_polyhedral_states.jl
+++ b/src/analysis/canonical_polyhedral_states.jl
@@ -12,7 +12,7 @@
 # Component order: index k corresponds to m = F-k+1, so index 1 is m=+F
 # and index 2F+1 is m=-F. F=0 component lives at index F+1.
 #
-# F=6 I_h canonical state lives in `IcosahedralMod.ZETA_F6_IH`
+# F=6 I_h canonical state lives in `ZETA_F6_IH`
 # (`src/hamiltonian/terms/lhy/icosahedral.jl`) — the function
 # `canonical_polyhedral_spinor(6)` delegates there so all callers go
 # through one accessor.
@@ -99,7 +99,7 @@ Return the canonical Paper #3 §V inert-state spinor for spin-F.
 | 2  | §V.A    | T_d         | `ZETA_F2_TD_CYCLIC`       |
 | 3  | §V.B    | O (A_2)     | `ZETA_F3_O_A2`            |
 | 4  | §V.C    | O_h (A_1)   | `ZETA_F4_OH_A1`           |
-| 6  | §V.D    | I_h         | `IcosahedralMod.ZETA_F6_IH` |
+| 6  | §V.D    | I_h         | `ZETA_F6_IH` |
 | 8  | §V.E    | O_h (A_1)   | `ZETA_F8_OH_A1`           |
 | 10 | §V.F    | I_h         | `ZETA_F10_IH_DODEC`       |
 | 12 | §V.G    | I_h (A)     | `ZETA_F12_IH_A`           |
@@ -116,7 +116,7 @@ function canonical_polyhedral_spinor(F::Int)
     elseif F == 4
         return ZETA_F4_OH_A1
     elseif F == 6
-        return IcosahedralMod.ZETA_F6_IH
+        return ZETA_F6_IH
     elseif F == 8
         return ZETA_F8_OH_A1
     elseif F == 10

--- a/src/analysis/phases/F6_phase_diagram.jl
+++ b/src/analysis/phases/F6_phase_diagram.jl
@@ -62,7 +62,7 @@ function _f6_pd_candidate_spinors()::Dict{Symbol, Vector{ComplexF64}}
     cyclic[D] = inv_sqrt3 * cis(4π / 3)
 
     Dict(:polar => polar, :FM => fm, :cyclic => cyclic,
-        :I_h => copy(IcosahedralMod.ZETA_F6_IH))
+        :I_h => copy(ZETA_F6_IH))
 end
 
 function _f6_pd_sigma_S(F::Int, S::Int, ζ::AbstractVector{ComplexF64})::Float64

--- a/src/foundation/types/interactions_zeeman.jl
+++ b/src/foundation/types/interactions_zeeman.jl
@@ -11,7 +11,7 @@
 # Raman-laser parameters; `TimeDependentInteractions` swaps c0/c1 in
 # time with `interactions_at(td, t)`.
 
-export InteractionParams, AbstractZeemanField, ZeemanParams, TimeDependentZeeman, c_dict
+export InteractionParams, AbstractZeemanField, ZeemanParams, TimeDependentZeeman, c_dict, get_cn
 export RamanCoupling, TimeDependentRaman, TimeDependentInteractions
 export linear_p, quadratic_q, transverse_b, interactions_at
 

--- a/src/hamiltonian/coefficients.jl
+++ b/src/hamiltonian/coefficients.jl
@@ -5,7 +5,6 @@ export compute_c_total, compute_c_dd_dimless, linear_zeeman_p
 export compute_eu151_interactions
 export compute_lhy_2d_params
 export compute_quadratic_zeeman
-export get_cn
 
 """
     compute_interaction_params(atom; N_atoms, dims, length_scale)

--- a/src/hamiltonian/terms/lhy/dispatch.jl
+++ b/src/hamiltonian/terms/lhy/dispatch.jl
@@ -246,7 +246,7 @@ function _compute_lhy_at_density(
 end
 
 # =================================================================
-# Closed-form polar LHY wrappers (PhiOneReg + PolarContactMod + PolarDipolarMod)
+# Closed-form polar LHY wrappers (phi_one_reg + polar_contact + polar_dipolar)
 # =================================================================
 #
 # These produce a TabulatedLHY identical in shape to :polar_two_channel /
@@ -273,13 +273,13 @@ function compute_spinor_lhy_polar_contact(;
 )
     n_points >= 3 || throw(ArgumentError("n_points must be >= 3"))
     n_max > 0 || throw(ArgumentError("n_max must be positive"))
-    coefs = PolarContactMod.build_polar_lhy_coefs(F, g_dict)
+    coefs = build_polar_lhy_coefs(F, g_dict)
 
     densities = collect(range(0.0, n_max; length=n_points))
     energy = zeros(Float64, n_points)
     for (i, n) in enumerate(densities)
         n < 1e-30 && continue
-        energy[i] = PolarContactMod.lhy_energy_polar(n, coefs)
+        energy[i] = lhy_energy_polar(n, coefs)
     end
     potential_values = _numerical_derivative(densities, energy)
     PolarContactLHY(densities, potential_values)
@@ -302,13 +302,13 @@ function compute_spinor_lhy_polar_dipolar(;
 )
     n_points >= 3 || throw(ArgumentError("n_points must be >= 3"))
     n_max > 0 || throw(ArgumentError("n_max must be positive"))
-    coefs = PolarContactMod.build_polar_lhy_coefs(F, g_dict)
+    coefs = build_polar_lhy_coefs(F, g_dict)
 
     densities = collect(range(0.0, n_max; length=n_points))
     energy = zeros(Float64, n_points)
     for (i, n) in enumerate(densities)
         n < 1e-30 && continue
-        energy[i] = PolarDipolarMod.lhy_energy_polar_dipolar(n, coefs, eps_tilde_dd)
+        energy[i] = lhy_energy_polar_dipolar(n, coefs, eps_tilde_dd)
     end
     potential_values = _numerical_derivative(densities, energy)
     PolarDipolarLHY(densities, potential_values)
@@ -331,13 +331,13 @@ function compute_spinor_lhy_fm_dipolar(;
 )
     n_points >= 3 || throw(ArgumentError("n_points must be >= 3"))
     n_max > 0 || throw(ArgumentError("n_max must be positive"))
-    coefs = FMContactMod.build_fm_lhy_coefs(F, g_dict)
+    coefs = build_fm_lhy_coefs(F, g_dict)
 
     densities = collect(range(0.0, n_max; length=n_points))
     energy = zeros(Float64, n_points)
     for (i, n) in enumerate(densities)
         n < 1e-30 && continue
-        energy[i] = FMDipolarMod.lhy_energy_fm_dipolar(n, coefs, eps_dd)
+        energy[i] = lhy_energy_fm_dipolar(n, coefs, eps_dd)
     end
     potential_values = _numerical_derivative(densities, energy)
     FMDipolarLHY(densities, potential_values)
@@ -361,13 +361,13 @@ function compute_spinor_lhy_fm_contact(;
 )
     n_points >= 3 || throw(ArgumentError("n_points must be >= 3"))
     n_max > 0 || throw(ArgumentError("n_max must be positive"))
-    coefs = FMContactMod.build_fm_lhy_coefs(F, g_dict)
+    coefs = build_fm_lhy_coefs(F, g_dict)
 
     densities = collect(range(0.0, n_max; length=n_points))
     energy = zeros(Float64, n_points)
     for (i, n) in enumerate(densities)
         n < 1e-30 && continue
-        energy[i] = FMContactMod.lhy_energy_fm(n, coefs)
+        energy[i] = lhy_energy_fm(n, coefs)
     end
     potential_values = _numerical_derivative(densities, energy)
     FMContactLHY(densities, potential_values)
@@ -403,7 +403,7 @@ function compute_spinor_lhy_icosahedral(;
     energy = zeros(Float64, n_points)
     for (i, n) in enumerate(densities)
         n < 1e-30 && continue
-        energy[i] = IcosahedralMod.epsilon_LHY_F6_Ih(n, g_dict)
+        energy[i] = epsilon_LHY_F6_Ih(n, g_dict)
     end
     potential_values = _numerical_derivative(densities, energy)
     IcosahedralLHY(densities, potential_values)

--- a/src/hamiltonian/terms/lhy/fm_contact.jl
+++ b/src/hamiltonian/terms/lhy/fm_contact.jl
@@ -41,13 +41,6 @@
 # with rank-2 spherical tensor coupling to m=+F-1 and m=+F-2 (parallel
 # session future deliverable).
 
-module FMContactMod
-
-function _phi_1_reg(t)
-    return parentmodule(@__MODULE__).PhiOneReg.phi_1_reg(t)
-end
-const phi_1_reg = _phi_1_reg
-
 export FMLHYCoefs, build_fm_lhy_coefs, lhy_energy_fm
 export sigma_fm, delta_fm
 
@@ -102,5 +95,3 @@ function lhy_energy_fm(n::Float64, coefs::FMLHYCoefs;
     kappa < 1e-12 && return 0.0
     return prefactor * (n * kappa)^2.5    # ν=1, t=0, φ_1^reg(0)=1
 end
-
-end # module FMContactMod

--- a/src/hamiltonian/terms/lhy/fm_dipolar.jl
+++ b/src/hamiltonian/terms/lhy/fm_dipolar.jl
@@ -29,14 +29,6 @@
 # Stage C spinor extension (proper S=2F-2 channel coupling) is research-
 # open and NOT covered here — see paper #2 "Open issues".
 
-module FMDipolarMod
-
-# Canonical `lima_pelster_Q5` (closed form, interactions.jl) reached via
-# parentmodule() to avoid `using SpinorBEC` cycles at module-load time.
-function _fm_contact()
-    return parentmodule(@__MODULE__).FMContactMod
-end
-
 export lhy_energy_fm_dipolar
 
 """
@@ -56,7 +48,7 @@ realistic dipolar atoms:
 """
 function lhy_energy_fm_dipolar(n::Float64, F::Int, g_dict, eps_dd::Real;
     M_mass::Float64=1.0, hbar::Float64=1.0)::Float64
-    coefs = _fm_contact().build_fm_lhy_coefs(F, g_dict)
+    coefs = build_fm_lhy_coefs(F, g_dict)
     return lhy_energy_fm_dipolar(n, coefs, eps_dd; M_mass, hbar)
 end
 
@@ -65,8 +57,6 @@ function lhy_energy_fm_dipolar(n::Float64, coefs, eps_dd::Real;
     prefactor = (8.0 * sqrt(M_mass^3)) / (15.0 * π^2 * hbar^3)
     kappa = coefs.delta_F     # δ_+F = g_{2F}, the only non-zero δ_m for FM
     kappa < 1e-12 && return 0.0
-    Q5 = parentmodule(@__MODULE__).lima_pelster_Q5(Float64(eps_dd))
+    Q5 = lima_pelster_Q5(Float64(eps_dd))
     return prefactor * (n * kappa)^2.5 * Q5
 end
-
-end # module FMDipolarMod

--- a/src/hamiltonian/terms/lhy/icosahedral.jl
+++ b/src/hamiltonian/terms/lhy/icosahedral.jl
@@ -54,8 +54,6 @@
 #   to (8/15π²)(g·n)^(5/2) which is identical to the scalar Lima-Pelster
 #   form at coupling g.
 
-module IcosahedralMod
-
 # ---------------------------------------------------------------------------
 # F=6 I_h ground state spinor (component order m=+6, +5, ..., -6).
 # Normalisation: ⟨ζ|ζ⟩ = 7/25 + 11/25 + 7/25 = 25/25 = 1.
@@ -95,7 +93,7 @@ end
 
 Convenience overload: extracts `g_dict[S]` for S ∈ {0,2,4,6,8,10,12},
 defaulting missing channels to 0. Accepts the same `g_dict` shape as
-`PolarContactMod.build_polar_lhy_coefs` etc.
+`build_polar_lhy_coefs` etc.
 """
 function compute_c0_lambda_F6_Ih(g_dict::AbstractDict)
     g_vec = Float64[Float64(get(g_dict, 2k, 0.0)) for k in 0:6]
@@ -124,5 +122,3 @@ function epsilon_LHY_F6_Ih(n::Real, g_S::Union{AbstractVector{<:Real}, AbstractD
 end
 
 export ZETA_F6_IH, compute_c0_lambda_F6_Ih, epsilon_LHY_F6_Ih
-
-end # module IcosahedralMod

--- a/src/hamiltonian/terms/lhy/modes_round45.jl
+++ b/src/hamiltonian/terms/lhy/modes_round45.jl
@@ -30,8 +30,6 @@
 # `docs/manuscript/papers/paper3_universal_theorem/main.md` §V (Round 5
 # Paper #3 v3) and the F=2 BN edge case in §VII.B.
 
-module LHYModesRound45
-
 export lhy_F2_BN, lhy_F3_octa, lhy_F4_cube, lhy_F8_octa, lhy_F10_dodec
 
 @inline function _prefactor(M::Real, hbar::Real)::Float64
@@ -178,5 +176,3 @@ function lhy_F10_dodec(g0::Real, g6::Real, g10::Real, g12::Real,
     _prefactor(M, hbar) * Float64(n)^2.5 *
     (c0^2.5 + 3 * abs(λspin)^2.5)
 end
-
-end # module LHYModesRound45

--- a/src/hamiltonian/terms/lhy/phi_one_reg.jl
+++ b/src/hamiltonian/terms/lhy/phi_one_reg.jl
@@ -14,8 +14,6 @@
 #
 # F-independent: any spinor LHY using the closed form re-uses this evaluator.
 
-module PhiOneReg
-
 export phi_1_reg, T_KNOTS, VAL_KNOTS, DERIV_KNOTS
 
 const T_KNOTS = Float64[
@@ -131,5 +129,3 @@ gap parameter `t = ξ/|Δ| - 1`.
             DERIV_KNOTS[lo], DERIV_KNOTS[hi])
     end
 end
-
-end # module PhiOneReg

--- a/src/hamiltonian/terms/lhy/polar_contact.jl
+++ b/src/hamiltonian/terms/lhy/polar_contact.jl
@@ -21,15 +21,6 @@
 # Eq. (266); for F=2 UN it reproduces Eq. (305-307); F=6 is the main
 # application (paper #1).
 
-module PolarContactMod
-
-# PhiOneReg lives one level up under SpinorBEC (included once there to avoid
-# duplicate module definitions). Reach it via parentmodule().
-function _phi_1_reg(t)
-    return parentmodule(@__MODULE__).PhiOneReg.phi_1_reg(t)
-end
-const phi_1_reg = _phi_1_reg
-
 export PolarLHYCoefs, build_polar_lhy_coefs, lhy_energy_polar
 export sigma_polar, delta_polar
 
@@ -119,5 +110,3 @@ function lhy_energy_polar(n::Float64, coefs::PolarLHYCoefs;
 
     return prefactor * total
 end
-
-end # module PolarContactMod

--- a/src/hamiltonian/terms/lhy/polar_dipolar.jl
+++ b/src/hamiltonian/terms/lhy/polar_dipolar.jl
@@ -22,19 +22,6 @@
 # intrinsic to the polar phase dipole geometry and independent of F.
 # F=6 Eu is the primary application (paper #1).
 
-module PolarDipolarMod
-
-function _phi_1_reg(t)
-    return parentmodule(@__MODULE__).PhiOneReg.phi_1_reg(t)
-end
-const phi_1_reg = _phi_1_reg
-
-# σ_m / δ_m and the cache live in PolarContactMod (sibling module already
-# loaded by SpinorBEC before this one).
-function _polar_contact()
-    return parentmodule(@__MODULE__).PolarContactMod
-end
-
 export lhy_energy_polar_dipolar
 export antisym_branch, sym_branch, sym_branch_quad
 
@@ -147,7 +134,7 @@ test_lhy_polar.jl).
 """
 function lhy_energy_polar_dipolar(n::Float64, F::Int, g_dict, eps_tilde_dd::Float64;
     M_mass::Float64=1.0, hbar::Float64=1.0)::Float64
-    coefs = _polar_contact().build_polar_lhy_coefs(F, g_dict)
+    coefs = build_polar_lhy_coefs(F, g_dict)
     return lhy_energy_polar_dipolar(n, coefs, eps_tilde_dd; M_mass, hbar)
 end
 
@@ -185,5 +172,3 @@ function lhy_energy_polar_dipolar(n::Float64, coefs, eps_tilde_dd::Float64;
 
     return prefactor * total
 end
-
-end # module PolarDipolarMod

--- a/src/hamiltonian/terms/lhy/sigma_delta_polar_F1_F8.jl
+++ b/src/hamiltonian/terms/lhy/sigma_delta_polar_F1_F8.jl
@@ -3,7 +3,7 @@
 # Auto-generated from sympy Clebsch-Gordan computation (50-digit precision
 # cast to Float64). σ_m, δ_m coefficients for polar-phase BdG, F=1..8.
 #
-# Usage (after `include` into PolarContactMod module):
+# Usage (included by polar_contact.jl into the SpinorBEC namespace):
 #   σ_m(F, m) = Σ (S, coef) ∈ SIGMA_TABLE[F][m+1]: coef × g_S
 #   δ_m(F, m) = Σ (S, coef) ∈ DELTA_TABLE[F][m+1]: coef × g_S
 #

--- a/src/workflow/initialization/make_workspace.jl
+++ b/src/workflow/initialization/make_workspace.jl
@@ -621,7 +621,7 @@ end
 function _build_spinor_lhy(::Val{:polar_dipolar}, atom, ws, psi_init, c_dd, enable_ddi)
     g_dict = _lhy_g_dict(atom, ws)
     c_dd_eff = enable_ddi && !isnan(c_dd) ? c_dd : 0.0
-    delta_1 = PolarContactMod.delta_polar(atom.F, 1, g_dict)
+    delta_1 = delta_polar(atom.F, 1, g_dict)
     eps_tilde_dd = abs(delta_1) > 1e-12 ? abs(c_dd_eff) / abs(delta_1) : 0.0
     compute_spinor_lhy_polar_dipolar(;
         F=atom.F, g_dict=g_dict, eps_tilde_dd=eps_tilde_dd,

--- a/test/analysis/test_sign_pattern.jl
+++ b/test/analysis/test_sign_pattern.jl
@@ -82,7 +82,7 @@ using Test
         # Under C_5z (axis=z, angle=2π/5): |m⟩ → e^{-i 2πm/5} |m⟩
         # m=±5 picks up e^{∓i 2π} = +1; m=0 picks up +1.
         # So ζ is invariant under C_5z → character +1.
-        zeta_Ih = Vector{ComplexF64}(SpinorBEC.IcosahedralMod.ZETA_F6_IH)
+        zeta_Ih = Vector{ComplexF64}(SpinorBEC.ZETA_F6_IH)
         chi = polyhedral_op_character(zeta_Ih, 6; axis=(0.0, 0.0, 1.0), angle=2π/5)
         @test isapprox(real(chi), 1.0; atol=1e-10)
         @test isapprox(imag(chi), 0.0; atol=1e-10)

--- a/test/hamiltonian/test_icosahedral_lhy.jl
+++ b/test/hamiltonian/test_icosahedral_lhy.jl
@@ -1,6 +1,6 @@
 using Test
 using SpinorBEC
-using SpinorBEC.IcosahedralMod
+using SpinorBEC: ZETA_F6_IH, compute_c0_lambda_F6_Ih, epsilon_LHY_F6_Ih
 using LinearAlgebra: Diagonal
 
 # F=6 icosahedral (I_h) closed-form contact LHY tests (Round-3 Task 1).
@@ -141,8 +141,8 @@ using LinearAlgebra: Diagonal
         for g in (1.0, 5.0, 50.0)
             gd = Dict(2k => g for k in 0:6)
             sca = (8.0 / (15.0 * π^2)) * (g * 1.0)^2.5
-            pol = SpinorBEC.PolarContactMod.lhy_energy_polar(1.0, 6, gd)
-            ico = SpinorBEC.IcosahedralMod.epsilon_LHY_F6_Ih(1.0, gd)
+            pol = SpinorBEC.lhy_energy_polar(1.0, 6, gd)
+            ico = SpinorBEC.epsilon_LHY_F6_Ih(1.0, gd)
             @test isapprox(pol, sca; rtol=1e-10)
             @test isapprox(ico, sca; rtol=1e-10)
         end
@@ -153,10 +153,10 @@ using LinearAlgebra: Diagonal
         # the ratio so a future "fix" that collapses one to the other
         # would be caught.
         g_eu = SpinorBEC._c0c1_to_gS(6, 100.0, 5.0)
-        pol = SpinorBEC.PolarContactMod.lhy_energy_polar(1.0, 6, g_eu)
-        ico = SpinorBEC.IcosahedralMod.epsilon_LHY_F6_Ih(1.0, g_eu)
+        pol = SpinorBEC.lhy_energy_polar(1.0, 6, g_eu)
+        ico = SpinorBEC.epsilon_LHY_F6_Ih(1.0, g_eu)
         # I_h c_0 must be positive (else I_h not the GS, NaN returned).
-        c0_ico, _ = SpinorBEC.IcosahedralMod.compute_c0_lambda_F6_Ih(g_eu)
+        c0_ico, _ = SpinorBEC.compute_c0_lambda_F6_Ih(g_eu)
         @test c0_ico > 0
         @test isfinite(ico) && ico > 0
         @test 1.3 < pol / ico < 1.6     # measured 1.4617 (2026-05-12)
@@ -165,10 +165,10 @@ using LinearAlgebra: Diagonal
         # state-dependence (Polar/I_h ratio ~ 2.4).
         g_ih = Dict(0 => 5.0, 2 => 2.0, 4 => 2.0, 6 => 5.0,
             8 => 2.0, 10 => 10.0, 12 => 50.0)
-        c0_ico2, _ = SpinorBEC.IcosahedralMod.compute_c0_lambda_F6_Ih(g_ih)
+        c0_ico2, _ = SpinorBEC.compute_c0_lambda_F6_Ih(g_ih)
         @test c0_ico2 > 0
-        pol2 = SpinorBEC.PolarContactMod.lhy_energy_polar(1.0, 6, g_ih)
-        ico2 = SpinorBEC.IcosahedralMod.epsilon_LHY_F6_Ih(1.0, g_ih)
+        pol2 = SpinorBEC.lhy_energy_polar(1.0, 6, g_ih)
+        ico2 = SpinorBEC.epsilon_LHY_F6_Ih(1.0, g_ih)
         @test 2.0 < pol2 / ico2 < 3.0   # measured 2.4440 (2026-05-12)
     end
 end

--- a/test/hamiltonian/test_lhy_modes_round45.jl
+++ b/test/hamiltonian/test_lhy_modes_round45.jl
@@ -3,7 +3,7 @@
 # phase verifications.
 
 using Test
-using SpinorBEC.LHYModesRound45
+using SpinorBEC: lhy_F2_BN, lhy_F3_octa, lhy_F4_cube, lhy_F8_octa, lhy_F10_dodec
 
 @testset "LHY modes (Round 4-5 closed forms)" begin
     # Universal scalar prefactor at M = ℏ = 1

--- a/test/hamiltonian/test_lhy_polar.jl
+++ b/test/hamiltonian/test_lhy_polar.jl
@@ -1,14 +1,9 @@
 using SpinorBEC
-using SpinorBEC: PhiOneReg, PolarContactMod, PolarDipolarMod, FMContactMod, FMDipolarMod
-using SpinorBEC.PhiOneReg: phi_1_reg, T_KNOTS, VAL_KNOTS, DERIV_KNOTS
-using SpinorBEC.PolarContactMod: lhy_energy_polar, sigma_polar, delta_polar,
-    build_polar_lhy_coefs
-using SpinorBEC.PolarDipolarMod:
-    lhy_energy_polar_dipolar, antisym_branch,
-    sym_branch, sym_branch_quad
-using SpinorBEC.FMContactMod: lhy_energy_fm, sigma_fm, delta_fm,
-    build_fm_lhy_coefs
-using SpinorBEC.FMDipolarMod: lhy_energy_fm_dipolar
+using SpinorBEC: phi_1_reg, T_KNOTS, VAL_KNOTS, DERIV_KNOTS,
+    lhy_energy_polar, sigma_polar, delta_polar, build_polar_lhy_coefs,
+    lhy_energy_polar_dipolar, antisym_branch, sym_branch, sym_branch_quad,
+    lhy_energy_fm, sigma_fm, delta_fm, build_fm_lhy_coefs,
+    lhy_energy_fm_dipolar
 using SpinorBEC: lima_pelster_Q5
 using Test
 using LinearAlgebra: norm

--- a/test/hamiltonian/test_majorana.jl
+++ b/test/hamiltonian/test_majorana.jl
@@ -67,13 +67,13 @@ using LinearAlgebra
         end
 
         @testset "Paper #3 §V.D — F=6 I_h ζ_{I_h} → :I_h (post-U2 stereo fix)" begin
-            # Canonical F=6 I_h state from IcosahedralMod. Pre-U2 this
+            # Canonical F=6 I_h state (ZETA_F6_IH). Pre-U2 this
             # returned :unknown due to a stereographic-projection bug
             # mapping both z=0 and z=∞ to the south pole — see the
             # `_stereo_to_sphere` docstring for the bug archaeology.
             # Post-fix the 12 Majorana stars form the icosahedron and
             # `detect_point_group` returns `:I_h` cleanly.
-            zeta_Ih = SpinorBEC.IcosahedralMod.ZETA_F6_IH
+            zeta_Ih = SpinorBEC.ZETA_F6_IH
             @test detect_point_group(zeta_Ih, 6) === :I_h
         end
 


### PR DESCRIPTION
Follow-up to #34. Unifies the module convention: the 7 LHY files each wrapped their content in a local `module XMod ... end` purely to avoid name collisions, then reached siblings through the awkward `parentmodule(@__MODULE__).XMod.foo` indirection. Every other Hamiltonian term file is a flat include. This flattens them so that **modules exist only for genuine independent-lifecycle subsystems** (Units, Calibration, Dashboard, Optimization).

## Changes
- Remove the `module`/`end` wrappers in `phi_one_reg`, `polar_contact`, `polar_dipolar`, `fm_contact`, `fm_dipolar`, `icosahedral`, `modes_round45`; their `export` lines now publish into `SpinorBEC`.
- Delete the forwarder shims (`_phi_1_reg`/`phi_1_reg` aliases, `_polar_contact()`, `_fm_contact()`); callers use the single flat name.
- Rewrite `parentmodule(@__MODULE__).X` and external `XMod.foo` qualified access (`dispatch.jl`, `make_workspace.jl`, `F6_phase_diagram.jl`, `canonical_polyhedral_states.jl`, tests) to bare names.
- **No symbol renames needed**: a collision audit confirmed every module-internal name (`T_KNOTS`, `_simpson`, `_prefactor`, `SIGMA_TABLE`, …) is unique across the flattened namespace.
- Move the stray `export get_cn` from `hamiltonian/coefficients.jl` to its definition site in `foundation/types/interactions_zeeman.jl` (export lives next to definition).

## Verification (A: code correctness)
- Package + CUDA extension load; all relocated symbols resolve; old module names (`PolarContactMod`, `IcosahedralMod`, …) confirmed gone.
- Tests green: LHY polar/fm suite, F=6 I_h 124/124, Round-4/5 modes 71/71, plus consumers Majorana 35/35 and Sign Pattern 46/46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)