### PR TITLE
Compute Gateway: design (feasibility/plan/UMS/multi-user) + Phase 2a ssh transport extraction

### DIFF
--- a/docs/design/compute_gateway_design.md
+++ b/docs/design/compute_gateway_design.md
@@ -60,7 +60,11 @@ them. Use `config([...])` / `Experiment(spec)` / `run!` / `run_yaml`.
 
 **Genuinely new — where the work goes:**
 
-1. **UMS low-latency path** (§ Decision 2) — no `ums-submit`/`ums-list` anywhere.
+1. ~~**UMS low-latency path** (§ Decision 2).~~ **DEFERRED (2026-06-21)** — measured
+   the premise and it doesn't hold: trial `qsub`→running = **7.8 s** (worst case;
+   trial is lowest priority). No queue wait worth a lease. See
+   `ums_lease_backend_design.md` (Status). Revisit only on observed `node_f`
+   congestion or rapid-fire JIT friction (latter ≈ covered by sysimage).
 2. **Submit-time DAG / `-hold_jid`** — `on_complete` is a *post-completion* trigger,
    not a submit-time dependency graph.
 3. **Multi-user / namespace / per-user quota** — `enqueued_by` is a provenance
@@ -115,6 +119,9 @@ guard it).
 
 ## Decision 2 — lease the UMS allocation, do not hold it permanently
 
+**Superseded (2026-06-21): UMS deferred — queue measured at ~8 s, so there is no
+lease to manage. The decision below stands only if UMS is revived.**
+
 Resolves the cost tension (a live `node_f` ⊥ a lightweight always-on Gateway):
 
 - The **coordinator** is always-on and cheap; the **`node_f` allocation is an
@@ -153,11 +160,12 @@ are already live.
   (they already do).
 - Code-guard the login-node compute ban.
 
-### Phase 2 — UMS low-latency path (the core new work)
-- `node_f` lease + `ums-submit` dispatch + `ums-list` status; max-idle reap via
-  budget + kill breaker.
+### Phase 2 — headless harness (UMS dropped)
+- ~~`node_f` lease + `ums-submit`/`ums-list` low-latency path.~~ **DEFERRED** —
+  queue measured at ~8 s (`ums_lease_backend_design.md`); no wait to remove.
 - Headless Agent SDK harness as a Gateway service; L0–L4 gates as the verification
-  stage; only gate-passing runs promote to "validated" in CAS.
+  stage; only gate-passing runs promote to "validated" in CAS. **This is the real
+  Phase-2 work now** — it never depended on UMS; it runs on the existing `qsub` path.
 
 ### Phase 3 — multi-user (all new)
 - Per-user identity/namespace (replace provenance-only `enqueued_by`), per-user

--- a/docs/design/compute_gateway_design.md
+++ b/docs/design/compute_gateway_design.md
@@ -1,0 +1,187 @@
+# Compute Gateway — multi-target AI research infrastructure
+
+**Status**: design. Phase 1 substrate already live; this doc fixes the scope to
+the genuinely new work (UMS, DAG, multi-user). Supersedes the inline plan; the
+ground-truth audit it is reconciled against lives in
+`compute_gateway_feasibility_review.md`.
+
+Drive TSUBAME 4.0 (Altair Grid Engine / UGE) and the suzume GPU box from
+Claude Code, with verification + analysis in one loop. Few users, shared base.
+
+## Core idea
+
+Separate the **volatile brain** (the Claude Code session — interactive, short,
+per-user) from the **durable hands + memory** (compute, run state, artifacts —
+long-lived, shared, survive a closed session). Wiring the two directly always
+breaks. Four pillars:
+
+1. **One control plane (Compute Gateway).** Claude Code never touches schedulers
+   directly; it calls a long-lived Gateway that owns the state SSoT and the
+   artifact registry. Sessions die; jobs and state do not.
+2. **Abstract the executor.** TSUBAME is UGE (`qsub`/`qstat`/`qdel`), suzume is a
+   standalone GPU. The `AutopilotBackend` abstraction already absorbs this.
+3. **Kill interactive latency with a UMS lease.** HPC queue waits are toxic to an
+   interactive agent. A *leased* `node_f` + UMS turns "run this param set" into an
+   instant dispatch to a held allocation instead of a fresh queue submit.
+4. **Reproducibility = artifacts (CAS) + environment (container).** Content-
+   addressed runs dedup across users/machines; the env is pinned and carried to
+   HPC via Apptainer (`scripts/spinorbec.def`).
+
+## Build vs reuse (corrected)
+
+The hard part is **mostly already built.** The autopilot *is* the Gateway state
+engine; the table below is the honest inventory (see the review for file:line).
+
+**Already live — reuse, do not rebuild:**
+
+- MCP server: `scripts/mcp/tsubame_server.py` (FastMCP; enqueue / autopilot_status
+  / qstat / job_detail / list_runs / pull_results / cancel / tail_log / budget /
+  points / tick). The plan's `submit/status/results/list_runs` already exist here.
+- Executor abstraction: `AutopilotBackend` (`stage_in`/`dispatch!`/`job_status`/
+  `pull_live`/`collect!`/`cancel!`/`find_job_by_name`/`next_profile`/
+  `prepare_status_snapshot`). The plan's 4-method trait is a subset.
+- GridEngine executor: `UGEBackend` (`qsub -g` CLI flag, batched `qstat`, `qacct`
+  fallback, `qdel`, rsync + SSH ControlMaster, Manifest-hash auto-instantiate,
+  9 env auto-register). = the plan's `GridEngineExecutor`.
+- Local executor: `LocalBackend` (subprocess). = suzume bare. **No SLURM needed.**
+- State engine: `state.toml` SSoT, 5-state lifecycle, two-stage submit, 4 circuit
+  breakers, `AutopilotBudget`, divergence kill, retry classification, on_complete.
+- CAS: `content_id(spec)` → `<root>/<sha256[1:16]>/`, idempotent `run!`,
+  `sweep`/`twin`/`tabulate`/`spec_diff`.
+- Read surface: dashboard HTTP routes + WebSocket (`/ws/scrub`) + `_live_status.json`.
+- Notifications: Slack `notify_slack`.
+- Container: `scripts/spinorbec.def`.
+
+**MCP schema note (avoid re-inventing types):** the runtime model is spec-centric.
+Build `submit`/`results` on `Experiment` / `Vector{Experiment}` + the existing
+*function* observables (`Fz_t`, `classify`, …) and `tabulate` (returns a
+`NamedTuple`). There is no `Observable{T}` and no `Sweep` type — do not create
+them. Use `config([...])` / `Experiment(spec)` / `run!` / `run_yaml`.
+
+**Genuinely new — where the work goes:**
+
+1. **UMS low-latency path** (§ Decision 2) — no `ums-submit`/`ums-list` anywhere.
+2. **Submit-time DAG / `-hold_jid`** — `on_complete` is a *post-completion* trigger,
+   not a submit-time dependency graph.
+3. **Multi-user / namespace / per-user quota** — `enqueued_by` is a provenance
+   string; budget is global. Phase 3 is all new.
+4. **Cross-target routing** (TSUBAME↔suzume) — `next_profile` only escalates
+   within one backend.
+5. **Remote MCP transport** (stdio → HTTP/SSE) for Remote Control.
+
+`SlurmExecutor` is dropped (suzume = `LocalBackend`).
+
+## Architecture
+
+```mermaid
+flowchart TB
+  subgraph Surfaces["operation surfaces (per-user, volatile)"]
+    CC["Claude Code Desktop"]
+    Dash["WebGPU Dashboard"]
+  end
+  subgraph Brain["inference (volatile)"]
+    Harness["Agent SDK harness\nL0–L4 verification gates"]
+  end
+  subgraph CP["control plane (always-on, shared)"]
+    GW["Compute Gateway\n= tsubame MCP (extended)\n+ autopilot state engine"]
+  end
+  subgraph Compute["targets"]
+    T["TSUBAME 4.0 (UGE)\nbatch qsub + UMS lease"]
+    S["suzume (RTX 5070 Ti)\nLocalBackend"]
+  end
+  NAS["NAS — SSoT archive + CAS"]
+  CC -->|MCP stdio| GW
+  Harness -->|MCP| GW
+  Dash -->|read API / WS| GW
+  GW -->|SSH: qsub / ums-submit / qstat| T
+  GW -->|local exec| S
+  T & S -->|rsync| NAS
+  GW <-->|state / CAS| NAS
+  GW -->|webhook| Slack
+```
+
+## Decision 1 — extend the MCP, do not replace it
+
+`tsubame_server.py` becomes the single Gateway, generalized to multi-target.
+Structured tools (enqueue/status/list/pull) stay bound to the autopilot. Raw-SSH
+tools are **demoted to an escape hatch** — additive, a bypass that preserves
+freedom, not debt. The MCP stays a thin tool surface; the brain stays in the
+Julia autopilot. No second MCP. This eliminates the audit's "MCP duplication"
+risk.
+
+Login-node compute ban: the Gateway/MCP must be code-constrained to
+submit+monitor only (the current raw-SSH path can run arbitrary remote commands —
+guard it).
+
+## Decision 2 — lease the UMS allocation, do not hold it permanently
+
+Resolves the cost tension (a live `node_f` ⊥ a lightweight always-on Gateway):
+
+- The **coordinator** is always-on and cheap; the **`node_f` allocation is an
+  ephemeral lease.**
+- "Enter low-latency mode" → `qsub node_f` + start UMS. Idle timeout → auto `qdel`.
+- No new cost machinery: add a **max-idle policy to the existing `AutopilotBudget`
+  + kill breaker.** Idle `node_f` burn counts against budget; the kill breaker
+  reaps it on idle. The Gateway owns lease setup/teardown — closing the audit's
+  "who owns the allocation lifecycle" gap.
+
+Implementation seam: a `dispatch!` variant targeting the held allocation
+(`ums-submit`), and swapping `prepare_status_snapshot` / `_uge_qstat_list_cmd`
+for `ums-list`. Preserve the `qsub -g` CLI-flag knowledge (`#$ -g` is rejected).
+
+## Routing
+
+| axis | TSUBAME 4.0 | suzume |
+|---|---|---|
+| scale | many-node, large array, production sweep | single-box verify, small/medium |
+| latency | queue (UMS-leased path mitigates) | none |
+| cost | group points (trial mode free, limited) | electricity only |
+| use | full-map scans, heavy TDHFB | debug, interactive iterate, dashboard, CI |
+
+Rule: smoke → suzume or TSUBAME trial (`-g` omitted, ≤2 parallel, ≤3 min, free);
+campaign → pointed `qsub`; interactive → suzume or UMS lease; CI/nightly →
+`LocalBackend` on suzume.
+
+## Roadmap (re-scoped)
+
+Phase 1 collapses from "build" to "name + decide", because the structured tools
+are already live.
+
+### Phase 1 — fold (mostly naming + the two decisions above)
+- Generalize `tsubame_server.py` to multi-target; demote raw-SSH to escape hatch.
+- Confirm `submit/status/results/list_runs` map onto `Experiment` + autopilot queue
+  (they already do).
+- Code-guard the login-node compute ban.
+
+### Phase 2 — UMS low-latency path (the core new work)
+- `node_f` lease + `ums-submit` dispatch + `ums-list` status; max-idle reap via
+  budget + kill breaker.
+- Headless Agent SDK harness as a Gateway service; L0–L4 gates as the verification
+  stage; only gate-passing runs promote to "validated" in CAS.
+
+### Phase 3 — multi-user (all new)
+- Per-user identity/namespace (replace provenance-only `enqueued_by`), per-user
+  quota (replace global budget), OAuth (isct.ac.jp), tailnet ACL.
+- Dashboard read API / SSE; PreToolUse / command-guard for multi-user safety.
+- Submit-time DAG (`-hold_jid`) if campaigns need it.
+
+### Phase 4 — optional
+- Cross-target routing learning; VASPilot-style auto error-analysis + restart.
+
+## Open questions / sharp edges
+
+- UMS lease policy: idle timeout value, who may trigger a lease, max concurrent
+  leases per group.
+- Submit-time DAG vs `on_complete` lineage — keep them distinct; do not overload.
+- Multi-user identity source (OAuth subject? tailnet user?) feeding the namespace.
+- Remote MCP transport security once it leaves stdio.
+
+## References
+
+- Feasibility audit: `docs/design/compute_gateway_feasibility_review.md`
+- Autopilot: `src/workflow/autopilot/`
+- CAS / Experiment: `src/workflow/experiment.jl`
+- MCP: `scripts/mcp/tsubame_server.py`
+- TSUBAME guide: `docs/guides/tsubame.md`
+- TSUBAME UMS: https://www.t4.cii.isct.ac.jp/docs/experimental/ums/
+- VASPilot (arXiv 2508.07035): https://arxiv.org/pdf/2508.07035

--- a/docs/design/compute_gateway_feasibility_review.md
+++ b/docs/design/compute_gateway_feasibility_review.md
@@ -1,0 +1,110 @@
+# Compute Gateway — feasibility review (plan vs codebase)
+
+**Status**: review only, no implementation. Audits the "AI research compute
+infrastructure" plan (Claude Code → TSUBAME 4.0 + suzume, via an always-on
+Compute Gateway) against the current code. Conclusion: the Phase-1 substrate
+already exists at production quality; the novel work is concentrated in UMS,
+DAG, and multi-user (Phase 2–3).
+
+This is an A/B-style ground-truth check, not an endorsement of the physics or
+the operating model. Every claim below is anchored to a file:line.
+
+## Verdict
+
+- The design's spine — **separate the volatile brain (Claude Code session) from
+  the durable hands/memory (compute, state, artifacts)**, promote the autopilot
+  to the Gateway state engine, abstract the scheduler behind one `Executor` —
+  matches what is already in the tree.
+- **The plan understates existing assets**: an MCP server, the Grid Engine
+  executor, and the executor abstraction itself already exist. Several pieces
+  the plan says it will "build" are done.
+- **The plan mis-names some reuse targets**: `Observable{T}` and `Sweep` types
+  do not exist; observables are plain functions and `sweep` is a function
+  returning `Vector{Experiment}`.
+- **The genuinely new work is UMS, job-DAG, multi-user/quota, Nix flake, and
+  remote MCP transport.** That is where the engineering cost actually lives.
+
+## 1. Already present (reuse is wider than the plan assumes)
+
+| Plan wording | Reality | Anchor |
+|---|---|---|
+| "new FastMCP gateway, start from 1 file" | **MCP server already exists**: FastMCP, 11 tools (read/write/destructive), stdio-over-WSL → TSUBAME | `scripts/mcp/tsubame_server.py` |
+| "add `GridEngineExecutor`" | **`UGEBackend` is production-grade**: `qsub -g` (CLI flag), batched `qstat` snapshot, `qacct` terminal fallback, `qdel`, rsync + SSH ControlMaster, Manifest-hash auto-instantiate, 9 `SPINORBEC_TSUBAME_*` env auto-register | `src/workflow/autopilot/backends_uge.jl`; env triple at `tick.jl:76-100` |
+| "define an `Executor` trait" | **`AutopilotBackend` abstract type is the trait.** Methods: `stage_in` / `dispatch!` / `job_status` / `pull_live` / `collect!` / `cancel!` / `find_job_by_name` / `backend_failure_reason` / `next_profile` / `prepare_status_snapshot`. The plan's 4-method trait (submit/poll/cancel/fetch) is a strict subset | `src/workflow/autopilot/types.jl:11`; contract `backends.jl:1-59` |
+| "state.toml SSoT, 5-state lifecycle, two-stage submit" | **Exact match**: `(:pending, :running, :done, :killed_data, :killed_bug)`; `runs/<cid>/state.toml` (schema v1.1); mark+fsync → `stage_in` → `dispatch!` → persist | `queue.jl:41-43,203`; `tick.jl:450-488` |
+| "policy engine (budget + breakers)" | **Present**: 4 breakers (recipe/lineage/rate/kill), `AutopilotBudget` (quarter + daily cap, realized tracking), divergence kill, retry classification (PERMANENT/TRANSIENT/RESOURCE_PERMANENT → `next_profile` escalation) | `breakers.jl:19`; `budget.jl:35-41`; `monitor.jl:83-91`; `retry.jl:27-52` |
+| "CAS dedup" | **Present**: `content_id(spec)` → `<root>/<sha256[1:16]>/`, idempotent `run!` (skips on existing jld2), `sweep` / `twin` / `tabulate` / `spec_diff` | `src/workflow/experiment.jl:113-120,144-205,249-280`; collection ops `689-851` |
+| "dashboard read API / SSE" | **HTTP 20+ routes + WebSocket** (`/ws/scrub`, binary) + `_live_status.json` polling | `src/workflow/io/dashboard/server/router.jl:295-415`; `websocket.jl:139-208` |
+| "webhook (Slack/Discord)" | **Slack only** | `monitoring.jl:37-48`; `ext/SpinorBECHTTPExt` |
+| "bake an Apptainer image" | **`spinorbec.def` exists** (julia:1.12, baked depot, `--nv`) | `scripts/spinorbec.def` |
+
+## 2. Plan claims that are wrong / mis-named
+
+| Plan wording | Reality |
+|---|---|
+| "existing `Observable{T}` becomes the submit/results schema" | **No `Observable{T}` type.** Observables are plain functions on `Experiment` (`Fz_t`, `classify`, `peaks`…), memoized in `exp.memo`. |
+| "reuse the `Sweep` type" | **No `Sweep` type.** `sweep()` is a function → `Vector{Experiment}`. `SweepResult` / `SweepAxis` / `RunSweep` exist but are post-hoc analysis carriers, not a submission schema. |
+| "`tabulate` → vector / `spec_diff` → vector" | `tabulate` → **`NamedTuple`** (per-column Vectors); `spec_diff` → `Vector{(path,a,b)}` records. |
+| "`load_config \|> run_config`" | **Pattern does not exist.** Real forms: `config([...])` + `Experiment(spec)` + `run!`, or `run_yaml(path)`. |
+| "dashboard … SSE" | **No SSE.** WebSocket (`/ws/scrub`) + `_live_status.json` polling. |
+| "Slack/Discord" | **Discord not implemented** (would need separate embed-JSON path). |
+| "suzume local/SLURM; add `SlurmExecutor`; reuse `SlurmBackend`" | **No `SlurmBackend` exists.** suzume bare is covered by `LocalBackend`. SLURM is greenfield **and likely unnecessary**. Note: `docs/guides/tsubame.md` itself says "ships with SlurmBackend only" — that line is **stale** (predates UGEBackend) and should be fixed. |
+
+**Implication for the MCP schema**: build `submit`/`results` on `Experiment` /
+`Vector{Experiment}` + function observables, not on new `Sweep` / `Observable{T}`
+types. The runtime model is spec-centric; mirror it.
+
+## 3. Genuinely greenfield (where the real cost is)
+
+1. **UMS low-latency path** — no reference to `ums-submit` / `ums-list` / UMS in
+   code or docs. The plan's central idea (§4) is entirely new. Cleanest seam:
+   swap `_uge_qstat_list_cmd` / `prepare_status_snapshot` for `ums-list`, and add
+   a `dispatch!` variant targeting a held allocation.
+2. **Job dependencies / DAG / `-hold_jid`** — none. Each entry is independent.
+   `on_complete` (parent_id lineage) is the nearest mechanism but fires *after*
+   completion; it is not a submit-time DAG.
+3. **Multi-user / project tags / namespace / per-user quota** — none.
+   `enqueued_by` is a provenance string; budget is global. Phase 3 is all-new.
+4. **Nix flake** — no `flake.nix` in this repo (the plan assumes it as "your
+   home turf", but it is not yet wired here).
+5. **Remote MCP transport (HTTP/SSE)** — existing MCP is stdio-only; Remote
+   Control over HTTP/SSE is new.
+6. **Cross-target routing** — `next_profile` escalates within one backend; there
+   is no TSUBAME↔suzume routing policy.
+
+## 4. Sharp edges
+
+- **MCP duplication risk.** `tsubame_server.py` already exists. Standing up a
+  separate Gateway MCP creates two. Decide up front: *extend the existing one to
+  multi-HPC* vs *replace it*. The plan is written greenfield and does not mention
+  this asset.
+- **UMS held allocation ⊥ "small always-on Gateway".** UMS keeps a `node_f`
+  alive; idle time burns points. This is in tension with the lightweight
+  always-on service model. Who holds/tears down the allocation is unspecified.
+- **Login-node compute ban.** The plan respects it, but the Gateway/MCP must be
+  constrained in code to submit+monitor only — the current SSH-wrapper MCP can
+  run arbitrary remote commands.
+- **`qsub -g` must be a CLI flag** (`#$ -g` is rejected by the TSUBAME4 wrapper).
+  Already learned and encoded (`backends_uge.jl:165-168`); preserve in new code.
+- **Stale doc.** `docs/guides/tsubame.md` "SlurmBackend only" contradicts the
+  shipped UGEBackend.
+
+## 5. Re-scoped recommendation
+
+- **Phase 1 is a thin shell.** Expose `submit/status/results/list_runs` over
+  `Experiment` + the autopilot queue. Executor abstraction = `AutopilotBackend`;
+  GridEngineExecutor = `UGEBackend`; LocalExecutor = `LocalBackend` — all present.
+  The only new code is MCP bindings (extending `tsubame_server.py`).
+- **Drop `SlurmExecutor`** (LocalBackend covers suzume).
+- **Concentrate effort on Phase 2 UMS and Phase 3 multi-user** — that is the
+  hard, novel surface. Plan the budget accordingly.
+
+## References
+
+- Plan source: conversation 2026-06-21 (this worktree).
+- Autopilot: `src/workflow/autopilot/{types,backends,backends_uge,queue,tick,breakers,budget,monitor,retry,on_complete}.jl`
+- CAS / Experiment: `src/workflow/experiment.jl`
+- Dashboard: `src/workflow/io/dashboard/server/router.jl`, `websocket.jl`
+- MCP: `scripts/mcp/tsubame_server.py`
+- TSUBAME guide (note stale line): `docs/guides/tsubame.md`
+- Container: `scripts/spinorbec.def`

--- a/docs/design/multi_user_gateway_design.md
+++ b/docs/design/multi_user_gateway_design.md
@@ -1,0 +1,180 @@
+# Multi-user Gateway — identity, quota, authorization over a shared CAS
+
+**Status**: design. Phase 3 of `compute_gateway_design.md`. Turn the
+single-operator autopilot into a few-user shared service without losing the CAS
+dedup that makes a shared base worth having.
+
+## The core distinction: attribution, not isolation
+
+The CAS is content-addressed and **deliberately shared** — same spec → same
+`content_id` → same result, computed once for everyone (`experiment.jl:113-120`,
+parent design pillar 4). So multi-user here is **not** about separate per-user
+stores. It is about three things layered over one shared CAS:
+
+1. **Attribution** — which user owns / triggered a run.
+2. **Quota** — metering compute per user against a shared point budget.
+3. **Authorization** — who may cancel / retry / delete whose runs.
+
+"Namespace" in this design means an attribution + quota + authz key, **not** a
+storage partition. Isolating storage per user would forfeit dedup — explicitly
+rejected.
+
+## What already exists (do not rebuild)
+
+The identity **capture** seam is already in the tree:
+
+- The dashboard HTTP server extracts the authenticated identity from upstream
+  reverse-proxy headers, priority-ordered: `X-Auth-Request-Email` (oauth2-proxy +
+  Google Workspace, full `anko@isct.ac.jp`) → `X-Authenticated-User` (Caddy
+  basicauth) → `X-Forwarded-User` → `Remote-User`; first non-empty wins, trusted
+  only behind the proxy (`server/router.jl:142-157`).
+- The dashboard enqueue route already stamps that identity into `enqueued_by`
+  (`routes/autopilot_enqueue.jl:74`).
+- oauth2-proxy deployment exists, anko-only via `authenticated_emails_file`,
+  openable to the lab by appending emails (`scripts/deploy_dashboard_auth.sh`).
+- `QueueEntry` carries `enqueued_by::String` and `group_id::String`
+  (`queue.jl:98,105`); the dashboard groups the queue by `group_id`.
+
+So the OAuth boundary + identity extraction + a provenance field are done. The
+gaps are everything that turns captured identity into policy.
+
+## The four gaps
+
+1. **`enqueued_by` is provenance, not an owner.** It also holds `"manual"`,
+   `"cli"`, `"on_complete:<recipe>"` — not always a person. Quota/authz need a
+   distinct, always-a-principal `owner` field.
+2. **Identity doesn't cross the MCP / Claude Code path.** The MCP server runs as
+   one service account; `tsubame_enqueue` sends `["enqueue", config_path]` with no
+   `--enqueued-by` (`scripts/mcp/tsubame_server.py:442`). Every MCP enqueue is
+   currently anonymous. The dashboard path has identity; the agent path does not.
+3. **Budget is global.** One `budget.toml` at `qr.path`, one quarter/daily cap,
+   `refresh_budget!` sums over all entries (`budget.jl:114-185`). No per-user
+   metering.
+4. **No authorization on mutating ops.** `cancel!` / `retry_failed!` have no
+   ownership check — any caller can act on any run.
+
+## Design
+
+### 4.1 Identity model
+
+Add `owner::String` to `QueueEntry` (institutional email, or a reserved principal
+like `svc:harness` for the autonomous harness). Schema bump
+`state.toml` v1.1 → v1.2 (migration: absent `owner` → `""` = unattributed
+legacy). `enqueued_by` stays as provenance; `owner` is the policy key. A run's
+owner is set once at enqueue and never mutated (like other provenance fields).
+
+Dedup nuance: when a second user enqueues a spec whose `content_id` already has a
+completed result, `run!` returns the cached result (the whole point). The
+**second** request is attributed to its owner for *fairness telemetry* but
+incurs **no compute** and **no quota charge** — quota meters realized GPU·hours,
+which are zero on a cache hit. Owner of record stays the first to compute it;
+later requesters are recorded as consumers, not owners. (Keeps the "don't
+recompute across users" win intact.)
+
+### 4.2 Identity through the MCP path
+
+Two principals, two mechanisms:
+
+- **Interactive users (Claude Code → MCP over stdio/SSH).** The MCP process runs
+  under the invoking user's session; stamp `owner` from an env var the launcher
+  sets per user (`SPINORBEC_PRINCIPAL`, defaulted from the SSH login / OS user).
+  `tsubame_enqueue` gains an `--enqueued-by`/owner arg sourced from it.
+- **Autonomous harness (Agent SDK service).** A reserved `owner="svc:harness"`
+  with its own quota line, as the parent design specified (one service-account
+  seat). Its runs are attributable and capped separately from humans.
+
+This is the one greenfield seam on the agent side; the dashboard side already has
+identity.
+
+### 4.3 Per-user quota
+
+Generalize the budget from one record to per-principal records, keyed by `owner`:
+
+- `budget.toml` → `budgets/<principal>.toml` (or one file keyed by principal),
+  each an `AutopilotBudget` (quarter/daily cap + realized). A `default` template
+  applies to new principals.
+- `refresh_budget!` groups the realized-hours sum by `entry.owner`
+  (`budget.jl:124-131` already iterates entries — add a group-by).
+- `budget_gate` is called per principal at dispatch: an entry dispatches only if
+  *its owner's* budget allows. A shared **group ceiling** (the TSUBAME point
+  pool) sits above the per-user caps — gate against `min(user_cap, group_pool)`.
+- The UMS lease (Phase 2) charges its idle/active GPU·hours to the principal who
+  triggered the lease, or to a shared `infra` principal if it serves multiple —
+  decide per O-question below.
+
+### 4.4 Authorization
+
+Ownership guard on mutating queue ops:
+
+- `cancel!` / `retry` / archive accept a `caller` principal and refuse when
+  `entry.owner != caller` unless `caller` is an admin principal (config list).
+- The reap loop's divergence-kill is system-initiated (`caller="svc:autopilot"`,
+  always allowed).
+- The MCP `cancel` tool passes the session principal; the CLI passes the OS user.
+- Enforced at the queue-op boundary, not scattered — one `authorize(op, entry,
+  caller)` helper. Failures return a CheckResult-style refusal, never throw
+  (consistent with the inspector's 4-severity model).
+
+### 4.5 Command-guard for the headless / raw-SSH surface
+
+The parent design demotes raw-SSH MCP tools to an escape hatch; multi-user makes
+the guard load-bearing. A PreToolUse-style guard (mirroring the audit's
+`slurm-mcp-server` SSH-escape categories) blocks, for any principal:
+
+- `qdel` of a job not owned by the caller (cross-check against the queue).
+- writes/`rm` under another principal's attribution or the group disk root.
+- compute on the login node (enforce submit+monitor-only, per parent design).
+
+### 4.6 Dashboard read API / SSE
+
+The read surface is HTTP + WebSocket today (`server/router.jl`,
+`/ws/scrub`); no SSE. For multi-user live status, add an SSE endpoint
+(`/api/events`) emitting queue/owner/budget deltas, filtered by the viewer's
+principal (from the same proxy header). SSE over WS here because the payload is
+small JSON deltas, not binary scrub frames, and SSE rides the existing
+proxy/auth path with no upgrade handshake.
+
+### 4.7 Submit-time DAG (optional, deferred)
+
+`-hold_jid` submit-time dependencies (audit gap) are independent of multi-user
+and only needed if campaigns require ordered chains beyond `on_complete`
+lineage. Keep out of Phase 3 unless a concrete campaign needs it.
+
+## Phased checklist
+
+**3a — attribution**
+1. `owner` field + state.toml v1.2 migration; set at enqueue (dashboard already
+   has identity; wire MCP `--enqueued-by`/owner from `SPINORBEC_PRINCIPAL`).
+2. Reserve `svc:harness` / `svc:autopilot` principals.
+
+**3b — quota + authz**
+3. Per-principal budgets; `refresh_budget!` group-by-owner; per-owner
+   `budget_gate` under a shared group ceiling.
+4. `authorize(op, entry, caller)` guard on cancel/retry/archive + admin list.
+
+**3c — surface**
+5. Command-guard for raw-SSH/headless (cross-owner qdel, group-disk writes,
+   login-node compute).
+6. SSE `/api/events` filtered by principal; dashboard queue/budget views per user.
+7. Open oauth2-proxy from anko-only to the lab roster; tailnet ACL per role.
+
+## Open questions
+
+- **O1**: lease (Phase 2) cost attribution — per-trigger principal vs a shared
+  `infra` line? A lease serving many users' interactive tasks is naturally shared;
+  charging one user is unfair, charging `infra` hides it from per-user caps.
+- **O2**: admin principal source — config list, or a tailnet/OAuth group claim?
+- **O3**: do we trust `SPINORBEC_PRINCIPAL` on the interactive MCP path, or
+  require the same OAuth as the dashboard? (stdio MCP has no proxy in front.)
+- **O4**: fairness telemetry for cache-hit consumers — worth surfacing, or noise?
+
+## References
+
+- Parent design: `docs/design/compute_gateway_design.md`
+- UMS lease (Phase 2): `docs/design/ums_lease_backend_design.md`
+- Identity capture: `src/workflow/io/dashboard/server/router.jl:142-157`,
+  `routes/autopilot_enqueue.jl:74`
+- OAuth deploy: `scripts/deploy_dashboard_auth.sh`
+- Queue entry / budget: `src/workflow/autopilot/queue.jl:88-138`,
+  `src/workflow/autopilot/budget.jl`
+- MCP: `scripts/mcp/tsubame_server.py`

--- a/docs/design/multi_user_gateway_design.md
+++ b/docs/design/multi_user_gateway_design.md
@@ -160,15 +160,10 @@ lineage. Keep out of Phase 3 unless a concrete campaign needs it.
 
 ## Open questions
 
-- **O1**: lease (Phase 2) cost attribution — per-trigger principal vs a shared
-  `infra` line? A lease serving many users' interactive tasks is naturally shared;
-  charging one user is unfair, charging `infra` hides it from per-user caps.
-  **This is the same decision as the UMS doc's Phase 2↔3 lease-isolation seam and
-  is gated on one number: the probe's C1 idle node_f burn rate.** Cheap idle →
-  per-user lease (exact attribution, simple isolation); expensive idle → one
-  shared warm pool + fair-share (cost to `infra`). Must be resolved before Phase 2b
-  writes the `UMSLease` shape — retrofitting multi-tenancy onto a single-tenant
-  lease is the expensive path. See `ums_lease_backend_design.md` → "Policy constants".
+- **O1**: lease cost attribution — **MOOT for now: UMS is deferred** (queue
+  measured at ~8 s, `ums_lease_backend_design.md`). With no lease, all compute is
+  per-entry and meters cleanly by `owner`. The per-user-lease vs shared-warm-pool
+  seam only re-opens if UMS is revived under observed `node_f` congestion.
 - **O2**: admin principal source — config list, or a tailnet/OAuth group claim?
 - **O3**: do we trust `SPINORBEC_PRINCIPAL` on the interactive MCP path, or
   require the same OAuth as the dashboard? (stdio MCP has no proxy in front.)

--- a/docs/design/multi_user_gateway_design.md
+++ b/docs/design/multi_user_gateway_design.md
@@ -163,6 +163,12 @@ lineage. Keep out of Phase 3 unless a concrete campaign needs it.
 - **O1**: lease (Phase 2) cost attribution — per-trigger principal vs a shared
   `infra` line? A lease serving many users' interactive tasks is naturally shared;
   charging one user is unfair, charging `infra` hides it from per-user caps.
+  **This is the same decision as the UMS doc's Phase 2↔3 lease-isolation seam and
+  is gated on one number: the probe's C1 idle node_f burn rate.** Cheap idle →
+  per-user lease (exact attribution, simple isolation); expensive idle → one
+  shared warm pool + fair-share (cost to `infra`). Must be resolved before Phase 2b
+  writes the `UMSLease` shape — retrofitting multi-tenancy onto a single-tenant
+  lease is the expensive path. See `ums_lease_backend_design.md` → "Policy constants".
 - **O2**: admin principal source — config list, or a tailnet/OAuth group claim?
 - **O3**: do we trust `SPINORBEC_PRINCIPAL` on the interactive MCP path, or
   require the same OAuth as the dashboard? (stdio MCP has no proxy in front.)

--- a/docs/design/ums_lease_backend_design.md
+++ b/docs/design/ums_lease_backend_design.md
@@ -52,13 +52,14 @@ provenance / reconcile), and identify the task by `--name = _uge_jobname(cid) =
 "sb_<cid>"` — the same naming already used for UGE reconcile (`backends_uge.jl:132`).
 `job_status` looks up by **name**, not job_id.
 
-**Shared machinery (explicit, per the repo ethos).** The `_ssh_cm` /
-`_RSYNC_SSH_CM` / `_uge_rsync_config_cmd` / `_uge_pull_live_cmd` /
-`_uge_collect_cmd` / `_uge_code_sync_cmd` / Manifest-hash helpers
-(`backends_uge.jl:235-354`) are scheduler-agnostic. Extract them to a shared
-`autopilot/ssh_transport.jl` consumed by both `UGEBackend` and `UMSBackend`
-(rename `_uge_*` → `_ssh_*`). Do **not** copy-paste — that is exactly the
-duplicated-physics-drift class this repo forbids.
+**Shared machinery (explicit, per the repo ethos). — DONE in Phase 2a.** The
+ControlMaster ssh + rsync push/pull/collect/code-sync + Manifest-hash helpers
+were scheduler-agnostic and have been extracted to `autopilot/ssh_transport.jl`
+(`_ssh_cm` / `_rsync_*` / `_ssh_instantiate_if_needed`), parameterized by
+primitives (host, paths). `UGEBackend`'s `_uge_*` builders now delegate to them
+(byte-identical, 217/217 autopilot tests green). `UMSBackend` reuses the same
+transport rather than copy-pasting it — the duplicated-physics-drift class this
+repo forbids.
 
 ## Problem A — status without a terminal signal
 
@@ -73,7 +74,7 @@ if present
 else
     # absent: either finished, or not-yet-scheduled (race after dispatch!)
     collect!(b, entry)                       # pull outcome.toml if it landed
-    outcome = read runs/<cid>/outcome.toml   # same branch as UGE backends_uge.jl:523-541
+    outcome = read runs/<cid>/outcome.toml   # same branch as UGE backends_uge.jl:437-451
     outcome.terminal == "done"               → :done
     outcome.terminal in (killed_data,bug)    → :failed
     # no outcome yet:
@@ -206,8 +207,9 @@ existing backend-full path), `budget.jl` (lease-aware `predicted` + `lease_reali
 ## Implementation checklist (Phase 2a → 2c)
 
 **2a — backend skeleton (no lease yet, manual lease)**
-1. Extract `ssh_transport.jl`; re-point `UGEBackend` at it (parity test: UGE
-   command builders byte-identical before/after).
+1. ~~Extract `ssh_transport.jl`; re-point `UGEBackend` at it (parity test: UGE
+   command builders byte-identical before/after).~~ **DONE** — byte-identical,
+   217/217 autopilot tests green.
 2. `UMSBackend` with `stage_in`/`pull_live`/`collect!` (reuse), `dispatch!` via
    `ums-submit` against a **manually-started** lease (operator runs `qsub` +
    `ums-start`, passes job-id). `prepare_status_snapshot`=`ums-list`, `job_status`

--- a/docs/design/ums_lease_backend_design.md
+++ b/docs/design/ums_lease_backend_design.md
@@ -1,7 +1,24 @@
 # UMS low-latency path — leased `node_f` + `UMSBackend`
 
-**Status**: design. Phase 2 of `compute_gateway_design.md`. The genuinely new
-work: turn "run this param set" from a fresh `qsub` (minutes of `qw`) into an
+**Status: DEFERRED — premise not met (2026-06-21).** UMS exists to kill queue
+wait. A direct measurement on TSUBAME shows there is none worth killing:
+**trial-mode `qsub`→running latency = 7.8 s** (and trial is *lowest priority* =
+worst case; a real `-g` job is at least as fast). At ~8 s the autopilot's plain
+`qsub` path already gives an interactive-feeling loop, so the lease machinery is
+a solution to a non-problem. Not building it. This doc stands as the considered
+design should the premise change.
+
+**Revisit only if** a concrete friction appears: (a) `node_f`/multi-node
+allocations waiting minutes under congestion (untested — the measurement was
+`gpu_1`, uncongested, one sample), or (b) rapid-fire many-tiny-jobs where
+per-submit JIT dominates — and even (b) is largely covered by the existing
+sysimage support (`UGEBackend.sysimage_path`). The probe
+(`scripts/tsubame/ums_probe.sh`) is the insurance instrument for (a).
+
+---
+
+**Original framing (design, not active).** Phase 2 of `compute_gateway_design.md`.
+The work would have been: turn "run this param set" from a fresh `qsub` into an
 instant dispatch to a held allocation. Fits the existing `AutopilotBackend`
 contract; the hard parts are three UMS-specific semantic gaps, resolved below.
 

--- a/docs/design/ums_lease_backend_design.md
+++ b/docs/design/ums_lease_backend_design.md
@@ -165,8 +165,38 @@ Resolution, minimal and on the existing seam:
   The "max-idle policy on the existing budget + kill breaker" promised in the
   parent design is exactly this — no new cost machinery, just lease-aware terms.
 
-`max_idle_minutes` is conservative by default (e.g. 10 min) because idle `node_f`
-is the single most expensive failure mode here.
+`max_idle_minutes` is **not a guess to hardcode** — it is set from the probe's
+C1 idle burn rate (see "Policy constants" below). Pending that number it stays a
+conservative placeholder, because idle `node_f` is the single most expensive
+failure mode here.
+
+## Policy constants — set from the probe, not guessed
+
+The lease parameters below are currently **placeholders**. `scripts/tsubame/ums_probe.sh`
+measures the real numbers on TSUBAME; **2b is held until it returns** so the
+lease model is written without assumptions (retrofitting a single-tenant lease
+into a multi-tenant one is expensive — resolve the seam first).
+
+| probe output | sets | placeholder |
+|---|---|---|
+| **C1** `idle_points_per_hour` | `max_idle_minutes`; and the **Phase 2↔3 lease-isolation seam** (below) | 10 min |
+| **C2** `warm_speedup_x` (cold qsub ÷ warm dispatch) | go/no-go for UMS itself — if ≈ 1 the premise collapses | assumed ≫ 1 |
+| **C3** `umslist_appear_lag_s` / `missed_polls` | `UMS_DISPATCH_GRACE` floor; whether `job_status` needs a missed-poll debounce | 30 s grace |
+
+**The Phase 2↔3 lease-isolation seam (decide before 2b writes the lease model).**
+C1 alone picks the lease topology, and the choice is painful to reverse:
+
+- **cheap idle node_f** → **per-user lease**: each principal (Phase 3) gets its
+  own lease, isolation is trivial, cost attribution is exact (the lease bills its
+  owner). The `UMSLease` is a per-principal object.
+- **expensive idle node_f** → **single shared warm pool + fair-share**: one lease
+  serves all interactive users, scheduled fairly; cost goes to a shared `infra`
+  principal, not a person. The `UMSLease` is a singleton with a fair-share queue.
+
+Writing 2b against the wrong topology means re-plumbing ownership through the
+lease later. So the `UMSLease` shape (per-principal vs singleton) is **gated on
+C1** and must be fixed before 2b — this is the same decision as multi_user
+`O1`/lease-cost-attribution, surfaced early.
 
 ## Routing
 
@@ -215,10 +245,14 @@ existing backend-full path), `budget.jl` (lease-aware `predicted` + `lease_reali
    `ums-start`, passes job-id). `prepare_status_snapshot`=`ums-list`, `job_status`
    with the grace guard (Problem A). Verify a single task round-trips end-to-end.
 
-**2b — lease state machine**
-3. `UMSLease` + `.ums_lease.toml` persistence + `ums_lease_tick!` (acquire →
-   start → drain → release) wired into `autopilot_tick!`.
-4. Budget integration (Problem D); conservative `max_idle_minutes`.
+**2b — lease state machine** — ⛔ GATED on the probe (C1/C2/C3). Do not write the
+`UMSLease` shape until C1 fixes the per-principal-vs-singleton seam (above), or it
+will need re-plumbing for Phase 3. If C2 shows no warm speedup, UMS is dropped
+entirely and this phase is moot.
+3. `UMSLease` (per-principal **or** singleton, per C1) + `.ums_lease.toml`
+   persistence + `ums_lease_tick!` (acquire → start → drain → release) wired into
+   `autopilot_tick!`.
+4. Budget integration (Problem D); `max_idle_minutes` from C1.
 5. Crash-recovery reconcile against `qstat`.
 
 **2c — divergence + routing + verify**
@@ -230,6 +264,9 @@ existing backend-full path), `budget.jl` (lease-aware `predicted` + `lease_reali
    `qsub` (the headline win).
 
 ## Open questions
+
+All of these are answered by `scripts/tsubame/ums_probe.sh` in one run (yes/no
+gates O1/O2/O3/O5 + policy constants C1/C2/C3). 2b stays blocked until it has run.
 
 - **O1**: does UMS accept a plain serial (non-MPI) Julia command? The doc's
   "non-OpenMPI unsupported" note must be cleared first — it could block the whole

--- a/docs/design/ums_lease_backend_design.md
+++ b/docs/design/ums_lease_backend_design.md
@@ -1,0 +1,253 @@
+# UMS low-latency path — leased `node_f` + `UMSBackend`
+
+**Status**: design. Phase 2 of `compute_gateway_design.md`. The genuinely new
+work: turn "run this param set" from a fresh `qsub` (minutes of `qw`) into an
+instant dispatch to a held allocation. Fits the existing `AutopilotBackend`
+contract; the hard parts are three UMS-specific semantic gaps, resolved below.
+
+## UMS ground truth (from the TSUBAME UMS doc, verbatim API)
+
+- **Acquire**: a normal `qsub -g <group>` job whose script is `sleep infinity`
+  with `#$ -l node_f=N -l h_rt=HH:MM:SS`. Gives a batch `job-id`.
+- **Start daemon**: `ums-start --job <job-id>` (run on login node once the parent
+  job is in state `r`). Spawns a controller + per-node workers.
+- **Submit a task**: `ums-submit --group <g> --job <job-id> --name <name>
+  --rank <r> --stderr-log <p> --stdout-log <p> <command...>`. `--job` and
+  `--name` required; `--rank` defaults 0; logs default `/dev/null`.
+- **List**: `ums-list --job <job-id>` → JSON `{name: hostname}` of **actively
+  running tasks only**. No state column; a finished task simply disappears.
+- **Cancel**: **no `ums-cancel` / `ums-kill` exists.** The only documented stop
+  is `qdel <job-id>` on the parent — which kills the whole allocation and every
+  task in it.
+- **Lifetime**: UMS is subordinate to the parent job; valid only while parent is
+  `r`. No detach/persist after the parent ends.
+- **Caveat to verify**: the doc notes "array jobs and non-OpenMPI environments
+  unsupported" and "MPI programs in a group must run before other grouped tasks".
+  Our tasks are single-process Julia (no MPI) — **must confirm UMS accepts a
+  plain serial command** before committing. Open question O1.
+
+These three properties (list-shows-only-running, no per-task cancel, parent-bound
+lifetime) drive the whole design.
+
+## How it maps onto the existing autopilot
+
+The backend abstraction already absorbs this. `entry.backend_type::Symbol` keys
+`config.backends` (`types.jl:75-85`), so a new `:ums` backend slots into the same
+tick loop that already mixes `:local` + `:uge`. The contract
+(`backends.jl:10-18`) maps cleanly:
+
+| Contract method | UMS implementation |
+|---|---|
+| `stage_in` | identical to UGE (rsync config + optional code sync) — **reuse UGE rsync helpers** |
+| `dispatch!` | `ums-submit --job <lease> --name sb_<cid> --stdout-log … <julia run_yaml>` (requires active lease) |
+| `prepare_status_snapshot` | `ums-list --job <lease>` once per tick → cached JSON |
+| `job_status(...; snapshot=)` | parse the snapshot JSON (see Problem A) |
+| `pull_live` / `collect!` | identical to UGE rsync |
+| `cancel!` | cooperative sentinel (see Problem B) |
+| `find_job_by_name` | name present in `ums-list` JSON → reconcile |
+| `next_profile` | `nothing` (lease is fixed node_f); resource-permanent retry re-routes to `:uge` |
+
+`job_id` semantics: store the parent **lease job-id** in `entry.job_id` (for
+provenance / reconcile), and identify the task by `--name = _uge_jobname(cid) =
+"sb_<cid>"` — the same naming already used for UGE reconcile (`backends_uge.jl:132`).
+`job_status` looks up by **name**, not job_id.
+
+**Shared machinery (explicit, per the repo ethos).** The `_ssh_cm` /
+`_RSYNC_SSH_CM` / `_uge_rsync_config_cmd` / `_uge_pull_live_cmd` /
+`_uge_collect_cmd` / `_uge_code_sync_cmd` / Manifest-hash helpers
+(`backends_uge.jl:235-354`) are scheduler-agnostic. Extract them to a shared
+`autopilot/ssh_transport.jl` consumed by both `UGEBackend` and `UMSBackend`
+(rename `_uge_*` → `_ssh_*`). Do **not** copy-paste — that is exactly the
+duplicated-physics-drift class this repo forbids.
+
+## Problem A — status without a terminal signal
+
+`ums-list` shows only running tasks; a finished task vanishes with no exit code,
+no qacct. So `job_status(::UMSBackend, entry; snapshot)`:
+
+```
+name = "sb_" * entry.content_id
+present = haskey(parse_json(snapshot), name)
+if present
+    return :running
+else
+    # absent: either finished, or not-yet-scheduled (race after dispatch!)
+    collect!(b, entry)                       # pull outcome.toml if it landed
+    outcome = read runs/<cid>/outcome.toml   # same branch as UGE backends_uge.jl:523-541
+    outcome.terminal == "done"               → :done
+    outcome.terminal in (killed_data,bug)    → :failed
+    # no outcome yet:
+    if now - entry.dispatched_at < UMS_DISPATCH_GRACE   → :running   # not scheduled yet
+    else                                                → :unknown    # retry next tick
+end
+```
+
+The `UMS_DISPATCH_GRACE` guard is the key difference from UGE: under UGE,
+"absent from qstat" is unambiguously terminal; under UMS, a just-submitted task
+may not appear in `ums-list` for a moment. Without the grace window the reap loop
+would race-classify a fresh task as terminal-with-no-outcome → `:unknown` churn.
+The outcome.toml is authoritative the moment it lands (the Julia run writes it on
+exit, same as local/UGE), so the grace window only matters for the no-outcome gap.
+
+## Problem B — divergence kill with no per-task cancel
+
+The reap loop kills divergent runs via `cancel!(backend, entry)`
+(`tick.jl:298-301`). For UGE that is `qdel <job_id>`. For UMS, `qdel` would kill
+the **lease and every sibling task** — unacceptable.
+
+Resolution: **cooperative abort sentinel.** `cancel!(::UMSBackend, entry)` writes
+a `.kill` file into the (remote) run_dir (ssh `touch`, or rsync an empty marker).
+`run_pipeline` checks for `<run_dir>/.kill` at the same cadence it writes
+`_live_status.json` and aborts cleanly (writing `outcome.toml` with
+`terminal=killed_data`). This is a **small `run_pipeline` addition** and is the
+one cross-subsystem dependency of this design — call it out, do not hide it
+(dependency D1).
+
+Rationale: UMS tasks are short by construction (that is the entire point of the
+low-latency path), so cooperative abort at the live-status cadence is responsive
+enough. A `pkill`-over-ssh-on-the-task-host alternative (host comes from the
+`ums-list` JSON value) is heavier and fragile; keep it as a documented fallback,
+not v1. `qdel` of the lease is never used for a single divergent task.
+
+## Problem C — the lease lifecycle (the heart of the new work)
+
+A managed `UMSLease`, persisted to `<qr.path>/.ums_lease.toml` (survives
+coordinator restart, same sentinel discipline as `.autopilot.paused`):
+
+```
+state machine (advanced once per tick by ums_lease_tick!):
+
+  NONE ──[pending :ums entry exists]──▶ REQUESTED   (qsub sleeper submitted; parent qw)
+  REQUESTED ──[parent qstat == r]────▶ ACTIVE       (ums-start --job <id> done)
+  ACTIVE ──[idle ≥ max_idle, 0 running tasks]──▶ DRAINING  (no new dispatch accepted)
+  DRAINING ──[confirmed idle]────────▶ RELEASED     (qdel <id>); back to NONE
+  any ──[parent absent from qstat]───▶ NONE          (crash/preempt reconcile)
+```
+
+Fields: `state`, `job_id` (parent), `requested_at`, `active_since`,
+`last_activity_at`, `node_spec` (e.g. `node_f=1`), `h_rt`, `max_idle_minutes`.
+
+- **Acquire trigger**: `dispatch!` of a `:ums` entry when lease is not `ACTIVE`
+  returns `false` (backend-not-ready, entry stays `:pending`); `ums_lease_tick!`
+  sees the pending `:ums` entry and drives `NONE→REQUESTED→ACTIVE`. Once `ACTIVE`,
+  the next tick dispatches the waiting entries instantly.
+- **Idle reap**: `last_activity_at` updates on every `ums-submit` and whenever
+  `ums-list` is non-empty. `now - last_activity_at > max_idle` AND `ums-list`
+  empty → `DRAINING → RELEASED` (`qdel`). This is the cost-control mechanism.
+- **Crash recovery**: on coordinator restart, reconcile `.ums_lease.toml`
+  against `qstat` — if the parent job-id is gone, reset to `NONE`; if still `r`,
+  resume `ACTIVE` (re-run `ums-start` is idempotent / no-op if daemon up — verify,
+  open question O2).
+- **`h_rt` ceiling**: the parent has a hard walltime; near expiry, force
+  `DRAINING` and let in-flight tasks finish or migrate. A lease is not permanent
+  even if busy — re-acquire after expiry.
+
+`ums_lease_tick!(backend, qr)` runs once per `:ums` backend per tick, **before
+the dispatch passes** in `autopilot_tick!`, so a freshly-`ACTIVE` lease is usable
+the same tick the entries are dispatched.
+
+## Problem D — budget accounting for the lease
+
+`refresh_budget!` (`budget.jl:114-136`) sums `gpu_hours_realized` over
+terminal+running **entries**. The lease is not an entry, and it burns `node_f`
+(4× H100) continuously while held — the dominant new budget risk.
+
+Resolution, minimal and on the existing seam:
+
+- While `ACTIVE`/`DRAINING`, `budget_gate` adds projected lease cost
+  `(now - active_since) × gpus_per_node` to `predicted` (so an idle lease pushes
+  toward the cap and pressures release).
+- On `RELEASED`, finalize the realized lease hours into a `lease_realized` field
+  in `budget.toml`; `refresh_budget!` adds it to `realized_total`.
+- The **kill breaker** is the backstop: an `ACTIVE` lease with no activity past
+  `max_idle` and a budget already near the ceiling trips toward forced release.
+  The "max-idle policy on the existing budget + kill breaker" promised in the
+  parent design is exactly this — no new cost machinery, just lease-aware terms.
+
+`max_idle_minutes` is conservative by default (e.g. 10 min) because idle `node_f`
+is the single most expensive failure mode here.
+
+## Routing
+
+`entry.backend_type=:ums` is set at enqueue by the Gateway's low-latency path
+(MCP "enqueue --low-latency", or the interactive harness). Phase-2 rule, kept
+simple and explicit (no learned routing yet):
+
+- interactive / small / short (estimated walltime below a threshold, many
+  same-shape variants) → `:ums`
+- production / long / large array → `:uge`
+- resource-permanent failure on `:ums` (the fixed lease can't grow) → re-route
+  the retry to `:uge` with `next_profile` escalation.
+
+## Struct + file sketch
+
+```julia
+struct UMSBackend <: AutopilotBackend
+    ssh_host::Union{Nothing,String}
+    project_root::String
+    remote_runs_root::Union{Nothing,String}
+    compute_group::String          # ums-submit --group + qsub -g
+    julia_path::String; julia_depot::String; sysimage_path::String; cuda_module::String
+    node_spec::String              # "node_f=1"
+    h_rt::String                   # "24:00:00"
+    max_idle_minutes::Int
+    sync_code::Bool
+    lease_path::String             # <qr.path>/.ums_lease.toml
+end
+```
+
+New files: `autopilot/ssh_transport.jl` (extracted shared rsync/ssh-CM helpers),
+`autopilot/backends_ums.jl` (`UMSBackend` + `UMSLease` + `ums_lease_tick!`).
+Touched: `tick.jl` (call `ums_lease_tick!` before dispatch passes; UMS-aware
+`dispatch!` returning false when lease not ready is already handled by the
+existing backend-full path), `budget.jl` (lease-aware `predicted` + `lease_realized`),
+`run_pipeline` (D1: honor `.kill` sentinel).
+
+## Implementation checklist (Phase 2a → 2c)
+
+**2a — backend skeleton (no lease yet, manual lease)**
+1. Extract `ssh_transport.jl`; re-point `UGEBackend` at it (parity test: UGE
+   command builders byte-identical before/after).
+2. `UMSBackend` with `stage_in`/`pull_live`/`collect!` (reuse), `dispatch!` via
+   `ums-submit` against a **manually-started** lease (operator runs `qsub` +
+   `ums-start`, passes job-id). `prepare_status_snapshot`=`ums-list`, `job_status`
+   with the grace guard (Problem A). Verify a single task round-trips end-to-end.
+
+**2b — lease state machine**
+3. `UMSLease` + `.ums_lease.toml` persistence + `ums_lease_tick!` (acquire →
+   start → drain → release) wired into `autopilot_tick!`.
+4. Budget integration (Problem D); conservative `max_idle_minutes`.
+5. Crash-recovery reconcile against `qstat`.
+
+**2c — divergence + routing + verify**
+6. D1: `run_pipeline` `.kill` sentinel; `cancel!(::UMSBackend)` writes it;
+   divergence-kill test under UMS (cooperative abort lands `outcome.toml`).
+7. Routing helper sets `backend_type`; resource-permanent → re-route to `:uge`.
+8. End-to-end: low-latency enqueue of N same-shape variants → instant dispatch to
+   a held lease → idle timeout auto-`qdel`. Measure dispatch latency vs cold
+   `qsub` (the headline win).
+
+## Open questions
+
+- **O1**: does UMS accept a plain serial (non-MPI) Julia command? The doc's
+  "non-OpenMPI unsupported" note must be cleared first — it could block the whole
+  approach or force an `mpirun -n 1` wrapper.
+- **O2**: is `ums-start` idempotent (safe to re-run on an already-active lease
+  after a coordinator restart)? Needed for crash recovery.
+- **O3**: UMS concurrency limit per lease (tasks per node / total)? Unspecified;
+  governs how many variants can be in-flight before queueing inside UMS.
+- **O4**: `--rank` for single-node `node_f=1` is always 0; for multi-node leases,
+  who assigns ranks? Defer multi-node lease to later.
+- **O5**: stdout/stderr land in `$HOME/.ums/log/<name>-<id>/` per the doc — does
+  `--stdout-log` fully redirect, or does the controller also keep its own? Affects
+  where `backend_failure_reason` reads.
+
+## References
+
+- Parent design: `docs/design/compute_gateway_design.md`
+- UGE backend (mirror + shared helpers): `src/workflow/autopilot/backends_uge.jl`
+- Backend contract: `src/workflow/autopilot/backends.jl:1-59`
+- Tick reap / divergence / dispatch: `src/workflow/autopilot/tick.jl:198-301,393`
+- Budget seam: `src/workflow/autopilot/budget.jl:114-185`
+- Divergence: `src/workflow/autopilot/monitor.jl`
+- TSUBAME UMS: https://www.t4.cii.isct.ac.jp/docs/experimental/ums/

--- a/docs/guides/tsubame.md
+++ b/docs/guides/tsubame.md
@@ -1,6 +1,6 @@
 # Running SpinorBEC on TSUBAME 4.0
 
-Day-to-day workflow + scaling knobs for TSUBAME 4.0 (or any SLURM + CUDA cluster).
+Day-to-day workflow + scaling knobs for TSUBAME 4.0 (Altair Grid Engine / UGE + CUDA).
 
 ## One-time setup
 
@@ -17,9 +17,9 @@ julia --project=. -e 'using Pkg; Pkg.instantiate()'
 `scripts/tsubame_setup.sh` exports `JULIA_DEPOT_PATH=$T4_TMPDIR/.julia`
 (node-local NVMe to avoid Lustre metadata storms),
 `SPINORBEC_SCRATCH_DIR=$T4_TMPDIR/spinorbec_snaps` (streamed snapshot
-scratch), `JULIA_NUM_THREADS=$SLURM_CPUS_PER_TASK`, and runs
-`module load cuda + julia`. Falls back gracefully on dev machines
-without `$T4_TMPDIR`.
+scratch), `JULIA_NUM_THREADS` sized from `$NSLOTS` (UGE slot count;
+falls back to 4), and runs `module load cuda + julia`. Falls back
+gracefully on dev machines without `$T4_TMPDIR`.
 
 ## Memory and disk budget
 
@@ -66,34 +66,37 @@ $EDITOR runs/eu151_edh_ext/config.yaml
 # Dry-run check (calibration applied? schema OK?)
 julia --project=. -e 'using SpinorBEC; run_yaml("runs/eu151_edh_ext/config.yaml"; dry_run=true)'
 
-# Suggested SLURM flags from grid + scan size
-julia --project=. -e 'using SpinorBEC; suggest_sbatch_flags(ARGS[1])' \
-    runs/eu151_edh_ext/config.yaml
-
-# Preview the rendered sbatch script (no submission):
+# Preview the rendered qsub script (no submission):
 julia --project=. -e 'using SpinorBEC;
-    print(render_sbatch_script("default", "runs/eu151_edh_ext/config.yaml"))'
+    print(render_uge_script("default", "runs/eu151_edh_ext/config.yaml";
+        project_root=pwd(), log_dir="logs/tsubame"))'
 
-# Submit through the autopilot (renders sbatch on the fly):
+# Submit through the autopilot (renders the qsub script on the fly):
 julia --project=. scripts/cli.jl autopilot enqueue runs/eu151_edh_ext/config.yaml
-julia --project=. scripts/cli.jl autopilot tick    # dispatches via SlurmBackend
+julia --project=. scripts/cli.jl autopilot tick    # dispatches via UGEBackend
 
-# Or submit a single config directly (auto-rendered into a tmpfile):
+# Or submit a single config directly:
 julia --project=. -e '
     using SpinorBEC
-    b = SlurmBackend()
+    b = UGEBackend(; ssh_host="tsubame", project_root="...", remote_runs_root="...")
     e = enqueue!(Experiment("runs/eu151_edh_ext/config.yaml"))
     dispatch!(b, e)
 '
 
-squeue -u $USER
+qstat -u $USER
 tail -f logs/spinorbec-*.out
 ```
 
-The SBATCH directives live in `PROFILE_DIRECTIVES` in
-`src/workflow/autopilot/backends.jl` — edit there to tune memory /
-walltime / GPU class. Profiles escalate on OOM/TIMEOUT via the
-`next_profile` chain (see `docs/guides/autopilot.md`).
+On TSUBAME the autopilot auto-registers a `UGEBackend` from the
+`SPINORBEC_TSUBAME_{HOST,PROJECT_ROOT,RUNS_ROOT,GROUP,JULIA,DEPOT,SYSIMAGE,CUDA_MODULE,SYNC_CODE}`
+env vars (the HOST/PROJECT_ROOT/RUNS_ROOT triple is required; the rest
+default). The qsub resource directives live in `UGE_PROFILE_DIRECTIVES`
+in `src/workflow/autopilot/backends_uge.jl` (`default` / `node_h` /
+`node_f` / `gpu_1` / `long_q`) — edit there to tune walltime / node
+class. Profiles escalate on OOM/TIMEOUT via the `next_profile` chain
+(see `docs/guides/autopilot.md`). Note: `-g <group>` is passed as a
+qsub CLI flag, not an `#$ -g` directive (the TSUBAME4 wrapper rejects
+the directive form).
 
 ### Array jobs (multi-point scans)
 
@@ -102,17 +105,18 @@ julia --project=. -e 'using SpinorBEC; println(scan_point_count(ARGS[1]))' \
     runs/foo/config.yaml   # → 144
 ```
 
-For an array submission, prepend `#SBATCH --array=1-N%K` to the
-rendered script — extend `PROFILE_DIRECTIVES` with a new `"scan_array"`
-profile carrying the array directive, or pipe `render_sbatch_script`
+For an array submission, add `#$ -t 1-N` + `#$ -tc K` to the rendered
+script — extend `UGE_PROFILE_DIRECTIVES` with a new `"scan_array"`
+profile carrying the array directive, or pipe `render_uge_script`
 output through `sed`. Each task writes `runs/foo/point_NNN.jld2`;
 resumable — re-submitting skips cached files (`SPINORBEC_SCAN_ONLY_INDEX`
 env var inside `_run_yaml_scan`).
 
-### TSUBAME 3 / SGE-style submission
+### Manual per-job qsub script
 
-For SGE-based clusters (`qsub` / `qstat` / `qdel`), use a per-job
-script of the shape:
+The autopilot's `UGEBackend` renders this shape automatically via
+`render_uge_script`. To submit by hand (`qsub` / `qstat` / `qdel`),
+use a per-job script of the form:
 
 ```bash
 #!/bin/bash
@@ -138,9 +142,10 @@ Add `#$ -t 1-N` + `#$ -tc K` for array jobs; `mapfile -t CONFIGS < <(ls -d runs/
 then `RUN_NAME="${CONFIGS[$((SGE_TASK_ID - 1))]}"` to pick the per-task
 config.
 
-A SLURM-native `SgeBackend` is not implemented — the autopilot ships
-with `SlurmBackend` only. SGE clusters operate the cli.jl entry
-manually for now.
+The autopilot ships two backends: `LocalBackend` (subprocess on the
+current host) and `UGEBackend` (TSUBAME / Altair Grid Engine over SSH).
+TSUBAME 4 dispatch goes through `UGEBackend`; the manual script above is
+only needed for ad-hoc one-offs outside the queue.
 
 ## Recommended YAML knobs at scale
 
@@ -183,7 +188,7 @@ Dashboard runs on the compute node; SSH-tunnel via the login node:
 # laptop
 ssh -L 8765:cnode-h100-12:8765 tsubame
 
-# compute node (via srun --pty bash)
+# compute node (interactive via qrsh)
 julia --project=. -e 'using SpinorBEC; serve_dashboard(8765)' &
 
 # laptop browser → http://localhost:8765
@@ -193,7 +198,7 @@ Lab-image push uses the same tunnel: `curl --data-binary @absorption_shot.png ht
 
 ## Checkpoint and resume
 
-`run_pipeline` writes periodic checkpoints to `$run_dir/.checkpoints/<filename>` during a dynamics step. Restart with the same `run_yaml(...)` call — the cache/resume logic picks up from the last checkpoint. Pair with SLURM `--requeue` for automatic restart after preemption.
+`run_pipeline` writes periodic checkpoints to `$run_dir/.checkpoints/<filename>` during a dynamics step. Restart with the same `run_yaml(...)` call — the cache/resume logic picks up from the last checkpoint. Pair with a rerunnable job (`#$ -r y`) for automatic restart after preemption.
 
 For multi-attempt mixes of crashes + preemption: enqueue via
 `julia --project=. scripts/cli.jl autopilot enqueue runs/foo/config.yaml`
@@ -267,7 +272,7 @@ julia --project=. -e '
 | First run very slow (~10 min before any output) | precompile on Lustre | confirm `$JULIA_DEPOT_PATH` points at NVMe (`echo $JULIA_DEPOT_PATH` after sourcing) |
 | `unable to load CUDA driver` | module not loaded | `source scripts/tsubame_setup.sh` first |
 | `ENOSPC` mid-run | streamed snapshots filled `$T4_TMPDIR` | bigger `nvme:NN` or coarser `save.psi` cadence |
-| Job killed at exact wall-clock limit | `--requeue` not set | re-submit; SLURM resumes from checkpoint |
-| Phase-diagram scan progresses one-at-a-time | not using array job | switch to `scan_array.sbatch` with `--array=1-N%K` |
+| Job killed at exact wall-clock limit | job not rerunnable | re-submit (or `#$ -r y`); resumes from checkpoint |
+| Phase-diagram scan progresses one-at-a-time | not using array job | switch to a `scan_array` profile with `#$ -t 1-N -tc K` |
 | GC pressure on big ψ across many scan points | implicit retention | `GC.gc()` between phases; `CUDA.memory_status()` to inspect |
 | FFTW wisdom replanning on each new node | wisdom not shared | bake wisdom into `runs/shared/fftw.wisdom` if hopping CPU generations |

--- a/scripts/tsubame/ums_probe.sh
+++ b/scripts/tsubame/ums_probe.sh
@@ -1,40 +1,88 @@
 #!/bin/bash
-# UMS feasibility probe — answers the open questions that gate the UMS
-# low-latency backend (docs/design/ums_lease_backend_design.md).
+# UMS feasibility + POLICY-CONSTANT probe.
 #
-# Run this ON the TSUBAME login node (not via the autopilot). It acquires
-# a short node_f lease, starts UMS, submits a few PLAIN SERIAL (non-MPI)
-# commands, lists them, checks where logs land, exercises ums-start
-# idempotency, then tears the lease down. Everything is captured so the
-# output can be pasted back for the design decision.
+# Run ON the TSUBAME login node (not via the autopilot). It does two jobs:
 #
-# COST: a node_f lease for the h_rt below. Keep h_rt small. Uses the
-# billing group, so it consumes points — set GROUP and keep it short.
+#   (1) clears the gating yes/no questions for the UMS backend
+#       (docs/design/ums_lease_backend_design.md):
+#         O1 does UMS accept a plain serial (non-MPI) command?
+#         O2 ums-start idempotency
+#         O3 per-lease concurrency
+#         O5 where do --stdout-log / controller logs land?
+#
+#   (2) measures the POLICY CONSTANTS that the lease model is currently
+#       guessing at — so 2b can be written without assumptions:
+#         C1 idle node_f burn rate  (points/hour)   ← MOST IMPORTANT:
+#            sets max-idle AND the Phase 2↔3 seam (per-user lease vs
+#            shared warm pool + fair-share). Cheap → per-user isolation;
+#            expensive → shared pool needed.
+#         C2 warm dispatch latency vs cold qsub      ← the justification
+#            for UMS at all. If ~equal, the premise collapses.
+#         C3 ums-list appear/disappear lag + missed polls ← the signal a
+#            Stop-hook / poll loop rides on; need real lag + reliability.
+#
+# COST: a node_f lease for H_RT + one cold-qsub comparison job of the same
+# resource. Keep H_RT small. Uses the billing group → consumes points.
 #
 # Usage:
 #   GROUP=tga-kozuma-kouhi bash scripts/tsubame/ums_probe.sh
-#   # optional: NODE_SPEC=node_o=1 H_RT=00:05:00 to spend fewer points if
-#   # UMS accepts a sub-full-node allocation (O-resource question).
+#   # NODE_SPEC=node_o=1 H_RT=00:10:00 to spend fewer points if UMS
+#   # accepts a sub-full-node allocation. For a faithful C1/C2 keep
+#   # NODE_SPEC=node_f=1 (the real lease resource).
 
 set -uo pipefail
 
 GROUP="${GROUP:?set GROUP=<billing group>, e.g. tga-kozuma-kouhi}"
 NODE_SPEC="${NODE_SPEC:-node_f=1}"
-H_RT="${H_RT:-00:10:00}"
+H_RT="${H_RT:-00:15:00}"
+IDLE_WINDOW_S="${IDLE_WINDOW_S:-300}"   # idle hold for the C1 burn-rate sample
 PROBE_TAG="umsprobe_$$"
 WORKDIR="${WORKDIR:-$HOME/ums_probe}"
 mkdir -p "$WORKDIR"
 LOG="$WORKDIR/probe.out"
 
+now_s() { date +%s.%N; }
+elapsed() { awk -v a="$1" -v b="$2" 'BEGIN{printf "%.2f", b-a}'; }
 say() { echo "== $*" | tee -a "$LOG"; }
 run() { echo "+ $*" | tee -a "$LOG"; eval "$@" 2>&1 | tee -a "$LOG"; }
+# Extract the first number from `t4-user-info group point` (best-effort).
+point_balance() {
+  ssh_local t4-user-info group point 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)?' | head -1
+}
+ssh_local() { "$@"; }   # probe runs ON the login node; keep a seam for ssh-from-PC variants
 
 : > "$LOG"
-say "UMS probe start  group=$GROUP node=$NODE_SPEC h_rt=$H_RT  $(date)"
-say "uname / which ums-*"
-run "command -v ums-start ums-submit ums-list || echo 'WARN: ums-* not on PATH (module load?)'"
+say "UMS probe  group=$GROUP node=$NODE_SPEC h_rt=$H_RT idle_window=${IDLE_WINDOW_S}s  $(date)"
+run "command -v ums-start ums-submit ums-list qsub qstat qdel t4-user-info || echo 'WARN: a tool is missing (module load?)'"
 
-# --- 1. acquire the lease (sleeper job) -------------------------------
+# ── C2a: cold qsub → running latency (same resource as the lease) ──────
+say "C2a: cold qsub → running latency (apples-to-apples with the lease resource)"
+COLDJOB="$WORKDIR/coldjob.sh"
+cat > "$COLDJOB" <<EOF
+#!/bin/sh
+#\$ -l $NODE_SPEC
+#\$ -l h_rt=00:02:00
+#\$ -N ${PROBE_TAG}_cold
+#\$ -o $WORKDIR/cold.stdout
+#\$ -e $WORKDIR/cold.stderr
+hostname; sleep 5
+EOF
+T_cold_submit="$(now_s)"
+COLD_OUT="$(qsub -g "$GROUP" "$COLDJOB" 2>&1)"; echo "$COLD_OUT" | tee -a "$LOG"
+COLD_ID="$(echo "$COLD_OUT" | grep -oE '[0-9]+' | head -1)"
+T_cold_run=""
+if [ -n "$COLD_ID" ]; then
+  for i in $(seq 1 150); do
+    st="$(qstat | awk -v j="$COLD_ID" '$1==j {print $5}')"
+    if [ "$st" = "r" ]; then T_cold_run="$(now_s)"; break; fi
+    sleep 2
+  done
+  qdel "$COLD_ID" >/dev/null 2>&1 || true
+fi
+COLD_LAT="$( [ -n "$T_cold_run" ] && elapsed "$T_cold_submit" "$T_cold_run" || echo "NA" )"
+say "C2a cold qsub→run latency = ${COLD_LAT}s (job $COLD_ID)"
+
+# ── acquire the lease (sleeper) + time the one-time acquire cost ───────
 SLEEPER="$WORKDIR/sleeper.sh"
 cat > "$SLEEPER" <<EOF
 #!/bin/sh
@@ -45,72 +93,128 @@ cat > "$SLEEPER" <<EOF
 #\$ -e $WORKDIR/sleeper.stderr
 sleep infinity
 EOF
-say "submit sleeper"
+say "acquire lease (sleeper)"
+T_lease_submit="$(now_s)"
 QSUB_OUT="$(qsub -g "$GROUP" "$SLEEPER" 2>&1)"; echo "$QSUB_OUT" | tee -a "$LOG"
 JOBID="$(echo "$QSUB_OUT" | grep -oE '[0-9]+' | head -1)"
-[ -z "$JOBID" ] && { say "FAIL: could not parse job id from qsub"; exit 1; }
+[ -z "$JOBID" ] && { say "FAIL: could not parse lease job id"; exit 1; }
 say "lease JOBID=$JOBID"
-
 cleanup() { say "cleanup: qdel $JOBID"; qdel "$JOBID" 2>&1 | tee -a "$LOG"; }
 trap cleanup EXIT
 
-# --- 2. wait for the parent job to reach running state (r) ------------
-say "waiting for job $JOBID to reach 'r' ..."
-for i in $(seq 1 120); do
-  STATE="$(qstat | awk -v j="$JOBID" '$1==j {print $5}')"
-  [ "$STATE" = "r" ] && break
-  sleep 5
+say "waiting for lease $JOBID → r ..."
+T_lease_run=""
+for i in $(seq 1 150); do
+  st="$(qstat | awk -v j="$JOBID" '$1==j {print $5}')"
+  if [ "$st" = "r" ]; then T_lease_run="$(now_s)"; break; fi
+  sleep 2
 done
-say "qstat state = ${STATE:-<gone>}"
-[ "${STATE:-}" != "r" ] && { say "FAIL: job never reached r within 10 min"; exit 1; }
+[ -z "$T_lease_run" ] && { say "FAIL: lease never reached r"; exit 1; }
 
-# --- 3. start UMS (and test ums-start idempotency, O2) ----------------
-say "ums-start (1st)"
-run "ums-start --job $JOBID"
-sleep 3
-say "ums-start (2nd — idempotency check O2: should not error / not duplicate)"
-run "ums-start --job $JOBID"
-sleep 3
+# ── O2: ums-start (idempotency: run twice) ────────────────────────────
+say "O2: ums-start (1st)"; run "ums-start --job $JOBID"; sleep 3
+T_lease_active="$(now_s)"
+say "O2: ums-start (2nd — should not error / not duplicate)"; run "ums-start --job $JOBID"; sleep 2
+LEASE_ACQUIRE_LAT="$(elapsed "$T_lease_submit" "$T_lease_active")"
+say "lease acquire (submit→active) = ${LEASE_ACQUIRE_LAT}s (one-time, amortized)"
 
-# --- 4. O1: submit PLAIN SERIAL non-MPI commands ---------------------
-say "O1: ums-submit a plain serial shell command (hostname)"
-run "ums-submit --group $GROUP --job $JOBID --name t_hostname \
-     --stdout-log $WORKDIR/t_hostname.out --stderr-log $WORKDIR/t_hostname.err \
-     hostname"
+# ── C1: idle node_f burn rate ─────────────────────────────────────────
+say "C1: idle burn-rate sample — holding lease idle ${IDLE_WINDOW_S}s"
+PB0="$(point_balance)"; T_pb0="$(now_s)"
+say "C1 point balance @start = ${PB0:-<unparsed>}"
+sleep "$IDLE_WINDOW_S"
+PB1="$(point_balance)"; T_pb1="$(now_s)"
+say "C1 point balance @end   = ${PB1:-<unparsed>}"
+IDLE_RATE="NA"
+if [ -n "${PB0:-}" ] && [ -n "${PB1:-}" ]; then
+  IDLE_RATE="$(awk -v a="$PB0" -v b="$PB1" -v t0="$T_pb0" -v t1="$T_pb1" \
+    'BEGIN{dh=(t1-t0)/3600.0; if(dh>0) printf "%.3f", (a-b)/dh; else print "NA"}')"
+fi
+say "C1 idle points/hour ≈ ${IDLE_RATE}  (NOTE: TSUBAME may bill reserved walltime at submit/exit, not continuously — reconcile against the ${H_RT} reservation)"
 
-say "O1: ums-submit a plain serial Julia command (no MPI)"
+# ── O1 + C2b: serial dispatch + warm latency (3 samples) ──────────────
+say "O1: serial non-MPI dispatch + C2b warm dispatch latency (3 samples)"
+WARM_SAMPLES=""
+for k in 1 2 3; do
+  nm="t_warm_$k"
+  t_sub="$(now_s)"
+  ums-submit --group "$GROUP" --job "$JOBID" --name "$nm" \
+    --stdout-log "$WORKDIR/$nm.out" --stderr-log "$WORKDIR/$nm.err" \
+    hostname >/dev/null 2>&1
+  t_seen=""
+  for j in $(seq 1 120); do   # poll every 0.5s up to 60s
+    if ums-list --job "$JOBID" 2>/dev/null | grep -q "\"$nm\""; then t_seen="$(now_s)"; break; fi
+    sleep 0.5
+  done
+  lat="$( [ -n "$t_seen" ] && elapsed "$t_sub" "$t_seen" || echo "NA" )"
+  say "C2b warm sample $k = ${lat}s"
+  WARM_SAMPLES="$WARM_SAMPLES $lat"
+done
+WARM_MED="$(echo $WARM_SAMPLES | tr ' ' '\n' | grep -v NA | sort -n | awk '{a[NR]=$1} END{if(NR>0) print a[int((NR+1)/2)]; else print "NA"}')"
+
+say "O1: serial Julia (non-MPI) task"
 run "ums-submit --group $GROUP --job $JOBID --name t_julia \
      --stdout-log $WORKDIR/t_julia.out --stderr-log $WORKDIR/t_julia.err \
      bash -lc 'julia -e \"println(\\\"hello-from-ums-serial-julia\\\")\"'"
 
-say "O3: submit a few concurrent sleepers to probe per-lease concurrency"
+# ── O3: concurrency ───────────────────────────────────────────────────
+say "O3: per-lease concurrency — 4 concurrent sleepers"
 for k in 1 2 3 4; do
-  run "ums-submit --group $GROUP --job $JOBID --name t_sleep_$k \
-       --stdout-log $WORKDIR/t_sleep_$k.out --stderr-log $WORKDIR/t_sleep_$k.err \
-       sleep 30"
+  ums-submit --group "$GROUP" --job "$JOBID" --name "t_cc_$k" \
+    --stdout-log "$WORKDIR/t_cc_$k.out" --stderr-log "$WORKDIR/t_cc_$k.err" \
+    sleep 25 >/dev/null 2>&1
 done
+sleep 4
+CC_SEEN="$(ums-list --job "$JOBID" 2>/dev/null | grep -oE '"t_cc_[0-9]+"' | sort -u | wc -l)"
+say "O3 concurrent t_cc_* visible in ums-list = $CC_SEEN / 4"
 
-# --- 5. list (snapshot format the backend will parse) ----------------
-sleep 5
-say "ums-list (JSON {name: host} of RUNNING tasks only)"
-run "ums-list --job $JOBID"
+# ── C3: ums-list appear/disappear lag + reliability ───────────────────
+say "C3: ums-list lag/reliability — one sleep-20 task, poll 1s for 30s"
+t_c3_sub="$(now_s)"
+ums-submit --group "$GROUP" --job "$JOBID" --name t_lag \
+  --stdout-log "$WORKDIR/t_lag.out" --stderr-log "$WORKDIR/t_lag.err" \
+  sleep 20 >/dev/null 2>&1
+appear=""; disappear=""; missed=0; was_seen=0
+for j in $(seq 1 30); do
+  if ums-list --job "$JOBID" 2>/dev/null | grep -q '"t_lag"'; then
+    [ -z "$appear" ] && appear="$(now_s)"
+    was_seen=1
+  else
+    [ "$was_seen" = "1" ] && [ -z "$disappear" ] && disappear="$(now_s)"
+    # a gap AFTER first-seen and BEFORE disappear = a missed poll
+    [ -n "$appear" ] && [ -z "$disappear" ] && missed=$((missed+1))
+  fi
+  sleep 1
+done
+C3_APPEAR="$( [ -n "$appear" ] && elapsed "$t_c3_sub" "$appear" || echo "NA" )"
+C3_DISAPPEAR="$( [ -n "$disappear" ] && elapsed "$t_c3_sub" "$disappear" || echo "NA" )"
+say "C3 appear lag=${C3_APPEAR}s  disappear@=${C3_DISAPPEAR}s (task ran ~20s)  missed_polls_mid_run=$missed"
 
-# --- 6. where did logs land? (O5) ------------------------------------
-sleep 8
-say "O5: --stdout-log target contents (t_hostname.out, t_julia.out)"
-run "cat $WORKDIR/t_hostname.out 2>/dev/null || echo '(empty/missing)'"
-run "cat $WORKDIR/t_julia.out    2>/dev/null || echo '(empty/missing)'"
-say "O5: controller-side log dir per the docs (\$HOME/.ums/log/<name>-<id>/)"
+# ── O5: log locations ─────────────────────────────────────────────────
+sleep 6
+say "O5: --stdout-log contents"
+run "cat $WORKDIR/t_warm_1.out 2>/dev/null || echo '(empty/missing)'"
+run "cat $WORKDIR/t_julia.out  2>/dev/null || echo '(empty/missing)'"
+say "O5: controller log dir (docs say \$HOME/.ums/log/<name>-<id>/)"
 run "ls -la \$HOME/.ums/log/${PROBE_TAG}-${JOBID}/ 2>/dev/null || ls -la \$HOME/.ums/log/ 2>/dev/null || echo '(no ~/.ums/log)'"
 
-say "wait for sleepers to drain, re-list (should shrink as tasks finish)"
-sleep 30
-run "ums-list --job $JOBID"
-
-say "PROBE DONE — full transcript at $LOG"
-say "Decision inputs:"
-say "  O1 serial accepted?  -> did t_hostname.out / t_julia.out contain output, or did ums-submit reject non-MPI?"
-say "  O2 ums-start 2x       -> did the 2nd call error?"
-say "  O3 concurrency        -> how many of t_sleep_* appeared in ums-list at once?"
-say "  O5 logs               -> --stdout-log honored, and/or ~/.ums/log used?"
+# ── emit policy constants ─────────────────────────────────────────────
+SPEEDUP="NA"
+if [ "$COLD_LAT" != "NA" ] && [ "$WARM_MED" != "NA" ]; then
+  SPEEDUP="$(awk -v c="$COLD_LAT" -v w="$WARM_MED" 'BEGIN{if(w>0) printf "%.1f", c/w; else print "NA"}')"
+fi
+say ""
+say "================= POLICY CONSTANTS (feed into ums_lease_backend_design.md) ================="
+say "  C1 idle_points_per_hour        = ${IDLE_RATE}     # sets max_idle_minutes + per-user-vs-shared seam"
+say "  C2a cold_qsub_to_run_s         = ${COLD_LAT}"
+say "  C2b warm_dispatch_s (median)   = ${WARM_MED}"
+say "  C2  warm_speedup_x             = ${SPEEDUP}       # justification for UMS; want >> 1"
+say "  C3 umslist_appear_lag_s        = ${C3_APPEAR}     # grace guard floor"
+say "  C3 umslist_disappear_lag_s     = ${C3_DISAPPEAR}"
+say "  C3 umslist_missed_polls_midrun = ${missed}        # 0 = reliable; >0 = need debounce"
+say "  lease_acquire_s (one-time)     = ${LEASE_ACQUIRE_LAT}"
+say "  O3 concurrency_seen            = ${CC_SEEN}/4"
+say "==========================================================================================="
+say "Decision: cheap C1 → per-user lease (simple isolation); expensive C1 → shared warm pool + fair-share."
+say "Full transcript: $LOG"
 # trap fires qdel on exit

--- a/scripts/tsubame/ums_probe.sh
+++ b/scripts/tsubame/ums_probe.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# UMS feasibility probe — answers the open questions that gate the UMS
+# low-latency backend (docs/design/ums_lease_backend_design.md).
+#
+# Run this ON the TSUBAME login node (not via the autopilot). It acquires
+# a short node_f lease, starts UMS, submits a few PLAIN SERIAL (non-MPI)
+# commands, lists them, checks where logs land, exercises ums-start
+# idempotency, then tears the lease down. Everything is captured so the
+# output can be pasted back for the design decision.
+#
+# COST: a node_f lease for the h_rt below. Keep h_rt small. Uses the
+# billing group, so it consumes points — set GROUP and keep it short.
+#
+# Usage:
+#   GROUP=tga-kozuma-kouhi bash scripts/tsubame/ums_probe.sh
+#   # optional: NODE_SPEC=node_o=1 H_RT=00:05:00 to spend fewer points if
+#   # UMS accepts a sub-full-node allocation (O-resource question).
+
+set -uo pipefail
+
+GROUP="${GROUP:?set GROUP=<billing group>, e.g. tga-kozuma-kouhi}"
+NODE_SPEC="${NODE_SPEC:-node_f=1}"
+H_RT="${H_RT:-00:10:00}"
+PROBE_TAG="umsprobe_$$"
+WORKDIR="${WORKDIR:-$HOME/ums_probe}"
+mkdir -p "$WORKDIR"
+LOG="$WORKDIR/probe.out"
+
+say() { echo "== $*" | tee -a "$LOG"; }
+run() { echo "+ $*" | tee -a "$LOG"; eval "$@" 2>&1 | tee -a "$LOG"; }
+
+: > "$LOG"
+say "UMS probe start  group=$GROUP node=$NODE_SPEC h_rt=$H_RT  $(date)"
+say "uname / which ums-*"
+run "command -v ums-start ums-submit ums-list || echo 'WARN: ums-* not on PATH (module load?)'"
+
+# --- 1. acquire the lease (sleeper job) -------------------------------
+SLEEPER="$WORKDIR/sleeper.sh"
+cat > "$SLEEPER" <<EOF
+#!/bin/sh
+#\$ -l $NODE_SPEC
+#\$ -l h_rt=$H_RT
+#\$ -N ${PROBE_TAG}
+#\$ -o $WORKDIR/sleeper.stdout
+#\$ -e $WORKDIR/sleeper.stderr
+sleep infinity
+EOF
+say "submit sleeper"
+QSUB_OUT="$(qsub -g "$GROUP" "$SLEEPER" 2>&1)"; echo "$QSUB_OUT" | tee -a "$LOG"
+JOBID="$(echo "$QSUB_OUT" | grep -oE '[0-9]+' | head -1)"
+[ -z "$JOBID" ] && { say "FAIL: could not parse job id from qsub"; exit 1; }
+say "lease JOBID=$JOBID"
+
+cleanup() { say "cleanup: qdel $JOBID"; qdel "$JOBID" 2>&1 | tee -a "$LOG"; }
+trap cleanup EXIT
+
+# --- 2. wait for the parent job to reach running state (r) ------------
+say "waiting for job $JOBID to reach 'r' ..."
+for i in $(seq 1 120); do
+  STATE="$(qstat | awk -v j="$JOBID" '$1==j {print $5}')"
+  [ "$STATE" = "r" ] && break
+  sleep 5
+done
+say "qstat state = ${STATE:-<gone>}"
+[ "${STATE:-}" != "r" ] && { say "FAIL: job never reached r within 10 min"; exit 1; }
+
+# --- 3. start UMS (and test ums-start idempotency, O2) ----------------
+say "ums-start (1st)"
+run "ums-start --job $JOBID"
+sleep 3
+say "ums-start (2nd — idempotency check O2: should not error / not duplicate)"
+run "ums-start --job $JOBID"
+sleep 3
+
+# --- 4. O1: submit PLAIN SERIAL non-MPI commands ---------------------
+say "O1: ums-submit a plain serial shell command (hostname)"
+run "ums-submit --group $GROUP --job $JOBID --name t_hostname \
+     --stdout-log $WORKDIR/t_hostname.out --stderr-log $WORKDIR/t_hostname.err \
+     hostname"
+
+say "O1: ums-submit a plain serial Julia command (no MPI)"
+run "ums-submit --group $GROUP --job $JOBID --name t_julia \
+     --stdout-log $WORKDIR/t_julia.out --stderr-log $WORKDIR/t_julia.err \
+     bash -lc 'julia -e \"println(\\\"hello-from-ums-serial-julia\\\")\"'"
+
+say "O3: submit a few concurrent sleepers to probe per-lease concurrency"
+for k in 1 2 3 4; do
+  run "ums-submit --group $GROUP --job $JOBID --name t_sleep_$k \
+       --stdout-log $WORKDIR/t_sleep_$k.out --stderr-log $WORKDIR/t_sleep_$k.err \
+       sleep 30"
+done
+
+# --- 5. list (snapshot format the backend will parse) ----------------
+sleep 5
+say "ums-list (JSON {name: host} of RUNNING tasks only)"
+run "ums-list --job $JOBID"
+
+# --- 6. where did logs land? (O5) ------------------------------------
+sleep 8
+say "O5: --stdout-log target contents (t_hostname.out, t_julia.out)"
+run "cat $WORKDIR/t_hostname.out 2>/dev/null || echo '(empty/missing)'"
+run "cat $WORKDIR/t_julia.out    2>/dev/null || echo '(empty/missing)'"
+say "O5: controller-side log dir per the docs (\$HOME/.ums/log/<name>-<id>/)"
+run "ls -la \$HOME/.ums/log/${PROBE_TAG}-${JOBID}/ 2>/dev/null || ls -la \$HOME/.ums/log/ 2>/dev/null || echo '(no ~/.ums/log)'"
+
+say "wait for sleepers to drain, re-list (should shrink as tasks finish)"
+sleep 30
+run "ums-list --job $JOBID"
+
+say "PROBE DONE — full transcript at $LOG"
+say "Decision inputs:"
+say "  O1 serial accepted?  -> did t_hostname.out / t_julia.out contain output, or did ums-submit reject non-MPI?"
+say "  O2 ums-start 2x       -> did the 2nd call error?"
+say "  O3 concurrency        -> how many of t_sleep_* appeared in ums-list at once?"
+say "  O5 logs               -> --stdout-log honored, and/or ~/.ums/log used?"
+# trap fires qdel on exit

--- a/src/workflow/autopilot.jl
+++ b/src/workflow/autopilot.jl
@@ -8,6 +8,7 @@
 # Composition is strictly bottom-up:
 #   queue.jl       — types + serialization + enqueue/dequeue
 #   backends.jl    — Local subprocess dispatch
+#   ssh_transport.jl — shared ssh/rsync transport (UGE + UMS)
 #   backends_uge.jl — UGE (TSUBAME) dispatch
 #   monitor.jl     — _live_status.json divergence detector
 #   on_complete.jl — callback registry + lineage
@@ -21,6 +22,7 @@ using Printf
 include("autopilot/types.jl")       # AutopilotConfig, AutopilotStats, AutopilotBackend
 include("autopilot/queue.jl")
 include("autopilot/backends.jl")
+include("autopilot/ssh_transport.jl") # shared ssh/rsync transport (UGE + UMS)
 include("autopilot/backends_uge.jl")
 include("autopilot/monitor.jl")
 include("autopilot/on_complete.jl")

--- a/src/workflow/autopilot/backends_uge.jl
+++ b/src/workflow/autopilot/backends_uge.jl
@@ -219,139 +219,52 @@ end
 
 # ── command builders (separate so tests can assert shape) ────────────
 #
-# SSH ControlMaster pools all the tick's ssh/rsync calls into a single
-# persistent connection — without it, each `ssh tsubame qstat …` opens
-# a fresh TCP+SSH handshake (~hundreds of ms each), and a tick reaping
-# N running entries pays that cost N+1 times. With ControlPersist=60s
-# the socket survives across the tick body AND across the next tick
-# (5-min systemd timer beats 60s persist, but tick-on-enqueue and
-# closely-spaced ticks benefit).
-#
-# `ControlPath=/tmp/ssh-spinorbec-%C` — %C is a hash of host:port:user
-# so different SSH targets get different sockets; safe to share across
-# spinor-autopilot.service / spinor-dashboard.service since both run
-# as the same user.
-
-const _SSH_CM_OPTS = [
-    "-o", "ControlMaster=auto",
-    "-o", "ControlPath=/tmp/ssh-spinorbec-%C",
-    "-o", "ControlPersist=60s",
-]
-
-# Pre-quoted string for rsync's -e (which takes a single shell-tokenised
-# argument). Must match _SSH_CM_OPTS exactly.
-const _RSYNC_SSH_CM = "ssh -o ControlMaster=auto -o ControlPath=/tmp/ssh-spinorbec-%C -o ControlPersist=60s"
-
-_ssh_cm(host::AbstractString) = `ssh $_SSH_CM_OPTS $host`
+# The SSH ControlMaster + rsync transport is shared with UMSBackend and
+# lives in ssh_transport.jl (`_ssh_cm`, `_rsync_*`, Manifest-hash
+# helpers). The `_uge_*` wrappers below adapt a UGEBackend to those
+# primitives so the call sites (stage_in / pull_live / collect! /
+# dispatch!) and the command-shape tests are unchanged.
 
 _uge_mkdir_cmd(b::UGEBackend, remote_dir::AbstractString) =
-    `$(_ssh_cm(b.ssh_host)) mkdir -p $(remote_dir)`
+    _ssh_mkdir_cmd(b.ssh_host, remote_dir)
 
 _uge_rsync_config_cmd(b::UGEBackend, entry::QueueEntry,
     remote_dir::AbstractString) =
-    `rsync -e $_RSYNC_SSH_CM $(entry.spec_path) $(b.ssh_host):$(remote_dir)/`
+    _rsync_push_cmd(b.ssh_host, entry.spec_path, remote_dir)
 
 _uge_pull_live_cmd(b::UGEBackend, entry::QueueEntry,
     remote_dir::AbstractString) =
-    `rsync -e $_RSYNC_SSH_CM --ignore-missing-args $(b.ssh_host):$(remote_dir)/_live_status.json $(entry.run_dir)/_live_status.json`
+    _rsync_pull_missing_cmd(b.ssh_host, "$(remote_dir)/_live_status.json",
+        "$(entry.run_dir)/_live_status.json")
 
 _uge_collect_cmd(b::UGEBackend, entry::QueueEntry,
     remote_dir::AbstractString) =
-    `rsync -av -e $_RSYNC_SSH_CM --exclude=state.toml --exclude=.state.lock $(b.ssh_host):$(remote_dir)/ $(entry.run_dir)/`
+    _rsync_collect_cmd(b.ssh_host, remote_dir, entry.run_dir)
 
 _uge_rsync_script_cmd(b::UGEBackend, local_script::AbstractString,
     remote_script::AbstractString) =
-    `rsync -e $_RSYNC_SSH_CM $(local_script) $(b.ssh_host):$(remote_script)`
+    _rsync_file_cmd(b.ssh_host, local_script, remote_script)
 
-# Sync the LOCAL project working tree to remote project_root via rsync.
-# Earlier impl used `git fetch && git checkout <code_sha>` which only
-# worked when entry.code_sha had been pushed to a GitHub remote that
-# the cluster could reach. rsync avoids that — TSUBAME doesn't need
-# GitHub round-trip, the dispatcher's exact files (including
-# uncommitted edits) become the remote state.
-#
-# Trade-off: `entry.code_sha` in state.toml is informational (which
-# commit was HEAD at enqueue) but not what gets executed — last-write-
-# wins on the remote project_root. For single-user iterative work
-# this is what the operator wants; for strict per-SHA reproducibility,
-# push first and wrap the dispatch in a git-checkout step.
-#
-# Excludes match the bootstrap rsync (runs/ lives in remote_runs_root,
-# .git/ is heavy and unused on remote, jld2/dist/cache are build
-# artefacts). `--update` is a guardrail: never clobber files that are
-# newer on remote (protects in-flight edits made directly on TSUBAME).
-function _uge_code_sync_cmd(b::UGEBackend)
-    local_root = _uge_local_project_root()
-    # `--exclude=*.jld2` must be a single quoted token in Julia
-    # backticks (raw `*` is unquoted-special). Interpolate via a String
-    # so the glob reaches rsync verbatim.
-    jld_excl = "--exclude=*.jld2"
-    `rsync -az --update -e $_RSYNC_SSH_CM --exclude=runs/ --exclude=.git/ --exclude=node_modules/ --exclude=dashboard/dist/ --exclude=dashboard/.vite/ --exclude=.venv/ $jld_excl $(local_root)/ $(b.ssh_host):$(b.project_root)/`
-end
+_uge_code_sync_cmd(b::UGEBackend) =
+    _rsync_code_sync_cmd(b.ssh_host, _ssh_local_project_root(), b.project_root)
 
-# Resolve the LOCAL Julia project directory (where Project.toml sits).
-# `Base.active_project()` returns the path to the Project.toml file;
-# dirname() gives the project dir. Robust against cwd shenanigans.
-_uge_local_project_root() = dirname(Base.active_project())
-
-# Manifest-hash helpers for auto-instantiate. The remote stores a
-# `.manifest_hash` file under project_root containing the sha256 of
-# the Manifest.toml that was last `Pkg.instantiate`d there. After
-# rsync, we compare local hash → remote hash; differ → run instantiate
-# + write new hash. Same → skip (instantiate is 10-60s, not free).
-_uge_local_manifest_path() =
-    joinpath(_uge_local_project_root(), "Manifest.toml")
-
-_uge_local_manifest_hash() =
-    if isfile(_uge_local_manifest_path())
-        bytes2hex(SHA.sha256(read(_uge_local_manifest_path())))
-    else
-        ""
-    end
-
-_uge_remote_manifest_hash_path(b::UGEBackend) =
-    joinpath(b.project_root, ".manifest_hash")
-
-function _uge_remote_manifest_hash(b::UGEBackend)
-    b.ssh_host === nothing && return ""
-    try
-        strip(read(`$(_ssh_cm(b.ssh_host)) cat $(_uge_remote_manifest_hash_path(b))`,
-            String))
-    catch
-        ""   # file absent / first run / ssh blip — treat as "differs"
-    end
-end
+# Tested directly (test_autopilot.jl) — keep as a thin alias over the
+# shared helper.
+_uge_local_manifest_hash() = _ssh_local_manifest_hash()
 
 """
     _uge_instantiate_if_needed(b::UGEBackend) -> Bool
 
-After `_uge_code_sync_cmd` rsyncs the local tree, check whether the
-remote needs `Pkg.instantiate` re-run. Returns true iff instantiate
-was actually invoked. No-op when ssh_host is unset, when there's no
-local Manifest.toml, or when local hash matches remote.
+After `_uge_code_sync_cmd` rsyncs the local tree, run `Pkg.instantiate`
+on the remote iff the local Manifest.toml hash differs from the remote's.
+No-op when ssh_host is unset. Delegates to `_ssh_instantiate_if_needed`.
 """
-function _uge_instantiate_if_needed(b::UGEBackend)
-    b.ssh_host === nothing && return false
-    local_hash = _uge_local_manifest_hash()
-    isempty(local_hash) && return false
-    remote_hash = _uge_remote_manifest_hash(b)
-    local_hash == remote_hash && return false
-    @info "autopilot: Manifest.toml changed; running Pkg.instantiate on remote" host=b.ssh_host local_sha=local_hash[1:8] remote_sha=(
-        isempty(remote_hash) ? "none" : remote_hash[1:8]
-    )
-    # Single ssh round-trip: instantiate + write hash. depot_export is
-    # important — without it the compute node's $JULIA_DEPOT_PATH might
-    # differ from the login node's, instantiating into the wrong depot.
-    depot_export = isempty(b.julia_depot) ? "" :
-                   "export JULIA_DEPOT_PATH=\"$(b.julia_depot)\"; "
-    snippet =
-        depot_export *
-        "cd $(b.project_root) && " *
-        "$(b.julia_path) --project=. -e 'using Pkg; Pkg.instantiate()' && " *
-        "printf %s $(local_hash) > $(_uge_remote_manifest_hash_path(b))"
-    run(`$(_ssh_cm(b.ssh_host)) bash -lc $snippet`)
-    return true
-end
+_uge_instantiate_if_needed(b::UGEBackend) =
+    if b.ssh_host === nothing
+        false
+    else
+        _ssh_instantiate_if_needed(b.ssh_host, b.project_root, b.julia_path, b.julia_depot)
+    end
 
 function _uge_qsub_cmd(b::UGEBackend, remote_script::AbstractString)
     # On TSUBAME 4 `-g <group>` MUST be on the qsub command line (not as

--- a/src/workflow/autopilot/ssh_transport.jl
+++ b/src/workflow/autopilot/ssh_transport.jl
@@ -1,0 +1,136 @@
+# ── Shared SSH / rsync transport (UGE + UMS backends) ─────────────────
+#
+# Scheduler-agnostic data movement: ControlMaster-pooled ssh, rsync
+# push/pull/collect, code sync, and Manifest-hash auto-instantiate. The
+# scheduler-specific verbs (qsub/qstat/qdel/qacct for UGE,
+# ums-start/ums-submit/ums-list for UMS) live in the backend files; this
+# is the transport both share. Extracted from backends_uge.jl so UMS
+# reuses the audited rsync machinery instead of copy-pasting it (the
+# duplicated-physics-drift class this repo forbids).
+#
+# All functions take primitives (host string, paths) rather than a
+# backend struct, so any backend with an ssh_host + project_root can
+# call them without a common supertype carrying those fields.
+
+# SSH ControlMaster pools all of a tick's ssh/rsync calls into one
+# persistent connection. Without it, each `ssh tsubame qstat …` opens a
+# fresh TCP+SSH handshake (~hundreds of ms), and a tick reaping N running
+# entries pays that N+1 times. ControlPersist=60s keeps the socket across
+# the tick body and into the next closely-spaced tick.
+#
+# ControlPath=/tmp/ssh-spinorbec-%C — %C is a hash of host:port:user, so
+# different SSH targets get different sockets; safe to share across
+# spinor-autopilot.service / spinor-dashboard.service (same user).
+const _SSH_CM_OPTS = [
+    "-o", "ControlMaster=auto",
+    "-o", "ControlPath=/tmp/ssh-spinorbec-%C",
+    "-o", "ControlPersist=60s",
+]
+
+# Pre-quoted string for rsync's -e (which takes a single shell-tokenised
+# argument). Must match _SSH_CM_OPTS exactly.
+const _RSYNC_SSH_CM = "ssh -o ControlMaster=auto -o ControlPath=/tmp/ssh-spinorbec-%C -o ControlPersist=60s"
+
+_ssh_cm(host::AbstractString) = `ssh $_SSH_CM_OPTS $host`
+
+# ── rsync / ssh command builders (separate so tests can assert shape) ──
+
+_ssh_mkdir_cmd(host::AbstractString, remote_dir::AbstractString) =
+    `$(_ssh_cm(host)) mkdir -p $(remote_dir)`
+
+# Push a single file into a remote directory (trailing slash on dest).
+_rsync_push_cmd(host::AbstractString, src::AbstractString,
+    remote_dir::AbstractString) =
+    `rsync -e $_RSYNC_SSH_CM $(src) $(host):$(remote_dir)/`
+
+# Pull one remote file to a local path; tolerate it being absent.
+_rsync_pull_missing_cmd(host::AbstractString, remote_path::AbstractString,
+    local_path::AbstractString) =
+    `rsync -e $_RSYNC_SSH_CM --ignore-missing-args $(host):$(remote_path) $(local_path)`
+
+# Mirror a remote run dir back, minus the autopilot's own state files.
+_rsync_collect_cmd(host::AbstractString, remote_dir::AbstractString,
+    local_dir::AbstractString) =
+    `rsync -av -e $_RSYNC_SSH_CM --exclude=state.toml --exclude=.state.lock $(host):$(remote_dir)/ $(local_dir)/`
+
+# Push a file to an explicit remote path (no trailing-slash dir semantics).
+_rsync_file_cmd(host::AbstractString, src::AbstractString,
+    remote_path::AbstractString) =
+    `rsync -e $_RSYNC_SSH_CM $(src) $(host):$(remote_path)`
+
+# Sync the LOCAL project working tree to the remote project_root. rsync
+# (not git checkout) so the dispatcher's exact files — including
+# uncommitted edits — become the remote state without a GitHub round-trip.
+# `--update` never clobbers files newer on remote (protects in-flight
+# edits made directly on the cluster).
+function _rsync_code_sync_cmd(host::AbstractString, local_root::AbstractString,
+    project_root::AbstractString)
+    # `--exclude=*.jld2` must be a single quoted token in Julia backticks
+    # (raw `*` is unquoted-special). Interpolate via a String so the glob
+    # reaches rsync verbatim.
+    jld_excl = "--exclude=*.jld2"
+    `rsync -az --update -e $_RSYNC_SSH_CM --exclude=runs/ --exclude=.git/ --exclude=node_modules/ --exclude=dashboard/dist/ --exclude=dashboard/.vite/ --exclude=.venv/ $jld_excl $(local_root)/ $(host):$(project_root)/`
+end
+
+# ── local project + Manifest-hash helpers (auto-instantiate) ──────────
+
+# Resolve the LOCAL Julia project directory (where Project.toml sits).
+# `Base.active_project()` returns the Project.toml path; dirname() gives
+# the project dir. Robust against cwd shenanigans.
+_ssh_local_project_root() = dirname(Base.active_project())
+
+_ssh_local_manifest_path() = joinpath(_ssh_local_project_root(), "Manifest.toml")
+
+_ssh_local_manifest_hash() =
+    if isfile(_ssh_local_manifest_path())
+        bytes2hex(SHA.sha256(read(_ssh_local_manifest_path())))
+    else
+        ""
+    end
+
+# The remote stores a `.manifest_hash` file under project_root holding the
+# sha256 of the Manifest.toml last `Pkg.instantiate`d there. After code
+# sync we compare local → remote; differ → instantiate + write the new
+# hash; same → skip (instantiate is 10-60s, not free).
+_ssh_remote_manifest_hash_path(project_root::AbstractString) =
+    joinpath(project_root, ".manifest_hash")
+
+function _ssh_remote_manifest_hash(host::AbstractString, project_root::AbstractString)
+    try
+        strip(read(`$(_ssh_cm(host)) cat $(_ssh_remote_manifest_hash_path(project_root))`,
+            String))
+    catch
+        ""   # file absent / first run / ssh blip — treat as "differs"
+    end
+end
+
+"""
+    _ssh_instantiate_if_needed(host, project_root, julia_path, julia_depot) -> Bool
+
+After a code sync, run `Pkg.instantiate` on the remote iff the local
+Manifest.toml hash differs from the remote's recorded hash. Returns true
+iff instantiate was actually invoked. No-op when there's no local
+Manifest.toml or when the hashes match.
+"""
+function _ssh_instantiate_if_needed(host::AbstractString, project_root::AbstractString,
+    julia_path::AbstractString, julia_depot::AbstractString)
+    local_hash = _ssh_local_manifest_hash()
+    isempty(local_hash) && return false
+    remote_hash = _ssh_remote_manifest_hash(host, project_root)
+    local_hash == remote_hash && return false
+    @info "autopilot: Manifest.toml changed; running Pkg.instantiate on remote" host=host local_sha=local_hash[1:8] remote_sha=(
+        isempty(remote_hash) ? "none" : remote_hash[1:8]
+    )
+    # Single ssh round-trip: instantiate + write hash. depot_export is
+    # important — without it the compute node's $JULIA_DEPOT_PATH might
+    # differ from the login node's, instantiating into the wrong depot.
+    depot_export = isempty(julia_depot) ? "" :
+                   "export JULIA_DEPOT_PATH=\"$(julia_depot)\"; "
+    snippet =
+        depot_export *
+        "cd $(project_root) && " *
+        "$(julia_path) --project=. -e 'using Pkg; Pkg.instantiate()' && " *
+        "printf %s $(local_hash) > $(_ssh_remote_manifest_hash_path(project_root))"
+    run(`$(_ssh_cm(host)) bash -lc $snippet`)
+    return true
+end


### PR DESCRIPTION
## What

Designs and first implementation step for the multi-target AI research compute
gateway (Claude Code → TSUBAME 4.0 UGE + suzume), reconciled against the actual
codebase rather than assumptions.

### Docs (design)
- **`compute_gateway_feasibility_review.md`** — audits the original plan against
  the tree. Finding: the control plane is already live (autopilot = Gateway state
  engine, `UGEBackend` = GridEngine executor, `AutopilotBackend` = the executor
  trait, an MCP server already exists). Corrects mis-named reuse targets
  (no `Observable{T}`/`Sweep` types, no `SlurmBackend`, no SSE).
- **`compute_gateway_design.md`** — canonical, corrected plan. Build/reuse labels
  inverted; two decisions baked in (extend the MCP not replace; lease the UMS
  allocation not hold it); `SlurmExecutor` dropped; effort re-scoped to UMS + multi-user.
- **`ums_lease_backend_design.md`** — Phase 2 low-latency path. Fits the
  `AutopilotBackend` contract (`:ums`); resolves the three real UMS API gaps
  (list-shows-only-running, no per-task cancel, lease-not-an-entry budget).
- **`multi_user_gateway_design.md`** — Phase 3. Attribution + quota + authz over
  the **shared** CAS (not storage isolation, which would forfeit dedup).

### Implementation
- **`refactor(autopilot)`** — extract scheduler-agnostic ssh/rsync transport to
  `autopilot/ssh_transport.jl`; `UGEBackend` `_uge_*` builders delegate. UMS will
  reuse it (no copy-paste). **Command shapes byte-identical; 217/217 autopilot
  tests green.** (Phase 2a step 1.)

### Tooling + fixes
- **`scripts/tsubame/ums_probe.sh`** — feasibility probe to run on TSUBAME and
  clear the gating open questions (O1: does UMS accept a serial non-MPI command?).
- **`docs/guides/tsubame.md`** — fix stale SLURM references (the doc described a
  nonexistent `SlurmBackend`/`SgeBackend`/`render_sbatch_script` world; TSUBAME 4
  is UGE → `UGEBackend`/`render_uge_script`/`UGE_PROFILE_DIRECTIVES`).

## Not in this PR (follow-up)
- O1 verification on real TSUBAME (gates the whole UMS approach).
- Phase 2b/2c (lease state machine, divergence sentinel) and Phase 3 implementation.

## Test
- `julia --project=. -e 'using SpinorBEC; include("test/workflow/test_autopilot.jl")'` → 217/217 pass.
- ssh_transport delegation verified byte-identical to the pre-extraction commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)