### PR TITLE
fix(zeeman) + refactor(spin/raman): close ungated-physics-duplication classes

### DIFF
--- a/ext/SpinorBECCUDAExt/gpu_singlet_pair.jl
+++ b/ext/SpinorBECCUDAExt/gpu_singlet_pair.jl
@@ -55,7 +55,7 @@ function SpinorBEC.apply_singlet_pair_step!(
     c2_t = T(c2)
     dt_t = T(dt)
 
-    signs = T[iseven(F - (F - (c - 1))) ? one(T) : -one(T) for c in 1:D]
+    signs = T[SpinorBEC.singlet_pair_sign(F, F - (c - 1)) for c in 1:D]
 
     psi_2d = reshape(psi, N, D)
     cache = _get_gpu_singlet_pair_cache(N, T)

--- a/ext/SpinorBECCUDAExt/gpu_spin_mixing.jl
+++ b/ext/SpinorBECCUDAExt/gpu_spin_mixing.jl
@@ -108,10 +108,9 @@ function SpinorBEC.apply_spin_mixing_step!(
 
     fx .= zero(T)
     fy .= zero(T)
+    fp_coeffs = SpinorBEC.fp_ladder_coeffs(T, sm.system.F, Val(D))
     for c in 2:D
-        # fp = sqrt(F(F+1) - m(m+1)) where m = F - (c-1)
-        m = F_t - T(c - 1)
-        fp = sqrt(F_t * (F_t + one(T)) - m * (m + one(T)))
+        fp = fp_coeffs[c]
         pb .= conj.(view(psi_mf_2d, :, c-1)) .* view(psi_mf_2d, :, c)
         fx .+= fp .* real.(pb)
         fy .+= fp .* imag.(pb)

--- a/src/foundation/spin_matrices.jl
+++ b/src/foundation/spin_matrices.jl
@@ -1,4 +1,35 @@
-export spin_matrices
+export spin_matrices, fp_ladder_coeff, fp_ladder_coeffs, singlet_pair_sign
+
+"""
+    fp_ladder_coeff([T=Float64,] F, m) -> √(F(F+1) − m(m+1))
+
+The F₊ raising-operator matrix element ⟨F,m+1|F₊|F,m⟩. **Single source** for every
+spin-ladder coefficient in the codebase — c₁ spin mixing, Raman, spatial-Zeeman,
+and the DDI/c₁ gradients all delegate here so a sign or algebra change can only
+happen in one place. Matches the off-diagonal of `spin_matrices(F).Fp`.
+"""
+@inline fp_ladder_coeff(::Type{T}, F::Integer, m) where {T <: AbstractFloat} =
+    sqrt(T(F * (F + 1)) - T(m) * (T(m) + one(T)))
+@inline fp_ladder_coeff(F::Integer, m) = fp_ladder_coeff(Float64, F, m)
+
+"""
+    fp_ladder_coeffs([T=Float64,] F, ::Val{D}) -> NTuple{D,T}
+
+Per-component F₊ coefficients for the spinor layout ψ[...,c] (c=1→m=F), with the
+top component (c=1) set to 0. Built from [`fp_ladder_coeff`](@ref).
+"""
+@inline fp_ladder_coeffs(::Type{T}, F::Integer, ::Val{D}) where {T <: AbstractFloat, D} =
+    ntuple(c -> c == 1 ? zero(T) : fp_ladder_coeff(T, F, F - (c - 1)), Val(D))
+@inline fp_ladder_coeffs(F::Integer, ::Val{D}) where {D} =
+    fp_ladder_coeffs(Float64, F, Val(D))
+
+"""
+    singlet_pair_sign(F, m) -> ±1.0
+
+Sign factor σ_c = (−1)^{F−m} of the spin-singlet pair amplitude. **Single source**
+for the c₂ singlet-pairing propagator and gradient.
+"""
+@inline singlet_pair_sign(F::Integer, m::Integer) = iseven(F - m) ? 1.0 : -1.0
 
 function spin_matrices(F::Int)
     sys = SpinSystem(F)
@@ -19,7 +50,7 @@ function spin_matrices(F::Int)
     # We need m[i] = m[j] + 1
     for j in 1:n, i in 1:n
         if m[i] == m[j] + 1
-            Fp_dense[i, j] = sqrt(F * (F + 1) - m[j] * (m[j] + 1))
+            Fp_dense[i, j] = fp_ladder_coeff(F, m[j])
         end
     end
 

--- a/src/hamiltonian/terms/contact/contact.jl
+++ b/src/hamiltonian/terms/contact/contact.jl
@@ -190,7 +190,7 @@ function _grad_c1_spin!(grad, psi, ws, c1, fx, fy, fz, n_pts, D, ::Val{N}) where
     for c in 2:D
         idx_c = _component_slice(N, n_pts, c)
         idx_cm1 = _component_slice(N, n_pts, c - 1)
-        fp = sqrt(Float64(F * (F + 1) - (F - c + 1) * (F - c + 2)))
+        fp = fp_ladder_coeff(F, F - c + 1)
         view(grad, idx_cm1...) .+= c1 .* 0.5 .* fp .* (fx .- im .* fy) .* view(psi, idx_c...)
         view(grad, idx_c...) .+= c1 .* 0.5 .* fp .* (fx .+ im .* fy) .* view(psi, idx_cm1...)
     end
@@ -327,8 +327,7 @@ function _accumulate_singlet_pair_operator!(out, psi, F, c2, ndim)
     @inbounds for I in CartesianIndices(n_pts)
         AI = A[I]
         for c in 1:D
-            m_c = F - (c - 1)
-            sgn = iseven(F - m_c) ? 1.0 : -1.0
+            sgn = singlet_pair_sign(F, F - (c - 1))
             out[I, c] += coeff * sgn * AI * conj(psi[I, D - c + 1])
         end
     end

--- a/src/hamiltonian/terms/contact/singlet_pair.jl
+++ b/src/hamiltonian/terms/contact/singlet_pair.jl
@@ -60,10 +60,7 @@ function _singlet_pair_loop!(psi, psi_mf, ::Val{D}, n_pts, c2, dt, imaginary_tim
     F = (D - 1) ÷ 2
     inv_sqrt_D = 1.0 / sqrt(Float64(D))
 
-    signs = ntuple(Val(D)) do c
-        m = F - (c - 1)
-        iseven(F - m) ? 1.0 : -1.0
-    end
+    signs = ntuple(c -> singlet_pair_sign(F, F - (c - 1)), Val(D))
 
     mid = (D + 1) ÷ 2
 

--- a/src/hamiltonian/terms/contact/spin_mixing.jl
+++ b/src/hamiltonian/terms/contact/spin_mixing.jl
@@ -66,9 +66,7 @@ function _spin_mixing_loop!(
     # Saves 30–35% on the per-step rotation cost (matched the DDI win).
     N_spatial = prod(n_pts)
     F = T(sm.system.F)
-    Ff1 = T(sm.system.F * (sm.system.F + 1))
-    fp_coeffs = ntuple(c -> c == 1 ? T(0) :
-                            sqrt(Ff1 - T(F - (c - 1)) * T(F - (c - 1) + 1)), Val(D))
+    fp_coeffs = fp_ladder_coeffs(T, sm.system.F, Val(D))
 
     rc = _get_ddi_rotation_cache_cpu(psi, sm, ndim_from_n_pts(n_pts))
     alpha = rc.alpha
@@ -150,10 +148,9 @@ function _spin_mixing_loop!(
     psi, psi_mf::AbstractArray, sm, c1, dt_frac, ::Val{D}, n_pts, imaginary_time
 ) where {D}
     F = sm.system.F
-    Ff1 = Float64(F * (F + 1))
     m_vals = SVector{D, Float64}(ntuple(c -> F - (c - 1), Val(D)))
     m_vals_t = ntuple(c -> Float64(F - (c - 1)), Val(D))
-    fp_coeffs = ntuple(c -> c == 1 ? 0.0 : sqrt(Ff1 - m_vals_t[c] * (m_vals_t[c] + 1.0)), Val(D))
+    fp_coeffs = fp_ladder_coeffs(F, Val(D))
 
     V_Fy = sm.Fy_eigvecs
     Vt_Fy = sm.Fy_eigvecs_adj

--- a/src/hamiltonian/terms/ddi/ddi_term.jl
+++ b/src/hamiltonian/terms/ddi/ddi_term.jl
@@ -126,7 +126,7 @@ function _grad_ddi!(grad, psi, ws, n_pts, D, ::Val{N}) where {N}
     for c in 2:D
         idx_c = _component_slice(N, n_pts, c)
         idx_cm1 = _component_slice(N, n_pts, c - 1)
-        fp = sqrt(Float64(F * (F + 1) - (F - c + 1) * (F - c + 2)))
+        fp = fp_ladder_coeff(F, F - c + 1)
         view(grad, idx_cm1...) .+= 0.5 .* fp .* (phi_x .- im .* phi_y) .* view(psi, idx_c...)
         view(grad, idx_c...) .+= 0.5 .* fp .* (phi_x .+ im .* phi_y) .* view(psi, idx_cm1...)
     end

--- a/src/hamiltonian/terms/raman.jl
+++ b/src/hamiltonian/terms/raman.jl
@@ -92,9 +92,8 @@ Manual per-voxel reduction inlines the kr phase + Fz/F+ contractions.
 function _raman_energy(psi, sm::SpinMatrices{D}, raman::RamanCoupling{N},
     grid::Grid{N}, ndim, n_pts, dV) where {D, N}
     F = sm.system.F
-    Ff1 = Float64(F * (F + 1))
     m_vals = ntuple(c -> Float64(F - (c - 1)), Val(D))
-    fp_coeffs = ntuple(c -> c == 1 ? 0.0 : sqrt(Ff1 - m_vals[c] * (m_vals[c] + 1.0)), Val(D))
+    fp_coeffs = fp_ladder_coeffs(F, Val(D))
 
     E = 0.0
     @inbounds for I in CartesianIndices(n_pts)
@@ -135,7 +134,21 @@ end
 # remains active.
 apply_operator!(out, ::RamanTerm, ws, psi) = out
 
-sign_oracle(::Type{RamanTerm}) = (
-    name="RamanTerm: KNOWN-LIMIT (no gradient implemented)",
-    predicate=(_, _) -> true,
-)
+# Directional oracle anchored on the PROPAGATOR (apply_raman_step!), since the
+# gradient face is a declared no-op. With δ·F_z the dominant term, ITP minimises
+# the energy δ·⟨F_z⟩, so the converged ⟨F_z⟩ takes the sign opposite to δ. A
+# flipped δ sign in the propagator inverts ⟨F_z⟩ and trips this. (δ = 0 — pure
+# transverse drive — has no F_z anchor and short-circuits to true.)
+function sign_oracle(::Type{RamanTerm})
+    return (
+        name="RamanTerm: +δ ⇒ ⟨F_z⟩ < 0 (energy δ⟨F_z⟩ minimised by ITP)",
+        predicate=function (psi, ws)
+            ws.raman === nothing && return true
+            r = raman_at(ws.raman, ws.state.t)
+            abs(r.delta) <= 1e-30 && return true
+            sm = ws.spin_matrices
+            _, _, fz = spin_density_vector(psi, sm, ndims(psi) - 1)
+            return sign(sum(fz) * cell_volume(ws.grid)) == -sign(r.delta)
+        end,
+    )
+end

--- a/src/hamiltonian/terms/spatial_zeeman.jl
+++ b/src/hamiltonian/terms/spatial_zeeman.jl
@@ -45,8 +45,7 @@ function _spatial_zeeman_apply!(
     F = sm.system.F
     n_pts = ntuple(d -> size(psi, d), Val(N))
     m_vals = ntuple(c -> Float64(F - (c - 1)), Val(D))
-    fp = ntuple(c -> c == 1 ? 0.0 :
-                     sqrt(Float64(F * (F + 1)) - m_vals[c] * (m_vals[c] + 1.0)), Val(D))
+    fp = fp_ladder_coeffs(F, Val(D))
     @inbounds for I in CartesianIndices(n_pts)
         # diagonal: (-bz·m + q·m²)
         bzI, qI = bz[I], q[I]
@@ -93,8 +92,7 @@ function _spatial_zeeman_energy(
     F = sm.system.F
     n_pts = ntuple(d -> size(psi, d), Val(N))
     m_vals = ntuple(c -> Float64(F - (c - 1)), Val(D))
-    fp = ntuple(c -> c == 1 ? 0.0 :
-                     sqrt(Float64(F * (F + 1)) - m_vals[c] * (m_vals[c] + 1.0)), Val(D))
+    fp = fp_ladder_coeffs(F, Val(D))
     E = 0.0
     @inbounds for I in CartesianIndices(n_pts)
         bzI, qI = bz[I], q[I]

--- a/src/validation/dumb_reference.jl
+++ b/src/validation/dumb_reference.jl
@@ -182,6 +182,23 @@ function dumb_zeeman_pqbxby(ws)
     return (p, q, bx, by)
 end
 
+# Independent restatement of the UNIFORM Zeeman operator for a tilted field:
+#   H = -(b·F) + q(b̂·F)²,  b = (bx, by, p),  b̂ = b/|b|.
+# Field-axis quadratic (the unified production convention, 2026-06-21), built from
+# this module's own dumb_spin_matrices — NOT production's `zeeman_field_matrix!`,
+# so it stays an independent statement (the oracle's whole value). B∥ẑ keeps the
+# diagonal -p·m + q·m² form (which equals q(b̂·F)² when b̂ = ẑ), so callers only
+# invoke this for a transverse field.
+function dumb_uniform_zeeman_matrix(sm, bx, by, p, q)
+    BdotF = bx .* sm.Fx .+ by .* sm.Fy .+ p .* sm.Fz
+    M = ComplexF64.(-BdotF)
+    bmag2 = bx^2 + by^2 + p^2
+    if abs(q) > 1e-30 && bmag2 > 0.0
+        M = M .+ (q / bmag2) .* (BdotF * BdotF)
+    end
+    return M
+end
+
 function dumb_lhy_coefficient(ws)
     l = ws.lhy
     l === nothing && return ws.interactions.c_lhy
@@ -518,20 +535,27 @@ function dumb_energy_breakdown(
     end
     E_trap *= dV
 
-    # zeeman
+    # zeeman: H = -(b·F) + q(b̂·F)², b = (bx, by, p). B∥ẑ (bx=by=0) reduces to the
+    # diagonal -p·m + q·m²; a tilted field uses the field-axis quadratic matrix.
     p, q, bx, by = dumb_zeeman_pqbxby(ws)
-    E_zz = 0.0
-    for c in 1:D
-        coef = -p * sm.m[c] + q * sm.m[c]^2
-        for I in _dumb_spatial(ψ)
-            E_zz += coef * abs2(ψ[I, c])
+    if abs(bx) + abs(by) <= 1e-30
+        E_zz = 0.0
+        for c in 1:D
+            coef = -p * sm.m[c] + q * sm.m[c]^2
+            for I in _dumb_spatial(ψ)
+                E_zz += coef * abs2(ψ[I, c])
+            end
         end
+        E_zz *= dV
+        E_zt = 0.0
+    else
+        Hz = dumb_uniform_zeeman_matrix(sm, bx, by, p, q)
+        E_zz = sum(dumb_local_expectation(ψ, Hz)) * dV
+        E_zt = 0.0
     end
-    E_zz *= dV
     fx = dumb_local_expectation(ψ, sm.Fx)
     fy = dumb_local_expectation(ψ, sm.Fy)
     fz = dumb_local_expectation(ψ, sm.Fz)
-    E_zt = sum(-bx .* fx .- by .* fy) * dV
 
     # contact + LHY
     c0 = ws.interactions[0]
@@ -680,17 +704,22 @@ function dumb_rhs_breakdown(
         g_trap[I, c] = ws.potential_values[I] * ψ[I, c]
     end
 
+    # zeeman: H = -(b·F) + q(b̂·F)², b = (bx, by, p). B∥ẑ keeps the diagonal
+    # -p·m + q·m²; a tilted field applies the field-axis quadratic matrix.
     p, q, bx, by = dumb_zeeman_pqbxby(ws)
     g_zz = zed()
-    for c in 1:D
-        coef = -p * sm.m[c] + q * sm.m[c]^2
-        for I in _dumb_spatial(ψ)
-            g_zz[I, c] = coef * ψ[I, c]
-        end
-    end
-    Ht = ComplexF64.(-bx .* sm.Fx .- by .* sm.Fy)
     g_zt = zed()
-    dumb_add_matrix_action!(g_zt, ψ, Ht, _ -> 1.0)
+    if abs(bx) + abs(by) <= 1e-30
+        for c in 1:D
+            coef = -p * sm.m[c] + q * sm.m[c]^2
+            for I in _dumb_spatial(ψ)
+                g_zz[I, c] = coef * ψ[I, c]
+            end
+        end
+    else
+        Hz = dumb_uniform_zeeman_matrix(sm, bx, by, p, q)
+        dumb_add_matrix_action!(g_zz, ψ, Hz, _ -> 1.0)
+    end
 
     c0 = ws.interactions[0]
     c1 = ws.interactions[1]

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -235,6 +235,11 @@ const CI_EXTRA = [
     "oracles/test_raman_analytic.jl",
     "oracles/test_term_legacy_equivalence.jl",
     "oracles/test_term_consistency.jl",
+    # Single-source gate for the F₊ ladder coefficient √(F(F+1)−m(m+1)) and the
+    # singlet-pair sign (−1)^{F−m}. Pins every spin-ladder propagator/energy/
+    # gradient to `fp_ladder_coeff` / `singlet_pair_sign`, so the formula can no
+    # longer drift independently across c₁ / Raman / spatial-Zeeman / DDI sites.
+    "oracles/test_spin_ladder_single_source.jl",
     # Imaginary-time propagator generator == registry operator (spin-mixing
     # + DDI). Gates the 2026-06-15 per-voxel exp(-(m+F)θ) density-bias class
     # that only the propagator↔operator generator comparison can see.

--- a/test/oracles/test_imag_time_propagator_generator.jl
+++ b/test/oracles/test_imag_time_propagator_generator.jl
@@ -26,6 +26,7 @@ using Test
 using FFTW
 using SpinorBEC
 using SpinorBEC: SpinC1Term, DDITerm, ZeemanTerm, SpatialZeemanTerm,
+    RamanTerm, RamanCoupling, dumb_rhs_breakdown,
     apply_operator!, apply_step!, build_h_terms_registry, make_workspace,
     cell_volume, zeeman_field
 using LinearAlgebra
@@ -124,5 +125,25 @@ end
             sim_params=SimParams(; dt=0.01, n_steps=1, imaginary_time=true),
             enable_ddi=false, fft_flags=FFTW.ESTIMATE)
         _check(SpatialZeemanTerm, ws, _textured_state(ws))
+    end
+
+    @testset "Raman propagator: gate vs INDEPENDENT dumb RHS (gradient face is nil)" begin
+        # RamanTerm.apply_operator! is a declared no-op, so _check (which targets
+        # apply_operator!) cannot gate the propagator. The Raman direction (δ, Ω,
+        # ±k phase, F₊↔F₋) was only pinned on the energy face. Gate the PROPAGATOR
+        # generator against the independent dumb Raman RHS H_R·ψ instead.
+        raman = RamanCoupling{3}(1.3, -0.7, (0.6, -0.3, 0.9))
+        ws = make_workspace(; grid, atom=Eu151,
+            interactions=InteractionParams(Dict(0 => 0.0, 1 => 0.0)),
+            zeeman=ZeemanParams(0.0, 0.0), potential=HarmonicTrap((1.0, 1.0, 1.0)),
+            raman=raman,
+            sim_params=SimParams(; dt=0.01, n_steps=1, imaginary_time=true),
+            enable_ddi=false, fft_flags=FFTW.ESTIMATE)
+        psi = _textured_state(ws)
+        HR = dumb_rhs_breakdown(ws, psi).raman              # independent H_R·ψ
+        Gi = _generator(psi, (p, dt) -> apply_step!(RamanTerm(), p, dt, true, ws))
+        Gr = _generator(psi, (p, dt) -> apply_step!(RamanTerm(), p, dt, false, ws))
+        @test _residual_mod_psi(Gi, HR, psi) < 1e-3         # imag generator == H_R·ψ
+        @test _residual_mod_psi(Gr, im .* HR, psi) < 1e-3   # real generator == i·H_R·ψ
     end
 end

--- a/test/oracles/test_physics_aware_sign_oracles.jl
+++ b/test/oracles/test_physics_aware_sign_oracles.jl
@@ -21,8 +21,8 @@ using Test
 using FFTW
 using SpinorBEC
 using SpinorBEC:
-    SpinC1Term, DDITerm, LHYTerm, TensorTerm,
-    apply_step!, energy_contribution, spin_density_vector
+    SpinC1Term, DDITerm, LHYTerm, TensorTerm, RamanTerm, RamanCoupling,
+    apply_step!, energy_contribution, spin_density_vector, sign_oracle, cell_volume
 using Random
 
 # ============================================================================
@@ -236,4 +236,44 @@ end
     @test E_polar > 0  # c2 > 0 + polar → positive E_pair
     @test abs(E_fm) < 1e-10  # FM stretched has zero singlet amplitude
     @test E_polar > E_fm
+end
+
+# ============================================================================
+# (5) RamanTerm:  +δ → ⟨F_z⟩ < 0  (energy δ·⟨F_z⟩ minimised by ITP)
+# ============================================================================
+#
+# RamanTerm's gradient face is a declared no-op, so the previous in-term
+# sign_oracle was the placeholder `predicate=true` — it could not detect a
+# δ-sign flip in the PROPAGATOR (apply_raman_step!), the face production
+# actually runs. Here we anchor on the propagator: ITP under H = δ·F_z (Ω=0,
+# k=0) from a transverse (⟨F_z⟩=0) start drives ⟨F_z⟩ to the sign opposite to
+# δ. This also gives the now-real sign_oracle predicate teeth.
+
+@testset "Physics-aware sign oracle: RamanTerm (+δ ⇒ ⟨F_z⟩ < 0)" begin
+    grid = make_grid(GridConfig((8,), (8.0,)))
+    dV = cell_volume(grid)
+    for δ in (0.8, -0.8)
+        raman = RamanCoupling{1}(0.0, δ, (0.0,))   # pure δ·F_z propagator
+        ws = make_workspace(; grid, atom=Rb87,
+            interactions=InteractionParams(Dict(0 => 0.0, 1 => 0.0)),
+            zeeman=ZeemanParams(0.0, 0.0), potential=NoPotential(),
+            raman=raman,
+            sim_params=SimParams(; dt=0.01, n_steps=1, imaginary_time=true),
+            fft_flags=FFTW.ESTIMATE)
+        # transverse start: equal weight on m=+1,0,−1 ⇒ ⟨F_z⟩ = 0 initially.
+        psi = zeros(ComplexF64, 8, 3)
+        for i in 1:8
+            g = exp(-0.1 * (i - 4.5)^2)
+            psi[i, :] .= g / sqrt(3)
+        end
+        psi ./= sqrt(sum(abs2, psi) * dV)
+        for _ in 1:600
+            apply_step!(RamanTerm(), psi, 0.01, true, ws)
+            psi ./= sqrt(sum(abs2, psi) * dV)
+        end
+        _, _, fz = spin_density_vector(psi, ws.spin_matrices, ndims(psi) - 1)
+        fzsum = sum(fz) * dV
+        @test sign(fzsum) == -sign(δ)
+        @test sign_oracle(RamanTerm).predicate(psi, ws)
+    end
 end

--- a/test/oracles/test_spin_ladder_single_source.jl
+++ b/test/oracles/test_spin_ladder_single_source.jl
@@ -1,0 +1,72 @@
+# test/oracles/test_spin_ladder_single_source.jl
+#
+# Single-source gate for two spinor primitives that used to be hand-written
+# in many places (the exact "same physics in N locations" disease the
+# sign-bug-proof architecture exists to kill):
+#
+#   1. The F₊ ladder coefficient √(F(F+1) − m(m+1)) — formerly re-derived
+#      inline in c₁ spin-mixing, Raman, spatial-Zeeman, and the DDI/c₁
+#      gradients, in two different algebraic forms.
+#   2. The singlet-pair sign σ_c = (−1)^{F−m} — formerly re-stated in the
+#      propagator and the gradient.
+#
+# These tests pin `fp_ladder_coeff` / `fp_ladder_coeffs` / `singlet_pair_sign`
+# to the canonical references (the F₊ matrix built by `spin_matrices`, and the
+# legacy index/m(m+1) forms) and prove the migration is bit-identical. A drift
+# in the single source now breaks here loudly; a re-introduced inline copy that
+# disagrees breaks the call sites' own oracles.
+
+using Test
+using SpinorBEC
+using SpinorBEC: fp_ladder_coeff, fp_ladder_coeffs, singlet_pair_sign
+
+@testset "Spin-ladder single source" begin
+    @testset "fp_ladder_coeff == spin_matrices(F).Fp off-diagonal (F=$F)" for F in 1:6
+        sm = spin_matrices(F)
+        D = 2F + 1
+        m = [Float64(F - (c - 1)) for c in 1:D]   # m[c]: c=1→+F … c=D→−F
+        # Fp[i,j] is nonzero only for m[i] == m[j]+1, i.e. i == j-1.
+        for j in 2:D
+            i = j - 1
+            @test sm.Fp[i, j] ≈ fp_ladder_coeff(F, m[j])
+            @test real(sm.Fp[i, j]) == fp_ladder_coeff(F, m[j])  # exact
+        end
+    end
+
+    @testset "fp_ladder_coeffs bit-identical to legacy forms (F=$F)" for F in 1:6
+        D = 2F + 1
+        coeffs = fp_ladder_coeffs(F, Val(D))
+        @test length(coeffs) == D
+        @test coeffs[1] == 0.0   # top component (c=1, m=F) has no F₊ partner
+        for c in 2:D
+            m = Float64(F - (c - 1))
+            # m(m+1) form (c₁ mixing / Raman / spatial-Zeeman used this)
+            legacy_mm = sqrt(Float64(F * (F + 1)) - m * (m + 1.0))
+            # integer index form (DDI / c₁ gradient used this)
+            legacy_idx = sqrt(Float64(F * (F + 1) - (F - c + 1) * (F - c + 2)))
+            @test coeffs[c] == legacy_mm
+            @test coeffs[c] == legacy_idx
+        end
+    end
+
+    @testset "fp_ladder_coeffs Float32 bit-identical to legacy F32 form (F=$F)" for F in 1:6
+        D = 2F + 1
+        coeffs32 = fp_ladder_coeffs(Float32, F, Val(D))
+        @test eltype(coeffs32) == Float32
+        Ff1 = Float32(F * (F + 1))
+        for c in 2:D
+            m = Float32(F - (c - 1))
+            legacy32 = sqrt(Ff1 - m * (m + one(Float32)))
+            @test coeffs32[c] === legacy32
+        end
+    end
+
+    @testset "singlet_pair_sign == (−1)^{F−m} (F=$F)" for F in 1:6
+        D = 2F + 1
+        for c in 1:D
+            m = F - (c - 1)
+            @test singlet_pair_sign(F, m) == (-1.0)^(F - m)
+            @test singlet_pair_sign(F, m) == (iseven(c - 1) ? 1.0 : -1.0)
+        end
+    end
+end


### PR DESCRIPTION
物理バグ削減のための徹底リファクタリング。ゲートされていない物理重複を単一ソース化し、検出網（オラクル）を実体化。作業中に発見した既存の検証バグも修正。

## 🔴 既存バグ修正：master_oracle was RED at HEAD
`540db394 fix(zeeman)`

commit `b3881a23`（quadratic Zeeman を field-axis `q(b̂·F)²` に統一）が production・`reference_rhs` オラクル・GPU は更新したが、**もう一方の独立オラクル `dumb_reference.jl` を更新し忘れ**ていた。傾いた場で両者が食い違い、sign-drift を守る要のゲート `test_master_oracle.jl` が **HEAD で RED**（587/599、全 zeeman スロット）。コミットの "oracle suite 7/7 green" のリストが master_oracle を見落としていたため見過ごされた。

→ `dumb_reference` に field-axis 二次項を**独立に**実装（`dumb_uniform_zeeman_matrix`、dumb 自前の spin matrices から構築）。`B∥ẑ` は対角 `-p·m+q·m²` を bit-identical 維持、傾いた場のみ行列。spatial Zeeman は本番も lab-z 設計のため据え置き。**master_oracle 587/599 → 599/599**。

## A. ゲートされていない物理重複の単一ソース化
`169a329c refactor(spin)`

- **F+ ladder 係数 `√(F(F+1)−m(m+1))`** — 7箇所の独立記述（2つの代数形）→ `fp_ladder_coeff`/`fp_ladder_coeffs`（F32 path 対応）に。CPU 全項 + GPU host 側2箇所 + `spin_matrices` 自身が委譲。
- **Singlet-pair 符号 `(−1)^{F−m}`** → `singlet_pair_sign` に（CPU 2 + GPU 1）。
- 新ゲート `test_spin_ladder_single_source.jl`（F=1..6 で Fp・旧2形と bit-identical を証明、ci tier）。
- 純 no-op（master_oracle / term_consistency の数値不変を確認）。
- `dumb_reference` / `reference_rhs` は独立性契約のため自前のまま（オラクルの価値）。

## B+C. Raman propagator の方向性を実オラクル化
`f9877fda refactor(raman)`

`RamanTerm.apply_operator!` が no-op のため sign_oracle は `predicate=true` で、**propagator（apply_raman_step!）の δ 符号反転を検出不能**だった（エネルギー面のみ符号 pin 済み）。

- 述語を実方向性に：`+δ ⇒ ⟨F_z⟩<0`。
- physics_aware に ±δ の方向性 ITP テスト追加（述語に teeth）。
- generator-consistency テストに Raman propagator ゲート追加（**独立な dumb RHS** と比較。apply_operator! が nil なので通常の generator==operator 経路では届かない）。
- **teeth 実証**：δ 符号を反転すると両ゲートが fail（`predicate=true` 時は不可視だった）。

### 計画からの逸脱（実装中の発見）
- **singlet_pair propagator ゲート**：元計画の「propagator vs apply_operator! 比較」は数学的に不成立（propagator=Hartree-Fock 平均場、operator=異常対項）。符号は A の単一ソース化＋unitarity＋master energy で既にゲート済みのため未追加。
- **DDI/LightShift 述語**：方向性符号は既に physics_aware / 符号敏感 analytic でゲート済み。fragile な単一状態 fake oracle は追加せず据え置き。

## 検証
全オラクルスイート green：master_oracle 599/599、ladder / term_consistency / sign_oracles / physics_aware / reference_rhs / generator / raman_analytic + 追加11オラクル。全変更ファイル formatter-clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)