### PR TITLE
fix: 5 RED-at-HEAD oracle gates (RF Zeeman propagator + GPU gradient) + per-PR oracle CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,31 @@ jobs:
           # julia-actions/cache@v2 restore actually hit on test-time precompile.
           coverage: false
 
+  oracles:
+    name: Oracle gates (tier=oracles)
+    runs-on: ubuntu-latest
+    # The sign-bug-proof / validation oracle gates live in the `ci` tier, which
+    # only runs nightly — so a PR could break one and merge green. It happened:
+    # master_oracle + 4 sibling gates sat RED at HEAD (2026-06-21), undetected
+    # for weeks. This job runs JUST the oracle gates (`test/oracles/`, a few
+    # minutes) so they are a per-PR merge gate. GPU-only oracle assertions
+    # (gpu_cpu_per_term_parity) still no-op here — they need a GPU runner
+    # (nightly / TSUBAME), not the CPU ubuntu runner.
+    timeout-minutes: 15
+    env:
+      SPINORBEC_TEST_TIER: oracles
+      SPINORBEC_TEST_WORKERS: auto
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1.12"
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: false
+
   format:
     name: JuliaFormatter check
     runs-on: ubuntu-latest

--- a/src/hamiltonian/integrator/split_step.jl
+++ b/src/hamiltonian/integrator/split_step.jl
@@ -137,48 +137,49 @@ end
 @inline function _resolve_zeeman_diag(ws, t::Float64)
     ωR = ws.sim_params.spin_rotating_frame_omega
     is_uniform(ws.zeeman) || return zeeman_diagonal(ZeemanParams(0.0, 0.0), ws.spin_matrices, ωR)
-    if !is_active(ωR, ROTATION_TOL)
-        bx, by = transverse_b(ws.zeeman, t)
-        (bx != 0.0 || by != 0.0) &&
-            return zeeman_diagonal(ZeemanParams(0.0, 0.0), ws.spin_matrices, ωR)
-    end
+    bx, by = transverse_b(ws.zeeman, t)
+    # A transverse/tilted field is applied WHOLE by `_apply_transverse_zeeman_step!`
+    # (the field-axis quadratic AND the RF inertial p_eff = p − ω_R, via the same
+    # ZeemanTerm the registry builds), so carry NOTHING diagonal here — both ω_R = 0
+    # and ω_R ≠ 0. Folding a lab-z q or p here would double-count and, in the RF,
+    # desync the propagator from the operator/energy faces (App. A defect-5).
+    (bx != 0.0 || by != 0.0) &&
+        return zeeman_diagonal(ZeemanParams(0.0, 0.0), ws.spin_matrices, 0.0)
     zeeman_diagonal(zeeman_at(ws.zeeman, t), ws.spin_matrices, ωR)
 end
 
-# Zeeman step taken when a transverse field is present. Two regimes:
+# Zeeman step taken when a transverse field is present. The WHOLE Zeeman operator
+# `H = -(b·F) + q(b̂·F)²` is applied as one eigen-exact D×D matrix exp via
+# `_zeeman_propagator`, built from the SAME `ZeemanTerm` the registry constructs
+# (`build_h_terms_registry`) — so the propagator, the gradient face
+# (`apply_operator!`) and the energy face are one declaration. The field-axis
+# quadratic and the spin-rotating-frame correction (rotate (Bx,By) into RF coords,
+# p_eff = p − ω_R) are folded into that single term.
 #
-#  * ω_R = 0 (no spin rotating frame): the diagonal fold carried NO Zeeman
-#    (see `_resolve_zeeman_diag`), so apply the WHOLE operator
-#    `H = -(b·F) + q(b̂·F)²` as one eigen-exact D×D matrix exp. The quadratic is
-#    along the FIELD axis b̂ (physical; matches the rotating-basis path),
-#    single-sourced through `_zeeman_propagator` (shared with the HamTerm faces).
-#    This is the "proper compute" branch for a tilted field.
-#  * ω_R ≠ 0 (spin rotating frame): the diagonal q stayed folded (lab-z) and
-#    only the linear transverse (Bx,By), rotated into RF coords, is applied here
-#    — the legacy split, untouched.
+# Pre-2026-06-21 the ω_R ≠ 0 branch instead applied only the rotated transverse
+# LINEAR step and left a lab-z `q F_z²` in the diagonal fold — i.e. the RF
+# propagator carried lab-z q while the operator/energy faces (unified by b3881a23)
+# carried field-axis q. That desync was App. A defect-5's surviving half: the
+# one-step strang generator plateaued at ~5.5e-2 vs the dumb RHS. Unifying on the
+# registry term closes it.
 function _apply_transverse_zeeman_step!(
     ws::Workspace, t::Float64, dt_frac::Float64, ndim::Int, imaginary_time::Bool
 )
     bx_lab, by_lab = transverse_b(ws.zeeman, t)
     (bx_lab == 0.0 && by_lab == 0.0) && return nothing
+    zp = zeeman_at(ws.zeeman, t)   # ZeemanParams(p(t), q(t)); p ≡ bz
     omega_R = ws.sim_params.spin_rotating_frame_omega
+    bx, by, p_eff = bx_lab, by_lab, zp.p
     if is_active(omega_R, ROTATION_TOL)
-        # Spin rotating frame: rotate (Bx, By) into RF; q stays in the lab-z
-        # diagonal fold. User-spec convention `H = -(g_F μ_B B·F)`;
-        # `apply_uniform_spin_rotation!` realizes `exp(-i·dt·(phi·F̂))`, so pass
-        # (-bx, -by). Fixed 2026-06-04 (mistake_transverse_zeeman_sign_inversion).
+        # Spin rotating frame: rotate (Bx,By) into RF coords and shift p_eff,
+        # exactly as the registry builds the RF ZeemanTerm.
         c = cos(omega_R * t)
         s = sin(omega_R * t)
         bx = bx_lab * c + by_lab * s
         by = -bx_lab * s + by_lab * c
-        @timeit_debug TIMER "transverse_zeeman" apply_uniform_spin_rotation!(
-            ws.state.psi, ws.spin_matrices, -bx, -by, 0.0, dt_frac, ndim;
-            imaginary_time, scratch=ws.state.psi_scratch,
-        )
-        return nothing
+        p_eff = zp.p - omega_R
     end
-    zp = zeeman_at(ws.zeeman, t)   # ZeemanParams(p(t), q(t)); p ≡ bz
-    term = ZeemanTerm(bx_lab, by_lab, zp.p, zp.q)
+    term = ZeemanTerm(bx, by, p_eff, zp.q)
     P = _zeeman_propagator(ws.spin_matrices, term, dt_frac, imaginary_time)
     @timeit_debug TIMER "transverse_zeeman" _apply_rotation_to_spin_axis!(
         ws.state.psi, P, ndim; scratch=ws.state.psi_scratch

--- a/src/hamiltonian/terms/zeeman.jl
+++ b/src/hamiltonian/terms/zeeman.jl
@@ -373,19 +373,18 @@ function _uniform_spin_expectation(
 end
 
 # out[r] .+= M·ψ[r] for a spatially-uniform D×D spin matrix M (CPU accumulate).
+# out[I,i] += Σ_j M[i,j]·ψ[I,j]  ≡  out_2d += ψ_2d · Mᵀ over the (N_spatial, D)
+# reshape. Batched matmul (not a per-voxel scalar loop) so the same body is
+# GPU-safe: a CuArray scalar `getindex(psi, I, j)` would error. M is moved to
+# psi's device via similar+copyto! — the established uniform-rotation idiom.
 function _accumulate_uniform_spin!(
     out::AbstractArray, M::AbstractMatrix{ComplexF64}, psi::AbstractArray, D::Int, N::Int
 )
-    n_pts = ntuple(d -> size(psi, d), N)
-    @inbounds for I in CartesianIndices(n_pts)
-        for i in 1:D
-            acc = zero(ComplexF64)
-            for j in 1:D
-                acc += M[i, j] * psi[I, j]
-            end
-            out[I, i] += acc
-        end
-    end
+    n_spatial = prod(ntuple(d -> size(psi, d), N))
+    MT = similar(psi, ComplexF64, D, D)
+    copyto!(MT, permutedims(M))                       # Mᵀ on psi's device
+    mul!(reshape(out, n_spatial, D), reshape(psi, n_spatial, D), MT,
+        one(ComplexF64), one(ComplexF64))             # out_2d += ψ_2d · Mᵀ
     out
 end
 

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -407,6 +407,14 @@ const MANUAL_TESTS_ALLOWLIST = [
     "workflow/test_live_monitor.jl",                 # spawns dashboard server on a TCP port
 ]
 
+# Derived view (NOT a partition list): every `oracles/` gate, regardless of which
+# tier list it lives in. The `oracles` pseudo-tier runs JUST these so the per-PR
+# CI can gate the bug classes cheaply (the full `ci` tier is ~30-45 min and only
+# runs nightly — that is how 5 oracle gates rotted RED unprotected, 2026-06-21).
+# Auto-maintaining: a new `test/oracles/<x>.jl` added to any tier list is picked
+# up here for free.
+const ORACLE_TESTS = filter(t -> startswith(t, "oracles/"), vcat(FAST_TESTS, CI_EXTRA, FULL_EXTRA))
+
 function select_tests(tier::String)
     if tier == "fast"
         return FAST_TESTS
@@ -416,6 +424,8 @@ function select_tests(tier::String)
         return vcat(FAST_TESTS, CI_EXTRA, FULL_EXTRA)
     elseif tier == "physics"
         return PHYSICS_TESTS
+    elseif tier == "oracles"
+        return ORACLE_TESTS
     else
         @warn "Unknown SPINORBEC_TEST_TIER=$tier, falling back to full"
         return vcat(FAST_TESTS, CI_EXTRA, FULL_EXTRA)

--- a/test/helpers/oracle_fixtures.jl
+++ b/test/helpers/oracle_fixtures.jl
@@ -36,7 +36,9 @@ TODO(week-1 §7): variants with MagneticGradient, LightShift, Raman,
 Loss active — every slot of `H_TERMS_CANONICAL_ORDER` needs an active
 fixture before its canary mutants mean anything.
 """
-function oracle_full_ws(; rotating_frame_omega=0.2, box=4.0, ddi=true, secular=true)
+function oracle_full_ws(;
+    rotating_frame_omega=0.2, box=4.0, ddi=true, secular=true, imaginary_time=true
+)
     grid = make_grid(GridConfig{3}((6, 6, 6), (box, box, box)))
     zeeman = TimeDependentZeeman(
         ConstantWaveform(0.3),   # p_wf  — linear Zeeman (Bz)
@@ -44,9 +46,12 @@ function oracle_full_ws(; rotating_frame_omega=0.2, box=4.0, ddi=true, secular=t
         ConstantWaveform(0.2),   # bx_wf — transverse Zeeman
         ConstantWaveform(0.15),  # by_wf — transverse Zeeman
     )
+    # Real-time callers (Strang↔RK4 order checks) must not renormalize: the
+    # reference is the unitary -iH RK4 flow, and an imaginary-time renormalize
+    # would diverge from it.
     sp = SimParams(;
-        dt=0.005, n_steps=1, imaginary_time=true,
-        normalize_every=1, rotating_frame_omega,
+        dt=0.005, n_steps=1, imaginary_time,
+        normalize_every=imaginary_time ? 1 : 0, rotating_frame_omega,
     )
     ws = make_workspace(;
         grid, atom=Rb87,

--- a/test/oracles/test_propagator_references.jl
+++ b/test/oracles/test_propagator_references.jl
@@ -192,7 +192,10 @@ end
     end
 
     @testset "Strang order slope vs dumb RK4 (3D, no DDI)" begin
-        ws, psi = oracle_full_ws(; ddi=false)
+        # Real-time fixture: dumb_rk4_evolve integrates the unitary -iH flow, so
+        # the production Strang must also be real-time (imaginary-time exp(-dtH)
+        # would plateau against it at a constant ~0.1, not converge).
+        ws, psi = oracle_full_ws(; ddi=false, imaginary_time=false)
         dV = SpinorBEC.cell_volume(ws.grid)
         n_comp = ws.spin_matrices.system.n_components
         T_total = 0.02
@@ -226,7 +229,7 @@ end
         # of placement bugs (the *_ddi_strang_save_every regression
         # family). End-to-end order 2 with DDI active gates the
         # placement, the kernel, and the dt accounting together.
-        ws, psi = oracle_full_ws()
+        ws, psi = oracle_full_ws(; imaginary_time=false)   # real-time vs -iH RK4
         dV = SpinorBEC.cell_volume(ws.grid)
         n_comp = ws.spin_matrices.system.n_components
         T_total = 0.02

--- a/test/oracles/test_redundancy_gates.jl
+++ b/test/oracles/test_redundancy_gates.jl
@@ -183,21 +183,9 @@ _fidelity(a, b) =
         end
     end
 
-    # (g) Rotating-basis gauge connection Â. The gauge-active local-spin step
-    # folds -Â into H; apply_gauge_step! applies the generator -Â. Both now
-    # read ONE declaration, `_gauge_connection_vector`. Pin its closed form
-    # (Âx,Ây,Âz) = (-φ̇ sinθ, θ̇, φ̇ cosθ) and the gauge_fix F_z absorption so a
-    # formula edit turns this red instead of silently desyncing the two steps.
-    @testset "(g) rotating gauge connection Â single-source" begin
-        θ, θdot, φdot = π / 3, 0.7, 1.3
-        ax, ay, az = SpinorBEC._gauge_connection_vector(θ, θdot, φdot, false)
-        @test ax ≈ -φdot * sin(θ)
-        @test ay ≈ θdot
-        @test az ≈ φdot * cos(θ)
-        # gauge_fix absorbs the F_z piece (Âz = 0), transverse intact.
-        ax2, ay2, az2 = SpinorBEC._gauge_connection_vector(θ, θdot, φdot, true)
-        @test az2 == 0.0
-        @test ax2 ≈ ax
-        @test ay2 ≈ ay
-    end
+    # (g) RETIRED: the rotating-basis gauge connection Â (`_gauge_connection_vector`)
+    # lived in the RotatingBasisWS engine retired 2026-06-?? (commit 12a80058,
+    # −2580 lines). Magnetostir now routes through the standard lab-frame path,
+    # which has no separate gauge connection, so there is nothing left to pin.
+    # The previous gate referenced the deleted symbol and errored at load.
 end


### PR DESCRIPTION
PR #38 の作業中、要のオラクル `test_master_oracle` が HEAD で RED だったのを発見・修正した。その流れで ci-tier オラクルゲート55個を全数走らせたところ、**同じ blind spot で RED のまま放置されていたゲートがさらに4個**見つかった（CI は fast tier しか回さず、ci-tier は nightly=main のみ → PR で保護されない）。本 PR はその4個を修正し、根本原因（オラクルが PR ゲートでない）を塞ぐ。

すべて私の変更前から RED（base 3134626c で確認済み、回帰ではない）。

## 実バグ修正（2件）

### 1. `fix(zeeman)` GPU transverse Zeeman 勾配 — eef716a0
`_accumulate_uniform_spin!`（傾き場 Zeeman の勾配面）が per-voxel スカラーループで、CuArray を scalar-index → `apply_operator!(ZeemanTerm)` が GPU で例外。**GPU + 傾き場の LBFGS が全てクラッシュ**していた。batched matmul `out_2d += ψ_2d·Mᵀ`（CPU/GPU 単一実装、device 非依存）に書き換え。CPU 数値は master-oracle tol 内で不変。

### 2. `fix(zeeman)` spin-rotating-frame propagator の field-axis q（defect-5）— 10b44819
b3881a23 が quadratic Zeeman を field-axis `q(b̂·F)²` に統一した際、**RF propagator だけ lab-z `q F_z²` のまま取り残した**。結果、rotating frame で propagator は lab-z q、operator/energy/dumb は field-axis q を適用 ＝ **LBFGS(ITP) と RTP が異なる Hamiltonian を解く**実バグ。defect-5 gate が one-step Strang generator の rel ~5.5e-2（dt 非依存）で検出。

RF propagator を registry と同一の `ZeemanTerm`（RF回転 bx/by、p_eff=p−ω_R、q）→ `_zeeman_propagator` の field-axis 行列に統一（ω_R=0/≠0 分岐を統合、対角 fold は transverse 時ゼロ化で二重計上回避）。propagator≡operator≡dumb を構造的に保証。

## テスト修正（1件）

### 3. `test(oracles)` real-time Strang fixtures + 退役ゲート削除 — 45f3ff84
- Strang-order-vs-RK4（×2）が**虚時間**の production Strang を**実時間** RK4 と比較（slope≈0、定数誤差0.096）。`oracle_full_ws` に `imaginary_time` kwarg 追加、order テストを実時間化 → slope≈2.0、errs[end]~2e-9。
- `redundancy_gates` の (g) が退役エンジン（commit 12a80058）で削除済みの `_gauge_connection_vector` を参照しロード時 error → 削除（magnetostir は lab-frame 標準パスに移行、gauge connection 概念なし）。

## 根本原因（1件）

### 4. `ci` オラクルスイートを per-PR ゲート化 — 108479f5
オラクルゲートは ci-tier（nightly=main のみ）で、PR では未保護 → 腐っていた。`oracles` 派生 tier（全 `test/oracles/` を自動包含）+ 専用 PR ジョブ（~25秒）を追加。これが無いと個別修正も再び腐る。GPU 専用アサーションは CPU runner では no-op（GPU runner=nightly/TSUBAME が必要）。

## 検証
- オラクルスイート **55ファイル全 pass**（実 runtests ランナー、並列チャンク、GPU parity 含む）
- propagator_references 49/49、master_oracle 599/599、term_consistency、strang_energy_conservation、propagator_unitarity、generator、magnetostir、itp/rtp_ddi_strang_save_every、redundancy_gates、registry parity — 回帰なし
- 全変更ファイル formatter-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)