### PR TITLE
perf(ci): unify per-job depot cache + guard the parallel-balance cost model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,19 @@ jobs:
         with:
           version: "1.12"
       - uses: julia-actions/cache@v2
+        with:
+          # Share ONE depot cache across the per-PR `test` + `oracles` jobs: same
+          # Project/Manifest/Julia/OS ⇒ byte-identical depot. The action's
+          # default cache-name embeds `job=<name>`, so each job kept its own
+          # ~1.3 GB cache; 3 jobs × N branches pushed the repo past GitHub's
+          # 10 GB cache ceiling (10.7 GB on 2026-06-21) → LRU eviction → silent
+          # cold runs (the new `oracles` job ran cold every time). Dropping the
+          # `job=` segment unifies them; `test` finishes first and wins the save
+          # race, so `oracles` restores `test`'s rich compiled/ cache instead of
+          # precompiling cold. Keep `bench` (push/main-only) on its own key so a
+          # fast main-push bench run can't overwrite the shared cache with a thin
+          # depot.
+          cache-name: julia-cache;workflow=${{ github.workflow }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
@@ -70,6 +83,9 @@ jobs:
         with:
           version: "1.12"
       - uses: julia-actions/cache@v2
+        with:
+          # Shared with the `test` job — see the rationale on that job's cache step.
+          cache-name: julia-cache;workflow=${{ github.workflow }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -415,6 +415,80 @@ const MANUAL_TESTS_ALLOWLIST = [
 # up here for free.
 const ORACLE_TESTS = filter(t -> startswith(t, "oracles/"), vcat(FAST_TESTS, CI_EXTRA, FULL_EXTRA))
 
+# ── Parallel-balance cost model ───────────────────────────────────────
+# Per-file cost estimate (seconds), measured on the full tier, used only to
+# balance the parallel chunks (LPT bin-packing in runtests.jl). Only the heavy
+# outliers need an entry; the long tail defaults to _DEFAULT_COST. A wrong
+# estimate costs balance, never correctness — but a silently-stale estimate lets
+# CI wall-time regress unnoticed, which `warn_cost_drift` (below) guards against.
+# Lives here (not runtests.jl) so the chunk processes (run_chunk.jl) can run the
+# drift check against the same numbers. Every key must reference a real file —
+# the Cost-model meta-test in test_tier_membership.jl enforces that, so a
+# renamed/retired test can't leave dead weight in the balancer.
+const _DEFAULT_COST = 3.0
+const _COST = Dict{String, Float64}(
+    "workflow/test_multi_fidelity_bo.jl" => 161.0,
+    "workflow/test_triple_point.jl" => 127.0,
+    "test_dealias_2_3.jl" => 76.0,
+    "solvers/test_continuation.jl" => 58.0,
+    "test_quality.jl" => 40.0,
+    "workflow/test_pipeline.jl" => 17.0,
+    "workflow/test_infrastructure.jl" => 15.0,
+    "workflow/test_active_learning.jl" => 15.0,
+    "test_level4_general_F_phase_emergence.jl" => 13.0,
+    "test_level10_hpsi_self_consistency.jl" => 12.0,
+    "workflow/test_autopilot.jl" => 12.0,
+    "oracles/test_propagator_references.jl" => 11.0,
+    "oracles/test_master_oracle.jl" => 11.0,
+    "oracles/test_path_coverage.jl" => 10.0,
+    "analysis/test_tof_multiframe.jl" => 9.5,
+    "gpu/test_mixed_precision.jl" => 9.0,
+    "dynamics/test_tdhfb_f1_validation.jl" => 8.5,
+    "analysis/test_physics_invariants.jl" => 8.0,
+    "solvers/test_simulation.jl" => 8.0,
+    "test_reference_rhs.jl" => 7.5,
+    "solvers/test_lbfgs_sobolev_preconditioner.jl" => 6.5,
+    "rotating_basis/test_rotating_basis_pipeline_parsing.jl" => 6.0,
+    "solvers/test_3d.jl" => 5.0,
+    "dynamics/test_twa.jl" => 5.0,
+    "solvers/test_lbfgs.jl" => 5.0,
+)
+
+_cost(f) = get(_COST, f, _DEFAULT_COST)
+
+"""
+    warn_cost_drift(timings; factor=3.0, abs_gap=15.0, floor_s=8.0) -> stale
+
+Degradation guard for the `_COST` balance model. If a file's *measured* time
+grossly exceeds its estimate, the LPT balancer mis-packs the chunks and CI
+wall-time regresses silently. Emit a GitHub-Actions `::warning` annotation (so it
+surfaces on the run) for each such file. One-directional — only under-estimates
+hurt makespan; an over-estimate merely over-reserves a slot. Returns the stale
+entries (for tests).
+"""
+function warn_cost_drift(
+    timings; factor::Float64=3.0, abs_gap::Float64=15.0, floor_s::Float64=8.0
+)
+    stale = NamedTuple{(:file, :measured, :estimate), Tuple{String, Float64, Float64}}[]
+    for (f, t) in timings
+        est = _cost(f)
+        if t > floor_s && t > factor * est && (t - est) > abs_gap
+            push!(stale, (file=f, measured=t, estimate=est))
+        end
+    end
+    isempty(stale) && return stale
+    ci = lowercase(get(ENV, "GITHUB_ACTIONS", "")) == "true"
+    for s in stale
+        msg = string(
+            s.file, " took ", round(s.measured; digits=1), "s but _COST estimates ",
+            round(s.estimate; digits=1), "s — update _COST in test/_tiers.jl to keep ",
+            "parallel CI balanced",
+        )
+        println(ci ? "::warning title=Stale test-cost estimate::$msg" : "⚠️  cost drift: $msg")
+    end
+    return stale
+end
+
 function select_tests(tier::String)
     if tier == "fast"
         return FAST_TESTS

--- a/test/run_chunk.jl
+++ b/test/run_chunk.jl
@@ -18,5 +18,9 @@ include(joinpath(@__DIR__, "_tiers.jl"))
 
 failed, timings = run_test_files(ARGS)
 print_timing(timings, get(ENV, "SPINORBEC_TEST_TIER", "?"))
+# Flag files whose measured time has drifted above the _COST estimate — the
+# parent relays this chunk's stdout to the CI log, so the ::warning annotation
+# surfaces on the run (keeps the LPT balance honest as tests get heavier).
+warn_cost_drift(timings)
 
 exit(failed ? 1 : 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,49 +51,9 @@ end
 # default — catches a genuine hang, not a merely-slow chunk (cold F32 ≈ 600 s).
 const _TIMEOUT = parse(Float64, get(ENV, "SPINORBEC_TEST_TIMEOUT", "1800"))
 
-# Per-file cost estimate (seconds), measured on the full tier, used only to
-# balance the parallel chunks. Only the heavy outliers need an entry; the long
-# tail defaults to _DEFAULT_COST. A wrong estimate costs balance, never
-# correctness.
-#
-# Note on rotating_basis F32: its first-time JIT is ~10 min, but it is cached
-# afterwards (CLAUDE.md), and the depot cache persists across nightly runs, so
-# the steady-state cost is small — estimate it modestly (30 s) so it leads
-# without monopolising a whole chunk. Pinning it at the cold 600 s would idle an
-# entire worker on every (warm) run.
-const _DEFAULT_COST = 3.0
-const _COST = Dict{String, Float64}(
-    "workflow/test_multi_fidelity_bo.jl" => 161.0,
-    "workflow/test_triple_point.jl" => 127.0,
-    "test_dealias_2_3.jl" => 76.0,
-    "solvers/test_continuation.jl" => 58.0,
-    "test_quality.jl" => 40.0,
-    "rotating_basis/test_rotating_basis_f32.jl" => 30.0,  # warm; ~10 min only on a cold cache
-    "workflow/test_pipeline.jl" => 17.0,
-    "workflow/test_infrastructure.jl" => 15.0,
-    "workflow/test_active_learning.jl" => 15.0,
-    "test_level4_general_F_phase_emergence.jl" => 13.0,
-    "test_level10_hpsi_self_consistency.jl" => 12.0,
-    "workflow/test_autopilot.jl" => 12.0,
-    "oracles/test_propagator_references.jl" => 11.0,
-    "oracles/test_master_oracle.jl" => 11.0,
-    "oracles/test_path_coverage.jl" => 10.0,
-    "analysis/test_tof_multiframe.jl" => 9.5,
-    "gpu/test_mixed_precision.jl" => 9.0,
-    "rotating_basis/test_rotating_basis_gpe.jl" => 9.0,
-    "dynamics/test_tdhfb_f1_validation.jl" => 8.5,
-    "analysis/test_physics_invariants.jl" => 8.0,
-    "solvers/test_simulation.jl" => 8.0,
-    "test_reference_rhs.jl" => 7.5,
-    "solvers/test_lbfgs_sobolev_preconditioner.jl" => 6.5,
-    "rotating_basis/test_rotating_basis_pipeline_parsing.jl" => 6.0,
-    "hamiltonian/test_integrator_order_meanfield.jl" => 5.0,
-    "solvers/test_3d.jl" => 5.0,
-    "dynamics/test_twa.jl" => 5.0,
-    "solvers/test_lbfgs.jl" => 5.0,
-)
-
-_cost(f) = get(_COST, f, _DEFAULT_COST)
+# _DEFAULT_COST / _COST / _cost (the per-file balance model) + warn_cost_drift
+# live in _tiers.jl, shared with the chunk processes (run_chunk.jl) so the
+# drift guard runs against the same numbers everywhere.
 
 # Greedy longest-processing-time bin-packing: assign each file (heaviest first)
 # to the currently-lightest chunk. Minimises makespan for the skewed full-tier
@@ -120,6 +80,7 @@ include(joinpath(@__DIR__, "_run_files.jl"))
 if _NWORKERS <= 1
     failed, timings = run_test_files(_FILES)
     print_timing(timings, TEST_TIER)
+    warn_cost_drift(timings)
     failed && error("SpinorBEC test suite (tier=$TEST_TIER): failures above")
     println("\nSpinorBEC ($(length(_FILES)) files, tier=$TEST_TIER): all passed")
 else

--- a/test/test_tier_membership.jl
+++ b/test/test_tier_membership.jl
@@ -19,9 +19,9 @@
 #      check).
 #
 # Runs as a pure file-glob + set comparison (no SpinorBEC needed); lives
-# in FAST so every push enforces it. The tier-list constants and
-# MANUAL_TESTS_ALLOWLIST are defined in runtests.jl, which include()s
-# this file in global scope.
+# in FAST so every push enforces it. The tier-list constants,
+# MANUAL_TESTS_ALLOWLIST and the _COST balance model are defined in
+# _tiers.jl, include()d in global scope before this file runs.
 
 using Test
 
@@ -67,4 +67,27 @@ using Test
     @test isempty(double_listed)
     isempty(double_listed) ||
         @info "DOUBLE-LISTED across FAST/CI/FULL — would run twice" double_listed
+end
+
+# The parallel-balance cost model + its degradation guard. Pinned here so the
+# guard that keeps CI wall-time honest cannot itself silently break.
+@testset "Cost model + drift guard" begin
+    # Every _COST key must reference a real, accounted-for test file — a stale
+    # key (renamed/deleted file) silently stops weighting anything.
+    test_root = @__DIR__
+    for f in keys(_COST)
+        @test isfile(joinpath(test_root, f))
+    end
+
+    @test _cost("test_dealias_2_3.jl") == _COST["test_dealias_2_3.jl"]
+    @test _cost("file_with_no_entry.jl") == _DEFAULT_COST
+
+    # Drift guard: flag a gross under-estimate, ignore near-estimate and sub-floor.
+    stale = warn_cost_drift([
+        ("solvers/test_3d.jl", 60.0),   # 60s vs 5s estimate → stale
+        ("test_quality.jl", 42.0),      # 42s vs 40s estimate → within factor
+        ("tiny.jl", 4.0),               # below floor_s → ignored
+    ])
+    @test length(stale) == 1
+    @test stale[1].file == "solvers/test_3d.jl"
 end


### PR DESCRIPTION
## Why
The three CI jobs (`test` / `oracles` / `bench`) each kept their **own ~1.3 GB** `julia-actions/cache` depot because the default `cache-name` embeds `job=<name>`. With 3 jobs × N branch scopes the repo blew past GitHub's **10 GB cache ceiling** (10.72 GB on 2026-06-21, right after the `oracles` job landed) → LRU eviction → the `oracles` job went **cold on every run** (`Cache not found`, ~9.5 min vs ~6 min warm).

## What

**Speed + cost — cache unification**
- Share ONE depot cache across the per-PR `test` + `oracles` jobs (drop the `job=` segment). `test` finishes first → wins the save race → `oracles` restores `test`'s rich `compiled/` cache instead of precompiling cold. `bench` (push/main-only) stays on its own key so a fast bench run can't overwrite the shared cache with a thin depot.
- Effect: ~0.4 GB/branch removed from the cache footprint (repo back under 10 GB → reliably warm), and the `oracles` long pole drops from cold (~9.5 min) to warm (~5–6 min).

**Degradation guard — keep the optimization from rotting silently**
- Moved the `_COST` parallel-balance model to `test/_tiers.jl` (shared with the chunk processes via `run_chunk.jl`).
- `warn_cost_drift(timings)`: a file whose measured time grossly exceeds its `_COST` estimate (≥3× and ≥15 s over, floor 8 s) emits a `::warning` annotation on the run, so the LPT balance can't silently rot as tests get heavier. The next warm `oracles` run will surface precise estimates for the heavy oracle files (currently defaulting to 3 s).

**Coverage certainty — pin the model itself**
- Meta-test in `test_tier_membership.jl` (FAST tier, runs per-PR) asserts every `_COST` key references a real file. On first run it caught **3 stale keys** left by the rotating_basis engine retirement (`test_rotating_basis_{gpe,f32}`, `test_integrator_order_meanfield`) — removed.

## Verification
- `_tiers.jl` + `test_tier_membership.jl` run standalone: green (29/29 cost-model asserts, tier membership total/exact).
- `warn_cost_drift` flags a 60 s-vs-5 s file, ignores a 42 s-vs-40 s file and a sub-floor file.
- YAML valid; JuliaFormatter 2.5.0 clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)