### PR TITLE
perf: optimize split_step (CPU + TSUBAME GPU) + fix GPU ITP density-bias

### DIFF
--- a/bench/accuracy_gpu.jl
+++ b/bench/accuracy_gpu.jl
@@ -1,0 +1,71 @@
+# Accuracy audit of the optimized GPU kernels.
+#  (1) Unitarity: the Euler rotation must preserve each voxel's spinor norm
+#      exactly (reference-independent — a direct measure of matvec accuracy).
+#  (2) Norm + energy drift over many RTP steps (the physical accuracy metric),
+#      GPU vs CPU.
+#   julia --project=. bench/accuracy_gpu.jl [N]
+
+import CUDA
+using SpinorBEC
+using Printf, LinearAlgebra
+
+include(joinpath(@__DIR__, "eu151_params.jl"))
+const N = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 64
+
+# ---------- (1) Per-voxel unitarity of the DDI Euler rotation ----------
+# Random spinor field + random dipolar field; rotation is unitary so each
+# voxel's Σ_c|ψ_c|² must be invariant. Max relative norm change = accuracy.
+println("="^64)
+println("(1) Euler rotation unitarity (per-voxel norm preservation)")
+let
+    sm = spin_matrices(6); D = 13
+    psi_h = randn(ComplexF64, N, N, N, D)
+    phix_h = randn(Float64, N, N, N); phiy_h = randn(Float64, N, N, N); phiz_h = randn(Float64, N, N, N)
+    for (lbl, dev) in (("CPU", false), ("GPU", true))
+        psi = dev ? CUDA.CuArray(psi_h) : copy(psi_h)
+        phx = dev ? CUDA.CuArray(phix_h) : copy(phix_h)
+        phy = dev ? CUDA.CuArray(phiy_h) : copy(phiy_h)
+        phz = dev ? CUDA.CuArray(phiz_h) : copy(phiz_h)
+        P0 = reshape(Array(psi), N^3, D)
+        n_before = vec(sum(abs2, P0; dims=2))
+        SpinorBEC._apply_ddi_rotation!(psi, phx, phy, phz, sm, 0.01, 3)
+        dev && CUDA.synchronize()
+        P1 = reshape(Array(psi), N^3, D)
+        n_after = vec(sum(abs2, P1; dims=2))
+        rel = maximum(abs.(n_after .- n_before) ./ n_before)
+        @printf("    %s  max per-voxel |Δ‖s‖²|/‖s‖² = %.3e\n", lbl, rel)
+    end
+end
+
+# ---------- (2) Norm + energy drift over RTP steps ----------
+println("="^64)
+println("(2) RTP norm + energy drift over 200 steps (Eu $(N)^3 DDI)")
+function build(backend)
+    grid = make_grid(GridConfig(ntuple(_->N,3), ntuple(_->12.0,3)))
+    sp = SimParams(; dt=0.002, n_steps=1, imaginary_time=false)
+    psi0 = zeros(ComplexF64, N,N,N,13)
+    for I in CartesianIndices((N,N,N))
+        r2 = sum((I[d]-N/2)^2 for d in 1:3)/N
+        psi0[I,1]=exp(-r2); psi0[I,3]=0.1exp(-r2); psi0[I,7]=0.05exp(-r2)
+    end
+    ws = make_workspace(; grid, atom=Eu151,
+        interactions=InteractionParams(Dict(0=>EU_c0,1=>0.3)),
+        zeeman=ZeemanParams(EU_p_weak,0.05), potential=HarmonicTrap((1.0,1.0,EU_λ_z)),
+        sim_params=sp, psi_init=copy(psi0), enable_ddi=true, c_dd=100.0, backend=backend)
+    dV = prod(grid.config.box_size ./ grid.config.n_points)
+    ws.state.psi ./= sqrt(sum(abs2, ws.state.psi)*dV)
+    ws, dV
+end
+
+for (lbl, backend) in (("CPU", CPUBackend()), ("GPU", CUDABackend()))
+    ws, dV = build(backend)
+    norm0 = sum(abs2, ws.state.psi)*dV
+    e0 = total_energy(ws)
+    for _ in 1:200; split_step!(ws); end
+    backend isa CUDABackend && CUDA.synchronize()
+    norm1 = sum(abs2, ws.state.psi)*dV
+    e1 = total_energy(ws)
+    @printf("    %s  |‖ψ‖²-1|: start %.2e → end %.2e | energy rel drift %.3e\n",
+            lbl, abs(norm0-1), abs(norm1-1), abs((e1-e0)/e0))
+end
+println("DONE")

--- a/bench/micro_ddi_rotation.jl
+++ b/bench/micro_ddi_rotation.jl
@@ -1,0 +1,40 @@
+# Decompose ddi_rotation cost: BLAS gemm stages vs per-voxel phase loops.
+using SpinorBEC
+using BenchmarkTools, LinearAlgebra, Printf
+
+const SB = SpinorBEC
+
+function setup(n)
+    sm = spin_matrices(6)             # F=6 → D=13
+    D = 13
+    N = n^3
+    P = randn(ComplexF64, N, D) ./ 100
+    W = similar(P)
+    conj_V = Matrix{ComplexF64}(conj(sm.Fy_eigvecs))
+    V_T = Matrix{ComplexF64}(transpose(sm.Fy_eigvecs))
+    alpha = randn(N); beta = randn(N); theta = randn(N) ./ 100
+    (; P, W, conj_V, V_T, alpha, beta, theta, F=6.0, N, D)
+end
+
+# Just the 4 gemms (BLAS-bound, OpenBLAS-threaded)
+function gemm_only!(s)
+    mul!(s.W, s.P, s.conj_V)
+    mul!(s.P, s.W, s.V_T)
+    mul!(s.W, s.P, s.conj_V)
+    mul!(s.P, s.W, s.V_T)
+    nothing
+end
+
+for n in (16, 32)
+    s = setup(n)
+    println("\n=== n=$n (N_spatial=$(s.N), D=$(s.D), jl_threads=$(Threads.nthreads()), blas=$(BLAS.get_num_threads())) ===")
+    b_full = @benchmark SB._apply_euler_5stage_batched_real!(
+        $s.P, $s.W, $s.conj_V, $s.V_T, $s.alpha, $s.beta, $s.theta, $s.F, Val(13)
+    ) samples=300 seconds=8
+    b_gemm = @benchmark gemm_only!($s) samples=300 seconds=8
+    tf = time(minimum(b_full))/1e3
+    tg = time(minimum(b_gemm))/1e3
+    @printf("  full 5-stage:  %8.1f μs\n", tf)
+    @printf("  4 gemms only:  %8.1f μs  (%.0f%%)\n", tg, 100*tg/tf)
+    @printf("  phase loops:   %8.1f μs  (%.0f%%)  [by difference]\n", tf-tg, 100*(tf-tg)/tf)
+end

--- a/bench/profile_1step.jl
+++ b/bench/profile_1step.jl
@@ -1,0 +1,64 @@
+# Profile ONE split_step! by kernel. Two configs:
+#   (A) bench config: Eu151 16³, c0/c1, NO DDI  (matches baseline split_step bench)
+#   (B) production:    Eu151 16³ + 32³, c0 + DDI (Klaus/Matsui regime)
+# Uses the built-in TimerOutputs tracing (enable_tracing! / TIMER) for a
+# per-kernel breakdown, plus a BenchmarkTools minimum for the whole step.
+
+using SpinorBEC
+using BenchmarkTools
+using Printf
+
+include(joinpath(@__DIR__, "eu151_params.jl"))
+
+ferro_init(grid, D) = begin
+    psi = zeros(ComplexF64, grid.config.n_points..., D)
+    @inbounds for I in CartesianIndices(grid.config.n_points)
+        r2 = sum(grid.x[d][I[d]]^2 for d in 1:length(grid.config.n_points))
+        psi[I, 1] = exp(-r2 / 2)
+    end
+    psi
+end
+
+function build_ws(; n, ddi::Bool)
+    L = 12.0
+    grid = make_grid(GridConfig(ntuple(_ -> n, 3), ntuple(_ -> L, 3)))
+    sp = SimParams(; dt = 0.005, n_steps = 1)
+    psi0 = ferro_init(grid, 13)
+    ws = make_workspace(;
+        grid, atom = Eu151,
+        interactions = InteractionParams(Dict(0 => EU_c0, 1 => 0.0)),
+        zeeman = ZeemanParams(EU_p_weak, 0.0),
+        potential = HarmonicTrap((1.0, 1.0, EU_λ_z)),
+        sim_params = sp, psi_init = psi0,
+        enable_ddi = ddi, c_dd = ddi ? 100.0 : 0.0,
+    )
+    # normalize
+    dV = prod(grid.config.box_size ./ grid.config.n_points)
+    ws.state.psi ./= sqrt(sum(abs2, ws.state.psi) * dV)
+    ws
+end
+
+function profile_config(label; n, ddi)
+    println("\n" * "="^70)
+    println("CONFIG: $label   (n=$n, ddi=$ddi, threads=$(Threads.nthreads()))")
+    println("="^70)
+    ws = build_ws(; n, ddi)
+
+    for _ in 1:5; SpinorBEC.split_step!(ws); end   # warmup JIT
+
+    SpinorBEC.enable_tracing!()
+    SpinorBEC.reset_tracing!()
+    for _ in 1:200; SpinorBEC.split_step!(ws); end
+    println(SpinorBEC.TIMER)
+    SpinorBEC.disable_tracing!()
+
+    b = @benchmark SpinorBEC.split_step!($ws) samples=200 seconds=15
+    m = minimum(b)
+    @printf("\n  WHOLE split_step!: min %.1f μs / %d allocs / %d bytes\n",
+            time(m)/1e3, allocs(m), memory(m))
+    time(m)
+end
+
+# Eu production is always DDI-on; the no-DDI case is not a real scenario.
+profile_config("prod-DDI-16"; n=16, ddi=true)   # smoke/test size (serial path)
+profile_config("prod-DDI-32"; n=32, ddi=true)   # production-shaped (threaded path)

--- a/bench/profile_1step_gpu.jl
+++ b/bench/profile_1step_gpu.jl
@@ -1,0 +1,116 @@
+# GPU profile of ONE split_step! for Eu F=6 + DDI (TSUBAME H100 production path).
+# Per-kernel breakdown via CUDA.@profile + whole-step wall via CUDA.@sync.
+#
+#   julia --project=. bench/profile_1step_gpu.jl [N] [dtype]
+#   N      grid size per dim (default 128)
+#   dtype  f64 | f32 (default f64)
+
+import CUDA
+using SpinorBEC
+using Printf
+
+include(joinpath(@__DIR__, "eu151_params.jl"))
+
+const N      = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 128
+const DTYPE  = length(ARGS) >= 2 && lowercase(ARGS[2]) == "f32" ? Float32 : Float64
+
+println("="^70)
+println("GPU split_step profile — Eu F=6 + DDI")
+println("  N=$N^3, dtype=$DTYPE, device=", CUDA.name(CUDA.device()))
+println("="^70)
+
+function ferro_init(grid, D, ::Type{CT}) where {CT}
+    psi = zeros(CT, grid.config.n_points..., D)
+    @inbounds for I in CartesianIndices(grid.config.n_points)
+        r2 = sum(grid.x[d][I[d]]^2 for d in 1:length(grid.config.n_points))
+        psi[I, 1] = exp(-r2 / 2)
+    end
+    psi
+end
+
+L = 16.0
+grid = make_grid(GridConfig(ntuple(_ -> N, 3), ntuple(_ -> L, 3)))
+sp = SimParams(; dt = 0.005, n_steps = 1)
+psi0 = ferro_init(grid, 13, Complex{DTYPE})
+
+ws = make_workspace(;
+    grid, atom = Eu151,
+    interactions = InteractionParams(Dict(0 => EU_c0, 1 => 0.0)),
+    zeeman = ZeemanParams(EU_p_weak, 0.0),
+    potential = HarmonicTrap((1.0, 1.0, EU_λ_z)),
+    sim_params = sp, psi_init = psi0,
+    enable_ddi = true, c_dd = 100.0,
+    backend = CUDABackend(),
+)
+dV = prod(grid.config.box_size ./ grid.config.n_points)
+ws.state.psi ./= sqrt(sum(abs2, ws.state.psi) * dV)
+
+println("\nGPU free/total: ",
+    round(CUDA.available_memory() / 2^30; digits=1), "/",
+    round(CUDA.total_memory() / 2^30; digits=1), " GiB")
+flush(stdout)
+
+# --- Warmup (JIT all kernels) ---
+println("Warmup…"); flush(stdout)
+for _ in 1:5; split_step!(ws); end
+CUDA.synchronize()
+
+# --- Whole-step wall time (min over many) ---
+function timed(ws, iters)
+    best = Inf
+    for _ in 1:iters
+        CUDA.synchronize()
+        t0 = time_ns()
+        split_step!(ws)
+        CUDA.synchronize()
+        best = min(best, (time_ns() - t0) / 1e3)  # μs
+    end
+    best
+end
+whole = timed(ws, 50)
+@printf("\nWHOLE split_step!: min %.1f μs/step  (%.2f ms)\n", whole, whole/1e3)
+flush(stdout)
+
+# --- Per-kernel breakdown via CUDA.@sync timing of each sub-step ---
+function gtime(f; iters=40)
+    best = Inf
+    for _ in 1:iters
+        CUDA.synchronize(); t0 = time_ns()
+        f()
+        CUDA.synchronize(); best = min(best, (time_ns() - t0) / 1e3)
+    end
+    best
+end
+
+n_pts = ntuple(d -> size(ws.state.psi, d), 3)
+psi = ws.state.psi
+sm = ws.spin_matrices
+bufs = ws.ddi_bufs
+zd = SpinorBEC.zeeman_diagonal(SpinorBEC.zeeman_at(ws.zeeman, 0.0), sm, 0.0)
+
+# warm each isolated call
+SpinorBEC._compute_and_convolve_ddi!(psi, sm, ws.ddi, bufs, Val(13), 3, n_pts)
+SpinorBEC._apply_ddi_rotation!(psi, bufs.Phi_x, bufs.Phi_y, bufs.Phi_z, sm, 0.0025, 3)
+SpinorBEC.apply_kinetic_step_batched!(psi, ws.batched_kinetic)
+SpinorBEC._dispatch_diagonal_step!(ws, Val(3), zd, 0.00125, false, ws.interactions)
+CUDA.synchronize()
+
+t_conv = gtime(() -> SpinorBEC._compute_and_convolve_ddi!(psi, sm, ws.ddi, bufs, Val(13), 3, n_pts))
+t_rot  = gtime(() -> SpinorBEC._apply_ddi_rotation!(psi, bufs.Phi_x, bufs.Phi_y, bufs.Phi_z, sm, 0.0025, 3))
+t_kin  = gtime(() -> SpinorBEC.apply_kinetic_step_batched!(psi, ws.batched_kinetic))
+t_diag = gtime(() -> SpinorBEC._dispatch_diagonal_step!(ws, Val(3), zd, 0.00125, false, ws.interactions))
+
+println("\n=== Per-kernel min (μs), isolated CUDA.@sync ===")
+@printf("  ddi_convolve   %8.1f\n", t_conv)
+@printf("  ddi_rotation   %8.1f   <-- (×2/step)\n", t_rot)
+@printf("  kinetic        %8.1f   <-- (×1/step)\n", t_kin)
+@printf("  diagonal       %8.1f   <-- (×4/step)\n", t_diag)
+@printf("  rough step est %8.1f  (2·conv + 2·rot + kin + 4·diag)\n",
+        2t_conv + 2t_rot + t_kin + 4t_diag)
+flush(stdout)
+
+# --- Device kernel trace (names + times) ---
+println("\n=== CUDA.@profile (one step) ===")
+prof = CUDA.@profile split_step!(ws)
+show(stdout, MIME("text/plain"), prof)
+println("\nDONE")

--- a/bench/run_gpu_tests.jl
+++ b/bench/run_gpu_tests.jl
@@ -1,0 +1,8 @@
+using Test
+import CUDA
+using SpinorBEC
+@info "CUDA functional" CUDA.functional()
+include(joinpath(@__DIR__, "..", "test", "gpu", "test_cuda_equivalence.jl"))
+include(joinpath(@__DIR__, "..", "test", "oracles", "test_gpu_cpu_per_term_parity.jl"))
+include(joinpath(@__DIR__, "..", "test", "test_level0_gpu_cpu_consistency.jl"))
+println("ALL GPU TESTS DONE")

--- a/bench/tsubame_run.sh
+++ b/bench/tsubame_run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#$ -cwd
+#$ -l node_q=1
+#$ -l h_rt=0:30:00
+#$ -o /gs/fs/tga-kozuma-kouhi/uk07267/BEC-opt/logs/
+#$ -e /gs/fs/tga-kozuma-kouhi/uk07267/BEC-opt/logs/
+# Usage: qsub -g tga-kozuma-kouhi -N <name> bench/tsubame_run.sh <julia_script> [args...]
+set -e
+GRP=tga-kozuma-kouhi
+export JULIA_DEPOT_PATH=/gs/fs/$GRP/shared/.julia
+cd /gs/fs/$GRP/uk07267/BEC-opt
+SCRIPT="$1"; shift
+echo "host=$(hostname) script=$SCRIPT args=$* date=$(date)"
+nvidia-smi --query-gpu=name --format=csv,noheader || true
+/gs/fs/$GRP/shared/.juliaup/bin/julia --project=. "$SCRIPT" "$@"
+echo "EXIT=$?"

--- a/bench/verify_gpu_split_step.jl
+++ b/bench/verify_gpu_split_step.jl
@@ -1,0 +1,53 @@
+# Correctness gate: GPU split_step! must match CPU to ~F64 round-off after
+# the GPU DDI-rotation custom-kernel switch. Eu F=6 + DDI, both real & imag time.
+#   julia --project=. bench/verify_gpu_split_step.jl [N]
+
+import CUDA
+using SpinorBEC
+using Printf
+
+include(joinpath(@__DIR__, "eu151_params.jl"))
+
+const N = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 32
+
+function build(backend; it::Bool, psi0)
+    grid = make_grid(GridConfig(ntuple(_ -> N, 3), ntuple(_ -> 12.0, 3)))
+    sp = SimParams(; dt = 0.005, n_steps = 1, imaginary_time = it, normalize_every = 0)
+    make_workspace(;
+        grid, atom = Eu151,
+        interactions = InteractionParams(Dict(0 => EU_c0, 1 => 0.3)),  # c1≠0 → spin-mixing too
+        zeeman = ZeemanParams(EU_p_weak, 0.05),
+        potential = HarmonicTrap((1.0, 1.0, EU_λ_z)),
+        sim_params = sp, psi_init = copy(psi0),
+        enable_ddi = true, c_dd = 100.0, backend = backend,
+    )
+end
+
+psi0 = zeros(ComplexF64, N, N, N, 13)
+for I in CartesianIndices((N, N, N))
+    r2 = 0.0
+    for d in 1:3; r2 += 0.0; end
+    psi0[I, 1] = exp(-(sum((I[d] - N/2)^2 for d in 1:3)) / (N))
+    psi0[I, 3] = 0.1 * psi0[I, 1]
+    psi0[I, 7] = 0.05 * psi0[I, 1]
+end
+
+for it in (false, true)
+    label = it ? "imag-time (ITP)" : "real-time (RTP)"
+    ws_c = build(CPUBackend(); it, psi0)
+    ws_g = build(CUDABackend(); it, psi0)
+    for _ in 1:5
+        split_step!(ws_c)
+        split_step!(ws_g)
+    end
+    pc = ws_c.state.psi
+    pg = Array(ws_g.state.psi)
+    absdiff = maximum(abs.(pc .- pg))
+    scale = maximum(abs.(pc))
+    @printf("%-16s  max|Δ|=%.3e  rel=%.3e  (scale %.3e)\n",
+            label, absdiff, absdiff / scale, scale)
+    # CPU/GPU agree to FFT/gemm reassociation round-off (~1e-9 over 5 steps
+    # of F64 with the DDI-convolve FFTs); 1e-7 catches real algorithmic bugs.
+    @assert absdiff / scale < 1e-7 "GPU/CPU mismatch in $label"
+end
+println("GPU == CPU split_step parity OK")

--- a/ext/SpinorBECCUDAExt/SpinorBECCUDAExt.jl
+++ b/ext/SpinorBECCUDAExt/SpinorBECCUDAExt.jl
@@ -19,6 +19,8 @@ using CUDA: CuArray, CuGraph, CuGraphExec, @captured
 
 include("backend.jl")
 include("gpu_euler_kernel.jl")
+include("gpu_ddi_rotation.jl")
+include("gpu_diagonal.jl")
 include("gpu_spin_mixing.jl")
 include("gpu_normalize.jl")
 include("gpu_singlet_pair.jl")

--- a/ext/SpinorBECCUDAExt/gpu_ddi_rotation.jl
+++ b/ext/SpinorBECCUDAExt/gpu_ddi_rotation.jl
@@ -1,0 +1,77 @@
+# GPU DDI Euler rotation via the single-launch phi-angle kernel.
+#
+# The generic `SpinorBEC._apply_ddi_rotation!(::AbstractArray, …)` drove the
+# GPU through the broadcast-+-cuBLAS chain (~4 gemms + ~9 elementwise launches
+# + W HBM round-trips, twice per step). This override computes the per-voxel
+# Euler angles from the dipolar field IN the rotation kernel
+# (`apply_ddi_euler_fused_kernel!`, gpu_euler_kernel.jl) — one launch, no
+# separate angle-broadcast pass, no α/β/θ scratch round-trip.
+#
+# Math matches the CPU batched path to machine epsilon and the prior GPU
+# broadcast path (Step1 +m·α, Ry(β), Dz ∓m·θ, Ry(-β), Step5 -m·α). Padded-DDI
+# fields are cropped to the spatial corner first (matches `_ddi_crop_phi`).
+
+mutable struct GPUDDIRotCache{D, T <: AbstractFloat}
+    V::CuArray{Complex{T}, 2}        # D×D Fy eigenvectors
+    conj_V::CuArray{Complex{T}, 2}   # D×D conj(V)
+    m_row::CuArray{T, 2}             # (1,D)  [F, F-1, …, -F]
+    λ_row::CuArray{T, 2}             # (1,D)  Fy eigenvalues ascending
+end
+
+const _GPU_DDI_ROT_CACHE = Dict{UInt64, Any}()
+
+function _get_gpu_ddi_rot_cache(
+    psi::CuArray{Complex{T}}, sm::SpinorBEC.SpinMatrices{D}, ndim::Int
+) where {D, T <: AbstractFloat}
+    N = prod(ntuple(d -> size(psi, d), ndim))
+    key = hash((objectid(sm), N, D, T))
+    cache = get(_GPU_DDI_ROT_CACHE, key, nothing)
+    cache !== nothing && return cache::GPUDDIRotCache{D, T}
+
+    F = T(sm.system.F)
+    m_vals = T[F - T(c - 1) for c in 1:D]
+    λ_host = T.(sm.Fy_eigvals)
+    V_host = Matrix{Complex{T}}(sm.Fy_eigvecs)
+
+    cache = GPUDDIRotCache{D, T}(
+        CuArray(V_host),
+        CuArray(conj.(V_host)),
+        CuArray(reshape(m_vals, 1, D)),
+        CuArray(reshape(λ_host, 1, D)),
+    )
+    _GPU_DDI_ROT_CACHE[key] = cache
+    cache
+end
+
+# Crop a (possibly padded) dipolar field to the spatial corner and flatten to
+# (N,). Unpadded (size == n_pts, every production run) is a zero-copy reshape.
+@inline function _gpu_phi_vec(phi::CuArray, n_pts::NTuple{M, Int}, N::Int) where {M}
+    size(phi) == n_pts && return reshape(phi, N)
+    reshape(phi[CartesianIndices(n_pts)], N)
+end
+
+function SpinorBEC._apply_ddi_rotation!(
+    psi::CuArray{Complex{T}},
+    phi_x::CuArray,
+    phi_y::CuArray,
+    phi_z::CuArray,
+    sm::SpinorBEC.SpinMatrices{D},
+    dt_frac::Float64,
+    ndim::Int;
+    imaginary_time::Bool=false,
+) where {T <: AbstractFloat, D}
+    n_pts = ntuple(d -> size(psi, d), ndim)
+    N = prod(n_pts)
+    cache = _get_gpu_ddi_rot_cache(psi, sm, ndim)
+
+    P = reshape(psi, N, D)
+    px = _gpu_phi_vec(phi_x, n_pts, N)
+    py = _gpu_phi_vec(phi_y, n_pts, N)
+    pz = _gpu_phi_vec(phi_z, n_pts, N)
+
+    apply_ddi_euler_fused_kernel!(
+        P, px, py, pz, cache.m_row, cache.λ_row, cache.V, cache.conj_V, dt_frac;
+        imaginary_time=imaginary_time,
+    )
+    nothing
+end

--- a/ext/SpinorBECCUDAExt/gpu_diagonal.jl
+++ b/ext/SpinorBECCUDAExt/gpu_diagonal.jl
@@ -1,0 +1,68 @@
+# Fused GPU diagonal potential step.
+#
+# The generic `_diagonal_step_svec!(::AbstractArray, …)` builds the density
+# with D `abs2` broadcasts and then applies the per-component phase with D
+# more `cis`/`exp` broadcasts — 2D ≈ 26 kernel launches per call at D=13,
+# ×4 calls/step. This single kernel does one launch: each thread computes
+# its voxel density once and applies all D component phases from registers.
+#
+# Handles the scalar / no-LHY contact term (covers the Eu DDI production
+# path). Non-scalar LHY (Tabulated, Quasi2D, …) does not match the c_lhy
+# type bound and falls back to the generic broadcast method.
+
+using StaticArrays: SVector
+
+@inline function _diag_step_kernel!(
+    P, Pmf, Vt, db, zee, c0::T, clhy::T, shift::T, dt::T, ::Val{D}, ::Val{IT},
+) where {T, D, IT}
+    i = (CUDA.blockIdx().x - 1) * CUDA.blockDim().x + CUDA.threadIdx().x
+    i > size(P, 1) && return nothing
+
+    n = zero(T)
+    @inbounds for c in 1:D
+        v = Pmf[i, c]
+        n += abs2(v)
+    end
+    @inbounds db[i] = n
+
+    lhy = clhy == zero(T) ? zero(T) : clhy * n * sqrt(n)
+    base = @inbounds(Vt[i]) + c0 * n + lhy
+    @inbounds for c in 1:D
+        arg = (base + (zee[c] - shift)) * dt
+        P[i, c] *= IT ? exp(-arg) : cis(-arg)
+    end
+    return nothing
+end
+
+function SpinorBEC._diagonal_step_svec!(
+    ::Val{N},
+    psi::CuArray{Complex{T}},
+    V_trap,
+    zeeman_diag::SVector{D, Float64},
+    c0,
+    c_lhy::Union{Nothing, SpinorBEC.NoLHY, Float64, SpinorBEC.ScalarLHY},
+    dt_frac,
+    density_buf,
+    imaginary_time;
+    psi_mf::Union{Nothing, AbstractArray}=nothing,
+) where {N, T <: AbstractFloat, D}
+    n_pts = ntuple(d -> size(psi, d), Val(N))
+    Ns = prod(n_pts)
+    clhy = c_lhy isa SpinorBEC.ScalarLHY ? T(c_lhy.c_lhy) :
+           (c_lhy isa Float64 ? T(c_lhy) : zero(T))
+    shift = imaginary_time ? T(minimum(zeeman_diag)) : zero(T)
+    zee = SVector{D, T}(ntuple(c -> T(zeeman_diag[c]), Val(D)))
+
+    P = reshape(psi, Ns, D)
+    Pmf = reshape(psi_mf === nothing ? psi : psi_mf::CuArray{Complex{T}}, Ns, D)
+    Vt = reshape(V_trap, Ns)
+    db = reshape(density_buf, Ns)
+
+    threads = min(Ns, 256)
+    blocks = cld(Ns, threads)
+    CUDA.@cuda threads = threads blocks = blocks _diag_step_kernel!(
+        P, Pmf, Vt, db, zee, T(c0), clhy, shift, T(dt_frac),
+        Val(D), Val(imaginary_time === true),
+    )
+    nothing
+end

--- a/ext/SpinorBECCUDAExt/gpu_euler_kernel.jl
+++ b/ext/SpinorBECCUDAExt/gpu_euler_kernel.jl
@@ -1,71 +1,80 @@
-# Fused Euler 5-stage rotation kernel.
+# Fused Euler 5-stage rotation kernels (single launch).
 #
-# Replaces the broadcast-+-gemm chain in `apply_euler_5stage_fused!` with
-# a single CUDA kernel that processes every spatial point in registers
-# and reads the D×D Fy eigenvector matrices once into shared memory per
-# block. For F=6 (D=13) on a 64³ F32 grid this collapses the 7
-# kernel launches of the broadcast version (Step 1 phase, R_y(-β)
-# matmul-+-diag-+-matmul, D_z phase, R_y(β) matmul-+-diag-+-matmul,
-# Step 5 phase) into 1, eliminates the (N,D) tmp buffer round-trip
-# through HBM, and folds the per-point phase factors into the matvec
-# accumulation loops.
+# The sign-bearing 5-stage body lives in ONE device function
+# `_euler_apply_voxel!` (single declaration — the codebase forbids
+# duplicating sign-bearing physics). Two kernels call it:
+#   * `_euler_5stage_kernel!`  — angles supplied as (N,1) arrays
+#     (spin_mixing, raman: angles come from spin density / Raman field).
+#   * `_ddi_euler_kernel!`     — angles computed in-register from the dipolar
+#     field Φ(r), so DDI rotation pays no separate angle broadcast pass.
 #
-# Two layout assumptions:
-#   - `psi_2d` is column-major with shape (N, D). Each row is a spinor.
-#   - `V` is the Fy eigenvector matrix and `conj_V[c, j] = conj(V[c, j])`.
-#     The transpose `V_T` isn't needed: `Σ_j tmp[j] * V_T[j, c] = Σ_j
-#     tmp[j] * V[c, j]`.
+# Each holds the spinor in a thread-local MVector and reads the two D×D Fy
+# eigenvector matrices once per block into SHARED memory. A full `@nexprs`
+# unroll of the 13×13 matvecs EXPLODES register pressure (measured 3.5×
+# slower) — the looped MVector is the sweet spot. `ntuple(f, Val(D))` does
+# NOT unroll for D>10 (Base caps at 10 → dynamic jl_f_tuple, illegal on GPU).
+#
+# Layout: `psi` (N, D) column-major; `conj_V[c,j] = conj(V[c,j])`; shared
+# V/conj_V linear column-major, element [c,j] at (j-1)*D + c.
 
 using StaticArrays: MVector
 
-@inline function _euler_5stage_kernel!(
-    psi, α, β, θ, m_gpu, m_shift, λ_gpu, V, conj_V,
-    ::Val{D}, ::Val{IT},
-) where {D, IT}
-    i = (CUDA.blockIdx().x - 1) * CUDA.blockDim().x + CUDA.threadIdx().x
-    N = size(psi, 1)
-    i > N && return nothing
+@inline function _load_shared_eigvecs!(shV, shCV, V, conj_V, ::Val{DD}) where {DD}
+    tid = CUDA.threadIdx().x
+    nth = CUDA.blockDim().x
+    k = tid
+    @inbounds while k <= DD
+        shV[k] = V[k]
+        shCV[k] = conj_V[k]
+        k += nth
+    end
+    CUDA.sync_threads()
+    nothing
+end
 
+# Apply R_z(α) R_y(β) D_z(θ) R_y(-β) R_z(-α) to row i of psi in place.
+# `shV`/`shCV` are the block-shared Fy eigenvector matrices (already loaded).
+# ITP Dz uses exp(-m·θ) (NOT exp(-(m-F)·θ): the overflow shift is a spatially
+# varying density reweighting that biases the ITP fixed point — CPU fix
+# 2026-06-15, mistake_itp_imaginary_time_euler_stage3_density_bias).
+@inline function _euler_apply_voxel!(
+    psi, i, α_i, β_i, θ_i, m_gpu, λ_gpu, shV, shCV, ::Val{D}, ::Val{IT},
+) where {D, IT}
     T = real(eltype(psi))
     CT = Complex{T}
 
-    α_i = α[i, 1]
-    β_i = β[i, 1]
-    θ_i = θ[i, 1]
-
-    # Load spinor into thread-local stack array.
     s = MVector{D, CT}(undef)
     @inbounds for c in 1:D
         s[c] = psi[i, c]
     end
 
-    # --- Step 1: R_z(-α) → s_c *= cis(+m_c · α) ---
+    # Step 1: R_z(-α) → s_c *= cis(+m_c·α)
     @inbounds for c in 1:D
         s[c] *= cis(m_gpu[1, c] * α_i)
     end
 
-    # --- Step 2: R_y(-β) = V · diag(cis(+βλ)) · conj(V)ᵀ ---
-    # As row × matrix: s_new = (s · conj_V) ⊙ cis(βλ); s_final = s_new · V^T
+    # Step 2: R_y(-β) = V·diag(cis(+βλ))·conj(V)ᵀ
     tmp = MVector{D, CT}(undef)
     @inbounds for j in 1:D
         acc = zero(CT)
+        base = (j - 1) * D
         for c in 1:D
-            acc += s[c] * conj_V[c, j]
+            acc += s[c] * shCV[base + c]
         end
         tmp[j] = acc * cis(β_i * λ_gpu[1, j])
     end
     @inbounds for c in 1:D
         acc = zero(CT)
         for j in 1:D
-            acc += tmp[j] * V[c, j]   # V_T[j, c] = V[c, j]
+            acc += tmp[j] * shV[(j - 1) * D + c]
         end
         s[c] = acc
     end
 
-    # --- Step 3: D_z(θ) ---
+    # Step 3: D_z(θ)
     if IT
         @inbounds for c in 1:D
-            s[c] *= exp(-m_shift[1, c] * θ_i)
+            s[c] *= exp(-m_gpu[1, c] * θ_i)
         end
     else
         @inbounds for c in 1:D
@@ -73,23 +82,24 @@ using StaticArrays: MVector
         end
     end
 
-    # --- Step 4: R_y(β) (mirror of Step 2 with β → -β) ---
+    # Step 4: R_y(β)
     @inbounds for j in 1:D
         acc = zero(CT)
+        base = (j - 1) * D
         for c in 1:D
-            acc += s[c] * conj_V[c, j]
+            acc += s[c] * shCV[base + c]
         end
         tmp[j] = acc * cis(-β_i * λ_gpu[1, j])
     end
     @inbounds for c in 1:D
         acc = zero(CT)
         for j in 1:D
-            acc += tmp[j] * V[c, j]
+            acc += tmp[j] * shV[(j - 1) * D + c]
         end
         s[c] = acc
     end
 
-    # --- Step 5: R_z(α) → s_c *= cis(-m_c · α) ---
+    # Step 5: R_z(α) → s_c *= cis(-m_c·α)
     @inbounds for c in 1:D
         s[c] *= cis(-m_gpu[1, c] * α_i)
     end
@@ -97,28 +107,55 @@ using StaticArrays: MVector
     @inbounds for c in 1:D
         psi[i, c] = s[c]
     end
+    nothing
+end
+
+# --- Array-angle kernel (spin_mixing, raman) ---
+@inline function _euler_5stage_kernel!(
+    psi, α, β, θ, m_gpu, m_shift, λ_gpu, V, conj_V, ::Val{D}, ::Val{IT},
+) where {D, IT}
+    CT = Complex{real(eltype(psi))}
+    shV = CUDA.CuStaticSharedArray(CT, D * D)
+    shCV = CUDA.CuStaticSharedArray(CT, D * D)
+    _load_shared_eigvecs!(shV, shCV, V, conj_V, Val(D * D))
+    i = (CUDA.blockIdx().x - 1) * CUDA.blockDim().x + CUDA.threadIdx().x
+    i > size(psi, 1) && return nothing
+    _euler_apply_voxel!(psi, i, (@inbounds α[i, 1]), (@inbounds β[i, 1]),
+        (@inbounds θ[i, 1]), m_gpu, λ_gpu, shV, shCV, Val(D), Val(IT))
+    return nothing
+end
+
+# --- DDI phi-angle kernel: angles from the dipolar field, no broadcast pass ---
+@inline function _ddi_euler_kernel!(
+    psi, phi_x, phi_y, phi_z, m_gpu, λ_gpu, V, conj_V, dt::T, ::Val{D}, ::Val{IT},
+) where {T, D, IT}
+    CT = Complex{T}
+    shV = CUDA.CuStaticSharedArray(CT, D * D)
+    shCV = CUDA.CuStaticSharedArray(CT, D * D)
+    _load_shared_eigvecs!(shV, shCV, V, conj_V, Val(D * D))
+    i = (CUDA.blockIdx().x - 1) * CUDA.blockDim().x + CUDA.threadIdx().x
+    i > size(psi, 1) && return nothing
+    px = @inbounds phi_x[i]
+    py = @inbounds phi_y[i]
+    pz = @inbounds phi_z[i]
+    pm = sqrt(px * px + py * py + pz * pz)
+    α_i = atan(py, px)
+    β_i = acos(clamp(pz / max(pm, floatmin(T)), -one(T), one(T)))
+    θ_i = pm * dt
+    _euler_apply_voxel!(psi, i, α_i, β_i, θ_i, m_gpu, λ_gpu, shV, shCV, Val(D), Val(IT))
     return nothing
 end
 
 """
     apply_euler_5stage_fused_kernel!(psi_2d, α, β, θ, m_gpu, m_shift, λ_gpu, V, conj_V; imaginary_time)
 
-GPU-only single-launch fused replacement for the 7-launch broadcast-+-gemm
-chain in `SpinorBEC.apply_euler_5stage_fused!`. `psi_2d` has shape
-`(N, D)`; `α`, `β`, `θ` are `(N, 1)` per-point angles; `m_gpu`,
-`m_shift`, `λ_gpu` are `(1, D)` row vectors; `V` and `conj_V` are the
-D×D Fy eigenvector matrices (with `conj_V[c, j] = conj(V[c, j])`).
+Single-launch fused Euler rotation with angles supplied as `(N,1)` arrays.
 """
 function apply_euler_5stage_fused_kernel!(
     psi_2d::CuArray{Complex{T}, 2},
-    α::CuArray{T, 2},
-    β::CuArray{T, 2},
-    θ::CuArray{T, 2},
-    m_gpu::CuArray{T, 2},
-    m_shift::CuArray{T, 2},
-    λ_gpu::CuArray{T, 2},
-    V::CuArray{Complex{T}, 2},
-    conj_V::CuArray{Complex{T}, 2};
+    α::CuArray{T, 2}, β::CuArray{T, 2}, θ::CuArray{T, 2},
+    m_gpu::CuArray{T, 2}, m_shift::CuArray{T, 2}, λ_gpu::CuArray{T, 2},
+    V::CuArray{Complex{T}, 2}, conj_V::CuArray{Complex{T}, 2};
     imaginary_time::Bool=false,
 ) where {T <: AbstractFloat}
     N = size(psi_2d, 1)
@@ -126,8 +163,31 @@ function apply_euler_5stage_fused_kernel!(
     threads = min(N, 256)
     blocks = cld(N, threads)
     CUDA.@cuda threads = threads blocks = blocks _euler_5stage_kernel!(
-        psi_2d, α, β, θ, m_gpu, m_shift, λ_gpu, V, conj_V,
-        Val(D), Val(imaginary_time),
-    )
+        psi_2d, α, β, θ, m_gpu, m_shift, λ_gpu, V, conj_V, Val(D), Val(imaginary_time))
+    nothing
+end
+
+"""
+    apply_ddi_euler_fused_kernel!(psi_2d, phi_x, phi_y, phi_z, m_gpu, λ_gpu, V, conj_V, dt; imaginary_time)
+
+DDI rotation: per-voxel Euler angles computed in-register from the dipolar
+field `Φ` (N-vectors `phi_x/y/z`) then the 5-stage rotation — one launch, no
+separate angle-broadcast pass.
+"""
+function apply_ddi_euler_fused_kernel!(
+    psi_2d::CuArray{Complex{T}, 2},
+    phi_x::CuArray{T}, phi_y::CuArray{T}, phi_z::CuArray{T},
+    m_gpu::CuArray{T, 2}, λ_gpu::CuArray{T, 2},
+    V::CuArray{Complex{T}, 2}, conj_V::CuArray{Complex{T}, 2},
+    dt::Real;
+    imaginary_time::Bool=false,
+) where {T <: AbstractFloat}
+    N = size(psi_2d, 1)
+    D = size(psi_2d, 2)
+    threads = min(N, 256)
+    blocks = cld(N, threads)
+    CUDA.@cuda threads = threads blocks = blocks _ddi_euler_kernel!(
+        psi_2d, phi_x, phi_y, phi_z, m_gpu, λ_gpu, V, conj_V, T(dt),
+        Val(D), Val(imaginary_time))
     nothing
 end

--- a/src/foundation/spinor_utils/euler_batched.jl
+++ b/src/foundation/spinor_utils/euler_batched.jl
@@ -3,6 +3,26 @@
 # but the V_Fy eigenmatrix is constant. Two variants: real-time (cis on
 # the diagonal stage) and imaginary-time (exp with -F shift).
 
+# Per-voxel phase stages are memory-bandwidth bound; `Threads.@threads`
+# only pays off above ~16k voxels. Below that (≤16³ smoke / test grids)
+# task-spawn overhead + per-task allocation make threading a net loss, so
+# run serial. `f` is a `where {F}` parameter so the captured closure stays
+# concretely typed — no boxing on either branch.
+const _VOXEL_THREAD_MIN = 1 << 14   # 16384 ≈ 25³
+
+@inline function _voxel_loop!(f::F, n::Integer) where {F}
+    if n >= _VOXEL_THREAD_MIN
+        Threads.@threads :static for i in 1:n
+            f(i)
+        end
+    else
+        @inbounds for i in 1:n
+            f(i)
+        end
+    end
+    nothing
+end
+
 """
     _apply_euler_5stage_batched_real!(P, W, conj_V, V_T, alpha, beta, theta, F, Val(D))
 
@@ -35,66 +55,76 @@ Stage 5: Rz(+α) — phase recurrence
     F_int = Int(F)
 
     # Stage 1 — Rz(-α): P[i, c] *= cis((F - c + 1) · α[i])
-    @inbounds for i in 1:N_spatial
-        ai = alpha[i]
-        sa, ca = sincos(ai)
-        z_a = Complex{T}(ca, -sa)         # cis(-α) — Complex{T} keeps F32 workspaces F32
-        phase = Complex{T}(ca, sa)^F_int  # cis(F·α) = cis(α)^F
-        for c in 1:D
-            P[i, c] *= phase
-            phase *= z_a
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            ai = alpha[i]
+            sa, ca = sincos(ai)
+            z_a = Complex{T}(ca, -sa)         # cis(-α) — Complex{T} keeps F32 workspaces F32
+            phase = Complex{T}(ca, sa)^F_int  # cis(F·α) = cis(α)^F
+            for c in 1:D
+                P[i, c] *= phase
+                phase *= z_a
+            end
         end
     end
 
     # Stage 2 — Ry(-β) = V · diag(exp(+iβλ)) · V†, λ_Fy = -F..F ascending
     mul!(W, P, conj_V)
-    @inbounds for i in 1:N_spatial
-        bi = beta[i]
-        sb, cb = sincos(bi)
-        z_b = Complex{T}(cb, sb)              # cis(β)
-        phase = Complex{T}(cb, -sb)^F_int      # cis(-F·β) = cis(-β)^F
-        for j in 1:D
-            W[i, j] *= phase
-            phase *= z_b
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            bi = beta[i]
+            sb, cb = sincos(bi)
+            z_b = Complex{T}(cb, sb)              # cis(β)
+            phase = Complex{T}(cb, -sb)^F_int      # cis(-F·β) = cis(-β)^F
+            for j in 1:D
+                W[i, j] *= phase
+                phase *= z_b
+            end
         end
     end
     mul!(P, W, V_T)
 
     # Stage 3 — Dz(θ): P[i, c] *= cis(-(F - c + 1) · θ[i])
-    @inbounds for i in 1:N_spatial
-        ti = theta[i]
-        st, ct = sincos(ti)
-        z_t = Complex{T}(ct, st)              # cis(θ)
-        phase = Complex{T}(ct, -st)^F_int      # cis(-F·θ)
-        for c in 1:D
-            P[i, c] *= phase
-            phase *= z_t
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            ti = theta[i]
+            st, ct = sincos(ti)
+            z_t = Complex{T}(ct, st)              # cis(θ)
+            phase = Complex{T}(ct, -st)^F_int      # cis(-F·θ)
+            for c in 1:D
+                P[i, c] *= phase
+                phase *= z_t
+            end
         end
     end
 
     # Stage 4 — Ry(+β) = conj of Stage 2 phases
     mul!(W, P, conj_V)
-    @inbounds for i in 1:N_spatial
-        bi = beta[i]
-        sb, cb = sincos(bi)
-        z_b = Complex{T}(cb, -sb)              # cis(-β)
-        phase = Complex{T}(cb, sb)^F_int        # cis(F·β)
-        for j in 1:D
-            W[i, j] *= phase
-            phase *= z_b
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            bi = beta[i]
+            sb, cb = sincos(bi)
+            z_b = Complex{T}(cb, -sb)              # cis(-β)
+            phase = Complex{T}(cb, sb)^F_int        # cis(F·β)
+            for j in 1:D
+                W[i, j] *= phase
+                phase *= z_b
+            end
         end
     end
     mul!(P, W, V_T)
 
     # Stage 5 — Rz(+α)
-    @inbounds for i in 1:N_spatial
-        ai = alpha[i]
-        sa, ca = sincos(ai)
-        z_a = Complex{T}(ca, sa)               # cis(α)
-        phase = Complex{T}(ca, -sa)^F_int       # cis(-F·α)
-        for c in 1:D
-            P[i, c] *= phase
-            phase *= z_a
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            ai = alpha[i]
+            sa, ca = sincos(ai)
+            z_a = Complex{T}(ca, sa)               # cis(α)
+            phase = Complex{T}(ca, -sa)^F_int       # cis(-F·α)
+            for c in 1:D
+                P[i, c] *= phase
+                phase *= z_a
+            end
         end
     end
     nothing
@@ -114,27 +144,31 @@ path runs the same shift-free `cis(-m·θ)`)."""
     F_int = Int(F)
 
     # Stage 1 — Rz(-α)
-    @inbounds for i in 1:N_spatial
-        ai = alpha[i]
-        sa, ca = sincos(ai)
-        z_a = Complex{T}(ca, -sa)
-        phase = Complex{T}(ca, sa)^F_int
-        for c in 1:D
-            P[i, c] *= phase
-            phase *= z_a
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            ai = alpha[i]
+            sa, ca = sincos(ai)
+            z_a = Complex{T}(ca, -sa)
+            phase = Complex{T}(ca, sa)^F_int
+            for c in 1:D
+                P[i, c] *= phase
+                phase *= z_a
+            end
         end
     end
 
     # Stage 2 — Ry(-β)
     mul!(W, P, conj_V)
-    @inbounds for i in 1:N_spatial
-        bi = beta[i]
-        sb, cb = sincos(bi)
-        z_b = Complex{T}(cb, sb)
-        phase = Complex{T}(cb, -sb)^F_int
-        for j in 1:D
-            W[i, j] *= phase
-            phase *= z_b
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            bi = beta[i]
+            sb, cb = sincos(bi)
+            z_b = Complex{T}(cb, sb)
+            phase = Complex{T}(cb, -sb)^F_int
+            for j in 1:D
+                W[i, j] *= phase
+                phase *= z_b
+            end
         end
     end
     mul!(P, W, V_T)
@@ -146,39 +180,45 @@ path runs the same shift-free `cis(-m·θ)`)."""
     # normalization (only its spatial mean is removed) and biases the ITP
     # fixed point off the variational GP minimum. The real-time variant is
     # immune (there the same factor is an irrelevant global phase).
-    @inbounds for i in 1:N_spatial
-        ti = theta[i]
-        dz_step = exp(ti)
-        dz_r = exp(-F * ti)        # c=1 (m=+F): exp(-F·θ) = exp(-m·θ)
-        for c in 1:D
-            P[i, c] *= dz_r
-            dz_r *= dz_step
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            ti = theta[i]
+            dz_step = exp(ti)
+            dz_r = exp(-F * ti)        # c=1 (m=+F): exp(-F·θ) = exp(-m·θ)
+            for c in 1:D
+                P[i, c] *= dz_r
+                dz_r *= dz_step
+            end
         end
     end
 
     # Stage 4 — Ry(+β)
     mul!(W, P, conj_V)
-    @inbounds for i in 1:N_spatial
-        bi = beta[i]
-        sb, cb = sincos(bi)
-        z_b = Complex{T}(cb, -sb)
-        phase = Complex{T}(cb, sb)^F_int
-        for j in 1:D
-            W[i, j] *= phase
-            phase *= z_b
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            bi = beta[i]
+            sb, cb = sincos(bi)
+            z_b = Complex{T}(cb, -sb)
+            phase = Complex{T}(cb, sb)^F_int
+            for j in 1:D
+                W[i, j] *= phase
+                phase *= z_b
+            end
         end
     end
     mul!(P, W, V_T)
 
     # Stage 5 — Rz(+α)
-    @inbounds for i in 1:N_spatial
-        ai = alpha[i]
-        sa, ca = sincos(ai)
-        z_a = Complex{T}(ca, sa)
-        phase = Complex{T}(ca, -sa)^F_int
-        for c in 1:D
-            P[i, c] *= phase
-            phase *= z_a
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            ai = alpha[i]
+            sa, ca = sincos(ai)
+            z_a = Complex{T}(ca, sa)
+            phase = Complex{T}(ca, -sa)^F_int
+            for c in 1:D
+                P[i, c] *= phase
+                phase *= z_a
+            end
         end
     end
     nothing

--- a/src/foundation/spinor_utils/euler_fused.jl
+++ b/src/foundation/spinor_utils/euler_fused.jl
@@ -57,7 +57,10 @@ on the rotation block.
         W .*= cis.(β_col .* λ_row)
         mul!(P, W, V_T)
         if imaginary_time
-            P .*= exp.(.-m_shift_row .* θ_col)
+            # exp(-m·θ), NOT exp(-(m-F)·θ): the overflow shift is a spatially
+            # varying density reweighting that biases the ITP fixed point
+            # (see mistake_itp_imaginary_time_euler_stage3_density_bias).
+            P .*= exp.(.-m_row .* θ_col)
         else
             P .*= cis.(.-m_row .* θ_col)
         end
@@ -74,9 +77,9 @@ on the rotation block.
         @. cis_PD = cis(β_col * λ_row)         # reuse same scratch on W (same shape)
         @. W *= cis_PD
         mul!(P, W, V_T)
-        # Step 3: D_z(θ)
+        # Step 3: D_z(θ) — exp(-m·θ) (see imaginary_time note above).
         if imaginary_time
-            @. cis_PD = exp(-m_shift_row * θ_col)
+            @. cis_PD = exp(-m_row * θ_col)
         else
             @. cis_PD = cis(-m_row * θ_col)
         end

--- a/src/hamiltonian/integrator/propagators.jl
+++ b/src/hamiltonian/integrator/propagators.jl
@@ -189,21 +189,25 @@ function _diagonal_step_svec_real!(
     c0, c_lhy, dt_frac, density_buf,
 ) where {N, D}
     n_pts = ntuple(d -> size(psi, d), Val(N))
-    @inbounds for I in CartesianIndices(n_pts)
-        s = 0.0
-        for c in 1:D
-            s += abs2(psi_mf[I, c])
-        end
-        density_buf[I] = s
-    end
+    Ns = prod(n_pts)
     zee_dt = SVector{D, Float64}(ntuple(c -> zeeman_diag[c] * dt_frac, Val(D)))
     zee_cis = SVector{D, ComplexF64}(ntuple(c -> cis(-zee_dt[c]), Val(D)))
-    @inbounds for I in CartesianIndices(n_pts)
-        n = density_buf[I]
-        V_int = c0 * n + _lhy_V(n, c_lhy)
-        cis_base = cis(-(V_trap[I] + V_int) * dt_frac)
-        for c in 1:D
-            psi[I, c] *= cis_base * zee_cis[c]
+    P = reshape(psi, Ns, D)
+    Pmf = reshape(psi_mf, Ns, D)
+    Vt = reshape(V_trap, Ns)
+    db = reshape(density_buf, Ns)
+    _voxel_loop!(Ns) do i
+        @inbounds begin
+            s = 0.0
+            for c in 1:D
+                s += abs2(Pmf[i, c])
+            end
+            db[i] = s
+            V_int = c0 * s + _lhy_V(s, c_lhy)
+            cis_base = cis(-(Vt[i] + V_int) * dt_frac)
+            for c in 1:D
+                P[i, c] *= cis_base * zee_cis[c]
+            end
         end
     end
     nothing
@@ -214,22 +218,26 @@ function _diagonal_step_svec_imag!(
     c0, c_lhy, dt_frac, density_buf,
 ) where {N, D}
     n_pts = ntuple(d -> size(psi, d), Val(N))
-    @inbounds for I in CartesianIndices(n_pts)
-        s = 0.0
-        for c in 1:D
-            s += abs2(psi_mf[I, c])
-        end
-        density_buf[I] = s
-    end
+    Ns = prod(n_pts)
     zee_shift = minimum(zeeman_diag)
     zee_dt = SVector{D, Float64}(ntuple(c -> (zeeman_diag[c] - zee_shift) * dt_frac, Val(D)))
     zee_exp = SVector{D, Float64}(ntuple(c -> exp(-zee_dt[c]), Val(D)))
-    @inbounds for I in CartesianIndices(n_pts)
-        n = density_buf[I]
-        V_int = c0 * n + _lhy_V(n, c_lhy)
-        exp_base = exp(-(V_trap[I] + V_int) * dt_frac)
-        for c in 1:D
-            psi[I, c] *= exp_base * zee_exp[c]
+    P = reshape(psi, Ns, D)
+    Pmf = reshape(psi_mf, Ns, D)
+    Vt = reshape(V_trap, Ns)
+    db = reshape(density_buf, Ns)
+    _voxel_loop!(Ns) do i
+        @inbounds begin
+            s = 0.0
+            for c in 1:D
+                s += abs2(Pmf[i, c])
+            end
+            db[i] = s
+            V_int = c0 * s + _lhy_V(s, c_lhy)
+            exp_base = exp(-(Vt[i] + V_int) * dt_frac)
+            for c in 1:D
+                P[i, c] *= exp_base * zee_exp[c]
+            end
         end
     end
     nothing

--- a/src/hamiltonian/terms/ddi/rotation.jl
+++ b/src/hamiltonian/terms/ddi/rotation.jl
@@ -51,21 +51,24 @@ end
 ) where {T <: AbstractFloat}
     z = zero(T)
     one_t = one(T)
-    @inbounds @simd for i in 1:N_spatial
-        px = T(phi_x[i])
-        py = T(phi_y[i])
-        pz = T(phi_z[i])
-        pm = sqrt(px * px + py * py + pz * pz)
-        if pm < T(1e-100)
-            alpha[i] = z
-            beta[i] = z
-            theta[i] = z
-        else
-            alpha[i] = atan(py, px)
-            cb = pz / pm
-            cb = cb > one_t ? one_t : (cb < -one_t ? -one_t : cb)
-            beta[i] = acos(cb)
-            theta[i] = pm * T(dt_frac)
+    dt_t = T(dt_frac)
+    _voxel_loop!(N_spatial) do i
+        @inbounds begin
+            px = T(phi_x[i])
+            py = T(phi_y[i])
+            pz = T(phi_z[i])
+            pm = sqrt(px * px + py * py + pz * pz)
+            if pm < T(1e-100)
+                alpha[i] = z
+                beta[i] = z
+                theta[i] = z
+            else
+                alpha[i] = atan(py, px)
+                cb = pz / pm
+                cb = cb > one_t ? one_t : (cb < -one_t ? -one_t : cb)
+                beta[i] = acos(cb)
+                theta[i] = pm * dt_t
+            end
         end
     end
     nothing


### PR DESCRIPTION
## Summary

Profiled and optimized **one `split_step!`** for the production target ¹⁵¹Eu F=6 (D=13) + DDI, on both CPU (local) and a **TSUBAME H100** (GPU production path). Also fixes a pre-existing GPU ITP correctness bug surfaced by the GPU↔CPU parity gate.

The dominant cost in both paths is `ddi_rotation` (the Euler 5-stage spin rotation); the diagonal step is second.

## CPU (`perf(integrator)`)
- Thread the Euler 5-stage phase loops + DDI angle pre-pass across voxels (each voxel independent → bit-identical to serial), gated by a size threshold (`_VOXEL_THREAD_MIN = 16384 ≈ 25³`) via a typed-closure helper `_voxel_loop!` — serial below (≤16³ smoke/test, where task-spawn overhead dominates), `:static`-threaded above.
- Fuse the diagonal step's two passes into one.

**@ 32³ Eu/DDI: 28.8 → 18.5 ms/step (−36%)** (ddi_rotation −29%, diagonal −45%); ≤16³ unaffected.

## GPU / TSUBAME (`perf(gpu)!`)
GPU DDI rotation used the slow broadcast+cuBLAS Euler path (~4 gemms + ~9 elementwise launches + W HBM round-trips) while spin_mixing/raman already used the single-launch register kernel.

- **`gpu_ddi_rotation.jl`** (new): route GPU DDI rotation through a single-launch kernel that computes the Euler angles in-register from the dipolar field — no broadcast euler, no angle-broadcast pass, no scratch round-trip.
- **`gpu_euler_kernel.jl`**: shared-memory `V`/`conj_V` (loaded once per block); the 5 sign-bearing stages live in **one** device function `_euler_apply_voxel!` shared by the array-angle (spin_mixing/raman) and phi-angle (DDI) kernels — no duplication. (A full `@nexprs` unroll of the 13×13 matvecs explodes register pressure → 3.5× slower; looped MVector is the sweet spot.)
- **`gpu_diagonal.jl`** (new): fuse the diagonal density+phase into one launch (was ~26 broadcast launches/call); non-scalar LHY falls back to the generic broadcast.

**@ 128³ F64, H100: 25.45 → 21.08 ms/step (−17.2%)** (ddi_rotation −21%, diagonal −36%).

## Correctness fix (the `!`)
The GPU Euler **ITP** Dz step used `exp(-(m-F)·θ)` — the overflow-shifted form the CPU dropped on 2026-06-15. Since `θ ∝ |Φ(r)|` is spatially varying, the shift is a per-voxel density reweighting that biases the ITP fixed point. Fixed to `exp(-m·θ)` (kernel + `euler_fused` broadcast fallback). GPU↔CPU ITP parity **11% → 1.9e-14**.

## Verification (H100)
- GPU == CPU `split_step` parity: RTP rel 4.9e-9 (FFT round-off), **ITP rel 1.9e-14**.
- GPU test trio green: per-step equivalence 89/89, per-term parity 142/142, level0 29/29.
- Accuracy audit: rotation unitarity **6e-15** (better than CPU 1.2e-14); 200-step norm drift 1.1e-12 and energy drift 5.1e-4 — **both identical to CPU** (the energy drift is the dt² Strang error, unchanged).
- CPU: DDI 4644, Split Step 48, Level1/3, ITP-DDI-Strang all green.

## Notes / not done
- `ddi_rotation` (still ~50% of the GPU step) is local-memory-latency bound at the F64 D=13 frontier; cuFFT (convolve+kinetic) is vendor-bound. F32 is not a lever on the lab DDI path (mixed-precision is rotating_basis-only).
- New bench/diagnostic tools under `bench/` (`profile_1step{,_gpu}.jl`, `verify_gpu_split_step.jl`, `accuracy_gpu.jl`, `run_gpu_tests.jl`, `tsubame_run.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)