### PR TITLE
fix(integrator)!: restore 2nd-order Strang for DDI (midpoint mean-field)

### DIFF
--- a/bench/conv_order.jl
+++ b/bench/conv_order.jl
@@ -1,0 +1,109 @@
+# Strang dt-convergence order for DDI split_step on Eu F=6.
+# order = log2( ‖ψ(dt)-ψ_ref‖ / ‖ψ(dt/2)-ψ_ref‖ ).  Strang ⇒ 2.0.
+using SpinorBEC, Printf, LinearAlgebra
+
+include(joinpath(@__DIR__, "eu151_params.jl"))
+
+const N = 12
+const T_FINAL = 0.05
+
+function build(; c_dd, c1)
+    grid = make_grid(GridConfig(ntuple(_->N,3), ntuple(_->10.0,3)))
+    atom = Eu151
+    psi0 = zeros(ComplexF64, N,N,N,13)
+    for I in CartesianIndices((N,N,N))
+        r2 = sum((I[d]-N/2)^2 for d in 1:3)/N
+        psi0[I,1]=exp(-r2); psi0[I,3]=0.15exp(-r2); psi0[I,7]=0.08exp(-r2)
+    end
+    (; grid, atom, psi0, c_dd, c1)
+end
+
+# Freeze the mean field at each half-step ENTRY (snapshot ψ, pass as psi_mf
+# to all substeps) — symmetric inner V at ~zero extra cost vs the predictor.
+function step_frozen!(ws, buf)
+    dt = ws.sim_params.dt
+    t = ws.state.t
+    nc = ws.spin_matrices.system.n_components
+    copyto!(buf, ws.state.psi)
+    SpinorBEC._half_potential_step!(ws, dt/2, nc, 3, false; t_eval=t+dt/4, t_start=t, psi_mf=buf)
+    SpinorBEC.apply_step!(SpinorBEC.KineticTerm(), ws.state.psi, 0.0, false, ws)
+    copyto!(buf, ws.state.psi)
+    SpinorBEC._half_potential_step!(ws, dt/2, nc, 3, false; t_eval=t+3dt/4, t_start=t+dt/2, psi_mf=buf)
+    ws.state.t += dt; ws.state.step += 1
+    nothing
+end
+
+# midpoint half-potential with tunable n_picard (omega=0 ⇒ no coriolis).
+function step_midpoint_np!(ws, n_picard)
+    dt = ws.sim_params.dt
+    t = ws.state.t
+    nc = ws.spin_matrices.system.n_components
+    SpinorBEC._half_potential_step_midpoint!(ws, dt/2, nc, 3, false; t_eval=t+dt/4, t_start=t, n_picard=n_picard)
+    SpinorBEC.apply_step!(SpinorBEC.KineticTerm(), ws.state.psi, 0.0, false, ws)
+    SpinorBEC._half_potential_step_midpoint!(ws, dt/2, nc, 3, false; t_eval=t+3dt/4, t_start=t+dt/2, n_picard=n_picard)
+    ws.state.t += dt; ws.state.step += 1
+    nothing
+end
+
+# stepper ∈ (:plain, :midpoint, :frozen)
+function run_to_T(cfg, dt; stepper=:plain, n_picard=2)
+    n_steps = Int(round(T_FINAL/dt))
+    sp = SimParams(; dt=dt, n_steps=n_steps, imaginary_time=false)
+    ws = make_workspace(; cfg.grid, cfg.atom,
+        interactions=InteractionParams(Dict(0=>EU_c0, 1=>cfg.c1)),
+        zeeman=ZeemanParams(EU_p_weak, 0.05), potential=HarmonicTrap((1.0,1.0,EU_λ_z)),
+        sim_params=sp, psi_init=copy(cfg.psi0),
+        enable_ddi=(cfg.c_dd!=0), c_dd=cfg.c_dd)
+    dV = prod(cfg.grid.config.box_size ./ cfg.grid.config.n_points)
+    ws.state.psi ./= sqrt(sum(abs2, ws.state.psi)*dV)
+    buf = stepper === :frozen ? similar(ws.state.psi) : nothing
+    for _ in 1:n_steps
+        if stepper === :midpoint
+            step_midpoint_np!(ws, n_picard)
+        elseif stepper === :frozen
+            step_frozen!(ws, buf)
+        else
+            split_step!(ws)
+        end
+    end
+    Array(ws.state.psi)
+end
+
+function order(cfg; stepper=:plain, n_picard=2, dts=(0.001,0.0005,0.00025))
+    ref = run_to_T(cfg, dts[end]/4; stepper, n_picard)
+    ds = [maximum(abs, run_to_T(cfg, dt; stepper, n_picard) .- ref) for dt in dts]
+    ords = [log2(ds[i]/ds[i+1]) for i in 1:length(ds)-1]
+    (ds, ords)
+end
+
+println("N=$N, T=$T_FINAL, threads=$(Threads.nthreads())")
+println("MEANFIELD_MIDPOINT_ENABLED = ", SpinorBEC.MEANFIELD_MIDPOINT_ENABLED[])
+for (lbl, cfg) in (
+    ("c_dd=0  split_step!", build(c_dd=0.0, c1=0.3)),
+    ("c_dd=100 split_step!", build(c_dd=100.0, c1=0.3)),
+)
+    ds, ords = order(cfg)
+    @printf("%-20s  diffs=%s  order≈ %s\n", lbl,
+        join([@sprintf("%.2e",d) for d in ds], ","),
+        join([@sprintf("%.3f",o) for o in ords], ","))
+end
+# toggle OFF → split_step! should revert to ~1st order for DDI
+SpinorBEC.MEANFIELD_MIDPOINT_ENABLED[] = false
+let cfg = build(c_dd=100.0, c1=0.3)
+    ds, ords = order(cfg)
+    @printf("%-20s  diffs=%s  order≈ %s\n", "c_dd=100 toggle-off",
+        join([@sprintf("%.2e",d) for d in ds], ","),
+        join([@sprintf("%.3f",o) for o in ords], ","))
+end
+SpinorBEC.MEANFIELD_MIDPOINT_ENABLED[] = true
+# frozen + midpoint(n_picard=1,2) for c_dd=100
+for (lbl, st, np) in (
+        ("c_dd=100 frozen   ", :frozen, 0),
+        ("c_dd=100 mid np=1 ", :midpoint, 1),
+        ("c_dd=100 mid np=2 ", :midpoint, 2))
+    cfg = build(c_dd=100.0, c1=0.3)
+    ds, ords = order(cfg; stepper=st, n_picard=np)
+    @printf("%-18s  diffs=%s  order≈ %s\n", lbl,
+        join([@sprintf("%.2e",d) for d in ds], ","),
+        join([@sprintf("%.3f",o) for o in ords], ","))
+end

--- a/src/hamiltonian/integrator/split_step.jl
+++ b/src/hamiltonian/integrator/split_step.jl
@@ -8,6 +8,59 @@
 
 export split_step!, split_step_midpoint!
 
+# --- 2nd-order mean-field (midpoint) half-potential ---
+#
+# The plain `_half_potential_step!` evaluates each inner-V substep's mean field
+# (Φ_DDI, c₀|ψ|², c₁⟨F⟩, c₂A₀₀, tensor h) at that substep's ENTRY ψ. With DDI
+# active the central DDI substep's one-sided O(τ) mean-field error does NOT
+# cancel, collapsing the Strang order from 2 to ~1 (measured: Eu F=6 + DDI
+# drops to ~1.0-1.5; the c_dd=0 control stays 2.0). The midpoint predictor-
+# corrector freezes the mean field at the half-step's TEMPORAL midpoint for all
+# substeps, restoring 2nd order. A single Picard iteration (n_picard=1) is
+# sufficient for 2nd order (n_picard≥2 is only needed for MPS-4/Y6 order
+# recovery). See `bench/conv_order.jl`.
+#
+# `_half_potential!` is the dispatcher used by `split_step!` and the RTP
+# leapfrog loop: midpoint when DDI is active (and the toggle is on), plain
+# otherwise (already 2nd order, cheaper). Toggle off to reproduce the legacy
+# 1st-order DDI path.
+const MEANFIELD_MIDPOINT_ENABLED = Ref(true)
+
+@inline function _half_potential!(
+    ws::Workspace{N}, dt_half, n_comp, ndim, imaginary_time;
+    t_eval::Float64=ws.state.t, t_start::Float64=NaN,
+) where {N}
+    # Midpoint is for REAL-TIME dynamics accuracy (Strang dt²-order). Imaginary
+    # time is relaxation to a fixed point — its dt-order is irrelevant and the
+    # non-norm-conserving predictor can overflow — so ITP keeps the plain path.
+    if MEANFIELD_MIDPOINT_ENABLED[] && ws.ddi !== nothing && !imaginary_time
+        _half_potential_step_midpoint!(
+            ws, dt_half, n_comp, ndim, imaginary_time; t_eval, t_start, n_picard=1
+        )
+    else
+        _half_potential_step!(
+            ws, dt_half, n_comp, ndim, imaginary_time; t_eval, t_start
+        )
+    end
+end
+
+# Persistent midpoint scratch (one pair per (size, eltype, array-type)) so the
+# predictor-corrector does not allocate `similar(psi)` every step — at 128³ F64
+# that would churn ~1.7 GB/step through the GC. Buffers are reused across the
+# two halves of a step (sequential, no aliasing); only the first is needed for
+# n_picard=1, both for n_picard≥2.
+const _MIDPOINT_SCRATCH = Dict{UInt64, Any}()
+
+function _get_midpoint_scratch(psi::A) where {A <: AbstractArray}
+    key = hash((size(psi), eltype(psi), nameof(typeof(psi).name.wrapper)))
+    bufs = get(_MIDPOINT_SCRATCH, key, nothing)
+    if bufs === nothing
+        bufs = (similar(psi), similar(psi))
+        _MIDPOINT_SCRATCH[key] = bufs
+    end
+    bufs::Tuple{A, A}
+end
+
 """
 Perform one Strang-split time step: V(dt/2) K(dt) V(dt/2).
 
@@ -32,7 +85,7 @@ function split_step!(ws::Workspace{N}) where {N}
         )
     end
 
-    @timeit_debug TIMER "half_potential" _half_potential_step!(
+    @timeit_debug TIMER "half_potential" _half_potential!(
         ws, dt / 2, n_comp, N, it; t_eval=t_eval_1, t_start=it ? NaN : t
     )
 
@@ -47,7 +100,7 @@ function split_step!(ws::Workspace{N}) where {N}
         CoriolisTerm(omega), ws.state.psi, dt / 2, it, ws
     )
 
-    @timeit_debug TIMER "half_potential" _half_potential_step!(
+    @timeit_debug TIMER "half_potential" _half_potential!(
         ws, dt / 2, n_comp, N, it; t_eval=t_eval_2, t_start=it ? NaN : t + dt / 2
     )
 
@@ -369,9 +422,9 @@ end
 # The predictor's accuracy only needs to be O(dt²) for the corrector to
 # achieve a fully symmetric V step, so frozen-MF Strang half-step suffices.
 #
-# Allocation note: this implementation calls `similar(psi)` per invocation
-# to obtain the midpoint buffer. For production tuning move to a dedicated
-# Workspace field; for Phase-0 validation per-call alloc is acceptable.
+# Allocation note: midpoint buffers come from `_get_midpoint_scratch` (a
+# persistent per-(size,eltype,array-type) cache) so the hot loop does not
+# allocate `similar(psi)` every step.
 # Transverse Zeeman / Raman currently use `ws.state.psi_scratch` as an
 # intermediate; they remain compatible with the midpoint variant because the
 # midpoint buffer is allocated separately from `psi_scratch`.
@@ -399,8 +452,7 @@ function _half_potential_step_midpoint!(
     # n_picard=2 lifts the time-reversal residual to O(τ⁴), which is sufficient
     # for MPS-4 order recovery. Cost: `n_picard × half-V-step + full V-step`.
     psi_orig = ws.state.psi
-    psi_mid_prev = similar(psi_orig)
-    psi_mid_curr = similar(psi_orig)
+    psi_mid_prev, psi_mid_curr = _get_midpoint_scratch(psi_orig)
 
     # Iteration 1: predictor with frozen MF = ψ_orig.
     copyto!(psi_mid_curr, psi_orig)

--- a/src/solvers/simulation/run_loops.jl
+++ b/src/solvers/simulation/run_loops.jl
@@ -96,7 +96,7 @@ function _run_simulation_leapfrog!(
         apply_orszag_2_3_filter!(ws.state.psi, ws.fft_plans, n_comp, N)
     end
 
-    _half_potential_step!(
+    _half_potential!(
         ws, dt / 2, n_comp, N, false; t_eval=(ws.state.t + dt / 4), t_start=ws.state.t
     )
 
@@ -132,7 +132,7 @@ function _run_simulation_leapfrog!(
             # fix in itp_loop.jl: drop the merge, always do close +
             # reopen so DDI is substepped. Cost: 2× _half_potential_step!
             # calls per step instead of 1 in the previously-merged path.
-            _half_potential_step!(
+            _half_potential!(
                 ws, dt / 2, n_comp, N, false; t_eval=t_now + 3dt / 4, t_start=t_now + dt / 2
             )
 
@@ -160,7 +160,7 @@ function _run_simulation_leapfrog!(
             # Reopen V(dt/2) for the next K-step. Skipped on the final
             # step since there's no further K to chain into.
             if !is_last
-                _half_potential_step!(
+                _half_potential!(
                     ws, dt / 2, n_comp, N, false; t_eval=(ws.state.t + dt / 4), t_start=ws.state.t
                 )
             end
@@ -168,7 +168,7 @@ function _run_simulation_leapfrog!(
     catch e
         if e isa InterruptException
             # Close the open half-step so psi is in a valid Strang-split state
-            _half_potential_step!(
+            _half_potential!(
                 ws, dt / 2, n_comp, N, false; t_eval=(ws.state.t + dt / 4), t_start=ws.state.t
             )
             _record_snapshot!(

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -388,6 +388,7 @@ const FULL_EXTRA = [
     "hamiltonian/test_light_shift.jl",
     "solvers/test_conservation_properties.jl",
     "solvers/test_itp_ddi_strang_save_every.jl",      # Bug-4 ITP regression pin
+    "solvers/test_ddi_strang_order.jl",               # DDI 2nd-order (midpoint MF)
     "solvers/test_lbfgs_sobolev_preconditioner.jl",
     "solvers/test_rtp_ddi_strang_save_every.jl",      # Bug-4 RTP regression pin
     "workflow/test_phase_diff_eval.jl",

--- a/test/solvers/test_ddi_strang_order.jl
+++ b/test/solvers/test_ddi_strang_order.jl
@@ -1,0 +1,72 @@
+# Regression: split_step! must stay 2nd-order in dt WITH DDI active.
+#
+# The plain inner-V evaluates each substep's mean field (Φ_DDI, c₀|ψ|²,
+# c₁⟨F⟩, …) at that substep's ENTRY ψ. With DDI the central DDI substep's
+# one-sided O(τ) mean-field error does not cancel and Strang collapses from
+# order 2 to ~1 (Eu F=6 + DDI measured ~1.0–1.5; the c_dd=0 control stays 2).
+# `split_step!` auto-routes to the midpoint mean-field scheme when DDI is on
+# (`MEANFIELD_MIDPOINT_ENABLED`), restoring slope-2. This trips if that
+# routing regresses (ratio → ~2) or the toggle defaults off.
+#
+# Method: consecutive-difference convergence at fixed grid,
+# ‖ψ(dt)-ψ(dt/2)‖ / ‖ψ(dt/2)-ψ(dt/4)‖ → 2^p. Slope-2 ⇒ ratio ~4.
+
+using SpinorBEC
+using Test
+
+@testset "DDI Strang order (split_step! 2nd order with DDI)" begin
+    n = 8
+    L = 9.0
+    grid = make_grid(GridConfig((n, n, n), (L, L, L)))
+    atom = Eu151   # F=6, D=13 — the production case the order drop was found on
+    T = 0.03
+
+    function _run(dt; c_dd=100.0)
+        n_steps = Int(round(T / dt))
+        sp = SimParams(; dt=dt, n_steps=n_steps, imaginary_time=false, normalize_every=0)
+        ws = make_workspace(; grid, atom,
+            interactions=InteractionParams(Dict(0 => 200.0, 1 => 2.0)),
+            potential=HarmonicTrap(1.0, 1.0, 1.0),
+            zeeman=ZeemanParams(1.0, 0.05),
+            sim_params=sp, enable_ddi=(c_dd > 0), c_dd=c_dd)
+        psi0 = zeros(ComplexF64, n, n, n, 13)
+        for I in CartesianIndices((n, n, n))
+            r2 = grid.x[1][I[1]]^2 + grid.x[2][I[2]]^2 + grid.x[3][I[3]]^2
+            psi0[I, 1] = exp(-r2 / 2)
+            psi0[I, 3] = 0.15 * exp(-r2 / 2)
+            psi0[I, 7] = 0.08 * exp(-r2 / 2)
+        end
+        dV = cell_volume(grid)
+        psi0 ./= sqrt(sum(abs2, psi0) * dV)
+        copyto!(ws.state.psi, psi0)
+        for _ in 1:n_steps
+            split_step!(ws)
+        end
+        return Array(ws.state.psi)
+    end
+
+    conv_ratio(; c_dd=100.0) = begin
+        ψ1 = _run(0.002; c_dd)
+        ψ2 = _run(0.001; c_dd)
+        ψ4 = _run(0.0005; c_dd)
+        maximum(abs, ψ1 .- ψ2) / maximum(abs, ψ2 .- ψ4)
+    end
+
+    @testset "DDI on: slope-2 restored" begin
+        @test 3.0 < conv_ratio(; c_dd=100.0) < 5.5
+    end
+
+    @testset "c_dd=0 control: slope-2" begin
+        @test 3.0 < conv_ratio(; c_dd=0.0) < 5.5
+    end
+
+    @testset "toggle off → reverts to ~1st order (mechanism check)" begin
+        SpinorBEC.MEANFIELD_MIDPOINT_ENABLED[] = false
+        try
+            r = conv_ratio(; c_dd=100.0)
+            @test r < 3.0           # 1st order ⇒ ratio ~2
+        finally
+            SpinorBEC.MEANFIELD_MIDPOINT_ENABLED[] = true
+        end
+    end
+end


### PR DESCRIPTION
## Problem

`split_step!` (and the RTP leapfrog loop) silently dropped from Strang **2nd order to ~1st order** whenever DDI was active. Measured convergence order on Eu F=6 + DDI:

| config | order |
|---|---|
| c_dd=0 (control) | **2.0** ✓ |
| c_dd=100 `split_step!` (before) | **~1.0–1.5** ✗ |
| c_dd=100 `split_step_midpoint!` | 2.0 |

**Cause:** the plain inner-V evaluates each substep's mean field (Φ_DDI, c₀|ψ|², c₁⟨F⟩, c₂A₀₀, tensor h) at that substep's *entry* ψ. With DDI active, the central DDI substep's one-sided O(τ) mean-field error does not cancel, collapsing the local error to O(τ).

## Fix

Route the half-potential through the existing **midpoint** predictor-corrector (mean field frozen at the half-step *temporal midpoint*) when DDI is active, via a `_half_potential!` dispatcher shared by `split_step!` and the leapfrog loop.

- **`n_picard=1` suffices** for 2nd order (n_picard≥2 is only for MPS-4/Y6 recovery) — verified order **2.02–2.07**, identical to n_picard=2.
- Freezing the mean field at the half-step *entry* instead does **not** work (still ~1.5; the error must be centered at the midpoint) — measured, ruled out.
- **Real time only**: imaginary time is relaxation to a fixed point (dt-order irrelevant) and the non-norm-conserving predictor can overflow, so ITP keeps the plain path. `MEANFIELD_MIDPOINT_ENABLED` Ref toggles it (default on) for reproducing the legacy 1st-order path.
- **Persistent midpoint scratch** (`_get_midpoint_scratch`) so the hot loop doesn't allocate `similar(psi)` each step (at 128³ F64 that would churn ~1.7 GB/step through the GC).

## Cost / benefit

~1.9× per step at 128³ F64 (the predictor doubles the DDI count), but 2nd order lets dt grow ~√(1/ε) for a target accuracy ε → **far fewer steps**, a large net win for production dynamics.

## Verification
- Order through `split_step!`: **2.02–2.07** (1.49 with the toggle off) — `bench/conv_order.jl`.
- GPU==CPU parity on a TSUBAME H100: RTP 3.3e-9, **ITP 1.9e-14** (the ITP-midpoint NaN was avoided by restricting to RT).
- Existing suites green: DDI 4644, Split Step 48, RTP/ITP DDI regressions, Strang energy conservation, Level2 (8/8, still fast tier), Level10.
- New regression `test/solvers/test_ddi_strang_order.jl` (full tier): DDI slope-2, c_dd=0 control, toggle-off→1st-order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)