### PR TITLE
perf(integrator): make adaptive_run! a genuine 4th-order integrator

### DIFF
--- a/bench/verify_adaptive4_gpu.jl
+++ b/bench/verify_adaptive4_gpu.jl
@@ -1,0 +1,20 @@
+import CUDA
+using SpinorBEC, Printf
+include(joinpath(@__DIR__,"eu151_params.jl"))
+n=24; grid=make_grid(GridConfig((n,n,n),(12.0,12.0,12.0)))
+sp=SimParams(; dt=0.002, n_steps=1, imaginary_time=false)
+ws=make_workspace(; grid, atom=Eu151, interactions=InteractionParams(Dict(0=>EU_c0,1=>2.0)),
+    potential=HarmonicTrap((1.0,1.0,EU_λ_z)), zeeman=ZeemanParams(EU_p_weak,0.05),
+    sim_params=sp, enable_ddi=true, c_dd=100.0, backend=CUDABackend())
+psi0=zeros(ComplexF64,n,n,n,13)
+for I in CartesianIndices((n,n,n)); r2=sum((I[d]-n/2)^2 for d in 1:3)/n
+    psi0[I,1]=exp(-r2); psi0[I,3]=0.15exp(-r2); psi0[I,7]=0.08exp(-r2); end
+copyto!(ws.state.psi, CUDA.CuArray(psi0))
+dV=prod(grid.config.box_size./grid.config.n_points); ws.state.psi ./= sqrt(sum(abs2,ws.state.psi)*dV)
+E0=total_energy(ws); nrm0=total_norm(ws.state.psi,ws.grid)
+out=adaptive_run!(ws; t_end=0.04, dt_init=0.002, tol_abs=1e-8, tol_rel=1e-7)  # default step! = yoshida4
+CUDA.synchronize()
+E1=total_energy(ws); nrm1=total_norm(ws.state.psi,ws.grid)
+@printf("GPU adaptive4 DDI: accepted=%d rejected=%d dE/E=%.2e dNorm=%.2e\n",
+    out.n_accept, out.n_reject, abs((E1-E0)/E0), abs(nrm1-nrm0))
+println("GPU_ADAPT4_OK")

--- a/src/hamiltonian/integrator/adaptive.jl
+++ b/src/hamiltonian/integrator/adaptive.jl
@@ -41,8 +41,10 @@ Take one adaptive timestep on `ws` using the Hairer-Wanner defect
 estimator and the Söderlind PI3.4 controller.
 
 Defect: `defect = ‖S(dt) ψ - S(dt/2)² ψ‖` where S is the `step!` function
-(default `split_step_midpoint!`). This estimates the local truncation
-error of the full step at order p (default 4 for Y4-mid).
+(default `split_step_yoshida4_midpoint!`, a genuine 4th-order step on the DDI
+path). This estimates the local truncation error of the full step at order p
+(default 4, consistent with the 4th-order default step). Pass
+`step!=split_step_midpoint!` with `p=2` for the cheaper 2nd-order adaptive.
 
 Tolerance: accept when `defect ≤ tol_abs + tol_rel · ‖ψ_half‖`.
 
@@ -68,7 +70,7 @@ function adaptive_step!(ws::Workspace{N}, state::AdaptiveDtState;
     max_factor::Float64=5.0,
     min_factor::Float64=0.05,
     max_rejects::Int=12,
-    step!::F=(split_step_midpoint!),
+    step!::F=(split_step_yoshida4_midpoint!),
 ) where {N, F}
     α = pi_alpha
     β = pi_beta

--- a/src/hamiltonian/integrator/yoshida.jl
+++ b/src/hamiltonian/integrator/yoshida.jl
@@ -134,3 +134,34 @@ function run_simulation_yoshida!(
         final_dt=dt,
     )
 end
+
+"""
+    split_step_yoshida4_midpoint!(ws; dt=ws.sim_params.dt)
+
+One 4th-order Yoshida step with the `(ws; dt)` signature `adaptive_step!`
+expects, advancing `ws.state.t` by `dt`. On the DDI lab path it composes the
+time-symmetric implicit-midpoint core as an un-merged triple-jump (n_picard=3,
+the count that makes the base time-symmetric enough for the 4th-order Richardson
+cancellation — see `_composition_midpoint_core!`); otherwise the cheaper plain
+`_yoshida_core!` (already 4th order without DDI). RTP.
+
+This is the 4th-order base for `adaptive_run!`: with it the Hairer-Wanner defect
+estimator and the p=4 controller are consistent, giving a genuinely 4th-order
+adaptive integrator on the DDI path (the previous default `split_step_midpoint!`
+is only 2nd order, so `adaptive_run!` was 2nd order despite the p=4 controller).
+"""
+function split_step_yoshida4_midpoint!(ws::Workspace{N}; dt::Float64=ws.sim_params.dt) where {N}
+    n_comp = ws.spin_matrices.system.n_components
+    t_base = ws.state.t
+    if MEANFIELD_MIDPOINT_ENABLED[] && ws.ddi !== nothing
+        _composition_midpoint_core!(ws, dt, n_comp, _COMP_YOSHIDA.b; t_base, n_picard=3)
+    else
+        _yoshida_core!(ws, dt, n_comp; t_base)
+    end
+    ws.sim_params.imaginary_time || apply_rt_dissipation!(ws, dt, n_comp, N)
+    ws.state.t = t_base + dt
+    ws.state.step += 1
+    nothing
+end
+
+export split_step_yoshida4_midpoint!

--- a/test/solvers/test_yoshida_ddi_order.jl
+++ b/test/solvers/test_yoshida_ddi_order.jl
@@ -47,11 +47,17 @@ using Test
         for _ in 1:Int(round(T / dt))
             if base === :mid
                 SB._composition_midpoint_core!(ws, dt, 13, b; t_base=ws.state.t, n_picard=3)
+                ws.state.t += dt
+                ws.state.step += 1
+            elseif base === :y4step
+                # the public 4th-order step (adaptive_run!'s default base);
+                # advances ws.state.t internally
+                split_step_yoshida4_midpoint!(ws; dt=dt)
             else
                 SB._aba_step!(ws, dt, 13, a, b; t_base=ws.state.t)
+                ws.state.t += dt
+                ws.state.step += 1
             end
-            ws.state.t += dt
-            ws.state.step += 1
         end
         Array(ws.state.psi)
     end
@@ -74,6 +80,10 @@ using Test
     end
     @testset "c_dd=0 control → 4th order" begin
         r1, _ = ratios(; c_dd=0.0, base=:mid)
+        @test r1 > 3.5
+    end
+    @testset "public split_step_yoshida4_midpoint! → 4th order (adaptive base)" begin
+        r1, _ = ratios(; c_dd=100.0, base=:y4step)
         @test r1 > 3.5
     end
 end


### PR DESCRIPTION
## Problem

`adaptive_step!` / `adaptive_run!` defaulted to `step!=split_step_midpoint!` (**2nd order**) while running the **p=4** (4th-order) Hairer-Wanner defect + PI controller. So the adaptive integrator the Yoshida docstring recommended "for production high-order" was actually only 2nd order, with a mismatched controller exponent.

## Fix

Add `split_step_yoshida4_midpoint!(ws; dt)` — a single 4th-order Yoshida step (the un-merged midpoint triple-jump from PR #46 when DDI is active, n_picard=3; plain `_yoshida_core!` otherwise) with the `(ws; dt)` signature `adaptive_step!` expects — and make it the **default `step!`**. Now the step order and the p=4 controller are consistent: a genuinely 4th-order adaptive integrator on the DDI lab path.

Pass `step!=split_step_midpoint!` with `p=2` for the cheaper 2nd-order adaptive.

## Verification
- Public `split_step_yoshida4_midpoint!` convergence order on Eu F=6 + DDI: **3.99**.
- **GPU H100**: `adaptive_run!` (new default) on Eu 24³ + DDI runs cleanly — accepted=17, rejected=5, **dE/E 3.1e-10**, dNorm 6.8e-13 (`bench/verify_adaptive4_gpu.jl`).
- `test_adaptive_dt` (hamiltonian + solvers) green — the default change is non-breaking.
- `test_yoshida_ddi_order` extended with the public-step 4th-order check (5/5).

Builds on #45 (split_step 2nd-order DDI) and #46 (Yoshida 4th-order DDI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)