### PR TITLE
fix(solvers)!: drive LBFGS ground state to its true gradient floor

### DIFF
--- a/src/solvers/ground_state.jl
+++ b/src/solvers/ground_state.jl
@@ -152,7 +152,7 @@ function find_ground_state(;
     spinor_lhy::Union{Nothing, Symbol}=nothing,
     method::Symbol=:strang,
     m_lbfgs::Int=10,
-    sobolev_alpha::Float64=0.0,
+    sobolev_alpha::Union{Float64, Symbol}=:auto,
     verbose::Bool=_default_solver_verbose(),
 )
     # KEEP IN SYNC: `_LBFGS_FORWARD_KWARGS` below lists every kwarg this

--- a/src/solvers/ground_state/polished.jl
+++ b/src/solvers/ground_state/polished.jl
@@ -38,6 +38,9 @@ Kwargs:
   * `enable_ddi`, `secular_ddi` — DDI controls; `c_dd` is taken from `preset`
   * `n_itp`, `dt_itp`, `tol_itp` — ITP knobs
   * `n_lbfgs`, `tol_lbfgs`, `sobolev_alpha` — LBFGS polish knobs
+  * `newton_polish` — append a trust-region Newton-CG pass after LBFGS
+                      (second-order; tightens the gradient residual ~10×
+                      for the stability/BdG gates, energy already converged)
   * `backend` — `CPUBackend()` or `CUDABackend()`
 """
 function find_ground_state_polished(
@@ -56,6 +59,7 @@ function find_ground_state_polished(
     n_lbfgs::Int=1000,
     tol_lbfgs::Float64=1e-5,
     sobolev_alpha::Float64=0.02,
+    newton_polish::Bool=false,
     backend::AbstractBackend=CPUBackend(),
 )
     if psi_init === nothing
@@ -85,6 +89,7 @@ function find_ground_state_polished(
             ws_init=ws_itp,
             n_steps=n_lbfgs, tol=tol_lbfgs,
             verbose=false, sobolev_alpha=sobolev_alpha,
+            newton_polish=newton_polish,
         )
         t_lbfgs = time() - t0
         ws = r_lbfgs.workspace

--- a/src/solvers/hessian.jl
+++ b/src/solvers/hessian.jl
@@ -21,7 +21,7 @@
 
 export hessian_vector_product,
     constrained_hessian_params, constrained_hessian_action,
-    trapped_bdg_lowest_eigenvalue
+    trapped_bdg_lowest_eigenvalue, trapped_bdg_low_modes
 
 """
     hessian_vector_product(ws, ψ, δ; ε=1e-5) → array
@@ -159,5 +159,151 @@ function trapped_bdg_lowest_eigenvalue(
     β_m = length(β) >= length(α) ? β[end] : 0.0
     ritz_residual = abs(β_m * s_min[end])
     converged = ritz_residual < tol_ritz * (abs(λ_min) + 1e-10)
-    (; λ_min, μ=p.μ, ritz_residual, niter_used=length(α), converged)
+
+    # Two-sided certificate (Kato–Temple). The Ritz value `λ_min = θ₁` is an
+    # UPPER bound on the true λ_min (Ritz values converge from above). The
+    # LOWER bound is `θ₁ − ρ²/δ` with ρ = ritz_residual and δ the gap to the
+    # next eigenvalue (estimated by the Ritz gap θ₂ − θ₁). Because ρ enters
+    # SQUARED, the certified interval is far tighter than the naive `±ρ`:
+    # ρ=5e-3, δ=0.1 ⇒ ±2.5e-4, not ±5e-3. Valid when δ > ρ (θ₂ a real
+    # separation); otherwise fall back to the loose `±ρ`. At a soft point δ
+    # shrinks and the bound loosens — that is where a preconditioned solver
+    # must drive ρ down directly (see the LOBPCG path).
+    θ2 = length(decomp.values) >= 2 ? decomp.values[2] : λ_min
+    gap = θ2 - λ_min
+    λ_lower = gap > ritz_residual ? λ_min - ritz_residual^2 / gap : λ_min - ritz_residual
+    (; λ_min, μ=p.μ, ritz_residual, niter_used=length(α), converged, λ_lower, gap)
+end
+
+# In-place kinetic Fourier preconditioner M⁻¹ = (½k² + α)⁻¹ per spin component.
+# The constrained Hessian's stiffness is the kinetic λ_max ~ 1/dx²; flattening
+# it restores the relative gap (λ₂−λ₁)/(λ_max−λ₁) that an unpreconditioned
+# Lanczos/LOBPCG is bound by. `α` ~ the low-mode scale (≈ μ).
+function _kinetic_precondition!(v::AbstractArray{<:Complex}, ws, k2, α::Float64)
+    N = ndims(ws.grid.k_squared)
+    n_pts = ntuple(d -> size(v, d), N)
+    n_comp = ws.spin_matrices.system.n_components
+    buf = ws.state.fft_buf
+    @inbounds for c in 1:n_comp
+        idx = _component_slice(N, n_pts, c)
+        buf .= view(v, idx...)
+        ws.fft_plans.forward * buf
+        buf ./= (0.5 .* k2 .+ α)
+        ws.fft_plans.inverse * buf
+        view(v, idx...) .= buf
+    end
+    v
+end
+
+# Modified Gram–Schmidt orthonormalisation in a given real inner product,
+# dropping near-dependent directions (so [X, W, P_prev] can be fed raw).
+function _mgs_ortho(vecs, ipR; tol::Float64=1e-10)
+    out = empty(vecs)
+    for v in vecs
+        w = copy(v)
+        for u in out
+            w = w .- u .* ipR(u, w)
+        end
+        nw = sqrt(max(ipR(w, w), 0.0))
+        nw > tol && push!(out, w ./ nw)
+    end
+    out
+end
+
+# Linear combination of a vector list by columns of C: returns [Σⱼ C[j,k] S[j]].
+_combine(S, C) = [reduce(.+, (C[j, k] .* S[j] for j in 1:length(S))) for k in 1:size(C, 2)]
+
+"""
+    trapped_bdg_low_modes(ws, ψ; nev=1, block=8, ...) → (; λ, λ_lower, residuals, converged, μ, iterations)
+
+Lowest `nev` eigenvalues of the constrained second variation `P(H−2μ)P` via
+block **LOBPCG with a kinetic Fourier preconditioner** — the
+preconditioned counterpart of `trapped_bdg_lowest_eigenvalue` (bare Lanczos).
+
+The bare Lanczos is bound by the relative gap `(λ₂−λ₁)/(λ_max−λ₁)`, which the
+kinetic `λ_max ~ 1/dx²` crushes; the preconditioner `M⁻¹ = (½k²+α)⁻¹`
+flattens that span (THIS, not the solver name, is what makes it converge — at
+a soft point it sets the certified-interval width, not just the speed). A
+block larger than the low-mode cluster + a recycled previous block (the
+conjugate term) handle clustered / crossing modes that defeat single-vector
+iteration.
+
+Returns the Ritz values `λ` (upper bounds), per-mode Kato–Temple lower bounds
+`λ_lower` (`θₖ − ρₖ²/δₖ`), residual norms, and `converged` (all `nev`
+residuals < `tol`). `extra_nullspace` projects out known Goldstone modes
+beyond the gauge `iψ` (vortex rotation / free-space translation) — these are
+DEFLATED (removed), the physical soft mode is NOT (the block grabs it).
+
+Keywords: `nev`, `block` (≥ nev+2), `max_iter`, `tol` (residual stop),
+`α_pre` (preconditioner shift, defaults to `max(|μ|, 1e-3)`), `ε`+`order`
+(HvP), `extra_nullspace`, `rng`.
+"""
+function trapped_bdg_low_modes(
+    ws, ψ;
+    nev::Int=1, block::Int=8, max_iter::Int=30, tol::Float64=1e-6,
+    α_pre::Union{Nothing, Float64}=nothing, ε::Float64=1e-5, order::Int=2,
+    extra_nullspace=nothing, params=nothing, rng=Random.default_rng(),
+)
+    p = params === nothing ? constrained_hessian_params(ws, ψ) : params
+    k2 = ws.grid.k_squared
+    ipR(a, b) = real(sum(conj.(a) .* b)) * p.dV
+    α = α_pre === nothing ? max(abs(p.μ), 1e-3) : α_pre
+
+    function project(v)
+        w = _tangent_project(v, ψ, p.dV, p.n2)
+        if extra_nullspace !== nothing
+            for m in extra_nullspace
+                w = w .- m .* (ipR(m, w) / ipR(m, m))
+            end
+        end
+        w
+    end
+    Tprec(v) = project(_kinetic_precondition!(copy(v), ws, k2, α))
+    A(v) = constrained_hessian_action(ws, ψ, v; p.μ, p.dV, p.n2, ε, order)
+
+    b = max(block, nev + 2)
+    X = _mgs_ortho([project(randn(rng, ComplexF64, size(ψ))) for _ in 1:b], ipR)
+    AX = [A(x) for x in X]
+    Xprev = typeof(ψ)[]
+    θ = zeros(length(X))
+    resn = fill(Inf, length(X))
+    iters = 0
+
+    for it in 1:max_iter
+        iters = it
+        # Rayleigh-Ritz on the current block → rotate X, AX to Ritz vectors.
+        nb = length(X)
+        Θ = [ipR(X[i], AX[j]) for i in 1:nb, j in 1:nb]
+        e = eigen(Symmetric((Θ .+ Θ') ./ 2))
+        X = _combine(X, e.vectors)
+        AX = _combine(AX, e.vectors)
+        θ = e.values
+        R = [AX[i] .- θ[i] .* X[i] for i in 1:nb]
+        resn = [sqrt(max(ipR(r, r), 0.0)) for r in R]
+        maximum(@view resn[1:min(nev, nb)]) < tol && break
+
+        W = [Tprec(R[i]) for i in 1:nb]
+        S = _mgs_ortho(vcat(X, W, Xprev), ipR)
+        AS = [A(s) for s in S]
+        ns = length(S)
+        Hs = [ipR(S[i], AS[j]) for i in 1:ns, j in 1:ns]
+        es = eigen(Symmetric((Hs .+ Hs') ./ 2))
+        keep = min(b, ns)
+        C = es.vectors[:, 1:keep]
+        Xprev = X
+        X = _combine(S, C)
+        AX = _combine(AS, C)
+    end
+
+    nb = length(X)
+    m = min(nev, nb)
+    λ = θ[1:m]
+    λ_lower = map(1:m) do k
+        δ = (k < nb ? θ[k + 1] : θ[k]) - θ[k]
+        δ > resn[k] ? θ[k] - resn[k]^2 / δ : θ[k] - resn[k]
+    end
+    (;
+        λ, λ_lower, residuals=resn[1:m], converged=maximum(@view resn[1:m]) < tol,
+        μ=p.μ, iterations=iters,
+    )
 end

--- a/src/solvers/hessian.jl
+++ b/src/solvers/hessian.jl
@@ -37,14 +37,18 @@ extraction in the anchor test). Central difference ⇒ O(ε²) truncation;
 ε=1e-5 sits at the roundoff/truncation optimum for the gated gradient.
 Anchored: `test/oracles/test_bdg_fd_hessian.jl` (≡ the hand-built BdG).
 """
-function hessian_vector_product(ws, ψ, δ; ε::Float64=1e-5)
-    gp = similar(ψ)
-    fill!(gp, 0)
-    energy_gradient!(gp, ψ .+ ε .* δ, ws)
-    gm = similar(ψ)
-    fill!(gm, 0)
-    energy_gradient!(gm, ψ .- ε .* δ, ws)
-    (gp .- gm) ./ (2ε)
+function hessian_vector_product(ws, ψ, δ; ε::Float64=1e-5, order::Int=2)
+    _g(s) = (out=similar(ψ); fill!(out, 0); energy_gradient!(out, ψ .+ s .* δ, ws); out)
+    if order == 4
+        # 5-point stencil: truncation O(ε⁴), so the finite-difference HvP
+        # cancellation floor drops from eps^(2/3)≈2e-11 (3-point) to
+        # eps^(4/5)≈1.6e-13, at a larger ε* ~ eps^(1/5)≈6e-4 (farther from the
+        # roundoff cliff). Only matters once the energy-comparison floor is
+        # removed (see residual_newton_refine); under an energy-gated step it
+        # is invisible. Costs 4 gradient evals.
+        return (_g(-2ε) .- 8 .* _g(-ε) .+ 8 .* _g(ε) .- _g(2ε)) ./ (12ε)
+    end
+    (_g(ε) .- _g(-ε)) ./ (2ε)   # 3-point central, O(ε²)
 end
 
 # Tangent projection: remove the complex-ψ gauge direction (norm AND phase
@@ -85,10 +89,10 @@ the ‖ψ‖²=N manifold at a stationary `ψ` — the SINGLE operator behind bo
 the gate-2 minimum-vs-saddle eigenvalue query and the Newton-CG linear
 solve. Pass `(μ, dV, n2)` from `constrained_hessian_params`.
 """
-function constrained_hessian_action(ws, ψ, δ; μ, dV, n2, ε::Float64=1e-5)
+function constrained_hessian_action(ws, ψ, δ; μ, dV, n2, ε::Float64=1e-5, order::Int=2)
     pδ = _tangent_project(δ, ψ, dV, n2)
     _tangent_project(
-        hessian_vector_product(ws, ψ, pδ; ε) .- 2μ .* pδ, ψ, dV, n2
+        hessian_vector_product(ws, ψ, pδ; ε, order) .- 2μ .* pδ, ψ, dV, n2
     )
 end
 

--- a/src/solvers/hessian.jl
+++ b/src/solvers/hessian.jl
@@ -238,6 +238,15 @@ DEFLATED (removed), the physical soft mode is NOT (the block grabs it).
 Keywords: `nev`, `block` (≥ nev+2), `max_iter`, `tol` (residual stop),
 `α_pre` (preconditioner shift, defaults to `max(|μ|, 1e-3)`), `ε`+`order`
 (HvP), `extra_nullspace`, `rng`.
+
+VALIDITY REGIME: correctness gated (≡ Lanczos λ_min) on gapped states. The
+preconditioner's convergence ADVANTAGE is NOT yet realised at Eu production
+scale — there the stiffness is interaction-dominated (`c₀·n~2343`), which the
+kinetic-only `(½k²+α)⁻¹` does not capture (production run: `ρ~2` at max_iter=40,
+worse than Lanczos). A combined kinetic+potential preconditioner and L_z
+symmetry-sector decomposition (one anomalous mode per `m` ⇒ recovered relative
+gap) are the documented next step; do NOT trust a production λ_min from this
+until it reports `converged=true`.
 """
 function trapped_bdg_low_modes(
     ws, ψ;

--- a/src/solvers/hessian.jl
+++ b/src/solvers/hessian.jl
@@ -136,7 +136,8 @@ function trapped_bdg_lowest_eigenvalue(
     ipR(a, b) = real(sum(conj.(a) .* b)) * p.dV
     Hc(δ) = constrained_hessian_action(ws, ψ, δ; p.μ, p.dV, p.n2, ε)
 
-    V = [_tangent_project(randn(rng, ComplexF64, size(ψ)), ψ, p.dV, p.n2)]
+    _randvec() = _to_device(ws.backend, randn(rng, ComplexF64, size(ψ)))
+    V = [_tangent_project(_randvec(), ψ, p.dV, p.n2)]
     V[1] ./= sqrt(ipR(V[1], V[1]))
     α = Float64[]
     β = Float64[]
@@ -245,7 +246,7 @@ function trapped_bdg_low_modes(
     extra_nullspace=nothing, params=nothing, rng=Random.default_rng(),
 )
     p = params === nothing ? constrained_hessian_params(ws, ψ) : params
-    k2 = ws.grid.k_squared
+    k2 = _to_device(ws.backend, ws.grid.k_squared)
     ipR(a, b) = real(sum(conj.(a) .* b)) * p.dV
     α = α_pre === nothing ? max(abs(p.μ), 1e-3) : α_pre
 
@@ -262,7 +263,8 @@ function trapped_bdg_low_modes(
     A(v) = constrained_hessian_action(ws, ψ, v; p.μ, p.dV, p.n2, ε, order)
 
     b = max(block, nev + 2)
-    X = _mgs_ortho([project(randn(rng, ComplexF64, size(ψ))) for _ in 1:b], ipR)
+    _randvec() = _to_device(ws.backend, randn(rng, ComplexF64, size(ψ)))
+    X = _mgs_ortho([project(_randvec()) for _ in 1:b], ipR)
     AX = [A(x) for x in X]
     Xprev = typeof(ψ)[]
     θ = zeros(length(X))

--- a/src/solvers/lbfgs/driver.jl
+++ b/src/solvers/lbfgs/driver.jl
@@ -31,7 +31,7 @@ function find_ground_state_lbfgs(;
     verbose::Bool=_default_solver_verbose(),
     light_shift::Union{Nothing, LightShift}=nothing,
     dtype::Union{Nothing, Type{<:AbstractFloat}}=nothing,
-    sobolev_alpha::Float64=0.0,
+    sobolev_alpha::Union{Float64, Symbol}=:auto,
     rotating_frame_omega::Float64=0.0,
 )
     # F32 gradient norm floors around unit roundoff (~1e-7 scaled by grid dV).
@@ -89,6 +89,17 @@ function find_ground_state_lbfgs(;
     F = atom.F
     D = 2F + 1
     dV = cell_volume(grid)
+
+    # Grid-adaptive Sobolev preconditioner default. `α = 1/k_max²` damps the
+    # highest-k (Nyquist) gradient mode by half — a mass-matrix preconditioner
+    # that improves the L-BFGS gradient floor on ill-conditioned (DDI / soft-
+    # manifold) problems for free (Eu F=6 24³+DDI: |∇E| floor 6.1e-6 → 3.4e-6,
+    # same energy, slightly faster) and is ≈identity on smooth, well-conditioned
+    # GS (no high-k gradient content to damp). Pass an explicit Float64 (incl.
+    # `0.0` to disable) to override.
+    sobolev_alpha =
+        sobolev_alpha === :auto ?
+        1.0 / Float64(maximum(grid.k_squared)) : Float64(sobolev_alpha)
 
     # Gradient coverage: energy_gradient! is registry-only, so it now covers
     # EVERY HamTerm including TensorTerm (c2 singlet-pair + tensor_cache
@@ -151,10 +162,11 @@ function find_ground_state_lbfgs(;
         end
 
         # L-BFGS direction (steepest descent for first step)
-        direction = if isempty(rho_hist)
+        is_sd = isempty(rho_hist)
+        direction = if is_sd
             -grad
         else
-            _lbfgs_direction(grad, s_hist, y_hist, rho_hist)
+            _lbfgs_direction(grad, s_hist, y_hist, rho_hist, dV)
         end
 
         # Ensure descent direction (`real(dot(a, b))` skips two
@@ -163,11 +175,14 @@ function find_ground_state_lbfgs(;
         if slope >= 0
             direction .= .-grad  # fall back to steepest descent
             slope = -sum(abs2, grad) * dV
+            is_sd = true
         end
 
-        # Line search: pure energy decrease (no slope condition — safe on manifold)
+        # Backtracking-Armijo line search from the natural L-BFGS step α=1.
+        # `expand` lets the unscaled steepest-descent step auto-find its scale.
         α, E_trial = _line_search_energy_decrease(
-            psi, direction, E, ws, grid, dV, target_magnetization, F
+            psi, direction, E, ws, grid, dV, target_magnetization, F;
+            slope=slope, expand=is_sd,
         )
 
         # Line search failed — reset L-BFGS and try steepest descent next

--- a/src/solvers/lbfgs/driver.jl
+++ b/src/solvers/lbfgs/driver.jl
@@ -33,6 +33,10 @@ function find_ground_state_lbfgs(;
     dtype::Union{Nothing, Type{<:AbstractFloat}}=nothing,
     sobolev_alpha::Union{Float64, Symbol}=:auto,
     rotating_frame_omega::Float64=0.0,
+    newton_polish::Bool=false,
+    newton_max_outer::Int=20,
+    newton_max_cg::Int=40,
+    newton_eps::Float64=1.0e-6,
 )
     # F32 gradient norm floors around unit roundoff (~1e-7 scaled by grid dV).
     # Relax the default convergence test so F32 runs don't burn all n_steps.
@@ -238,6 +242,24 @@ function find_ground_state_lbfgs(;
 
         E_prev = E_trial
         last_step = step
+    end
+
+    # Optional second-order polish: L-BFGS is first-order, so its projected
+    # gradient floors near √(machine-eps)·scale (~6e-8 on the scalar harmonic
+    # GS) even when the energy is already machine-exact. A trust-region
+    # Newton-CG pass (the gate-2 constrained Hessian via finite-difference
+    # HvP) drives the stationarity residual ~10× lower (6e-8 → 5e-9; energy
+    # unchanged to ~1e-15) — useful when ‖∇E‖ is itself the certificate
+    # (BdG / stability gates). Finite-difference ε floors the gain (ε≈1e-6
+    # optimal; smaller ε is dominated by FD noise), so this is not a route to
+    # machine-zero gradients. Opt-in: it costs ~max_outer × max_cg HvPs.
+    if newton_polish
+        rn = newton_cg_ground_state(
+            ws, psi;
+            tol=min(tol, 1.0e-12), max_outer=newton_max_outer, max_cg=newton_max_cg,
+            sobolev_alpha=sobolev_alpha, ε=newton_eps, verbose,
+        )
+        copyto!(psi, rn.psi)
     end
 
     # Atomic finalization (spine G, 2026-06-05). Guarantees the returned

--- a/src/solvers/lbfgs/driver.jl
+++ b/src/solvers/lbfgs/driver.jl
@@ -244,15 +244,21 @@ function find_ground_state_lbfgs(;
         last_step = step
     end
 
-    # Optional second-order polish: L-BFGS is first-order, so its projected
-    # gradient floors near √(machine-eps)·scale (~6e-8 on the scalar harmonic
-    # GS) even when the energy is already machine-exact. A trust-region
-    # Newton-CG pass (the gate-2 constrained Hessian via finite-difference
-    # HvP) drives the stationarity residual ~10× lower (6e-8 → 5e-9; energy
-    # unchanged to ~1e-15) — useful when ‖∇E‖ is itself the certificate
-    # (BdG / stability gates). Finite-difference ε floors the gain (ε≈1e-6
-    # optimal; smaller ε is dominated by FD noise), so this is not a route to
-    # machine-zero gradients. Opt-in: it costs ~max_outer × max_cg HvPs.
+    # Optional second-order polish. Both L-BFGS (line search) and Newton-CG
+    # (trust region) accept steps by an ENERGY comparison, so neither can
+    # resolve a step whose energy reduction (~‖∇E‖²/curvature) falls below the
+    # energy-evaluation roundoff (~eps·|E|). That puts a floor on the projected
+    # gradient at ‖∇E‖ ~ √eps·‖g‖ (≈ √eps·2|E|; measured `‖∇E‖/|E| ≈ 1.4e-7`
+    # constant as |E| is swept 256×, and INDEPENDENT of the HvP finite-
+    # difference order — a 4th-order stencil does not lower it). The Newton-CG
+    # pass still buys ~10× over L-BFGS (6.6e-8 → 5e-9 on the scalar harmonic;
+    # energy unchanged to ~1e-15) by getting closer to that √eps floor, but it
+    # is NOT a route below it — the bottleneck is the energy comparison, not
+    # the HvP, so a better (AD / analytic-Bogoliubov) HvP would not help. To
+    # break √eps·‖g‖ needs an eigenvector-residual iteration (RQI / inverse
+    # iteration) that drives (H−μ)ψ→0 directly, without energy-gated steps.
+    # Useful when ‖∇E‖ is itself the certificate (BdG / stability gates).
+    # Opt-in: it costs ~max_outer × max_cg HvPs (2 gradient evals each).
     if newton_polish
         rn = newton_cg_ground_state(
             ws, psi;

--- a/src/solvers/lbfgs/helpers.jl
+++ b/src/solvers/lbfgs/helpers.jl
@@ -31,10 +31,23 @@ function _sobolev_precondition!(
     grad
 end
 
-"""Two-loop L-BFGS direction."""
+"""
+Two-loop L-BFGS direction, evaluated under the manifold inner product
+`⟨a,b⟩ = real(dot(a,b))·dV` — the same convention the driver uses for
+`rho_hist` (`1/(⟨s,y⟩)`), `slope`, and `grad_norm`.
+
+The `·dV` on the `alphas`/`β` dot products is load-bearing: `rho_hist`
+already carries a `1/dV`, so omitting `dV` here under-weights every
+correction term by `1/dV` (≈8× on a 128-pt/L=16 grid), mis-scaling the
+search direction. That inconsistency was masked for years by the old
+shrink-only line search capping the step at `α=0.01`; once the line
+search takes the natural `α≈1` step the mis-scaling dominates. `γ` is
+invariant under the `dV` rescaling (it cancels), so it is unchanged.
+"""
 function _lbfgs_direction(
     grad::AbstractArray{<:Complex},
     s_hist::Vector, y_hist::Vector, rho_hist::Vector{Float64},
+    dV::Float64,
 )
     sc = _lbfgs_scratch(grad)
     q = sc.q
@@ -48,7 +61,7 @@ function _lbfgs_direction(
     # array — for a 16³ × D=13 spinor that's ~640 KB per call, repeated
     # 2m+1 times per L-BFGS direction).
     for i in m:-1:1
-        alphas[i] = rho_hist[i] * real(dot(s_hist[i], q))
+        alphas[i] = rho_hist[i] * real(dot(s_hist[i], q)) * dV
         q .-= alphas[i] .* y_hist[i]
     end
 
@@ -60,7 +73,7 @@ function _lbfgs_direction(
     end
 
     for i in 1:m
-        β = rho_hist[i] * real(dot(y_hist[i], q))
+        β = rho_hist[i] * real(dot(y_hist[i], q)) * dV
         q .+= (alphas[i] - β) .* s_hist[i]
     end
 
@@ -69,20 +82,37 @@ function _lbfgs_direction(
 end
 
 """
-Line search on the constraint manifold: require E_trial < E0 (strict decrease).
-No slope condition — avoids the retraction/normalization mismatch that makes
-Armijo unreliable on the sphere.
+Backtracking-Armijo line search on the constraint manifold, starting from
+the natural L-BFGS step `α_init = 1`.
+
+The L-BFGS direction is already curvature-scaled (the two-loop recursion
+multiplies by `γ = ⟨s,y⟩/⟨y,y⟩`), so it is an approximate Newton step whose
+natural length is `α ≈ 1` — the historical `α_init = 0.01` shrink-only search
+could never take more than 1 % of that step, capping LBFGS far above its
+gradient floor (scalar harmonic GS plateaued at `|∇E|≈4e-3`, `errE≈2e-6`, vs
+ITP's `2e-12`). Starting at `α = 1` and backtracking restores the Newton step.
+
+Acceptance is the Armijo sufficient-decrease test `E(α) ≤ E0 + c1·α·slope`
+(`slope = ⟨∇E, d⟩·dV ≤ 0` is the manifold directional derivative, passed from
+the driver). When `slope` is not supplied (`0`) it degrades to the strict-
+decrease test `E(α) < E0`, preserving the old manifold-safe behaviour.
+
+`expand=true` (used for the steepest-descent step, whose scale is unknown)
+permits a bounded doubling phase when `α = 1` already decreases, so the first
+unscaled step auto-finds its scale instead of being stuck at the Newton length.
 """
 function _line_search_energy_decrease(
     psi, direction, E0, ws, grid, dV, target_Mz, F;
-    α_init::Float64=0.01, shrink::Float64=0.5, max_iter::Int=30,
+    slope::Float64=0.0,
+    α_init::Float64=1.0, shrink::Float64=0.5, grow::Float64=2.0,
+    c1::Float64=1.0e-4, max_iter::Int=30, max_expand::Int=6,
+    expand::Bool=false,
 )
     D = 2F + 1
     N_dim = length(grid.config.n_points)
     psi_trial = _lbfgs_scratch(psi).psi_trial
 
-    α = α_init
-    for _ in 1:max_iter
+    eval_energy = function (α)
         psi_trial .= psi .+ α .* direction
         # Retraction: normalize back to manifold
         norm_sq = sum(abs2, psi_trial) * dV
@@ -90,15 +120,41 @@ function _line_search_energy_decrease(
         if target_Mz !== nothing
             _normalize_psi_constrained!(psi_trial, grid, D, N_dim, target_Mz, F)
         end
-
         copyto!(ws.state.psi, psi_trial)
-        E_trial = total_energy(ws)
+        total_energy(ws)
+    end
 
-        if E_trial < E0
+    # Armijo sufficient decrease (slope ≤ 0). slope == 0 ⇒ strict decrease.
+    accept(α, E) = slope < 0 ? (E ≤ E0 + c1 * α * slope) : (E < E0)
+
+    α = α_init
+    E_trial = eval_energy(α)
+
+    if accept(α, E_trial)
+        # Optional bounded expansion: only when the curvature step is not yet
+        # the local minimiser along the ray (steepest-descent scale finding).
+        if expand
+            best_α, best_E = α, E_trial
+            for _ in 1:max_expand
+                α2 = best_α * grow
+                E2 = eval_energy(α2)
+                (E2 < best_E && accept(α2, E2)) || break
+                best_α, best_E = α2, E2
+            end
+            best_α == α || eval_energy(best_α)  # leave ws.state.psi at best
+            return best_α, best_E
+        end
+        return α, E_trial
+    end
+
+    # Backtracking from α_init.
+    for _ in 1:max_iter
+        α *= shrink
+        E_trial = eval_energy(α)
+        if accept(α, E_trial)
             return α, E_trial
         end
-        α *= shrink
     end
-    # No decrease found — return zero step
+    # No sufficient decrease found — return zero step.
     (0.0, E0)
 end

--- a/src/solvers/newton_cg.jl
+++ b/src/solvers/newton_cg.jl
@@ -225,6 +225,13 @@ RESIDUAL-norm decrease `‖gp‖`, not energy. `‖gp‖` is evaluable to `~eps�
 the floor drops to the finite-difference HvP floor (`eps^(2/3)≈2e-11` at
 `order=2`; `eps^(4/5)≈1.6e-13` at `order=4`).
 
+VALIDITY REGIME: validated on gapped / in-basin / converged states (scalar
+harmonic, weak-coupling spinor). NOT validated at strong coupling — at Eu
+production scale (c₀·n≫1, μ~12) the kinetic-only inner preconditioner is
+insufficient and the polish stalls on a still-unconverged GS; that regime needs
+a combined kinetic+potential preconditioner (separate work). Do NOT read a
+stability verdict off a polish that has not actually reached its floor.
+
 PRECONDITION: `ψ0` must be in the convex basin (projected Hessian positive
 definite — i.e. a Bogoliubov-stable stationary point). This is a polish, NOT a
 globalized solver; seed it from L-BFGS / `newton_cg_ground_state`. On negative

--- a/src/solvers/newton_cg.jl
+++ b/src/solvers/newton_cg.jl
@@ -78,7 +78,7 @@ function newton_cg_ground_state(
     verbose::Bool=false,
 )
     ψ = copy(ψ0)
-    k2 = ws.grid.k_squared
+    k2 = _to_device(ws.backend, ws.grid.k_squared)
     dV = cell_volume(ws.grid)
     ipR(a, b) = real(sum(conj.(a) .* b)) * dV
     n2_init = ipR(ψ, ψ)
@@ -251,7 +251,7 @@ function residual_newton_refine(
     verbose::Bool=false,
 )
     ψ = copy(ψ0)
-    k2 = ws.grid.k_squared
+    k2 = _to_device(ws.backend, ws.grid.k_squared)
     dV = cell_volume(ws.grid)
     ipR(a, b) = real(sum(conj.(a) .* b)) * dV
     n2_init = ipR(ψ, ψ)

--- a/src/solvers/newton_cg.jl
+++ b/src/solvers/newton_cg.jl
@@ -29,7 +29,7 @@
 # point. The atomic return ({psi, energy, grad_norm, μ}) is the input to
 # those separate gates, never the verdict itself.
 
-export newton_cg_ground_state
+export newton_cg_ground_state, residual_newton_refine
 
 # In-place Sobolev metric M = (1 + α(−∇²)): per spinor component, k-space
 # multiply by (1 + α k²). The forward partner of `_sobolev_precondition!`
@@ -204,4 +204,146 @@ function _tr_tau(z, d, Δ, Mmul, ipR)
     c = ipR(z, Mmul(z)) - Δ^2
     disc = max(b^2 - 4 * a * c, 0.0)
     (-b + sqrt(disc)) / (2 * a)
+end
+
+"""
+    residual_newton_refine(ws, ψ0; kwargs...) → (; psi, energy, grad_norm, converged, iterations, mu)
+
+In-basin residual-driven Newton refinement (a J-method / generalized inverse
+iteration) that breaks the energy-comparison floor of `newton_cg_ground_state`.
+
+`newton_cg_ground_state` accepts steps by an ENERGY decrease (trust region on
+`ared = E − Etrial`); near the minimum the reduction `~‖∇E‖²/κ` drops below the
+energy roundoff `~eps·|E|`, so `ρ = ared/pred` becomes noise, every step is
+rejected, and the projected gradient floors at `√eps·‖g‖` (~6e-8 scalar). This
+routine instead drives the projected gradient (which equals `2·P·r` for the
+mean-field residual `r = (H[ψ]−μ)ψ`, since `g = 2H[ψ]ψ` and `Pψ = 0`) to zero
+DIRECTLY: a damped Newton step `J p = −gp` (J = `constrained_hessian_action`,
+the gate-2 Hessian incl. the anomalous block), with the step accepted by the
+RESIDUAL-norm decrease `‖gp‖`, not energy. `‖gp‖` is evaluable to `~eps·κ_max`
+(the kinetic-dominated `‖H‖`), so acceptance is no longer roundoff-limited and
+the floor drops to the finite-difference HvP floor (`eps^(2/3)≈2e-11` at
+`order=2`; `eps^(4/5)≈1.6e-13` at `order=4`).
+
+PRECONDITION: `ψ0` must be in the convex basin (projected Hessian positive
+definite — i.e. a Bogoliubov-stable stationary point). This is a polish, NOT a
+globalized solver; seed it from L-BFGS / `newton_cg_ground_state`. On negative
+curvature the inner PCG truncates and the damped step guards descent, but a
+saddle seed will not converge. Use `extra_nullspace` to pass known Goldstone /
+zero modes (vortex rotation, free-space translation) for explicit projection —
+without it those near-singular directions stall the residual.
+
+Keywords: `tol` (‖gp‖ stop), `max_outer`, `max_cg`, `sobolev_alpha`
+(Fourier/kinetic preconditioner `(1+α k²)⁻¹`), `ε` + `hvp_order` (HvP step /
+stencil), `cg_tol` (inner PCG relative residual), `extra_nullspace` (vector of
+tangent modes to project out each iteration), `verbose`.
+"""
+function residual_newton_refine(
+    ws, ψ0;
+    tol::Float64=1e-12,
+    max_outer::Int=40,
+    max_cg::Int=80,
+    sobolev_alpha::Float64=0.04,
+    cg_tol::Float64=1e-3,
+    ε::Float64=1e-5,
+    hvp_order::Int=2,
+    extra_nullspace=nothing,
+    verbose::Bool=false,
+)
+    ψ = copy(ψ0)
+    k2 = ws.grid.k_squared
+    dV = cell_volume(ws.grid)
+    ipR(a, b) = real(sum(conj.(a) .* b)) * dV
+    n2_init = ipR(ψ, ψ)
+
+    # Project out the gauge tangent (norm + phase Goldstone) AND any extra
+    # supplied zero modes (vortex / translation Goldstone), orthogonalised.
+    function project(v, prm)
+        w = _tangent_project(v, ψ, prm.dV, prm.n2)
+        if extra_nullspace !== nothing
+            for m in extra_nullspace
+                w = w .- m .* (ipR(m, w) / ipR(m, m))
+            end
+        end
+        w
+    end
+    Minv(r, prm) = project(_sobolev_precondition!(copy(r), ws, k2, sobolev_alpha), prm)
+
+    gnorm = Inf
+    converged = false
+    iters = 0
+    t0 = time()
+
+    # ‖gp‖ at the current ψ, reusing the constrained_hessian_params gradient.
+    function residual_norm(prm)
+        gp = project(prm.g, prm)
+        (sqrt(ipR(gp, gp)), gp)
+    end
+
+    for outer in 1:max_outer
+        iters = outer
+        prm = constrained_hessian_params(ws, ψ)
+        gnorm, gp = residual_norm(prm)
+        if verbose
+            @printf("  rNCG %2d/%d | ‖gp‖=%.3e μ=%.5f | %.1fs\n",
+                outer, max_outer, gnorm, prm.μ, time() - t0)
+            flush(stdout)
+        end
+        gnorm < tol && (converged=true; break)
+
+        Hc(δ) = constrained_hessian_action(ws, ψ, δ; prm.μ, prm.dV, prm.n2, ε, order=hvp_order)
+        p = _pcg_newton(Hc, -gp, r -> Minv(r, prm), ipR, max_cg, cg_tol)
+
+        # Damped step accepted by RESIDUAL decrease (NOT energy), so the
+        # acceptance test resolves to eps·κ_max, not eps·|E|.
+        accepted = false
+        t = 1.0
+        for _ in 1:20
+            ψt = ψ .+ t .* p
+            ψt .*= sqrt(n2_init / ipR(ψt, ψt))
+            prm_t = constrained_hessian_params(ws, ψt)
+            gnorm_t, _ = residual_norm(prm_t)
+            if gnorm_t < gnorm
+                ψ = ψt
+                accepted = true
+                break
+            end
+            t *= 0.5
+        end
+        accepted || break    # no residual decrease (floor reached or out of basin)
+    end
+
+    copyto!(ws.state.psi, ψ)
+    Efinal = total_energy(ws)
+    prm = constrained_hessian_params(ws, ψ)
+    gnorm, _ = residual_norm(prm)
+    copyto!(ws.state.psi, ψ)
+    (; psi=ψ, energy=Efinal, grad_norm=gnorm, converged, iterations=iters, mu=prm.μ)
+end
+
+# Preconditioned CG for the Newton step `Hc x = b` in the tangent space.
+# Truncates on negative curvature (returns the current iterate, which is still
+# a descent direction for the residual) — the damped outer step guards the rest.
+function _pcg_newton(Hc, b, Minv, ipR, maxit, cg_tol)
+    x = zero(b)
+    r = copy(b)
+    z = Minv(r)
+    d = copy(z)
+    rz = ipR(r, z)
+    rnorm0 = sqrt(ipR(r, r))
+    rnorm0 < 1e-300 && return x
+    for _ in 1:maxit
+        Hd = Hc(d)
+        dHd = ipR(d, Hd)
+        dHd <= 0 && break                 # negative curvature → stop
+        α = rz / dHd
+        x = x .+ α .* d
+        r = r .- α .* Hd
+        sqrt(ipR(r, r)) <= cg_tol * rnorm0 && break
+        z = Minv(r)
+        rz_new = ipR(r, z)
+        d = z .+ (rz_new / rz) .* d
+        rz = rz_new
+    end
+    x
 end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -345,6 +345,7 @@ const FULL_EXTRA = [
     "solvers/test_quasi_2d_api.jl",
     "hamiltonian/test_tensor_interaction.jl",
     "solvers/test_lbfgs.jl",
+    "solvers/test_lbfgs_accuracy_floor.jl",
     "workflow/test_pipeline.jl",
     "solvers/test_pause_resume.jl",
     "dynamics/test_twa.jl",
@@ -470,6 +471,7 @@ const _COST = Dict{String, Float64}(
     "solvers/test_3d.jl" => 5.0,
     "dynamics/test_twa.jl" => 5.0,
     "solvers/test_lbfgs.jl" => 5.0,
+    "solvers/test_lbfgs_accuracy_floor.jl" => 6.0,
 )
 
 _cost(f) = get(_COST, f, _DEFAULT_COST)

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -304,6 +304,10 @@ const CI_EXTRA = [
     # uniform limit: matrix-free σ_z[L M; M* L*] from the gated HvP vs the
     # CG-sum homogeneous matrices at the box k-modes + quartet symmetry.
     "oracles/test_trapped_bdg_spectrum.jl",
+    # gate-2 eigensolver: preconditioned block LOBPCG (trapped_bdg_low_modes)
+    # ≡ bare Lanczos (trapped_bdg_lowest_eigenvalue) on λ_min, + Kato–Temple
+    # two-sided certificate bracket.
+    "oracles/test_bdg_low_modes_lobpcg.jl",
     # StabilitySpec three-valued gate: replays the non-stationary /
     # non-converged false-verdict class (mistake_stability_verdict_from_
     # nonstationary_point) — gate returns :indeterminate, not a confident

--- a/test/oracles/test_bdg_low_modes_lobpcg.jl
+++ b/test/oracles/test_bdg_low_modes_lobpcg.jl
@@ -1,0 +1,45 @@
+using Test
+using SpinorBEC
+using SpinorBEC: trapped_bdg_lowest_eigenvalue, trapped_bdg_low_modes,
+    constrained_hessian_params
+using Random
+
+# gate-2 eigensolver: the preconditioned block LOBPCG (`trapped_bdg_low_modes`)
+# must agree with the bare Lanczos (`trapped_bdg_lowest_eigenvalue`) on the
+# lowest constrained-Hessian eigenvalue — two independent eigensolvers on the
+# SAME operator. Also pins the Kato–Temple two-sided certificate: the lower
+# bound never exceeds the Ritz value, and (when converged) brackets it.
+#
+# NOTE: this gates CORRECTNESS (agreement), not speed. The kinetic-Fourier
+# preconditioner's convergence advantage shows on stiff / soft-mode spectra
+# (fine 3D grid, λ_min→0), which this small gapped anchor does not exercise;
+# tuning the preconditioner + the shift-invert (MINRES) variant for soft
+# points is done against a real soft-mode case, not here.
+
+@testset "gate-2 eigensolver: LOBPCG ≡ Lanczos + Kato–Temple bracket" begin
+    grid = make_grid(GridConfig(16, 10.0))
+    interactions = InteractionParams(Dict(0 => 4.0, 1 => 0.3))
+    r = find_ground_state_lbfgs(;
+        grid, atom=Rb87, interactions, potential=HarmonicTrap(1.0),
+        n_steps=400, tol=1e-11, initial_state=:polar, verbose=false,
+    )
+    ws = r.workspace
+    ψ = copy(ws.state.psi)
+    prm = constrained_hessian_params(ws, ψ)
+
+    lanczos = trapped_bdg_lowest_eigenvalue(ws, ψ; niter=80, params=prm,
+        rng=MersenneTwister(1))
+    lobpcg = trapped_bdg_low_modes(ws, ψ; nev=1, block=6, max_iter=40, tol=1e-8,
+        params=prm, rng=MersenneTwister(1))
+
+    # Two independent eigensolvers, same operator → same λ_min.
+    @test isapprox(lobpcg.λ[1], lanczos.λ_min; atol=5e-3)
+
+    # Kato–Temple: lower bound ≤ Ritz value (upper bound), and the interval
+    # is finite / sane.
+    @test lanczos.λ_lower ≤ lanczos.λ_min + 1e-12
+    @test isfinite(lanczos.λ_lower)
+    @test lanczos.gap ≥ 0
+    # LOBPCG per-mode lower bound also ≤ its Ritz value.
+    @test lobpcg.λ_lower[1] ≤ lobpcg.λ[1] + 1e-12
+end

--- a/test/solvers/test_lbfgs_accuracy_floor.jl
+++ b/test/solvers/test_lbfgs_accuracy_floor.jl
@@ -62,4 +62,27 @@ using SpinorBEC
         # own residual). Pre-fix L-BFGS sat ABOVE ITP by ~1e-5.
         @test r.energy ≤ r_itp.energy + 1e-7
     end
+
+    @testset "Newton-CG polish tightens the gradient floor" begin
+        # L-BFGS is first-order, so its projected gradient floors near
+        # √(machine-eps)·scale even at a machine-exact energy. The opt-in
+        # `newton_polish` second-order pass drives the stationarity residual
+        # below that floor (≈10× on the scalar harmonic) without moving the
+        # (already converged) energy.
+        grid = make_grid(GridConfig(128, 16.0))
+        interactions = InteractionParams(Dict(0 => 0.0, 1 => 0.0))
+        trap = HarmonicTrap(1.0)
+
+        base = (;
+            grid, atom=Rb87, interactions, potential=trap,
+            n_steps=500, tol=1e-12, initial_state=:polar, verbose=false,
+        )
+        r_lbfgs = find_ground_state_lbfgs(; base...)
+        r_poly = find_ground_state_lbfgs(; base..., newton_polish=true)
+
+        # Polish lowers the gradient residual by a clear margin.
+        @test r_poly.grad_norm < 0.5 * r_lbfgs.grad_norm
+        # Energy stays at machine precision (polish must not regress it).
+        @test abs(r_poly.energy - 0.5) < 1e-12
+    end
 end

--- a/test/solvers/test_lbfgs_accuracy_floor.jl
+++ b/test/solvers/test_lbfgs_accuracy_floor.jl
@@ -1,0 +1,65 @@
+using Test
+using SpinorBEC
+
+# Regression gate for the L-BFGS ground-state accuracy floor.
+#
+# Before 2026-06-22 the L-BFGS solver could not reach its gradient floor:
+# the shrink-only line search capped every step at α=0.01 (1% of the
+# curvature-scaled, ≈Newton, two-loop direction), AND the two-loop
+# recursion omitted the `·dV` factor that `rho_hist` carries — mis-scaling
+# the direction by 1/dV. Together they stalled L-BFGS far above its floor:
+# on the trivially-conditioned scalar harmonic GS it plateaued at
+# E-error ≈ 1.9e-6 / |∇E| ≈ 4e-3 (vs the exact 0.5), while ITP reached
+# 1e-12. These tests pin the post-fix behaviour — machine-precision energy
+# and a true gradient floor — so the line-search / inner-product scaling
+# cannot silently regress.
+
+@testset "L-BFGS accuracy floor" begin
+    @testset "scalar harmonic GS reaches machine-precision energy" begin
+        # 1D ω=1 harmonic, no interactions: exact GS is the Gaussian with
+        # E_0 = 0.5. The minimiser is smooth and well-conditioned, so any
+        # competent optimiser should drive E to ~machine precision.
+        grid = make_grid(GridConfig(128, 16.0))
+        interactions = InteractionParams(Dict(0 => 0.0, 1 => 0.0))
+        trap = HarmonicTrap(1.0)
+
+        r = find_ground_state_lbfgs(;
+            grid, atom=Rb87, interactions, potential=trap,
+            n_steps=500, tol=1e-10,
+            initial_state=:polar, verbose=false,
+        )
+
+        # Pre-fix: errE ≈ 1.9e-6. Post-fix: < 1e-15. 1e-9 cleanly separates.
+        @test abs(r.energy - 0.5) < 1e-9
+        # Pre-fix: |∇E| ≈ 4e-3. Post-fix: < 1e-7 (F64 grid floor).
+        @test r.grad_norm < 1e-6
+    end
+
+    @testset "L-BFGS reaches its floor within a small step budget" begin
+        # A spinor F=1 problem with interactions + trap. L-BFGS should hit
+        # its gradient floor quickly (≈100 steps) rather than crawling for
+        # thousands. Pin: |∇E| floor reached by 200 steps, and the energy
+        # is no worse than a deeply-converged ITP run (L-BFGS optimises the
+        # exact functional, so it matches or beats split-step ITP).
+        grid = make_grid(GridConfig(64, 16.0))
+        interactions = InteractionParams(Dict(0 => 10.0, 1 => -0.5))
+        trap = HarmonicTrap(1.0)
+
+        r_itp = find_ground_state(;
+            grid, atom=Rb87, interactions, potential=trap,
+            dt=0.002, n_steps=20000, tol=1e-12,
+            initial_state=:m_plus_F, verbose=false,
+        )
+
+        r = find_ground_state_lbfgs(;
+            grid, atom=Rb87, interactions, potential=trap,
+            n_steps=200, tol=1e-10,
+            initial_state=:m_plus_F, verbose=false,
+        )
+
+        @test r.grad_norm < 1e-6
+        # L-BFGS energy is at or below ITP's (allow tiny slack for ITP's
+        # own residual). Pre-fix L-BFGS sat ABOVE ITP by ~1e-5.
+        @test r.energy ≤ r_itp.energy + 1e-7
+    end
+end

--- a/test/solvers/test_lbfgs_accuracy_floor.jl
+++ b/test/solvers/test_lbfgs_accuracy_floor.jl
@@ -63,6 +63,40 @@ using SpinorBEC
         @test r.energy ≤ r_itp.energy + 1e-7
     end
 
+    @testset "residual-Newton breaks the energy-comparison floor" begin
+        # The L-BFGS line search and the energy-gated Newton-CG trust region
+        # both floor the projected gradient at √eps·‖g‖ (~6e-8 here): a step
+        # whose energy reduction (~‖∇E‖²/κ) drops below the energy roundoff
+        # (~eps·|E|) can't be resolved. `residual_newton_refine` accepts steps
+        # by the RESIDUAL norm instead (evaluable to ~eps·κ_max), so it breaks
+        # that floor — down to the finite-difference HvP floor: eps^(2/3)≈2e-11
+        # at order=2, eps^(4/5)≈1.6e-13 at order=4. (Gapped/in-basin only;
+        # the scalar harmonic is the clean well-conditioned anchor.)
+        grid = make_grid(GridConfig(128, 16.0))
+        interactions = InteractionParams(Dict(0 => 0.0, 1 => 0.0))
+        trap = HarmonicTrap(1.0)
+
+        r0 = find_ground_state_lbfgs(;
+            grid, atom=Rb87, interactions, potential=trap,
+            n_steps=500, tol=1e-12, initial_state=:polar, verbose=false,
+        )
+        ws = r0.workspace
+        psi0 = copy(ws.state.psi)
+
+        r2 = residual_newton_refine(ws, psi0; tol=1e-14, max_outer=40, max_cg=120,
+            sobolev_alpha=0.04, ε=1e-5, hvp_order=2)
+        r4 = residual_newton_refine(ws, psi0; tol=1e-15, max_outer=40, max_cg=120,
+            sobolev_alpha=0.04, ε=6e-4, hvp_order=4)
+
+        # order=2 → finite-difference HvP floor eps^(2/3)≈2e-11 (≫ below LBFGS).
+        @test r2.grad_norm < 1e-10
+        @test r2.grad_norm < 0.05 * r0.grad_norm
+        # order=4 → eps^(4/5)≈1.6e-13.
+        @test r4.grad_norm < 1e-11
+        # Energy never regresses (already machine-exact).
+        @test abs(r4.energy - 0.5) < 1e-12
+    end
+
     @testset "Newton-CG polish tightens the gradient floor" begin
         # L-BFGS is first-order, so its projected gradient floors near
         # √(machine-eps)·scale even at a machine-exact energy. The opt-in

--- a/test/test_level4_f1_phase_emergence.jl
+++ b/test/test_level4_f1_phase_emergence.jl
@@ -307,11 +307,23 @@ using SpinorBEC: classify_phase, spin_matrices, bogoliubov_spectrum, BdGResult
             r.energy
         end
 
-        # c₁ < 0 (FM-favored): energy monotonically decreases with |Mz|.
+        # c₁ < 0 (FM-favored): energy is NON-increasing in |Mz|, with a
+        # plateau. Tilting out of the untilted |⟨F⟩|=0 saddle at Mz=0 into
+        # a finite-Mz FM state lowers E; but the FM energy depends on
+        # |⟨F⟩|, not Mz — in a single spatial mode a tilted FM reaches the
+        # fully-polarised |⟨F⟩|=1 for ANY |Mz|≤1, so E(Mz=0.5) ≈ E(Mz=1.0)
+        # rather than strictly greater. (Pre-2026-06-22 the assertion was
+        # strict `E[1]>E[2]>E[3]`; it only held because L-BFGS had not
+        # converged — gnorm ~1e-2 — and the residual faked an ordering.
+        # Once the line-search/dV fixes let L-BFGS reach its gradient floor
+        # the Mz=0.5 and Mz=1.0 energies coincide to ~10 digits.)
+        atol = 1e-5
         E_neg = [_energy_at_Mz(-0.5, Mz) for Mz in Mz_targets]
-        @test E_neg[1] > E_neg[2] > E_neg[3]
+        @test E_neg[1] > E_neg[2] + atol     # saddle → FM tilt lowers E
+        @test E_neg[3] ≤ E_neg[2] + atol     # FM plateau: |Mz|→1 not higher
 
-        # c₁ > 0 (polar-favored): energy monotonically increases with |Mz|.
+        # c₁ > 0 (polar-favored): energy monotonically increases with |Mz|
+        # (the polar Mz=0 state is the GS; forcing magnetization costs E).
         E_pos = [_energy_at_Mz(+0.5, Mz) for Mz in Mz_targets]
         @test E_pos[1] < E_pos[2] < E_pos[3]
     end


### PR DESCRIPTION
## Summary

Thoroughly optimizes L-BFGS ground-state **accuracy**. The solver previously plateaued far above its gradient floor — even on the trivially-conditioned scalar harmonic GS (exact `E=0.5`) it stalled at `errE≈1.9e-6` / `|∇E|≈4.3e-3` after 2000 steps while ITP reached `2e-12`. Root-caused to **two coupled bugs that mutually masked each other**, plus a grid-adaptive preconditioner default.

## Root causes

1. **Line search capped the step at α=0.01.** `_line_search_energy_decrease` started at `α_init=0.01` and only shrank. But the two-loop L-BFGS direction is curvature-scaled (≈Newton step, natural length `α≈1`), so every step was ≤1% of the intended step → ~100× too slow, never reaching the floor.
   → **backtracking-Armijo from α=1**, with a bounded expansion phase for the unscaled steepest-descent step.

2. **dV inconsistency in `_lbfgs_direction`.** `rho_hist = 1/(dot(s,y)·dV)` carries a `dV`, but the two-loop `alphas`/`β` computed `rho·dot(...)` **without** `·dV` → every correction term mis-scaled by `1/dV` (≈8× on a 128-pt/L=16 grid). `γ` is invariant (dV cancels), so it hid.
   → use the **manifold inner product (`·dV`) consistently**, matching the driver's `rho`/`slope`/`grad_norm`.

The two bugs compensated: fixing only the line search made the scalar case **worse** (`errE 1.9e-6 → 2.2e-5`) — the signal that there were two coupled bugs.

3. **`sobolev_alpha=:auto` grid-adaptive default** (`1/k_max²`, half-damps the Nyquist mode). A mass-matrix preconditioner that lowers the gradient floor on ill-conditioned (DDI / soft-manifold) problems for free and is ≈identity on smooth GS. Explicit `Float64` (incl. `0.0` to disable) overrides.

## Results (measured)

| case | before | after |
|---|---|---|
| scalar harmonic (exact E=0.5) | `errE 1.9e-6`, `\|∇E\| 4.3e-3` | **`errE 1.7e-16`, `\|∇E\| 6.6e-8`** |
| spinor F=1 | plateau | **gradient floor in ~100 steps, below deep ITP** |
| **Eu F=6 24³ + DDI (GPU)** | ITP "converged" at `E=-44.169` but **stalled** | LBFGS reaches **`E=-44.951`** (0.78 / 1.8% lower) |

The Eu case is the production target: ITP hit `dE=6.6e-14` at step 1920 but on the soft DDI manifold that small `dE` is **false convergence** — a non-GS stationary point 0.78 above the true ground state. The fixed L-BFGS escapes to the real GS.

## Tests

- **Adds** `test/solvers/test_lbfgs_accuracy_floor.jl` (CI tier) — a scalar machine-precision + spinor floor-in-200-steps oracle that **fails hard pre-fix**. None existed before; existing LBFGS tests only checked `isfinite` / `E≤E_itp` / `dE<1e-4`.
- **Corrects** `test_level4_f1_phase_emergence.jl` (d), which passed only on unconverged artifacts. The `c1<0` FM `target_Mz` sweep is a **plateau** (E depends on `|⟨F⟩|`, not Mz; `E(Mz=0.5)=E(Mz=1.0)` to 10 digits once converged), not strictly monotone. The old strict-`>` only held because L-BFGS hadn't converged (`gnorm~1e-2`).
- Green: `test_lbfgs_accuracy_floor` (4), `test_lbfgs` (13), `test_lbfgs_sobolev_preconditioner` (6), `test_polished_ground_state` (10), `test_level4_f1_phase_emergence` (29).

> Note: `test_level4_general_F_phase_emergence` "Analytic gap" at F=6/8 fails **identically on clean `main`** (pre-existing, ITP path, unrelated to this PR — likely the PR #47 integrator merge / high-F fixed-density approximation).

## ⚠️ Breaking change

`find_ground_state(_lbfgs)` `sobolev_alpha` default changed `0.0 → :auto` (grid-adaptive); kwarg type widened `Float64 → Union{Float64, Symbol}`. Default-LBFGS numerical results shift slightly, **toward the true GS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up commit: optional Newton-CG polish

Second commit adds an **opt-in** second-order polish for users who need a tighter stationarity residual than L-BFGS's first-order √eps floor (e.g. for stability / BdG gates):

```julia
find_ground_state_lbfgs(...; newton_polish=true)
find_ground_state_polished(...; newton_polish=true)
```

After the L-BFGS loop it runs a trust-region Newton-CG pass (the gate-2 constrained Hessian via finite-difference HvP). Measured `|∇E|` improvement, energy unchanged (already machine-exact):

| case | L-BFGS only | + `newton_polish` |
|---|---|---|
| scalar harmonic | `6.6e-8` | **`4.6e-9`** (~14×) |
| spinor F=1 | `9.9e-9` | **`1.1e-9`** (~9×) |

Finite-difference ε floors the gain (ε≈1e-6 optimal); this is a tighter certificate, not machine-zero gradients. Default **off** (costs `newton_max_outer × newton_max_cg` HvPs).


## Investigation: where the gradient floor actually is

I probed whether the Newton-CG polish could be pushed to machine-zero gradients. The textbook story — the finite-difference HvP `[g(ψ+εδ)−g(ψ−εδ)]/2ε` has a catastrophic-cancellation floor `eps^(2/3)≈2e-11`, so a 4th-order stencil (`eps^(4/5)≈1.6e-13`) or AD/analytic HvP should break it — turned out to be **the wrong bottleneck**, falsified by measurement:

- A 5-point (4th-order) stencil did **not** lower the floor.
- Sweeping `|E|` 256× gives `‖∇E‖/|E| ≈ 1.4e-7` **constant** (`∝‖g‖`, not `∝√E`).
- Verbose Newton-CG trace: every step **rejected** (`ρ=ared/pred` is noise), trust radius collapses `1→3e-11`, gradient frozen.

The real floor is the **energy-comparison limit**: both the L-BFGS line search and the Newton-CG trust region accept steps by comparing energies, so a step whose reduction (`~‖∇E‖²/curvature`) drops below the energy-evaluation roundoff (`~eps·|E|`) is unresolvable → `‖∇E‖` floors at `√eps·‖g‖`. Improving the HvP (AD / analytic Bogoliubov) would **not** help; breaking it would require an eigenvector-residual iteration (RQI / inverse iteration) that drives `(H−μ)ψ→0` directly, without energy-gated steps. (The energy and state are already machine-exact, so the gain would be only a tighter stationarity certificate.)

The `newton_polish` pass still buys ~10× (`6.6e-8 → 5e-9`) by getting nearer that floor — useful when `‖∇E‖` is itself the BdG/stability certificate. It is opt-in (default off).


## Layer analysis + gate-2 eigensolver (commits 4–6)

Pushing the accuracy further revealed the floor is a stack of nested layers, each found by measuring *what actually moves the number*:

```
energy-gate √eps·‖g‖  →  FD-HvP eps^(2/3)  →  eps·κ_max  →  eigensolver niter  →  discretisation
```

- **`residual_newton_refine`** (commit 4): accepts steps by the residual norm, not the energy, breaking the energy-comparison floor. Scalar harmonic: `6.6e-8 → 1.1e-11` (order 2) → `3.2e-13` (order 4), confirming `eps^(2/3)` then `eps^(4/5)`. Gapped/in-basin polish; the soft-mode (indefinite/near-singular) production J-method (real MINRES + deflation + analytic HvP) is the documented follow-up.
- **Kato–Temple two-sided bound** (commit 6) on `trapped_bdg_lowest_eigenvalue`: `λ_min ∈ [θ₁−ρ²/δ, θ₁]`. ρ enters **squared**, so the certified interval is far tighter than the naive `±ρ` (rotating Eu proxy at niter=160: width `1.1e-3`, certifies `λ_min>0`, vs `±1.3e-2`). Adds `λ_lower`/`gap` (backward compatible).
- **`trapped_bdg_low_modes`** (commit 6): block LOBPCG + kinetic Fourier preconditioner `(½k²+α)⁻¹`. Correct (≡ Lanczos, gated by `test_bdg_low_modes_lobpcg.jl`); the preconditioner's convergence advantage targets stiff/soft spectra.

**Key measured finding** (Step-0 on a rotating Eu F=6 proxy at the Barnett Ω≈0.27): the gate-2 `λ_min` uncertainty is dominated by the **eigensolver** (Lanczos still drifting at niter=160, `ritz_res~1e-2`), NOT the GS residual (tightening `‖r‖` 4×10⁴ moved `λ_min` ~1e-5). So for the Barnett soft-mode certificate the eigensolver is the binding layer; the residual-Newton, though validated, is overkill there.


## Validity regime (read before reusing these tools)

These tools are validated for **gapped / in-basin / converged** ground states (scalar harmonic to machine precision; weak-coupling spinor; rotating Eu *proxy* with `c₀=20`). Within that regime:
- `find_ground_state_lbfgs` reaches its true gradient floor / machine-exact energy;
- `residual_newton_refine` breaks the energy-comparison floor (`eps^(2/3)`–`eps^(4/5)`);
- `trapped_bdg_lowest_eigenvalue` + Kato–Temple gives a tight two-sided `λ_min` certificate;
- `trapped_bdg_low_modes` (LOBPCG) is correct (≡ Lanczos).

**Explicitly OUT OF SCOPE (separate PR):** strong-coupling Eu *production* (`c₀·n ~ 2343`, `μ~12`). There the GS LBFGS is slow (not at floor in a few thousand steps), the gate-2 eigensolver does not converge (Lanczos `ρ~0.3`, `λ_min` sign *undetermined*), and the kinetic-only preconditioner is insufficient (the stiffness is interaction-dominated). **Do not read a stability verdict off a state that has not actually reached its floor / an eigensolver that reports `converged=false`** — that is the exact "unconverged ψ read as λ_min" trap. The next PR adds a combined kinetic+potential preconditioner + `L_z` symmetry-sector decomposition for that regime.

The function docstrings carry this regime note inline so it travels with the code.
