### PR TITLE
fix(solvers): width-based gate-2 convergence flag + adaptive Lanczos

### DIFF
--- a/src/solvers/hessian.jl
+++ b/src/solvers/hessian.jl
@@ -97,9 +97,9 @@ function constrained_hessian_action(ws, ψ, δ; μ, dV, n2, ε::Float64=1e-5, or
 end
 
 """
-    trapped_bdg_lowest_eigenvalue(ws, ψ; niter=24, ε=1e-5, tol_ritz=1e-2,
-                                  params=nothing, rng=…)
-        → (; λ_min, μ, ritz_residual, niter_used, converged)
+    trapped_bdg_lowest_eigenvalue(ws, ψ; niter=300, atol=1e-6, ε=1e-5,
+                                  tol_ritz=1e-2, params=nothing, rng=…)
+        → (; λ_min, μ, ritz_residual, niter_used, converged, λ_lower, gap, width, goldstone)
 
 Lowest eigenvalue of the constrained second variation `P(H−2μ)P` at a
 STATIONARY ψ — the gate-2 minimum-vs-saddle verdict for a trapped state.
@@ -109,29 +109,38 @@ saddle. Requires ψ converged (`g ∥ ψ`); on a non-stationary ψ the `μ` and
 the verdict are not meaningful — `StabilitySpec` enforces that precondition
 before reading the sign.
 
-Self-certifying: `ritz_residual = |β_m · sₘ[end]|` is the classical
-a-posteriori Lanczos bound on the lowest Ritz value — `β_m` the residual
-norm of the last Lanczos vector, `sₘ` the tridiagonal eigenvector of the
-lowest Ritz value. A `λ_min` whose `ritz_residual` is not ≪ |λ_min| is NOT
-converged; the historical "λ_min still dropping at niter=200" false verdict
-is exactly a large `ritz_residual` the bare value hides. `converged` flags
-`ritz_residual < tol_ritz·(|λ_min| + 1e-10)`.
+**Two-sided certificate (Kato–Temple).** The min Ritz value `λ_min = θ₁` is an
+UPPER bound on the true eigenvalue (Ritz values converge from above); the
+LOWER bound is `λ_lower = θ₁ − ρ²/δ` (`ρ` = ritz_residual, `δ` = Ritz gap to θ₂).
+`ρ` enters SQUARED, so the certified interval `width = θ₁ − λ_lower` is far
+tighter than the naive `±ρ`. **The convergence test is on `width`, not the
+bare residual:** `converged = width < max(atol, tol_ritz·|λ_min|)`. This is the
+fix for soft / Goldstone modes — a purely RELATIVE test `ρ < tol_ritz·|λ_min|`
+is unsatisfiable as `λ_min → 0` (false negatives exactly where you care), while
+the absolute `atol` floor certifies `λ_min` once it is pinned to `±atol`.
 
-`λ_min` and `μ` are the first two NamedTuple fields, so legacy
-`λ, _ = trapped_bdg_lowest_eigenvalue(...)` and `…[1]` still yield λ_min.
-Pass `params` (a `constrained_hessian_params` result) to reuse an already-
-computed `(μ, dV, n2)` and skip the redundant `energy_gradient!`. `niter < 1`
-returns `converged=false` (λ_min=NaN) rather than erroring on an empty
-Krylov space — the gate abstains, it does not crash.
+**Adaptive:** the Lanczos loop early-stops as soon as `converged`, so easy
+(gapped) cells finish in tens of iterations while soft cells run to the `niter`
+cap. The historical "λ_min still dropping at niter=200" verdict is exactly a
+`converged=false` the bare value used to hide — trust the flag, not the value.
+
+**Goldstone:** `goldstone=true` flags a converged `|λ_min| < atol` — a marginal
+zero mode (e.g. the polar-phase spin Goldstone), classified as a minimum (NOT a
+saddle). The complex-ψ tangent projection removes only the U(1) gauge `iψ`;
+physical broken-symmetry Goldstones remain at `λ_min ≈ 0` and are correct.
+
+`λ_min` and `μ` are the first two NamedTuple fields (legacy `[1]`/`[2]` and
+`λ, _ = …` still yield λ_min, μ). Pass `params` to reuse `(μ, dV, n2)`.
+`niter < 1` returns `converged=false` (λ_min=NaN) — the gate abstains, no crash.
 """
 function trapped_bdg_lowest_eigenvalue(
-    ws, ψ; niter::Int=24, ε::Float64=1e-5, tol_ritz::Float64=1e-2,
-    params=nothing, rng=Random.default_rng(),
+    ws, ψ; niter::Int=300, atol::Float64=1e-6, ε::Float64=1e-5,
+    tol_ritz::Float64=1e-2, params=nothing, rng=Random.default_rng(),
 )
     p = params === nothing ? constrained_hessian_params(ws, ψ) : params
     if niter < 1
-        return (;
-            λ_min=NaN, μ=p.μ, ritz_residual=Inf, niter_used=0, converged=false)
+        return (; λ_min=NaN, μ=p.μ, ritz_residual=Inf, niter_used=0,
+            converged=false, λ_lower=NaN, gap=NaN, width=Inf, goldstone=false)
     end
     ipR(a, b) = real(sum(conj.(a) .* b)) * p.dV
     Hc(δ) = constrained_hessian_action(ws, ψ, δ; p.μ, p.dV, p.n2, ε)
@@ -141,39 +150,50 @@ function trapped_bdg_lowest_eigenvalue(
     V[1] ./= sqrt(ipR(V[1], V[1]))
     α = Float64[]
     β = Float64[]
+    λ_min = NaN
+    ritz_residual = Inf
+    gap = NaN
+    λ_lower = NaN
+    width = Inf
+    converged = false
+
     for _ in 1:niter
         w = Hc(V[end])
         push!(α, ipR(V[end], w))
         for u in V                              # full reorthogonalisation
             w = w .- u .* ipR(u, w)
         end
-        βj = sqrt(ipR(w, w))
-        βj < 1e-10 && break
+        βj = sqrt(max(ipR(w, w), 0.0))
+
+        # Ritz value + Kato–Temple width of the CURRENT Krylov space, with the
+        # candidate residual βj as the a-posteriori bound. Check convergence
+        # in-loop so easy cells stop early (β has length(α)-1 here).
+        if length(α) >= 2
+            decomp = eigen(SymTridiagonal(copy(α), copy(β)))
+            λ_min = decomp.values[1]
+            s_min = @view decomp.vectors[:, 1]
+            ritz_residual = abs(βj * s_min[end])
+            θ2 = decomp.values[2]
+            gap = θ2 - λ_min
+            width = gap > ritz_residual ? ritz_residual^2 / gap : ritz_residual
+            λ_lower = λ_min - width
+            if width < max(atol, tol_ritz * abs(λ_min))
+                converged = true
+                break
+            end
+        elseif length(α) == 1
+            λ_min = α[1]
+            λ_lower = λ_min
+        end
+
+        βj < 1e-10 && break                     # invariant subspace ⇒ exact
         push!(β, βj)
         push!(V, w ./ βj)
     end
-    decomp = eigen(SymTridiagonal(α, β[1:(length(α) - 1)]))
-    λ_min = decomp.values[1]
-    s_min = @view decomp.vectors[:, 1]
-    # β_m (residual norm of the last Lanczos vector) is present iff the loop
-    # ran to `niter`; on early break the residual is ≈0 (exact eigenvector).
-    β_m = length(β) >= length(α) ? β[end] : 0.0
-    ritz_residual = abs(β_m * s_min[end])
-    converged = ritz_residual < tol_ritz * (abs(λ_min) + 1e-10)
 
-    # Two-sided certificate (Kato–Temple). The Ritz value `λ_min = θ₁` is an
-    # UPPER bound on the true λ_min (Ritz values converge from above). The
-    # LOWER bound is `θ₁ − ρ²/δ` with ρ = ritz_residual and δ the gap to the
-    # next eigenvalue (estimated by the Ritz gap θ₂ − θ₁). Because ρ enters
-    # SQUARED, the certified interval is far tighter than the naive `±ρ`:
-    # ρ=5e-3, δ=0.1 ⇒ ±2.5e-4, not ±5e-3. Valid when δ > ρ (θ₂ a real
-    # separation); otherwise fall back to the loose `±ρ`. At a soft point δ
-    # shrinks and the bound loosens — that is where a preconditioned solver
-    # must drive ρ down directly (see the LOBPCG path).
-    θ2 = length(decomp.values) >= 2 ? decomp.values[2] : λ_min
-    gap = θ2 - λ_min
-    λ_lower = gap > ritz_residual ? λ_min - ritz_residual^2 / gap : λ_min - ritz_residual
-    (; λ_min, μ=p.μ, ritz_residual, niter_used=length(α), converged, λ_lower, gap)
+    goldstone = converged && abs(λ_min) < atol
+    (; λ_min, μ=p.μ, ritz_residual, niter_used=length(α), converged,
+        λ_lower, gap, width, goldstone)
 end
 
 # In-place kinetic Fourier preconditioner M⁻¹ = (½k² + α)⁻¹ per spin component.

--- a/src/workflow/validation/stability_spec.jl
+++ b/src/workflow/validation/stability_spec.jl
@@ -29,14 +29,18 @@
 export StabilitySpec
 
 """
-    StabilitySpec(; ε_stat=1e-4, tol_ritz=1e-2, λ_tol=1e-6, couple=10.0, niter=60)
+    StabilitySpec(; ε_stat=1e-4, tol_ritz=1e-2, λ_tol=1e-6, couple=10.0, niter=300)
 
 Bounds for the three-valued stability gate. `ε_stat` = relative
 stationarity residual bound; `tol_ritz` = Lanczos Ritz residual relative
 to |λ_min| for the energetic sign to count as converged; `λ_tol` = |λ_min|
 below which the curvature is treated as marginal (not a saddle); `couple`
 = require |λ_min| > couple·‖g−2μψ‖ for the sign to be resolvable above the
-stationarity error; `niter` = Lanczos iterations; `tol_dyn` = growth-rate
+stationarity error; `niter` = Lanczos iteration CAP (adaptive early-stop ⇒
+gapped cells finish in tens of iters; soft cells near a phase boundary, where
+λ_min→0, need the larger cap — production strong-coupling Eu needed ~400, so
+the default is 300 with the `converged` flag honestly reporting when even that
+is short); `tol_dyn` = growth-rate
 threshold RELATIVE to the spectral radius; `tol_quartet` = BdG symmetry
 self-check bound; `bdg_dim_cap` = max dense BdG dimension before the
 dynamical axis abstains.

--- a/test/oracles/test_bdg_low_modes_lobpcg.jl
+++ b/test/oracles/test_bdg_low_modes_lobpcg.jl
@@ -43,3 +43,39 @@ using Random
     # LOBPCG per-mode lower bound also ≤ its Ritz value.
     @test lobpcg.λ_lower[1] ≤ lobpcg.λ[1] + 1e-12
 end
+
+# Regression for the convergence-flag fix. The OLD flag was purely RELATIVE
+# (`ρ < tol_ritz·(|λ_min|+1e-10)`), so it false-negatived as λ_min→0 — exactly
+# the soft / Goldstone modes the gate-2 verdict cares about. The flag is now
+# width-based (`width < max(atol, tol_ritz·|λ_min|)`) with adaptive early-stop.
+# A polar (c₁>0, q=0) GS breaks spin-rotation symmetry ⇒ a spin-Goldstone zero
+# mode at λ_min≈0 — the case that used to misreport converged=false.
+@testset "gate-2 convergence flag: width-based + adaptive + Goldstone" begin
+    grid = make_grid(GridConfig(16, 10.0))
+    interactions = InteractionParams(Dict(0 => 4.0, 1 => 0.3))
+    r = find_ground_state_lbfgs(;
+        grid, atom=Rb87, interactions, potential=HarmonicTrap(1.0),
+        n_steps=500, tol=1e-10, initial_state=:polar, verbose=false,
+    )
+    ws = r.workspace
+    ψ = copy(ws.state.psi)
+
+    res = trapped_bdg_lowest_eigenvalue(ws, ψ; niter=300, atol=1e-6, rng=MersenneTwister(1))
+
+    # Adaptive early-stop: a tiny 16-pt problem converges well before the cap.
+    @test res.converged
+    @test res.niter_used < 300
+    # Kato–Temple bracket internal consistency.
+    @test res.width ≥ 0
+    @test res.λ_lower ≤ res.λ_min + 1e-12
+    @test isapprox(res.λ_lower, res.λ_min - res.width; atol=1e-12)
+    # converged ⇒ width under the absolute/relative threshold.
+    @test res.width < max(1e-6, 1e-2 * abs(res.λ_min)) + 1e-12
+    # goldstone flag is exactly "converged & |λ_min| < atol".
+    @test res.goldstone == (res.converged && abs(res.λ_min) < 1e-6)
+    # Polar GS spin Goldstone ⇒ λ_min≈0, tightly bracketed, flagged (the case
+    # the pre-fix relative-only flag would have called converged=false).
+    @test abs(res.λ_min) < 1e-5
+    @test res.width < 1e-6
+    @test res.goldstone
+end

--- a/test/oracles/test_stability_sneaky_prover.jl
+++ b/test/oracles/test_stability_sneaky_prover.jl
@@ -61,11 +61,15 @@ using Random: MersenneTwister
     # Small bdg_dim_cap ⇒ the dynamical axis abstains (keeps this fast); the
     # sneaky claim is entirely about the energetic verdict.
 
-    # (1) At the default Lanczos budget the gate cannot certify the sign and
+    # (1) At a TINY Lanczos budget the gate cannot certify the sign and
     # ABSTAINS — it does NOT falsely ACCEPT, and crucially it does NOT guess
-    # :fail without convergence. (Here niter=60 under-resolves a 64-pt system —
-    # exactly the abstain the three-valued discipline exists for.)
-    res_lo = check(StabilitySpec(; bdg_dim_cap=100), ws, ψ_saddle; rng=MersenneTwister(1))
+    # :fail without convergence. (niter=5 genuinely under-resolves a 64-pt
+    # system — exactly the abstain the three-valued discipline exists for. The
+    # default budget (niter=300) + adaptive early-stop now RESOLVES this
+    # well-separated saddle, so the abstain invariant is exercised with an
+    # explicit tiny budget rather than the default.)
+    res_lo = check(StabilitySpec(; bdg_dim_cap=100, niter=5), ws, ψ_saddle;
+        rng=MersenneTwister(1))
     stat = first(p.second for p in res_lo.details if p.first === :stationarity)
     en_lo = first(p.second for p in res_lo.details if p.first === :energetic)
     @test stat.status === :pass                  # the polar saddle IS a stationary point


### PR DESCRIPTION
Closes #50 (the bulk of it — see below).

## What this is

The Ω=0 gate-2 measurement (issue #50, Step 0) showed that at the **important** case — Eu F=6 strong coupling, Ω=0, the phase-diagram stability gate — the eigensolver is **not** the blocker once the rotating-frame stalls are gone. Bare Lanczos resolves λ_min across a full softness sweep:

| c₁ scale | λ_min (niter=400) | Kato–Temple width |
|---|---|---|
| 1× | −1.0872 (saddle) | converged at niter~200 |
| 2–16× | ≈ +1e-10 (polar spin Goldstone) | **1.4e-15** at niter~400 |

So the combined-preconditioner / shift-invert research originally planned for #50 is **unnecessary at Ω=0**. The real problems were ergonomics in the gate-2 eigensolver:

1. **`converged` was purely relative** — `ritz_residual < tol_ritz·(|λ_min|+1e-10)` false-negatives as `λ_min → 0`, i.e. exactly the soft / Goldstone modes the verdict cares about (width 1.4e-15 yet `converged=false`). Now **width-based**: `converged = width < max(atol, tol_ritz·|λ_min|)` with the Kato–Temple `width = ρ²/δ`. New `atol` kwarg (default `1e-6`).
2. **Adaptive early-stop** — the Lanczos checks the width in-loop and stops as soon as it is certified, so gapped cells finish in tens of iterations while soft cells run to the cap. Default `niter` 24 → 300.
3. **`goldstone` field** — flags a converged `|λ_min| < atol` (marginal zero mode = minimum, not saddle). The tangent projection removes only the U(1) gauge `iψ`; physical broken-symmetry Goldstones correctly stay at `λ_min ≈ 0`.

`StabilitySpec` default `niter` 60 → 300 (adaptive ⇒ free for easy cells; production soft cells near a boundary need the larger cap; the flag reports honestly when even 300 is short).

## Tests
- `test_bdg_low_modes_lobpcg.jl` — adds the convergence-flag regression: a polar (c₁>0, q=0) GS spin-Goldstone (`λ_min≈0`) is now `converged=true` + `goldstone=true` with `width<1e-6` (pre-fix: `converged=false`); adaptive early-stop (`niter_used < 300`); Kato–Temple bracket consistency. **10/10**.
- `test_stability_indeterminate.jl` — **17/17**; `niter=1` still `:indeterminate`, converged GS still `:pass`.

## Scope note
This resolves issue #50 **for the regime measured** (Ω=0, gapped→Goldstone polar sweep). Other phases (FM / cyclic / textures, denser low spectra) are spot-checks for a follow-up; if a genuinely harder cell appears (Lanczos can't converge in a practical cap, `converged=false` persists), the shift-invert + combined-preconditioner path from #50 is the escalation — but it is not needed for what we have measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
