### PR TITLE
feat(yaml): ground_state.newton_polish — opt-in 2nd-order stationarity polish

### DIFF
--- a/bench/verify_yaml_newton_polish.jl
+++ b/bench/verify_yaml_newton_polish.jl
@@ -1,0 +1,45 @@
+# Verify the YAML `ground_state.newton_polish` knob: schema accepts it and it
+# tightens the gradient floor end-to-end (1D scalar harmonic, CPU).
+using SpinorBEC
+
+yaml(polish) = """
+pipeline:
+  - ground_state:
+      method: lbfgs
+      atom: Rb87
+      grid: {n: 128, box: 16.0}
+      interactions: {c0: 0.0, c1: 0.0}
+      potential: {omega: 1.0}
+      n_steps: 500
+      tol: 1.0e-12
+      initial_state: polar
+      newton_polish: $(polish)
+"""
+
+function write_cfg(polish)
+    path = tempname() * ".yaml"
+    open(io -> print(io, yaml(polish)), path, "w")
+    path
+end
+
+# 1) schema must accept newton_polish (no :error / unknown-key)
+p_true = write_cfg(true)
+issues = inspect_config(p_true)
+ws = issues.warnings
+bad = filter(w -> w.severity in (:error, :block), ws)
+np = filter(w -> occursin("newton_polish", string(w)), ws)
+println("inspect_config: ", length(ws), " warnings, ", length(bad), " error/block, ",
+    length(np), " mention newton_polish")
+for b in vcat(bad, np)
+    println("   ", b)
+end
+
+# 2) both variants must run end-to-end through the YAML pipeline. The verbose
+# LBFGS/Newton log prints the gradient progression; newton_polish=true appends
+# a Newton-CG pass (only emitted when the flag actually reaches the solver).
+for polish in (false, true)
+    println("\n========== newton_polish=$polish ==========")
+    r = run_config(load_config(write_cfg(polish)))
+    println("RESULT newton_polish=$polish  E=$(r.ground_state_energy)  converged=$(r.ground_state_converged)")
+end
+println("DONE")

--- a/src/workflow/experiments/pipeline/run_step_ground_state.jl
+++ b/src/workflow/experiments/pipeline/run_step_ground_state.jl
@@ -275,6 +275,7 @@ function _run_step(
         )
     elseif method === :lbfgs
         m_lbfgs = Int(get(p, "m_lbfgs", 10))
+        newton_polish = get(p, "newton_polish", false) == true
         # Reuse existing workspace when available to preserve DDI flags (secular/q2d/l_z).
         # Skip reuse when backend is explicitly overridden (e.g. GPU ITP → CPU LBFGS).
         if ws_prev !== nothing && !haskey(p, "backend") &&
@@ -282,14 +283,14 @@ function _run_step(
             !haskey(p, "potential") && !haskey(p, "B")
             find_ground_state_lbfgs(;
                 ws_init=ws_prev, psi_init,
-                n_steps, tol, m_lbfgs,
+                n_steps, tol, m_lbfgs, newton_polish,
                 target_magnetization=target_mz,
                 verbose,
             )
         else
             find_ground_state_lbfgs(;
                 grid, atom, interactions, zeeman, potential,
-                n_steps, tol, m_lbfgs, initial_state, init_state_params, psi_init,
+                n_steps, tol, m_lbfgs, newton_polish, initial_state, init_state_params, psi_init,
                 enable_ddi, c_dd=c_dd_val,
                 secular_ddi=secular, quasi_2d_ddi=q2d, l_z_ddi=lz, ddi_trunc_radius=ddi_trunc,
                 ddi_padding=ddi_padded_b, ddi_pad_factor=ddi_pf,

--- a/src/workflow/experiments/schema/schema.jl
+++ b/src/workflow/experiments/schema/schema.jl
@@ -273,6 +273,11 @@ const GS_SCHEMA = Dict{String, FieldSpec}(
     "n_steps" => FieldSpec(; type=Number, default=100000, range=(0.0, 1e9)),
     "tol" => FieldSpec(; type=Number, default=1e-8, range=(1e-16, 1.0)),
     "m_lbfgs" => FieldSpec(; type=Number, default=10, range=(1.0, 100.0)),
+    # Append a 2nd-order Newton-CG trust-region pass after LBFGS to drive the
+    # stationarity residual below the first-order √eps gradient floor. Needed
+    # when ∇E (not just E) must be tight — Hessian λ_min / Bogoliubov near
+    # instabilities require a genuinely stationary ψ. lbfgs-only.
+    "newton_polish" => FieldSpec(; type=Bool, default=false),
     "initial_state" => FieldSpec(; type=String, default="polar",
         enum=["polar", "m_plus_F", "m_minus_F",
             "uniform", "antiferromagnetic", "random",


### PR DESCRIPTION
Wires the existing `find_ground_state_lbfgs(newton_polish=…)` flag into the
YAML `ground_state` schema + pipeline.

## Why
LBFGS is first-order, so its projected gradient floors near √eps·scale even at
a machine-exact energy. `newton_polish` appends a Newton-CG trust-region pass
that drives the stationarity residual below that floor. Needed when ∇E (not
just E) must be tight — Hessian λ_min / Bogoliubov near instabilities require a
genuinely stationary ψ.

## Change
- `schema.jl`: `newton_polish` FieldSpec (Bool, default false → no behaviour change).
- `run_step_ground_state.jl`: read + pass to both `find_ground_state_lbfgs` calls.

## Verification
`inspect_config` accepts the key (0 errors); both `newton_polish` true/false run
end-to-end through the pipeline (`bench/verify_yaml_newton_polish.jl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)