### PR TITLE
fix(zeeman): correct Eu quadratic-Zeeman geometry factor (was 11× too large)

### DIFF
--- a/src/foundation/types/spin_atom.jl
+++ b/src/foundation/types/spin_atom.jl
@@ -7,6 +7,31 @@
 # physical constants for Eu151/Dy164/Rb87/etc.
 
 export SpinSystem, SpinMatrices, AtomSpecies
+export quadratic_zeeman_geometry
+
+"""
+    quadratic_zeeman_geometry(F, I, J) -> dimensionless
+
+Closed-form geometry factor for the second-order (quadratic) Zeeman shift of a
+hyperfine level `F` coupled to `F-1` via `J_z`, from degenerate PT:
+
+    q = (g_J μ_B B)² · quadratic_zeeman_geometry(F, I, J) / |E_F - E_{F-1}|
+
+Derived from `|⟨F-1,m|J_z|F,m⟩|² = geometry · (F² - m²)` (verified against a
+direct Clebsch-Gordan evaluation):
+
+    geometry = [F² - (I-J)²] · [(I+J+1)² - F²] / (4 F² (4F² - 1))
+
+Cross-checks: Rb-87 (F=2, I=3/2, J=1/2) → 15/240 = 0.0625 → q/h = 71.6 Hz/G²;
+¹⁵¹Eu (F=6, I=5/2, J=7/2) → 455/20592 = 0.02210 → q/h = 1.43 kHz/G².
+Vanishes at the manifold edge F = |I-J|. Defined here (loaded before atoms.jl)
+so atom constructors can build `q_geometry` from it instead of hard-coding.
+"""
+function quadratic_zeeman_geometry(F::Real, I::Real, J::Real)
+    num = (F^2 - (I - J)^2) * ((I + J + 1)^2 - F^2)
+    den = 4 * F^2 * (4 * F^2 - 1)
+    Float64(num / den)
+end
 
 # --- Spin System ---
 

--- a/src/hamiltonian/coefficients.jl
+++ b/src/hamiltonian/coefficients.jl
@@ -300,7 +300,8 @@ In dimensionless internal units (B → p via p = g_F μ_B B / ℏω_ref):
     q_dimless = q_phys / (ℏω_ref)
               = p² · ω_ref · ℏ · (g_J/g_F)² · q_geometry / Δ_hf
 
-For Eu151 F=6: q_geometry = 35/144, exact (m⁴ correction zero at 2nd order).
+The atom's `q_geometry` should be built via [`quadratic_zeeman_geometry`]; for
+Eu151 F=6 it is 455/20592 = 0.02210 (m⁴ correction zero at 2nd order).
 
 Returns 0.0 if the atom lacks `Delta_E_hf` or `q_geometry` (not derivable);
 caller is responsible for either setting `q` explicitly or refusing to

--- a/src/workflow/experiments/runtime/b_block_builders.jl
+++ b/src/workflow/experiments/runtime/b_block_builders.jl
@@ -269,13 +269,19 @@ function _resolve_q_waveform(z::Dict, p_wf, atom, omega_ref::Float64, duration::
         return _make_waveform(z["q"], duration; omega_ref=omega_ref)
     end
     atom.Delta_E_hf > 0 || return ConstantWaveform(0.0)
+    # Guard: never silently return q=0 when B≠0 for a hyperfine atom. Either the
+    # geometry data is incomplete (fill g_J/q_geometry), or q_geometry is exactly
+    # 0 at the F=|I-J| manifold edge — e.g. effective spin-1 models — where the
+    # 2nd-order path vanishes and there is no physical auto-q. Both require an
+    # explicit `q:` rather than a silent zero.
     (atom.g_J > 0 && atom.q_geometry > 0) || throw(
         ArgumentError(
-            "atom $(atom.name): magnetic field set but quadratic-Zeeman " *
-            "geometry data is incomplete (g_J=$(atom.g_J), " *
-            "q_geometry=$(atom.q_geometry)). Set `q:` explicitly in the " *
-            "B block, or fill in `g_J` and `q_geometry` for this atom " *
-            "in src/workflow/initialization/atoms.jl."),
+            "atom $(atom.name): magnetic field set (B≠0) but quadratic-Zeeman " *
+            "cannot be auto-derived (g_J=$(atom.g_J), q_geometry=$(atom.q_geometry)). " *
+            "q_geometry=0 means the F=|I-J| edge / effective model (no physical " *
+            "auto-q); otherwise the geometry data is incomplete. Set `q:` " *
+            "explicitly in the B block, or build q_geometry via " *
+            "quadratic_zeeman_geometry(F, I, J) for this atom."),
     )
     n = _ZEEMAN_SAMPLE_N
     times = collect(range(0.0, duration; length=n))

--- a/src/workflow/initialization/atoms.jl
+++ b/src/workflow/initialization/atoms.jl
@@ -202,9 +202,12 @@ const _EU151_G_J = 1.9934
 #   g_F = g_J · 7/12 ≈ 1.1628 (Lande projection for F=I+J=6)
 #   F=6 ↔ F=5 hyperfine splitting: 121.0 MHz (A_hf ≈ -20.0523 MHz; Childs 1991)
 #     → F=6 is the absolute ground state (since A_hf < 0)
-#   q geometry factor for F=6 manifold: 35/144 (closed-form ⟨5,m|J_z|6,m⟩²
-#     = (35/144)(36 - m²); m⁴ correction is exactly zero at 2nd order in B).
-#   q at B=1G with these constants: q/h = 15.636 kHz/G²
+#   q geometry factor for F=6 manifold: 455/20592 = 0.02210 (closed-form
+#     ⟨5,m|J_z|6,m⟩² = 0.02210(36 - m²), verified by direct Clebsch-Gordan;
+#     m⁴ correction exactly zero at 2nd order). Built from the general
+#     quadratic_zeeman_geometry(F, I, J). The earlier hard-coded 35/144 dropped
+#     ((I+J+1)²-F²)/(4F²-1) = 13/143 = 1/11 and was 11× too large.
+#   q at B=1G: q/h = 1.43 kHz/G² (full Breit-Rabi diag, incl. quadrupole)
 const Eu151 = AtomSpecies(
     "151Eu",
     150.919857 * Units.AMU,
@@ -215,7 +218,7 @@ const Eu151 = AtomSpecies(
     _EU151_G_J * 7.0 / 12.0;
     Delta_E_hf=121.0e6 * 2π * Units.HBAR,
     g_J=_EU151_G_J,
-    q_geometry=35.0 / 144.0,
+    q_geometry=quadratic_zeeman_geometry(6, 5 // 2, 7 // 2),
 )
 
 # ¹⁵¹Eu effective F=1 model (Yan-Li-Saito 2026 PRL convention)
@@ -223,6 +226,9 @@ const Eu151 = AtomSpecies(
 #   This gives a_dd ≈ 25.2 a₀; at ε_dd = 1.2 → a_s = 21 a₀.
 #   Mass and hyperfine structure same as physical ¹⁵¹Eu.
 #   Source: T30 theorist §3 Check 2 (lines 320-326); memory yan_li_saito_2026_barnett_paper.md.
+#   q_geometry from the general formula is 0 at the F=|I-J| edge (auto-q disabled);
+#   this fictitious spin-1 truncation has no first-principles quadratic Zeeman —
+#   set `q` explicitly in the config if the model needs one. (Was 35/144: wrong.)
 const Eu151_f1_effective = AtomSpecies(
     "151Eu_f1eff",
     150.919857 * Units.AMU,
@@ -232,7 +238,7 @@ const Eu151_f1_effective = AtomSpecies(
     4.5 * Units.BOHR_MAGNETON,
     4.5;
     Delta_E_hf=121.0e6 * 2π * Units.HBAR,
-    q_geometry=35.0 / 144.0,
+    q_geometry=quadratic_zeeman_geometry(1, 5 // 2, 7 // 2),
 )
 
 # --- Spinless Species (F=0) ---

--- a/test/analysis/test_diagnostics.jl
+++ b/test/analysis/test_diagnostics.jl
@@ -47,11 +47,23 @@ using FFTW
         # so quadratic_zeeman_si throws.
         @test_throws ArgumentError quadratic_zeeman_si(Rb87, 1e-4)
 
-        # Eu151: full data (g_J=1.9934, q_geometry=35/144, Δ_hf=121 MHz).
-        # At B=1 G = 1e-4 T, expect q/h ≈ 15.6 kHz (per rigorous derivation).
+        # Physics anchor for the geometry formula (independent of any hard-coded
+        # constant). Rb-87 (F=2, I=3/2, J=1/2) has a well-known quadratic Zeeman;
+        # Eu-151 (F=6, I=5/2, J=7/2) matches a direct Clebsch-Gordan evaluation.
+        @test quadratic_zeeman_geometry(2, 3 // 2, 1 // 2) ≈ 0.0625     # 15/240
+        @test quadratic_zeeman_geometry(6, 5 // 2, 7 // 2) ≈ 455 / 20592 # 0.02210 (CG)
+        @test quadratic_zeeman_geometry(1, 5 // 2, 7 // 2) == 0          # F=|I-J| edge
+        # Rb-87 q/h ≈ 71.6 Hz/G² (g_J=2.0023, Δ_hf=6.835 GHz) via the same formula.
+        q_rb = (2.0023 * SpinorBEC.Units.BOHR_MAGNETON * 1e-4)^2 *
+               quadratic_zeeman_geometry(2, 3 // 2, 1 // 2) /
+               (6.834682e9 * 2π * SpinorBEC.Units.HBAR)
+        @test 70.0 < q_rb / (2π * SpinorBEC.Units.HBAR) < 73.0
+
+        # Eu151: full data (g_J=1.9934, q_geometry=455/20592, Δ_hf=121 MHz).
+        # At B=1 G = 1e-4 T, q/h ≈ 1.43 kHz (11× smaller than the 2026-07 bug).
         q_eu = quadratic_zeeman_si(Eu151, 1e-4)
         q_hz = q_eu / (2π * SpinorBEC.Units.HBAR)
-        @test 15.0e3 < q_hz < 16.5e3   # 15.636 kHz/G² ± rounding
+        @test 1.35e3 < q_hz < 1.50e3   # 1.43 kHz/G² (was wrongly pinned at 15.6)
 
         # Dy164 (I=0, no hyperfine) → 0 by physics.
         @test quadratic_zeeman_si(Dy164, 1e-4) == 0.0

--- a/test/analysis/test_diagnostics.jl
+++ b/test/analysis/test_diagnostics.jl
@@ -54,9 +54,10 @@ using FFTW
         @test quadratic_zeeman_geometry(6, 5 // 2, 7 // 2) ≈ 455 / 20592 # 0.02210 (CG)
         @test quadratic_zeeman_geometry(1, 5 // 2, 7 // 2) == 0          # F=|I-J| edge
         # Rb-87 q/h ≈ 71.6 Hz/G² (g_J=2.0023, Δ_hf=6.835 GHz) via the same formula.
-        q_rb = (2.0023 * SpinorBEC.Units.BOHR_MAGNETON * 1e-4)^2 *
-               quadratic_zeeman_geometry(2, 3 // 2, 1 // 2) /
-               (6.834682e9 * 2π * SpinorBEC.Units.HBAR)
+        q_rb =
+            (2.0023 * SpinorBEC.Units.BOHR_MAGNETON * 1e-4)^2 *
+            quadratic_zeeman_geometry(2, 3 // 2, 1 // 2) /
+            (6.834682e9 * 2π * SpinorBEC.Units.HBAR)
         @test 70.0 < q_rb / (2π * SpinorBEC.Units.HBAR) < 73.0
 
         # Eu151: full data (g_J=1.9934, q_geometry=455/20592, Δ_hf=121 MHz).


### PR DESCRIPTION
## Summary

`Eu151.q_geometry` was hard-coded `35/144 = 0.243`, **11× too large**. It kept
`35/(4F²)` but dropped `[(I+J+1)²−F²]/(4F²−1) = 13/143 = 1/11`. So
`compute_quadratic_zeeman` returned **q(1G) = 15.6 kHz instead of 1.43 kHz**, and
every Eu sim auto-deriving q from |B|² had q 11× too big.

Correct second-order geometry factor (F coupled to F−1 via J_z):

```
c = [F²−(I−J)²]·[(I+J+1)²−F²] / (4F²(4F²−1))  = 455/20592 = 0.02210   (F=6, I=5/2, J=7/2)
```

## The fix is the *general formula*, not a corrected constant

Swapping in a correct literal would re-invite the same class. Instead:

- **`quadratic_zeeman_geometry(F, I, J)`** added in `foundation/types/spin_atom.jl`
  (loads before `atoms.jl`; returns `Float64` — the `q_geometry` kwarg is `::Float64`
  and does not auto-convert `Rational`).
- Both Eu atoms build `q_geometry` from it: `Eu151` (F=6) → 0.02210;
  `Eu151_f1_effective` (F=1) → 0 at the `F=|I−J|` edge (was also 35/144).
- **Test re-anchored to physics.** `test/analysis/test_diagnostics.jl` had *pinned
  the bug* (`@test 15.0e3 < q_hz < 16.5e3`). Now: Eu 1.35–1.50 kHz, plus a **Rb-87
  cross-check** through the same formula (→ 71.8 Hz/G², literature 71.6) and a
  direct Clebsch-Gordan anchor for Eu.
- **Guard clarified.** `_resolve_q_waveform` already *throws* (not silent-0) on
  `q_geometry ≤ 0` at B≠0; message refined to name the `F=|I−J|` edge / effective-model
  case so the next author sets `q:` explicitly.

## Verification

- **Direct Clebsch-Gordan**: `⟨5,0|J_z|6,0⟩² = 0.7955` (code claimed 8.75 = 11×).
- **Full Breit-Rabi diagonalization** (48-dim, incl. quadrupole B_hf=−0.70 MHz + g_I):
  q(1G) = 1.424 kHz, pure quadratic to 3 G; quadrupole shifts it only 0.4%.
- Downstream RF-tomography error prefactor confirmed **q-independent** (geometry-only).

## Blast radius — saved by B=0, not by safety

The only `Eu151_f1_effective` consumer (`runs/yan_li_saito_f1_torus_gs`) runs at
**B=0**, where q ∝ B² = 0 regardless, so the bug had **zero live impact** — but that
is luck. At B≠0 every auto-q Eu run was 11× off. `goldstone`/`truegs` GS are
unaffected (`zeeman_q = 0.0` explicit; 10 µG q ~ 1e-7 Hz negligible).

Blocks: any future Eu sim on auto-q at B≠0. Merge so other branches can rebase.

Test: **Diagnostics 113/113 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)