### PR TITLE
refactor: eliminate derived magic numbers (q_geometry from I/J; gate LHY σ/δ tables by CG)

### DIFF
--- a/src/foundation/types/spin_atom.jl
+++ b/src/foundation/types/spin_atom.jl
@@ -7,7 +7,7 @@
 # physical constants for Eu151/Dy164/Rb87/etc.
 
 export SpinSystem, SpinMatrices, AtomSpecies
-export quadratic_zeeman_geometry
+export quadratic_zeeman_geometry, lande_g_factor
 
 """
     quadratic_zeeman_geometry(F, I, J) -> dimensionless
@@ -31,6 +31,23 @@ function quadratic_zeeman_geometry(F::Real, I::Real, J::Real)
     num = (F^2 - (I - J)^2) * ((I + J + 1)^2 - F^2)
     den = 4 * F^2 * (4 * F^2 - 1)
     Float64(num / den)
+end
+
+"""
+    lande_g_factor(F, I, J; g_J=2.0) -> dimensionless
+
+Hyperfine Landé g-factor (electronic part) of level `F`:
+
+    g_F = g_J · [F(F+1) + J(J+1) − I(I+1)] / [2F(F+1)]
+
+The (∼1/1836) nuclear-moment term is dropped, matching the convention used
+throughout the atom registry. Reproduces every hand-entered `g_F`:
+¹⁵¹Eu (F=6,I=5/2,J=7/2,g_J=1.9934) → 7/12·g_J; Rb-87 (F=1,I=3/2,J=1/2) → −1/2;
+Rb-85 (F=2,I=5/2) → −1/3; Cs-133 (F=3,I=7/2) → −1/4. Use this instead of
+hand-typing the Landé fraction (the `35/144`-class trap).
+"""
+function lande_g_factor(F::Real, I::Real, J::Real; g_J::Real=2.0)
+    Float64(g_J * (F * (F + 1) + J * (J + 1) - I * (I + 1)) / (2 * F * (F + 1)))
 end
 
 # --- Spin System ---

--- a/src/foundation/types/spin_atom.jl
+++ b/src/foundation/types/spin_atom.jl
@@ -96,10 +96,14 @@ Atomic species for spinor BEC simulation.
 - `g_J`: electronic Landé g-factor for the ground manifold. Used in
          second-order Zeeman (q) — q ∝ (g_J μ_B B)² / Δ_hf · geometry.
          Zero if not provided (q auto-derive disabled).
+- `nuclear_I`, `electronic_J`: nuclear spin I and electronic angular momentum J
+         of the ground manifold (atom/state-specific primitives, cited). Passed
+         as kwargs; from them `q_geometry` is DERIVED, never hand-entered.
 - `q_geometry`: dimensionless geometry factor for the quadratic Zeeman
-         calculation, q = (g_J μ_B B)² · q_geometry / Δ_hf. Specific to
-         the (J, I, F) manifold. Zero if unknown (q auto-derive
-         requires this; missing → user must set q explicitly).
+         calculation, q = (g_J μ_B B)² · q_geometry / Δ_hf. **Derived** in the
+         constructor via `quadratic_zeeman_geometry(F, nuclear_I, electronic_J)`;
+         0 when I/J are not supplied (q auto-derive disabled) or at the F=|I−J|
+         edge. Not a settable field — set `nuclear_I`/`electronic_J` instead.
 """
 struct AtomSpecies
     name::String
@@ -113,6 +117,8 @@ struct AtomSpecies
     scattering_lengths::Dict{Int, Float64}
     Delta_E_hf::Float64
     g_J::Float64
+    nuclear_I::Float64
+    electronic_J::Float64
     q_geometry::Float64
 
     function AtomSpecies(
@@ -126,11 +132,13 @@ struct AtomSpecies
         scattering_lengths;
         Delta_E_hf::Float64=0.0,
         g_J::Float64=0.0,
-        q_geometry::Float64=0.0,
+        nuclear_I::Real=0.0,
+        electronic_J::Real=0.0,
     )
         a_s = _compute_mean_scattering_length(F, a0, a2)
+        q_geometry = _derive_q_geometry(F, nuclear_I, electronic_J)
         new(name, mass, F, a0, a2, a_s, mu_mag, g_F, scattering_lengths,
-            Delta_E_hf, g_J, q_geometry)
+            Delta_E_hf, g_J, Float64(nuclear_I), Float64(electronic_J), q_geometry)
     end
 
     function AtomSpecies(
@@ -143,7 +151,8 @@ struct AtomSpecies
         g_F::Real;
         Delta_E_hf::Float64=0.0,
         g_J::Float64=0.0,
-        q_geometry::Float64=0.0,
+        nuclear_I::Real=0.0,
+        electronic_J::Real=0.0,
     )
         sl = if F == 1 && (a0 != 0.0 || a2 != 0.0)
             Dict{Int, Float64}(0 => a0, 2 => a2)
@@ -151,8 +160,9 @@ struct AtomSpecies
             Dict{Int, Float64}()
         end
         a_s = _compute_mean_scattering_length(F, a0, a2)
+        q_geometry = _derive_q_geometry(F, nuclear_I, electronic_J)
         new(name, mass, F, a0, a2, a_s, mu_mag, Float64(g_F), sl,
-            Delta_E_hf, g_J, q_geometry)
+            Delta_E_hf, g_J, Float64(nuclear_I), Float64(electronic_J), q_geometry)
     end
 
     function AtomSpecies(
@@ -165,24 +175,34 @@ struct AtomSpecies
         scattering_lengths::Dict;
         Delta_E_hf::Float64=0.0,
         g_J::Float64=0.0,
-        q_geometry::Float64=0.0,
+        nuclear_I::Real=0.0,
+        electronic_J::Real=0.0,
     )
         a_s = _compute_mean_scattering_length(F, a0, a2)
+        q_geometry = _derive_q_geometry(F, nuclear_I, electronic_J)
         new(name, mass, F, a0, a2, a_s, mu_mag, 0.0, scattering_lengths,
-            Delta_E_hf, g_J, q_geometry)
+            Delta_E_hf, g_J, Float64(nuclear_I), Float64(electronic_J), q_geometry)
     end
 
     function AtomSpecies(name, mass, F, a0, a2, mu_mag;
-        Delta_E_hf::Float64=0.0, g_J::Float64=0.0, q_geometry::Float64=0.0)
+        Delta_E_hf::Float64=0.0, g_J::Float64=0.0,
+        nuclear_I::Real=0.0, electronic_J::Real=0.0)
         sl = if F == 1 && (a0 != 0.0 || a2 != 0.0)
             Dict{Int, Float64}(0 => a0, 2 => a2)
         else
             Dict{Int, Float64}()
         end
         a_s = _compute_mean_scattering_length(F, a0, a2)
+        q_geometry = _derive_q_geometry(F, nuclear_I, electronic_J)
         new(name, mass, F, a0, a2, a_s, mu_mag, 0.0, sl,
-            Delta_E_hf, g_J, q_geometry)
+            Delta_E_hf, g_J, Float64(nuclear_I), Float64(electronic_J), q_geometry)
     end
 end
+
+# q_geometry is DERIVED from the atom/state primitives (F, I, J), never
+# hand-entered. Returns 0 when I/J absent (auto-q disabled) or at the F=|I−J|
+# manifold edge (quadratic_zeeman_geometry vanishes there).
+_derive_q_geometry(F, I, J) =
+    (I > 0 && J > 0) ? quadratic_zeeman_geometry(F, I, J) : 0.0
 
 AtomSpecies(name, mass, F, a0, a2) = AtomSpecies(name, mass, F, a0, a2, 0.0)

--- a/src/workflow/initialization/atoms.jl
+++ b/src/workflow/initialization/atoms.jl
@@ -215,7 +215,7 @@ const Eu151 = AtomSpecies(
     110.0 * Units.BOHR_RADIUS,
     0.0,
     _EU151_G_J * 3.5 * Units.BOHR_MAGNETON,
-    _EU151_G_J * 7.0 / 12.0;
+    lande_g_factor(6, 5 // 2, 7 // 2; g_J=_EU151_G_J);   # was 7/12·g_J (hand-typed)
     Delta_E_hf=121.0e6 * 2π * Units.HBAR,
     g_J=_EU151_G_J,
     nuclear_I=5 // 2,      # ¹⁵¹Eu nuclear spin (I=5/2)

--- a/src/workflow/initialization/atoms.jl
+++ b/src/workflow/initialization/atoms.jl
@@ -218,7 +218,8 @@ const Eu151 = AtomSpecies(
     _EU151_G_J * 7.0 / 12.0;
     Delta_E_hf=121.0e6 * 2π * Units.HBAR,
     g_J=_EU151_G_J,
-    q_geometry=quadratic_zeeman_geometry(6, 5 // 2, 7 // 2),
+    nuclear_I=5 // 2,      # ¹⁵¹Eu nuclear spin (I=5/2)
+    electronic_J=7 // 2,   # ⁸S₇/₂ ground state (J=7/2)
 )
 
 # ¹⁵¹Eu effective F=1 model (Yan-Li-Saito 2026 PRL convention)
@@ -226,9 +227,10 @@ const Eu151 = AtomSpecies(
 #   This gives a_dd ≈ 25.2 a₀; at ε_dd = 1.2 → a_s = 21 a₀.
 #   Mass and hyperfine structure same as physical ¹⁵¹Eu.
 #   Source: T30 theorist §3 Check 2 (lines 320-326); memory yan_li_saito_2026_barnett_paper.md.
-#   q_geometry from the general formula is 0 at the F=|I-J| edge (auto-q disabled);
-#   this fictitious spin-1 truncation has no first-principles quadratic Zeeman —
-#   set `q` explicitly in the config if the model needs one. (Was 35/144: wrong.)
+#   Same nucleus (I=5/2, J=7/2) as physical ¹⁵¹Eu, but F=1 sits at the F=|I−J|
+#   edge where quadratic_zeeman_geometry vanishes → q auto-derives to 0. This
+#   fictitious spin-1 truncation has no first-principles quadratic Zeeman; set
+#   `q` explicitly in the config if the model needs one. (Was 35/144: wrong.)
 const Eu151_f1_effective = AtomSpecies(
     "151Eu_f1eff",
     150.919857 * Units.AMU,
@@ -238,7 +240,8 @@ const Eu151_f1_effective = AtomSpecies(
     4.5 * Units.BOHR_MAGNETON,
     4.5;
     Delta_E_hf=121.0e6 * 2π * Units.HBAR,
-    q_geometry=quadratic_zeeman_geometry(1, 5 // 2, 7 // 2),
+    nuclear_I=5 // 2,
+    electronic_J=7 // 2,
 )
 
 # --- Spinless Species (F=0) ---

--- a/test/foundation/test_atoms.jl
+++ b/test/foundation/test_atoms.jl
@@ -22,6 +22,25 @@
         @test_throws ArgumentError resolve_atom(:Nonexistent)
     end
 
+    @testset "g_F ≡ Landé g-factor (magic-number gate)" begin
+        # Every registry g_F is the Landé projection g_J·[F(F+1)+J(J+1)-I(I+1)]/(2F(F+1)),
+        # not a hand-typed fraction. Recompute each from (F, I, J, g_J) and compare —
+        # gates the -1/2, -1/3, -1/4, 7/12·g_J literals against the formula (the
+        # 35/144-class guard). (I, J, g_J from standard atomic data.)
+        cases = [
+            (Li7, 1, 3 // 2, 1 // 2, 2.0), (Na23, 1, 3 // 2, 1 // 2, 2.0),
+            (K39, 1, 3 // 2, 1 // 2, 2.0), (K41, 1, 3 // 2, 1 // 2, 2.0),
+            (Rb87, 1, 3 // 2, 1 // 2, 2.0), (Rb85, 2, 5 // 2, 1 // 2, 2.0),
+            (Cs133, 3, 7 // 2, 1 // 2, 2.0), (He4star, 1, 0, 1, 2.0),
+            (Cr52, 3, 0, 3, 2.0), (Dy164, 8, 0, 8, 1.24), (Dy162, 8, 0, 8, 1.24),
+            (Er168, 6, 0, 6, 1.16), (Er166, 6, 0, 6, 1.16),
+            (Eu151, 6, 5 // 2, 7 // 2, 1.9934),
+        ]
+        for (a, F, I, J, gJ) in cases
+            @test isapprox(a.g_F, lande_g_factor(F, I, J; g_J=gJ); atol=1e-4)
+        end
+    end
+
     @testset "F=1 alkali: a_s consistency" begin
         f1_atoms = [Li7, Na23, K39, K41, Rb87, He4star]
         for a in f1_atoms

--- a/test/hamiltonian/test_icosahedral_lhy.jl
+++ b/test/hamiltonian/test_icosahedral_lhy.jl
@@ -171,4 +171,27 @@ using LinearAlgebra: Diagonal
         ico2 = SpinorBEC.epsilon_LHY_F6_Ih(1.0, g_ih)
         @test 2.0 < pol2 / ico2 < 3.0   # measured 2.4440 (2026-05-12)
     end
+
+    @testset "I_h channel + phase-boundary coefficients ≡ CG σ_S (magic-number gate)" begin
+        # The hand-entered c0/λ_spin rationals (121/323, 980/5681, …) and the
+        # F6-phase-diagram boundary coefficients are σ_S of the icosahedral inert
+        # spinor. Recompute from clebsch_gordan (via _f6_pd_sigma_S) and compare,
+        # instead of the previous sum-only / self-referential checks — the guard
+        # that would have caught a 35/144-style drift in the parallel-session table.
+        σS(Sv, ζ) = SpinorBEC._f6_pd_sigma_S(6, Sv, ζ)
+        unit(i) = (v=zeros(ComplexF64, 13); v[i]=1.0; v)
+        ζ_ih, ζ_fm, ζ_polar = ZETA_F6_IH, unit(1), unit(7)   # I_h, |m=+6>, |m=0>
+        onehot(k) = (g=zeros(7); g[k]=1.0; g)
+        Sidx = Dict(0 => 1, 2 => 2, 4 => 3, 6 => 4, 8 => 5, 10 => 6, 12 => 7)
+        for Sv in 0:2:12
+            c0, λ = compute_c0_lambda_F6_Ih(onehot(Sidx[Sv]))
+            fac = (Sv * (Sv + 1) - 2 * 6 * 7) / (2 * 6 * 7)   # Sign-Pattern Lemma 1
+            @test isapprox(c0, σS(Sv, ζ_ih); atol=1e-10)
+            @test isapprox(λ, fac * σS(Sv, ζ_ih); atol=1e-10)
+            @test isapprox(get(SpinorBEC._F6_PD_COEF_IH_VS_POLAR, Sv, 0.0),
+                σS(Sv, ζ_ih) - σS(Sv, ζ_polar); atol=1e-10)
+            @test isapprox(get(SpinorBEC._F6_PD_COEF_IH_VS_FM, Sv, 0.0),
+                σS(Sv, ζ_ih) - σS(Sv, ζ_fm); atol=1e-10)
+        end
+    end
 end

--- a/test/hamiltonian/test_lhy_polar.jl
+++ b/test/hamiltonian/test_lhy_polar.jl
@@ -201,6 +201,22 @@ end
     @test isapprox(2 * sigma_fm(6, 5, g_user), sigma_fm(6, 6, g_user); atol=1e-10)
 end
 
+@testset "FM contact LHY: σ_m coefficients ≡ Clebsch-Gordan (magic-number gate)" begin
+    # The hand-entered SIGMA_TABLE_FM coefficients are the CG weights
+    #   coef(m, S) = |⟨F,m; F,+F | S, m+F⟩|²   (even S; condensate at +F).
+    # Recompute every one from clebsch_gordan and compare against what the
+    # accessor returns (one-hot g_S isolates a single coefficient). This gates
+    # the transcribed table against an independent derivation — the same guard
+    # that would have caught the 35/144 quadratic-Zeeman error at commit time.
+    F = 6
+    for m in (-F):F, S in 0:2:(2F)
+        onehot = Dict(s => (s == S ? 1.0 : 0.0) for s in 0:2:(2F))
+        got = sigma_fm(F, m, onehot)                     # coefficient of g_S in σ_m
+        want = clebsch_gordan(F, m, F, F, S, m + F)^2
+        @test isapprox(got, want; atol=1e-12)
+    end
+end
+
 @testset "FM contact LHY: uniform g_S = c_0 reduces to scalar Lima-Pelster" begin
     c_0 = 100.0
     g_uniform = Dict(S => c_0 for S in (0, 2, 4, 6, 8, 10, 12))

--- a/test/hamiltonian/test_lhy_polar.jl
+++ b/test/hamiltonian/test_lhy_polar.jl
@@ -22,9 +22,45 @@ using LinearAlgebra: norm
     fp = (phi_1_reg(h) - phi_1_reg(-h)) / (2h)
     @test isapprox(fp, 0.625; atol=1e-3)
 
-    # All 39 knots recovered exactly
+    # All 39 knots recovered exactly (spline passes through its own knots —
+    # self-referential; the real gate is the independent quadrature below).
     for i in 1:length(T_KNOTS)
         @test isapprox(phi_1_reg(T_KNOTS[i]), VAL_KNOTS[i]; atol=1e-12)
+    end
+
+    @testset "φ₁ knots ≡ independent Gauss-Legendre quadrature (magic-number gate)" begin
+        # The 78 VAL/DERIV knots are mpmath values pasted into the source. Recompute
+        # φ₁ᵣₑ𝓰(t) = (15/8√2) ∫₀^∞ x²[Re√((x²+t)(x²+t+2)) − (x²+t+1) + 1/(2x²)] dx
+        # from scratch by GL quadrature (x = u/(1−u); split at the branch kink
+        # x²+t=0 for t<0; conjugate form avoids large-x cancellation) and compare
+        # to the stored knots — a genuine re-derivation, not a self-read.
+        function _phi1_integrand(x, t)
+            a = x^2 + t
+            prod = a * (a + 2)
+            diff = prod >= 0 ? 1 / ((a + 1) + sqrt(prod)) : (a + 1)  # (a+1)−Re√, cancel-free
+            x^2 * (diff - 1 / (2x^2))
+        end
+        function _phi1_quad(t; n=300)
+            breaks = t < 0 ? [0.0, sqrt(-t) / (1 + sqrt(-t)), 1.0 - 1e-12] :
+                     [0.0, 1.0 - 1e-12]
+            I = 0.0
+            for p in 1:(length(breaks) - 1)
+                nodes, wts = SpinorBEC._gauss_legendre(n, breaks[p], breaks[p + 1])
+                for (u, w) in zip(nodes, wts)
+                    I += w * _phi1_integrand(u / (1 - u), t) / (1 - u)^2
+                end
+            end
+            -(15 / (8 * sqrt(2))) * I
+        end
+        for t in (-1.0, -0.5, -0.05, 0.0, 0.5, 1.0, 5.0, 20.0, 50.0)
+            @test isapprox(phi_1_reg(t), _phi1_quad(t); atol=1e-6)
+        end
+        # derivative table via central difference of the independent quadrature
+        for t in (-0.5, 0.0, 1.0, 5.0)
+            i = findfirst(≈(t), T_KNOTS)
+            dq = (_phi1_quad(t + 1e-4) - _phi1_quad(t - 1e-4)) / 2e-4
+            @test isapprox(DERIV_KNOTS[i], dq; atol=1e-5)
+        end
     end
 
     # Petrov saturation for t < -1

--- a/test/hamiltonian/test_lhy_polar.jl
+++ b/test/hamiltonian/test_lhy_polar.jl
@@ -217,6 +217,23 @@ end
     end
 end
 
+@testset "polar contact LHY: σ_m/δ_m coefficients ≡ Clebsch-Gordan (magic-number gate)" begin
+    # Polar (nematic) condensate at m=0 ⇒ per-S coefficients are pure CG:
+    #   σ_m = |⟨F,m; F,0 | S,m⟩|²                          (normal)
+    #   δ_m = ⟨F,m; F,-m | S,0⟩ · ⟨F,0; F,0 | S,0⟩          (anomalous, pair m_tot=0)
+    # Recompute every SIGMA_TABLE / DELTA_TABLE entry (F=1..8, all m, even S) from
+    # clebsch_gordan and compare to the accessors — gates the ~1000 hand-entered
+    # polar coefficients against an independent derivation (35/144-class guard).
+    for F in 1:8, m in (-F):F, S in 0:2:(2F)
+        onehot = Dict(s => (s == S ? 1.0 : 0.0) for s in 0:2:(2F))
+        @test isapprox(sigma_polar(F, m, onehot),
+            clebsch_gordan(F, m, F, 0, S, m)^2; atol=1e-10)
+        @test isapprox(delta_polar(F, m, onehot),
+            clebsch_gordan(F, m, F, -m, S, 0) * clebsch_gordan(F, 0, F, 0, S, 0);
+            atol=1e-10)
+    end
+end
+
 @testset "FM contact LHY: uniform g_S = c_0 reduces to scalar Lima-Pelster" begin
     c_0 = 100.0
     g_uniform = Dict(S => c_0 for S in (0, 2, 4, 6, 8, 10, 12))


### PR DESCRIPTION
Follow-up to #63. Eliminates the **derived-constant magic-number class** (the
`35/144` bug's class) so it can't recur silently.

## 1. `q_geometry` is derived, not hand-entered

`AtomSpecies` gains cited `nuclear_I` / `electronic_J` fields (atom/state
primitives, like `g_J`/mass). `q_geometry` is no longer a settable kwarg — it is
**derived in the constructor** via `quadratic_zeeman_geometry(F, I, J)`.

- Eu151 now passes `nuclear_I=5//2, electronic_J=7//2` (was the bare literals
  `(6, 5//2, 7//2)` sitting in a helper call); `q_geometry` auto-derives to 0.02210.
- `Eu151_f1_effective` (F=1) sits at the `F=|I−J|` edge → auto-derives to 0.
- No call site can hand-enter a derived q_geometry anymore.

## 2. LHY σ/δ coefficient tables gated by Clebsch-Gordan

The FM (F=6) and polar (F=1..8) `σ_m`/`δ_m` tables are hundreds of
hand-transcribed CG² coefficients (`891.0/6188.0`, …), previously checked only
by 2–3 Goldstone identities per F — the bulk was **unverified** (a transcription
typo would pass silently, exactly the 35/144 failure mode).

New tests recompute **every** coefficient from `clebsch_gordan` and compare to
the accessors:
- FM (condensate at +F): `σ_m = |⟨F,m; F,+F | S,m+F⟩|²` — **91 cells**.
- Polar (condensate at m=0):
  `σ_m = |⟨F,m; F,0 | S,m⟩|²`, `δ_m = ⟨F,m; F,-m | S,0⟩·⟨F,0; F,0 | S,0⟩` — **1048 cells**.

All 1139 match — the tables were correct, but are now **verified against an
independent derivation**, not merely transcribed. This is the guard that would
have caught 35/144 at commit time.

## Scope / audit note

A codebase sweep found the derived-constant class is otherwise clean: other
literals are cited measured constants (g_J, scattering lengths, hyperfine A),
published integrator coefficients (Yoshida/Blanes-Moan), or well-known math
constants (γ_E, ζ(3)). The LHY tables were the one remaining cluster; a
subagent audit initially missed them (trusted a "sympy-generated" header) — the
lesson: generated-then-hand-pasted is still unverified magic without an in-code
re-derivation gate.

Tests: test_atoms + test_diagnostics 351/351; test_lhy_polar incl. the two new
gates all green. Pre-commit hook (JuliaFormatter 2.5.0 + gitleaks) now active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)