### PR TITLE
test(lhy): gate polyhedral LHY coefficients by independent CG reconstruction

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,19 +56,13 @@
       "Bash(git config --list)",
       "Bash(git config --list *)",
       "Bash(git config -l)",
-      "Write(.claude/**)",
       "Edit(.claude/**)",
-      "Write(runs/_loop/**)",
       "Edit(runs/_loop/**)",
-      "Write(runs/auto/**)",
+      "Edit(runs/auto/**)",
       "Edit(src/**)",
       "Edit(test/**)",
       "Edit(docs/**)",
-      "Edit(scripts/**)",
-      "Write(src/**)",
-      "Write(test/**)",
-      "Write(docs/**)",
-      "Write(scripts/**)"
+      "Edit(scripts/**)"
     ],
     "deny": [
       "Bash(rm -rf *)",

--- a/src/hamiltonian/terms/lhy/phi_one_reg.jl
+++ b/src/hamiltonian/terms/lhy/phi_one_reg.jl
@@ -3,7 +3,10 @@
 # φ_1^reg(t) evaluator for spinor LHY corrections.
 #
 # Definition (Petrov-prescribed, UKU 2010):
-#   φ_1^reg(t) = (15/(8√2)) ∫₀^∞ x²[(x²+t+1) - Re√((x²+t)(x²+t+2)) - 1/(2x²)] dx
+#   φ_1^reg(t) = (15/(8√2)) ∫₀^∞ x²[Re√((x²+t)(x²+t+2)) - (x²+t+1) + 1/(2x²)] dx
+#   (the stored knots are POSITIVE and monotone; the bracket is √ − poly, i.e.
+#   the negative of a naive (poly − √) ordering — gated by GL requad in
+#   test/hamiltonian/test_lhy_polar.jl.)
 #
 # Implementation:
 #   1. Cubic Hermite spline on 39 knots over t ∈ [-1, 50] (50-digit reference

--- a/test/hamiltonian/test_lhy_modes_round45.jl
+++ b/test/hamiltonian/test_lhy_modes_round45.jl
@@ -141,6 +141,47 @@ using SpinorBEC: lhy_F2_BN, lhy_F3_octa, lhy_F4_cube, lhy_F8_octa, lhy_F10_dodec
         @test lhy_F10_dodec(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0) == 0.0
     end
 
+    @testset "polyhedral c_0/λ ≡ CG σ_S energy reconstruction (magic-number gate)" begin
+        # Each closed form's stiffnesses are c_0 = Σ_S σ_S(ζ) g_S and
+        # λ_spin = Σ_S [(S(S+1)−2F(F+1))/(2F(F+1))] σ_S(ζ) g_S (Sign-Pattern
+        # Lemma 1), with ζ the canonical polyhedral inert state. Reconstruct the
+        # energy from σ_S (independent Clebsch-Gordan via _f6_pd_sigma_S) and
+        # compare to the source function — gates the hand-entered rationals
+        # (1372/12597, 586625/3163581, …) against a from-scratch derivation.
+        σ(F, S, ζ) = SpinorBEC._f6_pd_sigma_S(F, S, Complex{Float64}.(ζ))
+        fac(F, S) = (S * (S + 1) - 2 * F * (F + 1)) / (2 * F * (F + 1))
+        function eps_recon(F, ζ, gd)
+            c0 = sum(σ(F, S, ζ) * get(gd, S, 0.0) for S in 0:2:(2F))
+            λ = sum(fac(F, S) * σ(F, S, ζ) * get(gd, S, 0.0) for S in 0:2:(2F))
+            P_scalar * (c0^2.5 + 3 * abs(λ)^2.5)
+        end
+        let gd = Dict(0 => 1.3, 2 => 0.7, 4 => 1.1, 6 => 0.9)
+            @test isapprox(lhy_F3_octa(gd[0], gd[2], gd[4], gd[6], 1.0, 1.0),
+                eps_recon(3, SpinorBEC.ZETA_F3_O_A2, gd); rtol=1e-9)
+        end
+        let gd = Dict(0 => 1.3, 2 => 0.7, 4 => 1.1, 6 => 0.9, 8 => 1.05)
+            @test isapprox(lhy_F4_cube(gd[0], gd[2], gd[4], gd[6], gd[8], 1.0, 1.0),
+                eps_recon(4, SpinorBEC.ZETA_F4_OH_A1, gd); rtol=1e-9)
+        end
+        let gd = Dict(0 => 1.3, 2 => 0.7, 4 => 1.1, 6 => 0.9, 8 => 1.05,
+                10 => 0.95, 12 => 1.2, 14 => 0.8, 16 => 1.1)
+            @test isapprox(
+                lhy_F8_octa(gd[0], gd[2], gd[4], gd[6], gd[8], gd[10], gd[12],
+                    gd[14], gd[16], 1.0, 1.0),
+                eps_recon(8, SpinorBEC.ZETA_F8_OH_A1, gd); rtol=1e-9)
+        end
+        let gd = Dict(0 => 1.3, 6 => 0.9, 10 => 0.95, 12 => 1.2, 16 => 1.1,
+                18 => 0.85, 20 => 1.05)
+            @test isapprox(
+                lhy_F10_dodec(gd[0], gd[6], gd[10], gd[12], gd[16], gd[18],
+                    gd[20], 1.0, 1.0),
+                eps_recon(10, SpinorBEC.ZETA_F10_IH_DODEC, gd); rtol=1e-9)
+        end
+        # F=2 BN not gated: its D_4-split (λ_z, λ_⊥) inert state is absent from
+        # the canonical registry; its {1/5, 2/7, 18/35} c_0 coefficients remain
+        # a manuscript follow-up.
+    end
+
     @testset "Mass / hbar scaling (dimensional)" begin
         # ε ∝ √M³ / ℏ³ (with all g, n fixed)
         ε1 = lhy_F3_octa(1.0, 0.0, 1.0, 1.0, 1.0, 1.0; hbar=1.0)


### PR DESCRIPTION
## Summary

Adds an independent gate for the hand-entered polyhedral LHY closed-form coefficients and fixes a sign-ordering slip in the φ₁ᵣₑ𝓰 docstring.

- **Gate polyhedral coefficients (magic-number gate).** New `@testset` in `test/hamiltonian/test_lhy_modes_round45.jl` reconstructs each polyhedral closed form's energy from `σ_S` — computed via independent Clebsch-Gordan (`_f6_pd_sigma_S`) plus the Sign-Pattern Lemma 1 stiffness `λ_spin = Σ_S [(S(S+1)−2F(F+1))/(2F(F+1))] σ_S g_S` — and compares against the source function at `rtol=1e-9`. This pins the hand-entered rationals (`1372/12597`, `586625/3163581`, …) to a from-scratch derivation.
  - Covered: F3 octahedral (`ZETA_F3_O_A2`), F4 cube (`ZETA_F4_OH_A1`), F8 octahedral (`ZETA_F8_OH_A1`), F10 dodecahedral (`ZETA_F10_IH_DODEC`).
  - Not gated: F=2 biaxial-nematic — its D₄-split `(λ_z, λ_⊥)` inert state is absent from the canonical registry; `{1/5, 2/7, 18/35}` coefficients left as a manuscript follow-up (noted inline).
- **Fix φ₁ᵣₑ𝓰 docstring sign.** The stored knots are positive/monotone and the integrand bracket is √ − poly (the negative of a naive poly − √ ordering); docstring now states this and points to the GL-requadrature gate in `test_lhy_polar.jl`.
- **Trim settings.json Write permissions.** Removes broad `Write(src/**|test/**|docs/**|scripts/**|.claude/**)` and `Write(runs/_loop/**)`; `Write(runs/auto/**)` → `Edit(runs/auto/**)`.

## Validation

Type A (code correctness) — extends the CG-gated redundancy for the LHY tables per the day-0 gated-redundancy discipline. Continues the cross-check-load-bearing-constants line from the q-geometry / Landé derivation work already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)