### PR TITLE
perf(cuda): gate-first TensorTerm gradient — skip host round-trip when inactive

### DIFF
--- a/ext/SpinorBECCUDAExt/gpu_tensor.jl
+++ b/ext/SpinorBECCUDAExt/gpu_tensor.jl
@@ -142,6 +142,14 @@ end
 function SpinorBEC.apply_operator!(
     out::CuArray, term::SpinorBEC.TensorTerm, ws, psi::CuArray
 )
+    # Gate-first: an inactive tensor term (no c2 singlet, no tensor_cache) is
+    # the common LBFGS-gradient case. Skip the host round-trip entirely — the
+    # old code paid three device<->host copies of the full spinor field
+    # (~130 ms/gradient at 128³) only for the CPU body to early-return. Result
+    # is identical (accumulate contract: `out` unchanged when inactive).
+    SpinorBEC.is_active(SpinorBEC.get_cn(ws.interactions, 2)) ||
+        ws.tensor_cache !== nothing ||
+        return out
     out_h = Array(out)
     SpinorBEC.apply_operator!(out_h, term, ws, Array(psi))
     copyto!(out, out_h)


### PR DESCRIPTION
## What
`apply_operator!(::TensorTerm, out::CuArray, ws, psi::CuArray)` (the LBFGS gradient face) copied `out` and `psi` to host and the result back — **three full-spinor-field device↔host transfers** — on *every* call, only for the CPU body to early-return when the term is inactive (no c2 singlet, no `tensor_cache`). That is the common ground-state config. This adds a gate-first short-circuit before any copy.

## Why — profiled, not guessed
H100 profiling of `energy_gradient!` (Eu + DDI, c0/c1 only) at 128³ showed the gradient at **179 ms**, ~10× the split_step. Per-term timing pinned it: `TensorTerm.apply_operator!` = 34.7 ms at 64³ (86% of `apply_operator_via_registry!`), entirely wasted host transfers on an inactive term. The wasted traffic scales with volume (~130 ms/gradient at 128³).

## Result (H100, 128³, authoritative)
`energy_gradient!` (`gpu_gradient_us`) **179.5 ms → 25.0 ms (−86%)**. `split_step` unchanged (17.2 ms, 96% device-busy — no regression).

## Correctness (type A: GPU = CPU)
- Bit-equivalent by construction: an inactive term leaves `out` unchanged whether it short-circuits or round-trips through a CPU no-op; active tensor still uses the host fallback (unchanged).
- `test_gpu_cpu_per_term_parity` **156/156**; H100 gates GPU=CPU rel-L2 9.3e-12, norm 1.0.

Follows the gate-first HamTerm discipline (inactive terms short-circuit at the top of each method).

Assisted-by: Claude Code (model: claude-opus-4-8[1m])