### PR TITLE
fix(evap): correct condensate 3-body ⟨n²⟩ TF coefficient 4/7 → 8/21

### DIFF
--- a/src/solvers/evaporation/condensate.jl
+++ b/src/solvers/evaporation/condensate.jl
@@ -37,15 +37,16 @@ function condensate_split(N::Real, T::Real, ω̄::Real)
     (Float64(N) - N_th, N_th)
 end
 
-# Thomas–Fermi peak density of an N₀-atom condensate in a harmonic trap, and the
-# per-atom three-body loss rate K₃⟨n²⟩ it produces (⟨n²⟩_TF = 4/7 n₀²).
+# Thomas–Fermi peak density of an N₀-atom condensate in a harmonic trap, and the per-atom
+# three-body loss rate K₃⟨n²⟩ it produces (atoms-lost convention dN = −K₃⟨n²⟩N, K₃ ≡ Söding L₃).
+# For a TF condensate ⟨n²⟩ = ∫n³/∫n = (8/21) n₀² (NOT 4/7 n₀², which is ⟨n⟩/n₀ — a different moment).
 function _condensate_three_body_rate(N0::Float64, ω̄::Float64, p::EvapParams, m::Float64)
     (N0 <= 0 || ω̄ <= 0 || p.K3 <= 0) && return 0.0
     aho = sqrt(Units.HBAR / (m * ω̄))
     μ = 0.5 * Units.HBAR * ω̄ * (15 * N0 * p.a_s / aho)^(2 / 5)   # TF chemical potential
     g = 4π * Units.HBAR^2 * p.a_s / m
     n0 = μ / g                                                   # TF peak density
-    p.K3 * (4 / 7) * n0^2
+    p.K3 * (8 / 21) * n0^2
 end
 
 """Trajectory of a two-component evaporation run (thermal + condensate)."""


### PR DESCRIPTION
`_condensate_three_body_rate` used **⟨n²⟩ = (4/7)n₀²** for the condensate three-body loss. That is the **wrong moment**: 4/7 is `⟨n⟩/n₀` (density-weighted mean *density*, ∫n²/∫n), while the three-body rate needs the density-weighted **mean-square** density `⟨n²⟩ = ∫n³/∫n`, which for a Thomas–Fermi parabola is **(8/21)n₀²**.

**Verified:** a pure-TF seed measures `⟨n²⟩/n₀² = 0.3809 = 8/21` (not 0.5714 = 4/7), matching the closed-form Beta-function integral. The old factor over-estimated the condensate three-body loss by `(4/7)/(8/21) = 1.5×`.

Convention documented in the comment: atoms-lost `dN/dt = −K₃⟨n²⟩N` with `K₃ ≡` Söding `L₃`.

`test/solvers/test_condensate.jl` (48 assertions) still green (all qualitative / conservation / RHS-parity — none pinned the coefficient).

Context: found while auditing the K₃ calibration for [#75](https://github.com/KozumaLaboratory/BEC-simulation/issues/75). A separate convention-consistency fix (the worktree LRW model used an explicit ×3 event-rate factor) lands with that model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)