### PR TITLE
feat(cache): content-addressed GS stage cache (Stage 0 + Stage 1, opt-in)

### DIFF
--- a/scripts/backfill_gs_stage.jl
+++ b/scripts/backfill_gs_stage.jl
@@ -1,0 +1,106 @@
+#!/usr/bin/env julia
+# Backfill the content-addressed GS stage store from EXISTING run directories, so
+# ground states already computed under the old (per-config, per-scan-index) layout
+# are reused by future SPINORBEC_STAGE_CACHE runs instead of recomputed.
+#
+#   julia --project=. scripts/backfill_gs_stage.jl <run_dir>...           # dry-run
+#   BACKFILL_WRITE=1 julia --project=. scripts/backfill_gs_stage.jl <dir>...  # ingest
+#
+# For each point_*.jld2 it reconstructs the SAME gs_hash a live run would produce
+# (apply_overrides → parse_pipeline → the exact GS resolution path → _gs_cache_key)
+# and copies psi/energy/converged into <stage>/<gs_hash>.jld2 if absent. It only
+# ingests from-scratch cells (no seed_from / no explicit cache: / not a continuation
+# scan) — the same cells the auto-cache is valid for. Existing point files are never
+# modified. Stage dir = SPINORBEC_STAGE_DIR or <SPINORBEC_STORE|runs>/_stage/gs.
+
+using SpinorBEC, JLD2, YAML
+using SpinorBEC: apply_overrides, parse_pipeline, GroundStateStep,
+    _resolve_gs_atom, _resolve_gs_grid, _resolve_gs_interactions,
+    _resolve_gs_ddi_inheritance, _gs_cache_key, _gs_stage_dir
+
+const WRITE = get(ENV, "BACKFILL_WRITE", "0") in ("1", "true", "on", "yes")
+
+# Reproduce the live gs_hash for one cell; nothing if the cell is not auto-cacheable.
+function _gs_hash_for_cell(data::Dict, override, is_continuation::Bool)
+    is_continuation && return nothing
+    patched = apply_overrides(data, override)
+    delete!(patched, "scan")
+    cfg = parse_pipeline(patched)
+    gs = nothing
+    for s in cfg.steps
+        s isa GroundStateStep && (gs = s; break)
+    end
+    gs === nothing && return nothing
+    p = gs.params
+    (haskey(p, "seed_from") || haskey(p, "cache")) && return nothing
+    method = Symbol(get(p, "method", "itp"))
+    atom = _resolve_gs_atom(p, nothing; verbose=false)
+    grid, _ = _resolve_gs_grid(p, nothing)
+    inter = _resolve_gs_interactions(p, nothing, atom)
+    ddi = _resolve_gs_ddi_inheritance(p, nothing, atom)
+    tol = Float64(get(p, "tol", 1e-8))
+    n_steps = Int(get(p, "n_steps", method === :lbfgs ? 500 : 100000))
+    dt = Float64(get(p, "dt", 0.001))
+    _gs_cache_key(method, atom, grid, inter, ddi, tol, n_steps, dt, p)
+end
+
+function backfill_dir(rundir::String, stagedir::String)
+    cfgpath = joinpath(rundir, "config.yaml")
+    isfile(cfgpath) || (println("  skip (no config.yaml): $rundir"); return (0, 0, 0))
+    data = YAML.load_file(cfgpath)
+    scan = get(data, "scan", nothing)
+    is_cont = scan isa AbstractDict && get(scan, "continuation", false) == true
+    ingest = 0; present = 0; skip = 0
+    for f in sort(readdir(rundir))
+        (startswith(f, "point_") && endswith(f, ".jld2")) || continue
+        path = joinpath(rundir, f)
+        local override, psi, energy, converged
+        try
+            jldopen(path, "r") do d
+                override = d["override"]
+                psi = d["psi"]
+                energy = haskey(d, "energy") ? d["energy"] : NaN
+                converged = haskey(d, "converged") ? d["converged"] : true
+            end
+        catch
+            skip += 1; continue
+        end
+        h = try
+            _gs_hash_for_cell(data, override, is_cont)
+        catch err
+            @warn "hash failed" file=f exception=err
+            nothing
+        end
+        h === nothing && (skip += 1; continue)
+        dest = joinpath(stagedir, h * ".jld2")
+        if isfile(dest)
+            present += 1; continue
+        end
+        if WRITE
+            mkpath(stagedir)
+            tmp = dest * ".tmp." * string(getpid())
+            jldopen(tmp, "w") do g
+                g["psi"] = psi; g["energy"] = energy; g["converged"] = converged
+            end
+            mv(tmp, dest; force=true)
+        end
+        ingest += 1
+    end
+    println("  $rundir: ingest=$ingest present=$present skip=$skip")
+    (ingest, present, skip)
+end
+
+function main()
+    isempty(ARGS) && (println("usage: backfill_gs_stage.jl <run_dir>..."); return)
+    stagedir = _gs_stage_dir()
+    println("stage dir: $stagedir   mode: ", WRITE ? "WRITE" : "DRY-RUN")
+    tot = [0, 0, 0]
+    for d in ARGS
+        (i, p, s) = backfill_dir(d, stagedir)
+        tot .+= (i, p, s)
+    end
+    println("TOTAL ingest=$(tot[1]) present=$(tot[2]) skip=$(tot[3]) ",
+        WRITE ? "(written)" : "(dry-run — set BACKFILL_WRITE=1 to ingest)")
+end
+
+main()

--- a/src/workflow/experiments/pipeline/run_registry.jl
+++ b/src/workflow/experiments/pipeline/run_registry.jl
@@ -525,10 +525,22 @@ function _run_yaml_scan(data::Dict, scan::OverrideScan, run_dir, env; verbose=tr
 
             tmp_file = _scratch_tmp_path(psi_file)
             jld_kwargs = _snapshot_compression_kwargs(result)
+            # Light point (Stage 1): if the GS was stage-cached and the shared psi
+            # artifact exists, store only a `gs_ref` pointer — the heavy psi lives
+            # once in the stage store (open_result resolves it). Falls back to a
+            # full point when the ref/artifact is missing.
+            gs_ref = get(result, :gs_stage_ref, nothing)
+            light_point =
+                _light_points_enabled() && gs_ref !== nothing &&
+                isfile(joinpath(_gs_stage_dir(), gs_ref * ".jld2"))
             try
                 _run_yaml_status(verbose, "writing result: $(basename(psi_file))")
                 jldopen(tmp_file, "w"; jld_kwargs...) do f
-                    f["psi"] = psi_host
+                    if light_point
+                        f["gs_ref"] = gs_ref
+                    else
+                        f["psi"] = psi_host
+                    end
                     f["scan_index"] = i
                     f["run_name"] = run_name
                     f["override"] = merged

--- a/src/workflow/experiments/pipeline/run_registry.jl
+++ b/src/workflow/experiments/pipeline/run_registry.jl
@@ -475,7 +475,10 @@ function _run_yaml_scan(data::Dict, scan::OverrideScan, run_dir, env; verbose=tr
                 verbose && println("  ✓ $(basename(psi_file)) (cached)")
                 if scan.continuation
                     d = JLD2.load(psi_file)
-                    chain_state[run_name] = (psi=d["psi"], mz_actual=get(d, "mz_actual", NaN))
+                    psi_c =
+                        haskey(d, "psi") ? d["psi"] :
+                        _load_stage_psi(String(d["gs_ref"]), psi_file)  # light point
+                    chain_state[run_name] = (psi=psi_c, mz_actual=get(d, "mz_actual", NaN))
                 end
                 continue
             end

--- a/src/workflow/experiments/pipeline/run_step_ground_state.jl
+++ b/src/workflow/experiments/pipeline/run_step_ground_state.jl
@@ -78,6 +78,62 @@ end
     end
 end
 
+# --- Automatic content-addressed GS stage cache -------------------------------
+# The expensive ITP/LBFGS ground-state solve is a pure function of its RESOLVED
+# physics inputs, not of the downstream `analyze:` block or the enclosing
+# scan/config. Keying a shared artifact on those inputs lets any config (a
+# refined c1 grid, an extended κ range, a changed analyzer list, or an
+# overlapping [1-10] vs [5-10] scan) reuse a ground state computed by any other —
+# closing the per-config / per-scan-index CAS reuse gap. This only AUTO-populates
+# the existing manual `cache:` path (loaded just below, saved near the end of this
+# function); the load/save machinery is unchanged. Opt-in via SPINORBEC_STAGE_CACHE.
+_stage_cache_enabled() =
+    lowercase(get(ENV, "SPINORBEC_STAGE_CACHE", "0")) in ("1", "true", "on", "yes")
+
+_gs_stage_dir() = get(ENV, "SPINORBEC_STAGE_DIR",
+    joinpath(get(ENV, "SPINORBEC_STORE", "runs"), "_stage", "gs"))
+
+# content_id refuses to hash NaN/Inf (the gs_ddi tuple carries NaN for an unset
+# ddi_trunc_radius); replace non-finite floats with a stable sentinel, recursively.
+_hashable(x::AbstractFloat) = isfinite(x) ? x : "nonfinite:$(x)"
+_hashable(x::Union{Integer, Bool, AbstractString, Nothing}) = x
+_hashable(x::Symbol) = string(x)
+_hashable(x::Tuple) = Any[_hashable(v) for v in x]
+_hashable(x::AbstractVector) = Any[_hashable(v) for v in x]
+_hashable(x::AbstractDict) = Dict{String, Any}(string(k) => _hashable(v) for (k, v) in x)
+_hashable(x) = string(x)   # last resort: stringify anything exotic
+
+# Canonical key over the resolved physics of a FROM-SCRATCH GS solve. Uses
+# resolved objects where cheap+robust (atom, grid, c-dict, ddi tuple, scalars)
+# and the raw `potential`/`B`/`lhy`/init sub-blocks (which fully determine their
+# resolved objects given atom+grid). Excludes analyze/scan/metadata/cache. Only
+# valid when psi_prev === nothing — warm-started/continuation solves are
+# seed-dependent and are never auto-cached.
+function _gs_cache_key(method, atom, grid, interactions, gs_ddi, tol, n_steps, dt, p)
+    key = Dict{String, Any}(
+        "v" => 1,                                    # key-schema version
+        "method" => string(method),
+        "atom" => atom.name,
+        "F" => atom.F,
+        "n_points" => collect(Int, grid.config.n_points),
+        "box" => collect(Float64, grid.config.box_size),
+        "c" => _hashable(interactions.c),
+        "c_lhy" => _hashable(interactions.c_lhy),
+        "ddi" => _hashable(gs_ddi),
+        "tol" => tol,
+        "n_steps" => n_steps,
+        "dt" => dt,
+        "potential" => _hashable(get(p, "potential", nothing)),
+        "B" => _hashable(get(p, "B", nothing)),
+        "lhy" => _hashable(get(p, "lhy", nothing)),
+        "initial_state" => string(get(p, "initial_state", "polar")),
+        "init_state_params" => _hashable(get(p, "init_state_params", nothing)),
+        "target_magnetization" => _hashable(get(p, "target_magnetization", nothing)),
+        "temperature_ratio" => _hashable(get(p, "temperature_ratio", nothing)),
+    )
+    content_id(key)
+end
+
 function _run_step(
     step::GroundStateStep,
     psi_prev,
@@ -127,6 +183,24 @@ function _run_step(
     # --- Cache: skip ITP/LBFGS if file exists, but build a workspace so
     #     downstream analyzers (e.g. bogoliubov) can inspect the system ---
     cache_path = get(p, "cache", nothing)
+    # Auto content-addressed stage cache: a from-scratch solve keyed on its
+    # resolved physics is reusable by any other config. Only when opted-in, not
+    # already given an explicit `cache:`, and not warm-started (seed-dependent).
+    if cache_path === nothing && psi_prev === nothing && _stage_cache_enabled()
+        cache_path = try
+            joinpath(_gs_stage_dir(),
+                _gs_cache_key(method, atom, grid, interactions, gs_ddi,
+                    tol, n_steps, dt, p) * ".jld2")
+        catch err
+            verbose &&
+                @warn "GS stage-cache key failed; caching disabled for this cell" exception =
+                    err
+            nothing
+        end
+        if cache_path !== nothing && verbose
+            println("  GS stage-cache key → $(basename(cache_path))")
+        end
+    end
     if cache_path !== nothing && isfile(cache_path)
         if verbose
             println("  Loading cached GS from $cache_path")

--- a/src/workflow/experiments/pipeline/run_step_ground_state.jl
+++ b/src/workflow/experiments/pipeline/run_step_ground_state.jl
@@ -90,6 +90,13 @@ end
 _stage_cache_enabled() =
     lowercase(get(ENV, "SPINORBEC_STAGE_CACHE", "0")) in ("1", "true", "on", "yes")
 
+# Stage 1: when on, a scan point whose GS was stage-cached is written as a LIGHT
+# point (a `gs_ref` pointer + scalars/analyze, no inline psi) — the heavy psi
+# lives once in the stage store; open_result resolves it back. Requires the stage
+# cache to be producing refs, so it implies _stage_cache_enabled().
+_light_points_enabled() =
+    lowercase(get(ENV, "SPINORBEC_LIGHT_POINTS", "0")) in ("1", "true", "on", "yes")
+
 _gs_stage_dir() = get(ENV, "SPINORBEC_STAGE_DIR",
     joinpath(get(ENV, "SPINORBEC_STORE", "runs"), "_stage", "gs"))
 
@@ -186,19 +193,21 @@ function _run_step(
     # Auto content-addressed stage cache: a from-scratch solve keyed on its
     # resolved physics is reusable by any other config. Only when opted-in, not
     # already given an explicit `cache:`, and not warm-started (seed-dependent).
+    # `stage_ref` (the content hash) is threaded into step_result so the scan-loop
+    # save can write a light point that references the shared psi (Stage 1).
+    stage_ref = nothing
     if cache_path === nothing && psi_prev === nothing && _stage_cache_enabled()
-        cache_path = try
-            joinpath(_gs_stage_dir(),
-                _gs_cache_key(method, atom, grid, interactions, gs_ddi,
-                    tol, n_steps, dt, p) * ".jld2")
+        stage_ref = try
+            _gs_cache_key(method, atom, grid, interactions, gs_ddi, tol, n_steps, dt, p)
         catch err
             verbose &&
                 @warn "GS stage-cache key failed; caching disabled for this cell" exception =
                     err
             nothing
         end
-        if cache_path !== nothing && verbose
-            println("  GS stage-cache key → $(basename(cache_path))")
+        if stage_ref !== nothing
+            cache_path = joinpath(_gs_stage_dir(), stage_ref * ".jld2")
+            verbose && println("  GS stage-cache key → $(stage_ref)")
         end
     end
     if cache_path !== nothing && isfile(cache_path)
@@ -224,6 +233,7 @@ function _run_step(
             :ground_state_energy => energy,
             :ground_state_converged => converged,
             :workspace => ws_cached,
+            :gs_stage_ref => stage_ref,
         )
         return (psi_out, grid, atom, ws_cached, step_result)
     end
@@ -404,6 +414,7 @@ function _run_step(
         :ground_state_energy => gs.energy,
         :ground_state_converged => gs.converged,
         :workspace => gs.workspace,
+        :gs_stage_ref => stage_ref,
     )
     (psi_out, grid, atom, gs.workspace, step_result)
 end

--- a/src/workflow/io/dashboard/compute/density.jl
+++ b/src/workflow/io/dashboard/compute/density.jl
@@ -2,7 +2,7 @@
 
 function _compute_3d_densities(jld2_path::String; target_n::Int=0, max_components::Int=0)
     d = JLD2.load(jld2_path)
-    psi = d["psi"]
+    psi = haskey(d, "psi") ? d["psi"] : load_point_psi(jld2_path)  # light point → stage
     n_comp = size(psi, ndims(psi))
     ndim = ndims(psi) - 1
     F = div(n_comp - 1, 2)
@@ -67,7 +67,7 @@ sees the expanded grid.
 
 function _compute_column_densities(jld2_path::String, axis::Int=3)
     d = JLD2.load(jld2_path)
-    psi = d["psi"]
+    psi = haskey(d, "psi") ? d["psi"] : load_point_psi(jld2_path)  # light point → stage
     n_comp = size(psi, ndims(psi))
     ndim = ndims(psi) - 1
     F = div(n_comp - 1, 2)

--- a/src/workflow/io/dashboard/server/data_export.jl
+++ b/src/workflow/io/dashboard/server/data_export.jl
@@ -43,7 +43,10 @@ function generate_dashboard_data(run_dir::String; F::Union{Nothing, Int}=nothing
 
     for fname in jld2_files
         d = JLD2.load(joinpath(run_dir, fname))
-        psi = d["psi"]
+        # Light point (no inline psi) → resolve from the stage store; the M1
+        # scalar-export marker (psi = empty array) keeps its inline empty psi.
+        psi = haskey(d, "psi") ? d["psi"] :
+              load_point_psi(joinpath(run_dir, fname))
 
         # Two paths: psi-bearing point files (the standard YAML-pipeline
         # case) recompute observables on the fly; scalar-only exports

--- a/src/workflow/io/dashboard/snapshots.jl
+++ b/src/workflow/io/dashboard/snapshots.jl
@@ -31,7 +31,7 @@ function _load_psi_cached(
     get!(cache, key) do
         if snap_idx === nothing
             d = JLD2.load(src_path)
-            psi = d["psi"]
+            psi = haskey(d, "psi") ? d["psi"] : load_point_psi(src_path)  # light point → stage
         else
             # Two on-disk layouts are supported:
             #   (1) streamed — one key per frame, keys

--- a/src/workflow/validation/open_result.jl
+++ b/src/workflow/validation/open_result.jl
@@ -66,12 +66,41 @@ function _extract_hpsi(data::Dict, psi::AbstractArray)
 end
 
 function _extract_psi(data::Dict, path::AbstractString)
-    haskey(data, "psi") ||
-        throw(ArgumentError("open_result: no `psi` key in $path"))
+    if !haskey(data, "psi")
+        # Light point (Stage 1): psi lives once in the content-addressed stage
+        # store; resolve it via the `gs_ref` pointer. Old full points (psi inline)
+        # take the branch below unchanged — full backward compatibility.
+        gs_ref = get(data, "gs_ref", nothing)
+        gs_ref !== nothing && return _load_stage_psi(String(gs_ref), path)
+        throw(ArgumentError("open_result: no `psi` or `gs_ref` key in $path"))
+    end
     psi_raw = data["psi"]
     psi_raw isa AbstractArray ||
         throw(ArgumentError("open_result: `psi` is not an array (got $(typeof(psi_raw)))"))
     convert(Array{ComplexF64, ndims(psi_raw)}, psi_raw)
+end
+
+# Resolve a light point's psi from the stage store. Tries the env-configured stage
+# dir first, then the store root inferred from the point path (<root>/<cfg>/point
+# → <root>/_stage/gs), so results stay readable after a move as long as the store
+# tree is intact. Fails loud (never silently returns a zero/garbage psi).
+function _load_stage_psi(gs_ref::String, point_path::AbstractString)
+    sd_env = get(ENV, "SPINORBEC_STAGE_DIR",
+        joinpath(get(ENV, "SPINORBEC_STORE", "runs"), "_stage", "gs"))
+    root = dirname(dirname(abspath(point_path)))
+    candidates = [joinpath(sd_env, gs_ref * ".jld2"),
+        joinpath(root, "_stage", "gs", gs_ref * ".jld2")]
+    for c in candidates
+        isfile(c) || continue
+        d = JLD2.load(c)
+        haskey(d, "psi") || continue
+        return convert(Array{ComplexF64, ndims(d["psi"])}, d["psi"])
+    end
+    throw(
+        ArgumentError(
+            "open_result: light point $point_path references gs_ref=$gs_ref but no " *
+            "stage artifact was found (looked in: $(join(candidates, ", ")))"),
+    )
 end
 
 function _extract_grid(data::Dict, psi::AbstractArray)

--- a/src/workflow/validation/open_result.jl
+++ b/src/workflow/validation/open_result.jl
@@ -21,7 +21,26 @@
 # keys when present, otherwise from `units/atom` + `units/N_atoms` +
 # `units/omega_ref_rad_s` via `compute_interaction_params`.
 
-export open_result
+export open_result, load_point_psi
+
+"""
+    load_point_psi(path) -> Array{ComplexF64}
+
+Load the wavefunction from a run point file. Resolves a Stage-1 `gs_ref` pointer
+from the content-addressed stage store when the point is light; returns the inline
+`psi` for a full point. Use this instead of a bare `JLD2.load(path)["psi"]` in any
+consumer that reads a run point's ψ so it keeps working under SPINORBEC_LIGHT_POINTS.
+"""
+function load_point_psi(path::AbstractString)
+    isfile(path) || throw(ArgumentError("load_point_psi: file not found: $path"))
+    d = JLD2.load(path)
+    if haskey(d, "psi")
+        return convert(Array{ComplexF64, ndims(d["psi"])}, d["psi"])
+    end
+    gs_ref = get(d, "gs_ref", nothing)
+    gs_ref !== nothing && return _load_stage_psi(String(gs_ref), path)
+    throw(ArgumentError("load_point_psi: no `psi` or `gs_ref` key in $path"))
+end
 
 """
     open_result(path::String) -> RunResult

--- a/src/workflow/validation/scalar_summary.jl
+++ b/src/workflow/validation/scalar_summary.jl
@@ -24,7 +24,7 @@ export run_scalar_summary, write_run_summary,
 const RUN_SUMMARY_FILENAME = "summary.json"
 # Bump when extraction logic changes so stale summaries (older extractor)
 # can be targeted for re-backfill via `_extractor_version`.
-const RUN_SUMMARY_EXTRACTOR_VERSION = "1"
+const RUN_SUMMARY_EXTRACTOR_VERSION = "2"  # v2: + rotation-invariant mF
 
 # Run `f()`; on exception record "field: reason" in `errs` and return
 # `missing`. A `nothing` / non-finite result is treated as legitimately
@@ -95,6 +95,30 @@ function run_scalar_summary(r::RunResult)
         tot = sum(Nm)
         tot > 0 ? Nm ./ tot : Nm
     end)
+    # Rotation-invariant order parameter mF = |⟨F⟩|/F of the peak-density (bulk)
+    # spinor. Unlike Mz (=⟨F_z⟩), this stays correct when the FM state lies in the
+    # xy-plane (B=0 DDI soft manifold) — the FM↔polar order variable. Carrying it
+    # here lets a phase scan read the order parameter straight from summary.json,
+    # never loading the heavy psi (Stage 1 / "graphs are the deliverable").
+    bag["mF"] = _try_field(
+        errs,
+        "mF",
+        () -> begin
+            F = r.atom.F
+            D = 2F + 1
+            sdim = ndims(r.psi)
+            dens = dropdims(sum(abs2, r.psi; dims=sdim); dims=sdim)
+            z = ComplexF64[r.psi[argmax(dens), c] for c in 1:D]
+            nz = norm(z)
+            nz > 0 || return missing
+            z ./= nz
+            sm = spin_matrices(F)
+            sqrt(
+                real(dot(z, sm.Fx * z))^2 + real(dot(z, sm.Fy * z))^2 +
+                real(dot(z, sm.Fz * z))^2,
+            ) / F
+        end,
+    )
 
     # Dynamics-only drift metrics (getproperty throws without a series).
     if r.dynamics !== nothing

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -47,6 +47,7 @@ const FAST_TESTS = [
     "workflow/test_state_zoo_wrappers_runnable.jl",
     "workflow/test_checkpoint.jl",
     "workflow/test_checkpointed_sweep.jl",
+    "workflow/test_gs_stage_cache.jl",
     "manuscript/test_lemma1_general_S.jl",
     "manuscript/test_f5_f7_polyhedral.jl",
     "manuscript/test_f9_f11_polyhedral.jl",

--- a/test/workflow/test_gs_stage_cache.jl
+++ b/test/workflow/test_gs_stage_cache.jl
@@ -7,9 +7,10 @@
 # reuse; these probes flip red on that.
 
 using Test
+using JLD2
 using SpinorBEC
 using SpinorBEC: _gs_cache_key, _gs_stage_dir, _hashable, _stage_cache_enabled,
-    make_grid, GridConfig, InteractionParams, resolve_atom
+    _light_points_enabled, make_grid, GridConfig, InteractionParams, resolve_atom
 
 @testset "GS stage cache" begin
     atom = resolve_atom(:Eu151)
@@ -112,6 +113,50 @@ using SpinorBEC: _gs_cache_key, _gs_stage_dir, _hashable, _stage_cache_enabled,
                     @test n_after_A == 1                        # one GS artifact cached
                     run_yaml(cfgB; base_dir=joinpath(dir, "runsB"), verbose=false)
                     @test length(readdir(stage)) == n_after_A   # different analyze → NO new GS
+                end
+            end
+        end
+
+        # Stage 1: light points carry a gs_ref (no inline psi); open_result resolves
+        # the psi back from the stage store. Old full points stay readable.
+        @testset "light points reference stage psi; open_result resolves them" begin
+            mktempdir() do dir
+                stage = joinpath(dir, "stage")
+                cfg = joinpath(dir, "c.yaml")
+                write(
+                    cfg,
+                    """
+         defaults: {kind: spinor, backend: cpu}
+         pipeline:
+           - ground_state:
+               atom: Eu151
+               interactions: {N_atoms: 5000, omega_ref: 691.1504, c1_ratio: 0.03}
+               grid: {n: [16, 16, 16], box: [8.0, 8.0, 8.0]}
+               potential: {type: harmonic, omega: [1.0, 1.0, 1.0]}
+               method: lbfgs
+               n_steps: 50
+               tol: 1.0e-7
+           - analyze: [{energy_decomposition: {}}]
+         scan:
+           product: {pipeline.0.interactions.c1_ratio: {from: 0.030, to: 0.031, n: 2}}
+         """,
+                )
+                withenv("SPINORBEC_STAGE_CACHE" => "1", "SPINORBEC_LIGHT_POINTS" => "1",
+                    "SPINORBEC_STAGE_DIR" => stage) do
+                    rd = run_yaml(cfg; base_dir=joinpath(dir, "runs"), verbose=false)
+                    is_point(f) = startswith(f, "point_") && endswith(f, ".jld2")
+                    pts = sort(filter(is_point, readdir(rd)))
+                    @test length(pts) == 2
+                    p1 = joinpath(rd, pts[1])
+                    d = JLD2.load(p1)
+                    @test haskey(d, "gs_ref")          # light: pointer present
+                    @test !haskey(d, "psi")            # light: no inline psi
+                    @test haskey(d, "energy")          # scalars stay inline
+                    # open_result transparently resolves psi from the stage store.
+                    r = open_result(p1)
+                    @test size(r.psi, 4) == 13         # Eu F=6 → 13 components
+                    @test all(isfinite, abs.(r.psi))
+                    @test isfile(joinpath(stage, String(d["gs_ref"]) * ".jld2"))
                 end
             end
         end

--- a/test/workflow/test_gs_stage_cache.jl
+++ b/test/workflow/test_gs_stage_cache.jl
@@ -157,6 +157,11 @@ using SpinorBEC: _gs_cache_key, _gs_stage_dir, _hashable, _stage_cache_enabled,
                     @test size(r.psi, 4) == 13         # Eu F=6 → 13 components
                     @test all(isfinite, abs.(r.psi))
                     @test isfile(joinpath(stage, String(d["gs_ref"]) * ".jld2"))
+                    # summary scalars carry the rotation-invariant order param mF,
+                    # so a phase scan reads it without loading psi.
+                    bag = SpinorBEC.run_scalar_summary(r)
+                    @test haskey(bag, "mF")
+                    @test 0.0 <= bag["mF"] <= 1.0 + 1e-9
                 end
             end
         end

--- a/test/workflow/test_gs_stage_cache.jl
+++ b/test/workflow/test_gs_stage_cache.jl
@@ -1,0 +1,119 @@
+# Automatic content-addressed GS stage cache (SPINORBEC_STAGE_CACHE).
+# The key `_gs_cache_key` must be a pure function of the RESOLVED ground-state
+# physics — stable across configs/analyze blocks, sensitive to real physics
+# changes, and never thrown by the NaN the gs_ddi tuple carries for an unset
+# ddi_trunc_radius. A regression that folds the analyze block / scan into the
+# key (or that throws on non-finite ddi) would silently disable cross-config
+# reuse; these probes flip red on that.
+
+using Test
+using SpinorBEC
+using SpinorBEC: _gs_cache_key, _gs_stage_dir, _hashable, _stage_cache_enabled,
+    make_grid, GridConfig, InteractionParams, resolve_atom
+
+@testset "GS stage cache" begin
+    atom = resolve_atom(:Eu151)
+    grid = make_grid(GridConfig((16, 16, 16), (8.0, 8.0, 8.0)))
+    inter = InteractionParams(Dict(0 => 1.0, 1 => 0.03))
+    # gs_ddi tuple carries NaN in slot 6 (unset ddi_trunc_radius) — must not throw.
+    ddi = (true, 1.0, false, false, 0.0, NaN, false, 2.0)
+    p = Dict{String, Any}(
+        "initial_state" => "m_plus_F",
+        "potential" => Dict("type" => "harmonic", "omega" => [1.0, 1.0, 1.0]),
+        "B" => Dict("Bz" => "0.0 Gauss"),
+    )
+    k(; a=atom, g=grid, i=inter, d=ddi, tol=1e-9, ns=2500, dt=1e-3, pp=p) =
+        _gs_cache_key(:lbfgs, a, g, i, d, tol, ns, dt, pp)
+
+    @testset "non-finite ddi is hashable (no throw)" begin
+        @test _hashable(NaN) isa AbstractString
+        @test _hashable(Inf) isa AbstractString
+        @test _hashable(0.03) === 0.03
+        @test (k(); true)                       # NaN in ddi does not throw
+    end
+
+    @testset "determinism + format" begin
+        @test k() == k()
+        key = k()
+        @test key isa AbstractString
+        @test length(key) == 16
+        @test all(c -> c in "0123456789abcdef", key)
+    end
+
+    @testset "sensitivity to real physics" begin
+        @test k(i=InteractionParams(Dict(0 => 1.0, 1 => 0.031))) != k()   # c1
+        @test k(g=make_grid(GridConfig((32, 32, 32), (8.0, 8.0, 8.0)))) != k()  # grid
+        @test k(tol=1e-8) != k()
+        @test k(ns=1500) != k()
+        let p2 = copy(p)
+            p2["initial_state"] = "polar"
+            @test k(pp=p2) != k()                                          # seed
+        end
+        let p3 = copy(p)
+            p3["potential"] = Dict("type" => "harmonic", "omega" => [1.0, 1.0, 0.5])
+            @test k(pp=p3) != k()                                          # κ (ω_z)
+        end
+        let p4 = copy(p)
+            p4["B"] = Dict("Bz" => "6.0e-5 Gauss")
+            @test k(pp=p4) != k()                                          # field
+        end
+    end
+
+    @testset "INSENSITIVE to non-physics (analyze / metadata / cache in p)" begin
+        # The key reads only physics sub-blocks from p; extra keys must not move it.
+        let p5 = copy(p)
+            p5["cache"] = "/some/explicit/path.jld2"
+            p5["irrelevant_note"] = "hello"
+            @test k(pp=p5) == k()
+        end
+    end
+
+    @testset "stage dir + flag env" begin
+        withenv("SPINORBEC_STAGE_DIR" => "/tmp/spinorbec_stage_probe") do
+            @test _gs_stage_dir() == "/tmp/spinorbec_stage_probe"
+        end
+        withenv("SPINORBEC_STAGE_CACHE" => "1") do
+            @test _stage_cache_enabled()
+        end
+        withenv("SPINORBEC_STAGE_CACHE" => "0") do
+            @test !_stage_cache_enabled()
+        end
+    end
+
+    # ── Integration: cross-analyze reuse via run_yaml (heavy; env-guarded) ──
+    if lowercase(get(ENV, "SPINORBEC_RUN_HEAVY_YAML", "")) in ("1", "true", "on")
+        @testset "run_yaml reuses GS across differing analyze blocks" begin
+            mktempdir() do dir
+                stage = joinpath(dir, "stage")
+                base(an) = """
+                defaults: {kind: spinor, backend: cpu}
+                pipeline:
+                  - ground_state:
+                      atom: Eu151
+                      interactions: {N_atoms: 5000, omega_ref: 691.1504, c1_ratio: 0.03}
+                      grid: {n: [16, 16, 16], box: [8.0, 8.0, 8.0]}
+                      potential: {type: harmonic, omega: [1.0, 1.0, 1.0]}
+                      method: lbfgs
+                      n_steps: 60
+                      tol: 1.0e-7
+                  - analyze: [$an]
+                """
+                # Two configs identical in physics, differing ONLY in the analyze
+                # block — the GS must be computed once and reused by the second.
+                cfgA = joinpath(dir, "a.yaml");
+                write(cfgA, base("{energy_decomposition: {}}"))
+                cfgB = joinpath(dir, "b.yaml");
+                write(cfgB, base("{phase_classify_distance: {}}"))
+                withenv("SPINORBEC_STAGE_CACHE" => "1", "SPINORBEC_STAGE_DIR" => stage) do
+                    # Isolated base_dir per config so the per-point cache (runs/<hash>)
+                    # doesn't short-circuit the GS step on a re-run of the suite.
+                    run_yaml(cfgA; base_dir=joinpath(dir, "runsA"), verbose=false)
+                    n_after_A = length(readdir(stage))
+                    @test n_after_A == 1                        # one GS artifact cached
+                    run_yaml(cfgB; base_dir=joinpath(dir, "runsB"), verbose=false)
+                    @test length(readdir(stage)) == n_after_A   # different analyze → NO new GS
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Problem
CAS reuse is coarse: `content_id` keys the **whole config** and point files are keyed by **scan index**, so overlapping configs (`[1-10]` vs `[5-10]`), refined grids, extended κ ranges, and analyzer-only changes all **recompute the same ground states**. A ground-state solve is a pure function of its physics — it should be reused.

## Approach (reached after reading the impl — 90% already existed)
The GS `cache:` block already has load+save (a manual, user-path stage cache); `content_id` already exists; `summary.json` is already a light scalar sidecar. This series makes `cache:` **automatic + content-addressed** and adds a **light point** layout. All opt-in, default OFF → zero change to existing behaviour or on-disk data.

## Commits
- **Stage 0** `83971db5` — auto-populate `cache:` with `content_id` of the RESOLVED GS physics (excludes analyze/scan/metadata). `SPINORBEC_STAGE_CACHE`. From-scratch solves only; point files stay full → existing data untouched. ⇒ cross-config + analyze-change compute reuse.
- **backfill** `1ed54ec0` — `scripts/backfill_gs_stage.jl` ingests existing point psi via the same hash chain (validated byte-identical to a live run).
- **Stage 1 core** `ecb4c31e` — `SPINORBEC_LIGHT_POINTS`: point files store a `gs_ref` pointer, no inline psi (disk dedup); `open_result` resolves psi from the stage store; old full points still read (backward compat); fails loud if the artifact is missing.
- **Stage 1 consumers** `e38dd57c` — public `load_point_psi`; migrate continuation + dashboard psi readers (`haskey ? : resolve`, full-point behaviour unchanged).
- **Stage 1 summary** `3f07d597` — `summary.json` carries rotation-invariant `mF = |⟨F⟩|/F` (extractor v2) → psi-free order-parameter extraction.

## Tests
`test/workflow/test_gs_stage_cache.jl` (FAST + heavy-guarded): hash determinism / physics-sensitivity / non-physics-insensitivity / non-finite safety; run_yaml reuses GS across analyze blocks; light-point round-trip via open_result; summary mF. **30/30** + scalar_summary **28/28**.

## Notes / follow-ups
- Known cosmetic limit: dashboard volume-render peak-norm falls back to 1.0 for a light-point GS file (no crash).
- `seed_from` + eu extraction scripts live on the campaign branch (not main) — migrate on merge before enabling LIGHT_POINTS in the campaign.
- Stage 2 (content-based resume) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)