### PR TITLE
feat(analysis): superfluid fraction from the phase-twist free energy

### DIFF
--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -8,6 +8,8 @@
 #       spin observables, ensemble stat helpers
 #   energy/currents/vorticity     — energy decomposition, probability
 #       current, superfluid velocity/vorticity
+#   superfluid_fraction            — phase-twist f_s (Leggett plane-average
+#       bound + full variational relaxation)
 #   vortex_extraction              — per-m vortex line tracing (3D)
 #   diagnostics                    — Zeeman/healing-length/TF radius helpers
 #   sinatra_diagnostics/grid_resolution — TWA-validity (Sinatra) per-knob
@@ -27,6 +29,7 @@ include("analysis/ensemble.jl")
 include("analysis/energy.jl")
 include("analysis/currents.jl")
 include("analysis/vorticity.jl")
+include("analysis/superfluid_fraction.jl")  # phase-twist f_s (Leggett bound + relaxed)
 include("analysis/vortex_extraction.jl")
 include("analysis/diagnostics.jl")
 include("analysis/sinatra_diagnostics.jl")  # TWA-validity (Sinatra) per-knob helpers

--- a/src/analysis/superfluid_fraction.jl
+++ b/src/analysis/superfluid_fraction.jl
@@ -1,0 +1,246 @@
+export superfluid_fraction, plane_averaged_density
+
+# Translational superfluid fraction from the phase-twist free energy.
+#
+# Twisted boundary conditions ψ(r + L ê_d) = e^{iθ} ψ(r) are gauged into a
+# uniform phase gradient q = θ/L. Writing the phase as q(x_d + u(r)) with
+# periodic u, the energy cost at fixed density is
+#
+#     E(q) − E(0) = (q²/2) ∫ n |ê_d + ∇u|² dV        (ℏ = m = 1)
+#
+# and the superfluid fraction is that cost normalised by the rigid-flow value
+# (q²/2)∫n dV:
+#
+#     f_s = min_u ∫ n |ê_d + ∇u|² dV / ∫ n dV
+#
+# The density is held rigid, which makes f_s an upper bound on the true
+# superfluid fraction. Restricting u to depend on x_d alone gives Leggett's
+# closed form — a further upper bound, and the quantity usually reported for
+# supersolids.
+
+"""
+    plane_averaged_density(n, d) -> Vector{Float64}
+
+Density averaged over the hyperplane perpendicular to axis `d`,
+n̄(x_d) = ⟨n⟩_{other axes}.
+"""
+function plane_averaged_density(n::AbstractArray{Float64, N}, d::Int) where {N}
+    1 <= d <= N || throw(ArgumentError("direction $d outside 1:$N"))
+    nd = size(n, d)
+    nbar = zeros(Float64, nd)
+    @inbounds for I in CartesianIndices(n)
+        nbar[I[d]] += n[I]
+    end
+    nbar ./= (length(n) ÷ nd)
+    nbar
+end
+
+"""
+    superfluid_fraction(psi, grid; direction=1, method=:leggett) -> Float64
+    superfluid_fraction(n, grid; direction=1, method=:leggett) -> Float64
+
+Translational superfluid fraction along axis `direction`, from the free-energy
+cost of a phase twist across the periodic box (ℏ = m = 1).
+
+`psi` is a spinor `psi[x, y, …, c]` (all components contribute through the
+total density) or a bare density array `n`.
+
+`method`:
+
+- `:leggett` — Leggett's closed form for flow along `d`, obtained by letting
+  only the plane-averaged phase relax:
+
+      f_s = L² / [ (∫ n̄ dx_d)(∫ dx_d / n̄) ]     n̄ = plane-averaged density
+
+  Equals 1 iff n̄ is uniform, and falls as `1/n̄` develops peaks — a
+  Cauchy–Schwarz bound, so `0 ≤ f_s ≤ 1` always.
+
+- `:relaxed` — the full variational minimum over a periodic phase `u(r)`: solves
+  ∇·(n(ê_d + ∇u)) = 0 on the grid and returns `1 + ∫n ∂_d u / ∫n`. Letting the
+  phase vary transversally lets the flow concentrate where the density is high,
+  which *lowers* the energy cost and hence the fraction:
+  `f_s(:relaxed) ≤ f_s(:leggett)`, with equality when the density is modulated
+  along `d` only.
+
+Both branches hold the density rigid, so both are upper bounds on the true
+superfluid fraction.
+
+The twist is only meaningful when the cloud connects to itself across the
+periodic box. A trapped cloud surrounded by vacuum has no phase rigidity along
+the flow axis and gives `f_s ≈ 0`; that is the correct answer to the question
+asked, not a bug. Pass `warn_vacuum=false` to silence the advisory.
+
+References:
+- A. J. Leggett, "Can a solid be superfluid?", Phys. Rev. Lett. 25, 1543
+  (1970), doi:10.1103/PhysRevLett.25.1543 — the harmonic-mean bound.
+- G. Biagioni et al., "Measurement of the superfluid fraction of a supersolid
+  by Josephson effect", Nature (2024), doi:10.1038/s41586-024-07361-9 — the
+  experiment this quantity is the theory counterpart of.
+"""
+function superfluid_fraction(
+    psi::AbstractArray{<:Complex},
+    grid::Grid{N};
+    direction::Int=1,
+    method::Symbol=:leggett,
+    warn_vacuum::Bool=true,
+    rtol::Float64=1e-10,
+    maxiter::Int=0,
+) where {N}
+    superfluid_fraction(
+        total_density(psi, N), grid; direction, method, warn_vacuum, rtol, maxiter
+    )
+end
+
+function superfluid_fraction(
+    n::AbstractArray{Float64, N},
+    grid::Grid{N};
+    direction::Int=1,
+    method::Symbol=:leggett,
+    warn_vacuum::Bool=true,
+    rtol::Float64=1e-10,
+    maxiter::Int=0,
+) where {N}
+    1 <= direction <= N || throw(ArgumentError("direction $direction outside 1:$N"))
+    all(>=(0.0), n) || throw(ArgumentError("density must be non-negative"))
+
+    nbar = plane_averaged_density(n, direction)
+    n_mean = sum(nbar) / length(nbar)
+    n_mean > 0 || throw(ArgumentError("density is identically zero"))
+
+    if warn_vacuum && minimum(nbar) <= 1e-8 * n_mean
+        @warn "superfluid_fraction: plane-averaged density vanishes somewhere along \
+               axis $direction — the cloud does not connect across the periodic box, \
+               so f_s ≈ 0 is geometric, not a property of the state." min_over_mean =
+            minimum(nbar) / n_mean
+    end
+
+    if method === :leggett
+        _superfluid_fraction_leggett(nbar)
+    elseif method === :relaxed
+        _superfluid_fraction_relaxed(n, grid, direction, rtol, maxiter)
+    else
+        throw(ArgumentError("unknown method $method (expected :leggett or :relaxed)"))
+    end
+end
+
+# f_s = L² / [(∫ n̄)(∫ 1/n̄)]; the grid spacing cancels between the two integrals.
+function _superfluid_fraction_leggett(nbar::Vector{Float64})
+    minimum(nbar) > 0 || return 0.0
+    npt = length(nbar)
+    npt^2 / (sum(nbar) * sum(inv, nbar))
+end
+
+# --- Variational branch: ∇·(n(ê_d + ∇u)) = 0 on the periodic grid ---
+
+@inline _fwd(i::Int, n::Int) = ifelse(i == n, 1, i + 1)
+@inline _bwd(i::Int, n::Int) = ifelse(i == 1, n, i - 1)
+
+@inline function _shift(I::CartesianIndex{N}, d::Int, np::NTuple{N, Int}, fwd::Bool) where {N}
+    CartesianIndex(ntuple(e -> e == d ? (fwd ? _fwd(I[e], np[e]) : _bwd(I[e], np[e])) : I[e], N))
+end
+
+# Face densities n_{i+1/2} in each direction (arithmetic mean of the two cells).
+function _face_densities(n::AbstractArray{Float64, N}, np::NTuple{N, Int}) where {N}
+    ntuple(N) do d
+        nf = similar(n)
+        @inbounds for I in CartesianIndices(n)
+            nf[I] = 0.5 * (n[I] + n[_shift(I, d, np, true)])
+        end
+        nf
+    end
+end
+
+# out .= -∇·(n ∇u), the SPD operator of the variational problem.
+function _apply_flux_laplacian!(
+    out::Array{Float64, N},
+    u::Array{Float64, N},
+    nf::NTuple{N, Array{Float64, N}},
+    inv_dx2::NTuple{N, Float64},
+    np::NTuple{N, Int},
+) where {N}
+    fill!(out, 0.0)
+    @inbounds for I in CartesianIndices(u)
+        acc = 0.0
+        for d in 1:N
+            Ip = _shift(I, d, np, true)
+            Im = _shift(I, d, np, false)
+            acc += (nf[d][I] * (u[Ip] - u[I]) - nf[d][Im] * (u[I] - u[Im])) * inv_dx2[d]
+        end
+        out[I] = -acc
+    end
+    out
+end
+
+function _superfluid_fraction_relaxed(
+    n::AbstractArray{Float64, N},
+    grid::Grid{N},
+    d0::Int,
+    rtol::Float64,
+    maxiter::Int,
+) where {N}
+    np = grid.config.n_points
+    size(n) == np || throw(ArgumentError("density size $(size(n)) ≠ grid $(np)"))
+
+    nd = convert(Array{Float64, N}, n)
+    nf = _face_densities(nd, np)
+    inv_dx2 = ntuple(d -> 1.0 / grid.dx[d]^2, N)
+    inv_dx0 = 1.0 / grid.dx[d0]
+
+    # b = ∂_{d0} n, discretised through the same face values as the operator.
+    # Telescoping then makes ∑b vanish over every connected region, i.e. b is
+    # orthogonal to the null space of A and the singular system is compatible.
+    b = similar(nd)
+    @inbounds for I in CartesianIndices(b)
+        b[I] = (nf[d0][I] - nf[d0][_shift(I, d0, np, false)]) * inv_dx0
+    end
+
+    u = _solve_cg(b, nf, inv_dx2, np, rtol, maxiter <= 0 ? 10 * length(b) : maxiter)
+
+    # f_s = 1 + ∫n ∂_{d0} u / ∫n, with the flux form matching the operator.
+    flux = 0.0
+    @inbounds for I in CartesianIndices(u)
+        flux += nf[d0][I] * (u[_shift(I, d0, np, true)] - u[I]) * inv_dx0
+    end
+    1.0 + flux / sum(nd)
+end
+
+# Conjugate gradient for the consistent singular system A u = b. The null
+# space (one constant per connected region) never enters: b is orthogonal to
+# it by construction, and a constant offset in `u` drops out of the flux.
+function _solve_cg(
+    b::Array{Float64, N},
+    nf::NTuple{N, Array{Float64, N}},
+    inv_dx2::NTuple{N, Float64},
+    np::NTuple{N, Int},
+    rtol::Float64,
+    maxiter::Int,
+) where {N}
+    u = zeros(Float64, size(b))
+    r = copy(b)
+    p = copy(r)
+    Ap = similar(b)
+
+    rr = sum(abs2, r)
+    b_norm = sqrt(sum(abs2, b))
+    b_norm > 0 || return u
+    tol2 = (rtol * b_norm)^2
+
+    iter = 0
+    while rr > tol2 && iter < maxiter
+        _apply_flux_laplacian!(Ap, p, nf, inv_dx2, np)
+        pAp = sum(p .* Ap)
+        pAp > 0 || break                       # null direction: nothing left to relax
+        α = rr / pAp
+        @. u += α * p
+        @. r -= α * Ap
+        rr_new = sum(abs2, r)
+        @. p = r + (rr_new / rr) * p
+        rr = rr_new
+        iter += 1
+    end
+    if rr > tol2
+        @warn "superfluid_fraction(:relaxed): CG stopped at residual \
+               $(sqrt(rr) / b_norm) after $iter iterations"
+    end
+    u
+end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -112,6 +112,7 @@ const FAST_TESTS = [
     "foundation/test_property_based.jl",
     "foundation/test_types_validation.jl",
     "analysis/test_currents.jl",
+    "analysis/test_superfluid_fraction.jl",
     "hamiltonian/test_lhy_2d.jl",
     "analysis/test_bogoliubov_enhanced.jl",
     "hamiltonian/test_spinor_lhy.jl",

--- a/test/analysis/test_superfluid_fraction.jl
+++ b/test/analysis/test_superfluid_fraction.jl
@@ -1,0 +1,148 @@
+using Test
+using SpinorBEC
+
+# Analytic oracle: for n̄(x) = n₀(1 + A cos kx) on a full period,
+#   ∫dx/n̄ = L/(n₀√(1−A²))  ⇒  f_s = L²/[(∫n̄)(∫dx/n̄)] = √(1−A²).
+_fs_cosine(A) = sqrt(1 - A^2)
+
+@testset "Superfluid fraction (phase twist)" begin
+    @testset "uniform density is fully superfluid" begin
+        grid = make_grid(GridConfig((16, 16, 16), (10.0, 10.0, 10.0)))
+        n = fill(0.3, 16, 16, 16)
+
+        @test superfluid_fraction(n, grid; direction=1) ≈ 1.0 atol = 1e-14
+        @test superfluid_fraction(n, grid; direction=2) ≈ 1.0 atol = 1e-14
+        @test superfluid_fraction(n, grid; direction=3, method=:relaxed) ≈ 1.0 atol = 1e-12
+    end
+
+    @testset "cosine modulation matches √(1−A²)" begin
+        L = 10.0
+        npt = 128
+        grid = make_grid(GridConfig(npt, L))
+        k = 2π / L
+
+        for A in (0.0, 0.3, 0.6, 0.9)
+            n = [1.0 + A * cos(k * x) for x in grid.x[1]]
+            # The Leggett branch is a trapezoid sum of 1/n̄ over a period, which
+            # converges geometrically in the point count; the relaxed branch is
+            # a second-order finite-volume solve.
+            @test superfluid_fraction(n, grid) ≈ _fs_cosine(A) rtol = 1e-8
+            @test superfluid_fraction(n, grid; method=:relaxed) ≈ _fs_cosine(A) rtol = 5e-3
+        end
+    end
+
+    @testset "relaxed branch is second-order in dx" begin
+        L = 10.0
+        A = 0.9
+        k = 2π / L
+        err = map((32, 64, 128)) do npt
+            grid = make_grid(GridConfig(npt, L))
+            n = [1.0 + A * cos(k * x) for x in grid.x[1]]
+            abs(superfluid_fraction(n, grid; method=:relaxed) - _fs_cosine(A))
+        end
+        @test err[1] / err[2] > 3.5
+        @test err[2] / err[3] > 3.5
+    end
+
+    @testset "f_s decreases monotonically with contrast" begin
+        grid = make_grid(GridConfig(64, 8.0))
+        k = 2π / 8.0
+        fs = [
+            superfluid_fraction([1.0 + A * cos(k * x) for x in grid.x[1]], grid) for
+            A in 0.0:0.1:0.9
+        ]
+        @test all(diff(fs) .< 0.0)
+        @test fs[1] ≈ 1.0
+        @test fs[end] < 0.5
+    end
+
+    @testset "transverse modulation does not impede flow" begin
+        grid = make_grid(GridConfig((16, 16), (6.0, 6.0)))
+        ky = 2π / 6.0
+        n = [1.0 + 0.8 * cos(ky * y) for _ in grid.x[1], y in grid.x[2]]
+
+        @test superfluid_fraction(n, grid; direction=1) ≈ 1.0 atol = 1e-12
+        @test superfluid_fraction(n, grid; direction=1, method=:relaxed) ≈ 1.0 atol = 1e-12
+        # Along the modulated axis the same density is a barrier.
+        @test superfluid_fraction(n, grid; direction=2) ≈ _fs_cosine(0.8) rtol = 1e-3
+    end
+
+    @testset "a transverse channel pulls f_s below the Leggett bound" begin
+        # Modulate only half of the y range. Flow concentrates in the open
+        # channel instead of pushing uniformly through the barrier, which costs
+        # less energy than the plane-averaged (Leggett) ansatz allows — so the
+        # relaxed value must sit strictly below the bound.
+        grid = make_grid(GridConfig((32, 32), (6.0, 6.0)))
+        kx = 2π / 6.0
+        n = ones(32, 32)
+        for (i, x) in enumerate(grid.x[1]), j in 1:16
+            n[i, j] = 1.0 + 0.9 * cos(kx * x)
+        end
+
+        f_leggett = superfluid_fraction(n, grid; direction=1)
+        f_relaxed = superfluid_fraction(n, grid; direction=1, method=:relaxed)
+
+        @test f_leggett ≈ _fs_cosine(0.45) rtol = 1e-6
+        @test f_relaxed < f_leggett - 0.01
+        # Decoupled-channel limit: the open half alone already carries f_s ≥ 1/2.
+        @test f_relaxed > 0.5
+    end
+
+    @testset "bounds hold for arbitrary densities" begin
+        grid = make_grid(GridConfig((12, 12, 12), (5.0, 5.0, 5.0)))
+        for seed in 1:3
+            n = [
+                1.0 + 0.9 * sin(seed * x + 0.7y) * cos(0.5z + seed) for
+                x in grid.x[1], y in grid.x[2], z in grid.x[3]
+            ]
+            n .-= minimum(n)
+            n .+= 0.05
+            for d in 1:3
+                f_l = superfluid_fraction(n, grid; direction=d)
+                f_r = superfluid_fraction(n, grid; direction=d, method=:relaxed)
+                @test 0.0 <= f_r <= f_l <= 1.0 + 1e-10
+            end
+        end
+    end
+
+    @testset "spinor input uses the total density" begin
+        grid = make_grid(GridConfig(64, 10.0))
+        k = 2π / 10.0
+        A = 0.5
+        psi = zeros(ComplexF64, 64, 3)
+        for (i, x) in enumerate(grid.x[1])
+            amp = sqrt(1.0 + A * cos(k * x))
+            psi[i, 1] = 0.6 * amp
+            psi[i, 3] = 0.8 * amp * cis(0.3x)     # phase must not matter
+        end
+
+        @test superfluid_fraction(psi, grid) ≈ _fs_cosine(A) rtol = 1e-8
+    end
+
+    @testset "disconnected cloud has no phase rigidity" begin
+        grid = make_grid(GridConfig(64, 10.0))
+        n = zeros(64)
+        n[20:40] .= 1.0
+
+        @test superfluid_fraction(n, grid; warn_vacuum=false) == 0.0
+        @test superfluid_fraction(n, grid; method=:relaxed, warn_vacuum=false) < 1e-8
+        @test_logs (:warn, r"does not connect") superfluid_fraction(n, grid)
+    end
+
+    @testset "plane_averaged_density" begin
+        n = reshape(collect(1.0:12.0), 3, 4)
+        @test plane_averaged_density(n, 1) ≈ [(1 + 4 + 7 + 10) / 4, (2 + 5 + 8 + 11) / 4,
+            (3 + 6 + 9 + 12) / 4]
+        @test plane_averaged_density(n, 2) ≈ [2.0, 5.0, 8.0, 11.0]
+        @test_throws ArgumentError plane_averaged_density(n, 3)
+    end
+
+    @testset "argument validation" begin
+        grid = make_grid(GridConfig(16, 4.0))
+        n = ones(16)
+        @test_throws ArgumentError superfluid_fraction(n, grid; direction=2)
+        @test_throws ArgumentError superfluid_fraction(n, grid; method=:bogus)
+        @test_throws ArgumentError superfluid_fraction(-ones(16), grid)
+        @test_throws ArgumentError superfluid_fraction(zeros(16), grid; warn_vacuum=false)
+    end
+end


### PR DESCRIPTION
Adds `superfluid_fraction(psi_or_n, grid; direction, method)` — the translational $f_s$ along one axis, from the energy cost of twisting the phase across the periodic box ($\hbar = m = 1$).

## Two branches, gated against each other

- **`:leggett`** — plane-average closed form $f_s = L^2/[(\int \bar n)(\int dx/\bar n)]$, the harmonic-over-arithmetic mean of the density. Cheap, and the quantity the supersolid literature reports.
- **`:relaxed`** — the full variational minimum over a periodic phase: a finite-volume solve of $\nabla\cdot(n(\hat e_d + \nabla u)) = 0$ by CG on the singular-but-compatible system.

They agree to discretisation error whenever the density is modulated along the flow axis only — that is what gates one against the other. Elsewhere `:relaxed ≤ :leggett`, because letting the phase vary transversally lets the flow concentrate where the density is high, which lowers the cost.

## Why it isn't a tautology

The naive "boost the condensate and read off the kinetic energy" estimator returns 1 for *any* state, since $|\psi|^2$ is unchanged by the boost. Holding the density rigid while relaxing the phase is what makes the number informative — and is also why both branches are upper bounds on the true $f_s$.

## Validation (type A only, deliberately)

- Analytic oracle: a cosine density of contrast $A$ gives $f_s = \sqrt{1-A^2}$ exactly.
- The relaxed branch converges to that at second order in $dx$ (pinned by a refinement test).
- Bounds $0 \le f_s^{\text{relaxed}} \le f_s^{\text{leggett}} \le 1$ over arbitrary densities.
- Transverse-channel case where the two branches must *differ*, so the agreement test above cannot pass vacuously.

No type-B or type-C claim is made here. The rigid-density approximation is untested against a twisted-BC re-minimisation, and nothing has been compared to a published $f_s$ — both are follow-ups.

## Known limits

- CPU only: the `CartesianIndices` loops scalar-index, so a GPU ψ needs `_to_host` at the entry. Not yet wired through `_run_analyzer` (which already hosts ψ), so this lands with the analyzer follow-up.
- The CG is unpreconditioned and unbenchmarked at production grid sizes.
- A trapped cloud with vacuum at the box edge legitimately gives $f_s \approx 0$ (no phase rigidity across the box); that case warns rather than silently returning zero.

## Tests

`analysis/test_superfluid_fraction.jl` 42/42, registered in the fast tier. Full fast tier 142/142.

## References

- A. J. Leggett, *Can a solid be superfluid?*, Phys. Rev. Lett. **25**, 1543 (1970), doi:10.1103/PhysRevLett.25.1543
- G. Biagioni et al., *Measurement of the superfluid fraction of a supersolid by Josephson effect*, Nature (2024), doi:10.1038/s41586-024-07361-9