### PR TITLE
feat(atoms): add 153Eu to ATOM_REGISTRY

### DIFF
--- a/src/workflow/initialization/atoms.jl
+++ b/src/workflow/initialization/atoms.jl
@@ -1,5 +1,6 @@
 export Li7, Na23, K39, K41, Rb85, Rb87, Cs133              # alkali metals
-export Cr52, Dy164, Dy162, Er168, Er166, Eu151, Eu151_f1_effective  # magnetic lanthanides
+export Cr52, Dy164, Dy162, Er168, Er166      # magnetic lanthanides
+export Eu151, Eu153, Eu151_f1_effective      # europium
 export Ca40, Sr84, Sr86, Sr88, Yb170, Yb174, Yb176         # spinless
 export He4star                                              # metastable
 export ATOM_REGISTRY, resolve_atom
@@ -196,7 +197,7 @@ const Er166 = AtomSpecies(
 #   μ = g_J × J × μ_B ≈ 6.977μ_B
 #   a_s ≈ 110 a₀ (Matsui et al. Science 2026)
 #   Individual a_S unknown → scattering_lengths empty
-const _EU151_G_J = 1.9934
+const _EU_G_J = 1.9934   # ⁸S₇/₂ electronic g-factor; isotope-independent
 # ¹⁵¹Eu: F=6 ground state (⁸S₇/₂, J=7/2, I=5/2)
 #   g_J = 1.9934 (Sandars & Woodgate 1960)
 #   g_F = g_J · 7/12 ≈ 1.1628 (Lande projection for F=I+J=6)
@@ -214,12 +215,53 @@ const Eu151 = AtomSpecies(
     6,
     110.0 * Units.BOHR_RADIUS,
     0.0,
-    _EU151_G_J * 3.5 * Units.BOHR_MAGNETON,
-    lande_g_factor(6, 5 // 2, 7 // 2; g_J=_EU151_G_J);   # was 7/12·g_J (hand-typed)
+    _EU_G_J * 3.5 * Units.BOHR_MAGNETON,
+    lande_g_factor(6, 5 // 2, 7 // 2; g_J=_EU_G_J);   # was 7/12·g_J (hand-typed)
     Delta_E_hf=121.0e6 * 2π * Units.HBAR,
-    g_J=_EU151_G_J,
+    g_J=_EU_G_J,
     nuclear_I=5 // 2,      # ¹⁵¹Eu nuclear spin (I=5/2)
     electronic_J=7 // 2,   # ⁸S₇/₂ ground state (J=7/2)
+)
+
+# ¹⁵³Eu: F=6 ground state (⁸S₇/₂, J=7/2, I=5/2) — the other stable isotope
+#   (52.19 % natural abundance vs 47.81 % for ¹⁵¹Eu), added for isotope-mixture
+#   work. Same electronic structure as ¹⁵¹Eu, so g_J, μ, g_F and the F=6
+#   q-geometry factor are shared; only the mass and the hyperfine constant differ.
+#
+#   mass       152.921 2380(18) u (NIST/AME2020 relative atomic mass)
+#   a_hf       -8.853 MHz for the ⁸S₇/₂ state, vs -20.052 MHz for ¹⁵¹Eu
+#              (Sandars & Woodgate, Proc. R. Soc. Lond. A 257, 269 (1960);
+#              tabulated side by side in Zaremba-Kopczyk, Żuchowski & Tomza,
+#              Phys. Rev. A 98, 032704 (2018), arXiv:1806.02800, Table I:
+#              "¹⁵¹Eu ⁸S₇/₂ 7/2 5/2 1,...,6 -20.052 / ¹⁵³Eu ⁸S₇/₂ 7/2 5/2
+#              1,...,6 -8.853"). a_hf < 0 ⇒ F = I+J = 6 is the ground manifold.
+#   Δ_hf       F=6 ↔ F=5 splitting = 6·|a_hf| = 53.1 MHz from the magnetic-dipole
+#              term alone; the electric-quadrupole correction is neglected (≲ 2 %),
+#              as in Zaremba-Kopczyk et al. The stored ¹⁵¹Eu value (121.0 MHz)
+#              does include it — the pure dipole part there is 6·20.052 = 120.3 MHz.
+#   q          q ∝ 1/Δ_hf at fixed B (see `quadratic_zeeman_shift`), so ¹⁵³Eu has
+#              ≈ 2.3× the quadratic Zeeman of ¹⁵¹Eu: q/h ≈ 3.3 kHz/G² vs 1.43.
+#   a_s        PLACEHOLDER = the ¹⁵¹Eu measured 110(4) a₀ (Miyazawa et al.,
+#              Phys. Rev. Lett. 129, 223401 (2022), arXiv:2207.11692). No ¹⁵³Eu
+#              measurement exists and the isotope shift is unknown. Tomza's
+#              Eu+Eu ab initio potential fixes only the long range,
+#              C₆ = 3610 a.u. ⇒ R₆ = (2μC₆/ℏ²)^{1/4} = 178 a₀; that work treats
+#              a_{S=7} as a free parameter ("We set the scattering lengths a_S of
+#              the employed potential-energy curves by scaling them with
+#              appropriate factors λ"), illustrating with a_{S=7} = 1.5 R₆.
+#              Override `a_s` explicitly for any quantitative ¹⁵³Eu claim.
+const Eu153 = AtomSpecies(
+    "153Eu",
+    152.9212380 * Units.AMU,
+    6,
+    110.0 * Units.BOHR_RADIUS,
+    0.0,
+    _EU_G_J * 3.5 * Units.BOHR_MAGNETON,
+    lande_g_factor(6, 5 // 2, 7 // 2; g_J=_EU_G_J);
+    Delta_E_hf=53.1e6 * 2π * Units.HBAR,
+    g_J=_EU_G_J,
+    nuclear_I=5 // 2,
+    electronic_J=7 // 2,
 )
 
 # ¹⁵¹Eu effective F=1 model (Yan-Li-Saito 2026 PRL convention)
@@ -308,6 +350,7 @@ const ATOM_REGISTRY = Dict{Symbol, AtomSpecies}(
     :Er168 => Er168,
     :Er166 => Er166,
     :Eu151 => Eu151,
+    :Eu153 => Eu153,
     :Eu151_f1_effective => Eu151_f1_effective,
     :Ca40 => Ca40,
     :Sr84 => Sr84,

--- a/test/foundation/test_atoms.jl
+++ b/test/foundation/test_atoms.jl
@@ -1,7 +1,7 @@
 @testset "Atom Species Library" begin
     all_atoms = [
         Li7, Na23, K39, K41, Rb85, Rb87, Cs133,
-        Cr52, Dy164, Dy162, Er168, Er166, Eu151, Eu151_f1_effective,
+        Cr52, Dy164, Dy162, Er168, Er166, Eu151, Eu153, Eu151_f1_effective,
         Ca40, Sr84, Sr86, Sr88, Yb170, Yb174, Yb176,
         He4star,
     ]
@@ -34,7 +34,7 @@
             (Cs133, 3, 7 // 2, 1 // 2, 2.0), (He4star, 1, 0, 1, 2.0),
             (Cr52, 3, 0, 3, 2.0), (Dy164, 8, 0, 8, 1.24), (Dy162, 8, 0, 8, 1.24),
             (Er168, 6, 0, 6, 1.16), (Er166, 6, 0, 6, 1.16),
-            (Eu151, 6, 5 // 2, 7 // 2, 1.9934),
+            (Eu151, 6, 5 // 2, 7 // 2, 1.9934), (Eu153, 6, 5 // 2, 7 // 2, 1.9934),
         ]
         for (a, F, I, J, gJ) in cases
             @test isapprox(a.g_F, lande_g_factor(F, I, J; g_J=gJ); atol=1e-4)
@@ -67,7 +67,7 @@
     end
 
     @testset "Dipolar atoms: mu_mag > 0" begin
-        dipolar = [Cr52, Dy164, Dy162, Er168, Er166, Eu151, He4star]
+        dipolar = [Cr52, Dy164, Dy162, Er168, Er166, Eu151, Eu153, He4star]
         for a in dipolar
             @test a.mu_mag > 0
             @test a.g_F != 0.0
@@ -95,6 +95,47 @@
         @test Eu151.F == 6
         @test Eu151.a_s ≈ 110.0 * SpinorBEC.Units.BOHR_RADIUS rtol = 1e-6
         @test Eu151.mu_mag > 6.0 * SpinorBEC.Units.BOHR_MAGNETON
+    end
+
+    @testset "Eu153 shares Eu151's electronic structure" begin
+        # Same ⁸S₇/₂ configuration and same nucleus spin (I=5/2), so everything
+        # that depends only on (F, I, J, g_J) must be bit-identical.
+        @test Eu153.F == 6
+        @test Eu153.g_J == Eu151.g_J
+        @test Eu153.g_F == Eu151.g_F
+        @test Eu153.mu_mag == Eu151.mu_mag
+        @test Eu153.q_geometry == Eu151.q_geometry
+        @test Eu153.nuclear_I == 5 / 2
+        @test Eu153.electronic_J == 7 / 2
+
+        # NIST/AME2020 relative atomic masses 152.9212380 / 150.9198578.
+        @test Eu153.mass / Eu151.mass ≈ 152.9212380 / 150.919857 rtol = 1e-9
+        @test Eu153.mass > Eu151.mass
+    end
+
+    @testset "Eu153 hyperfine and quadratic Zeeman" begin
+        # a_hf = -8.853 MHz vs -20.052 MHz (Sandars & Woodgate 1960, as tabulated
+        # in Zaremba-Kopczyk/Żuchowski/Tomza PRA 98, 032704 (2018) Table I).
+        # F=6 ↔ F=5 splitting = 6|a_hf| = 53.1 MHz.
+        @test Eu153.Delta_E_hf ≈ 53.1e6 * 2π * SpinorBEC.Units.HBAR rtol = 1e-9
+        @test Eu153.Delta_E_hf < Eu151.Delta_E_hf
+
+        # q ∝ 1/Δ_hf at fixed B and identical g_J/q_geometry ⇒ ¹⁵³Eu feels a
+        # ~2.3× larger quadratic Zeeman. That is the isotope's headline
+        # difference, so pin it directionally rather than by a bare number.
+        ratio = quadratic_zeeman_si(Eu153, 1e-4) / quadratic_zeeman_si(Eu151, 1e-4)
+        @test ratio ≈ Eu151.Delta_E_hf / Eu153.Delta_E_hf rtol = 1e-12
+        @test 2.2 < ratio < 2.4
+        q_hz = quadratic_zeeman_si(Eu153, 1e-4) / (2π * SpinorBEC.Units.HBAR)
+        @test 3.1e3 < q_hz < 3.4e3     # ≈ 3.3 kHz/G², vs 1.43 kHz/G² for ¹⁵¹Eu
+    end
+
+    @testset "Eu153 scattering length is an unmeasured placeholder" begin
+        # No ¹⁵³Eu measurement exists; the entry carries the ¹⁵¹Eu value of
+        # 110(4) a₀ (Miyazawa et al. PRL 129, 223401 (2022)). This test exists
+        # to make any future substitution a deliberate, documented change.
+        @test Eu153.a_s == Eu151.a_s
+        @test isempty(Eu153.scattering_lengths)
     end
 
     @testset "Hyperfine splitting for alkali" begin


### PR DESCRIPTION
The other stable europium isotope (52.19 % abundance vs 47.81 % for ¹⁵¹Eu), needed before any isotope-mixture work.

## What is shared, and why

Same ⁸S₇/₂ electronic structure and same nuclear spin $I=5/2$, so $g_J$, $\mu$, $g_F$ and the $F=6$ q-geometry factor are shared with ¹⁵¹Eu **by construction** — the tests pin them bit-identical rather than re-typing the numbers. Only two inputs differ:

| | ¹⁵¹Eu | ¹⁵³Eu |
|---|---|---|
| mass | 150.9198578 u | 152.9212380 u |
| $a_{hf}$ (⁸S₇/₂) | −20.052 MHz | −8.853 MHz |
| $\Delta_{hf}$ (F=6↔5) | 121.0 MHz | 53.1 MHz |
| $q/h$ at 1 G | 1.43 kHz/G² | ≈ 3.3 kHz/G² |

## The one consequential difference

Since $q \propto 1/\Delta_{hf}$ at fixed $B$, the halved hyperfine splitting means **¹⁵³Eu carries ~2.3× the quadratic Zeeman of ¹⁵¹Eu**. That is the isotope's only physically consequential difference at the level this code models, and the test pins it against the $\Delta_{hf}$ ratio rather than a bare number, so it cannot drift silently against the atom data.

Usefully, this is orthogonal to the unknown scattering length below — any result that turns on $q$ alone is quotable today.

## `a_s` is an explicit placeholder

The entry carries the ¹⁵¹Eu measured 110(4) $a_0$ (Miyazawa et al., PRL **129**, 223401 (2022)). **No ¹⁵³Eu measurement exists**, and Tomza's Eu+Eu ab initio work does *not* supply one: it fixes only the long range ($C_6 = 3610$ a.u. ⇒ $R_6 = 178\,a_0$) and treats $a_{S=7}$ as a free parameter scaled by $\lambda \in [0.97, 1.03]$ — quoting: *"We set the scattering lengths $a_S$ of the employed potential-energy curves by scaling them with appropriate factors $\lambda$."*

A test asserts the placeholder equals the ¹⁵¹Eu value, so replacing it has to be a deliberate, reviewed change rather than a silent edit.

## Scope note

`atom: Eu153` works in YAML immediately (`resolve_atom` is symbol-driven), but this does **not** by itself enable isotope mixtures — two-component GP is still the deferred scaffold in `docs/design/two_component_gp_design.md`. Filed as data-layer groundwork.

Also renames the file-local `_EU151_G_J` → `_EU_G_J`: the ⁸S₇/₂ g-factor is electronic and isotope-independent, and both entries now read it.

## Sources

- Hyperfine constants: P. Sandars & G. Woodgate, Proc. R. Soc. Lond. A **257**, 269 (1960), as tabulated side by side in K. Zaremba-Kopczyk, P. S. Żuchowski, M. Tomza, Phys. Rev. A **98**, 032704 (2018), arXiv:1806.02800, Table I.
- Mass: NIST/AME2020 relative atomic masses.
- ¹⁵¹Eu $a_s$: H. Miyazawa et al., Phys. Rev. Lett. **129**, 223401 (2022), arXiv:2207.11692.

## Tests

`foundation/test_atoms.jl` 277/277, `analysis/test_diagnostics.jl` 113/113, fast tier 142/142.