### PR TITLE
feat(analysis): reach superfluid_fraction from YAML, Experiment and GPU

### DIFF
--- a/docs/reference/yaml_schema_reference.md
+++ b/docs/reference/yaml_schema_reference.md
@@ -500,6 +500,7 @@ A list of analyzers, each `{<name>: <params>}`. Names include:
 - `population_history`
 - `trap_population` (radius, center) — inside-vs-outside-trap norm split; tracks atoms spilling toward the absorbing boundary
 - `cloud_shape` — center of mass, per-axis RMS widths, principal-axis widths, aspect ratio, in-plane tilt; quantifies cloud deformation across a snapshot series
+- `superfluid_fraction` (directions, method) — per-axis $f_s$ from the phase-twist free energy: `leggett` (plane-average bound), `relaxed` (full variational minimum), or `both` (default). Rigid-density, so both are upper bounds; a cloud that does not span the periodic box legitimately reports ≈ 0
 
 Full list in `src/workflow/experiments/analyzers/`.
 

--- a/src/analysis/superfluid_fraction.jl
+++ b/src/analysis/superfluid_fraction.jl
@@ -13,10 +13,11 @@ export superfluid_fraction, plane_averaged_density
 #
 #     f_s = min_u ∫ n |ê_d + ∇u|² dV / ∫ n dV
 #
-# The density is held rigid, which makes f_s an upper bound on the true
-# superfluid fraction. Restricting u to depend on x_d alone gives Leggett's
-# closed form — a further upper bound, and the quantity usually reported for
-# supersolids.
+# The density is held rigid — exact at O(q²) within mean field, since the
+# untwisted state is stationary and the density response therefore only reaches
+# the energy at O(q⁴). Restricting u to depend on x_d alone gives Leggett's
+# closed form: a genuine upper bound on the above, and the quantity usually
+# reported for supersolids.
 
 """
     plane_averaged_density(n, d) -> Vector{Float64}
@@ -72,8 +73,17 @@ total density) or a bare density array `n`.
     the grid is coarse, not that the density reroutes flow. Only a gap well
     above that scale is physics. Refine until the gap stops shrinking.
 
-Both branches hold the density rigid, so both are upper bounds on the true
-superfluid fraction.
+Both branches hold the density rigid. Within Gross–Pitaevskii mean field that
+costs nothing at the order that matters: the density response to the twist is
+O(q²), and because the untwisted state is stationary that response only reaches
+the energy at O(q⁴) — so `f_s`, an O(q²) quantity, is *exact*, not an upper
+bound. `test_superfluid_fraction_gp_twist.jl` checks this against a direct
+twisted-boundary-condition GP minimisation across f_s from 1.5e-4 to 0.53.
+
+The upper-bound caveat belongs one level up, beyond mean field: a one-body
+phase cannot represent correlated backflow. That gap is where the long-standing
+solid-⁴He discrepancy lives — the Leggett bound gives ~20 % where experiment
+found ~1 %.
 
 The twist is only meaningful when the cloud connects to itself across the
 periodic box. A trapped cloud surrounded by vacuum has no phase rigidity along

--- a/src/analysis/superfluid_fraction.jl
+++ b/src/analysis/superfluid_fraction.jl
@@ -24,7 +24,7 @@ export superfluid_fraction, plane_averaged_density
 Density averaged over the hyperplane perpendicular to axis `d`,
 n̄(x_d) = ⟨n⟩_{other axes}.
 """
-function plane_averaged_density(n::AbstractArray{Float64, N}, d::Int) where {N}
+function plane_averaged_density(n::AbstractArray{<:Real, N}, d::Int) where {N}
     1 <= d <= N || throw(ArgumentError("direction $d outside 1:$N"))
     nd = size(n, d)
     nbar = zeros(Float64, nd)
@@ -62,6 +62,16 @@ total density) or a bare density array `n`.
   `f_s(:relaxed) ≤ f_s(:leggett)`, with equality when the density is modulated
   along `d` only.
 
+!!! warning "Comparing the two branches at a fixed grid"
+    That inequality is a *continuum* statement. `:leggett` is a trapezoid sum
+    over a periodic analytic integrand and is spectrally accurate; `:relaxed`
+    is a second-order finite-volume solve whose truncation error is positive —
+    it approaches the true value from above, by roughly `(k·dx)²` scaled by the
+    density contrast (~1e-4 at 128 points and contrast 0.5, ~8e-3 at 64 points
+    and contrast 0.99). So a *small* excess of `:relaxed` over `:leggett` means
+    the grid is coarse, not that the density reroutes flow. Only a gap well
+    above that scale is physics. Refine until the gap stops shrinking.
+
 Both branches hold the density rigid, so both are upper bounds on the true
 superfluid fraction.
 
@@ -87,12 +97,12 @@ function superfluid_fraction(
     maxiter::Int=0,
 ) where {N}
     superfluid_fraction(
-        total_density(psi, N), grid; direction, method, warn_vacuum, rtol, maxiter
+        total_density(_to_host(psi), N), grid; direction, method, warn_vacuum, rtol, maxiter
     )
 end
 
 function superfluid_fraction(
-    n::AbstractArray{Float64, N},
+    n_any::AbstractArray{<:Real, N},
     grid::Grid{N};
     direction::Int=1,
     method::Symbol=:leggett,
@@ -101,6 +111,10 @@ function superfluid_fraction(
     maxiter::Int=0,
 ) where {N}
     1 <= direction <= N || throw(ArgumentError("direction $direction outside 1:$N"))
+    # Every loop below scalar-indexes, so a device array has to come home; the
+    # widening also accepts the Float32 densities the mixed-precision path
+    # produces, which the solve then carries in Float64.
+    n = convert(Array{Float64, N}, _to_host(n_any))
     all(>=(0.0), n) || throw(ArgumentError("density must be non-negative"))
 
     nbar = plane_averaged_density(n, direction)
@@ -139,7 +153,14 @@ end
     CartesianIndex(ntuple(e -> e == d ? (fwd ? _fwd(I[e], np[e]) : _bwd(I[e], np[e])) : I[e], N))
 end
 
-# Face densities n_{i+1/2} in each direction (arithmetic mean of the two cells).
+# Face densities n_{i+1/2} in each direction, as the ARITHMETIC mean of the two
+# cells. Harmonic averaging — the usual finite-volume choice for a
+# discontinuous coefficient — is wrong here: it satisfies Σ 1/n_face = Σ 1/n
+# but breaks Σ n_face = Σ n, and that second identity is what makes the
+# rigid-flow reference in the f_s ratio consistent with the flux. Concretely, a
+# blob of 21 filled cells surrounded by vacuum has 20 harmonic faces against 21
+# cells of mass and reports f_s = 1/21 instead of the correct 0. Arithmetic
+# faces give the two half-weight edge faces that close the sum exactly.
 function _face_densities(n::AbstractArray{Float64, N}, np::NTuple{N, Int}) where {N}
     ntuple(N) do d
         nf = similar(n)
@@ -172,16 +193,15 @@ function _apply_flux_laplacian!(
 end
 
 function _superfluid_fraction_relaxed(
-    n::AbstractArray{Float64, N},
+    nd::Array{Float64, N},
     grid::Grid{N},
     d0::Int,
     rtol::Float64,
     maxiter::Int,
 ) where {N}
     np = grid.config.n_points
-    size(n) == np || throw(ArgumentError("density size $(size(n)) ≠ grid $(np)"))
+    size(nd) == np || throw(ArgumentError("density size $(size(nd)) ≠ grid $(np)"))
 
-    nd = convert(Array{Float64, N}, n)
     nf = _face_densities(nd, np)
     inv_dx2 = ntuple(d -> 1.0 / grid.dx[d]^2, N)
     inv_dx0 = 1.0 / grid.dx[d0]

--- a/src/workflow/experiment_observables.jl
+++ b/src/workflow/experiment_observables.jl
@@ -289,3 +289,26 @@ function _ensemble_peaks(exp::Experiment)
         ))
     end
 end
+
+"""
+    superfluid_fraction(exp; direction=1, method=:leggett) -> Float64
+    superfluid_fraction(exp, t; direction=1, method=:leggett) -> Float64
+
+Translational superfluid fraction of the run's stored state — the final ψ for
+the no-`t` form, the snapshot nearest `t` otherwise. Adds the `Experiment`
+faces of `superfluid_fraction(psi, grid; …)`; all keywords pass through, so
+the caveats there apply unchanged (rigid density ⇒ upper bound; a cloud that
+does not span the periodic box legitimately reports ≈ 0).
+
+Grid comes from the run's own `RunResult`, so the value is reproducible from
+the jld2 alone.
+"""
+superfluid_fraction(exp::Experiment; kwargs...) =
+    let r = _runresult(exp)
+        superfluid_fraction(r.psi, r.grid; kwargs...)
+    end
+
+function superfluid_fraction(exp::Experiment, t::Real; kwargs...)
+    grid = _runresult(exp).grid
+    superfluid_fraction(psi(exp, float(t)), grid; kwargs...)
+end

--- a/src/workflow/experiments/analyzers/spectroscopy.jl
+++ b/src/workflow/experiments/analyzers/spectroscopy.jl
@@ -171,3 +171,53 @@ function _analyze_droplet_profile(psi, grid, atom, params, ws_prev)
         surface_sharpness=sharpness,
         peak_index=collect(peak_idx))
 end
+
+"""
+    _analyze_superfluid_fraction(psi, grid, atom, params, ws_prev) -> NamedTuple
+
+Translational superfluid fraction from the phase-twist free energy, per axis.
+The supersolid counterpart of `droplet_profile`: `droplet_profile` says how
+modulated the density is, this says what that modulation costs in phase
+rigidity.
+
+YAML usage:
+
+    analyze:
+      - superfluid_fraction: {}                          # all axes, both methods
+      - superfluid_fraction: {directions: [1], method: leggett}
+
+Params:
+- `directions` — list of axes (1-based). Default: every spatial axis.
+- `method` — `leggett` (plane-average bound), `relaxed` (full variational
+  minimum), or `both` (default).
+
+Returns `(directions, f_s_leggett, f_s_relaxed)`; the branch that was not
+requested comes back as `NaN`. Both branches hold the density rigid and are
+therefore upper bounds — see `superfluid_fraction` for the caveats, in
+particular that a trapped cloud with vacuum at the box edge legitimately
+reports ≈ 0.
+"""
+function _analyze_superfluid_fraction(psi, grid, atom, params, ws_prev)
+    ndim = length(grid.config.n_points)
+    dirs = Int.(get(params, "directions", collect(1:ndim)))
+    all(d -> 1 <= d <= ndim, dirs) ||
+        throw(ArgumentError("superfluid_fraction: directions must lie in 1:$ndim"))
+    method = Symbol(get(params, "method", "both"))
+    method in (:leggett, :relaxed, :both) || throw(
+        ArgumentError("superfluid_fraction: method must be leggett, relaxed or both")
+    )
+
+    n = total_density(psi, ndim)
+    want_leggett = method === :leggett || method === :both
+    want_relaxed = method === :relaxed || method === :both
+
+    f_leg = [
+        want_leggett ? superfluid_fraction(n, grid; direction=d, method=:leggett) : NaN
+        for d in dirs
+    ]
+    f_rel = [
+        want_relaxed ? superfluid_fraction(n, grid; direction=d, method=:relaxed) : NaN
+        for d in dirs
+    ]
+    (directions=collect(dirs), f_s_leggett=f_leg, f_s_relaxed=f_rel)
+end

--- a/src/workflow/experiments/pipeline/pipeline_analyzers.jl
+++ b/src/workflow/experiments/pipeline/pipeline_analyzers.jl
@@ -15,7 +15,7 @@ using JSON
 #   analyzers/topology.jl      ← winding_map, winding_field, monopole_charge,
 #                                 vortex_detect, skyrmion_density, non_abelian_homotopy
 #   analyzers/spectroscopy.jl  ← bragg_spectroscopy, droplet_profile,
-#                                 correlation_length, defect_density,
+#                                 correlation_length, superfluid_fraction, defect_density,
 #                                 kibble_zurek_stats, domain_analysis
 #   analyzers/stability.jl     ← stability, bogoliubov, bogoliubov_dispersion,
 #                                 _run_bogoliubov_analyzer
@@ -69,6 +69,8 @@ function _run_analyzer(name::Symbol, psi, grid, atom, params; ws_prev=nothing,
         return _analyze_vortex_detect(psi, grid, atom, params, ws_prev)
     elseif name == :correlation_length
         return _analyze_correlation_length(psi, grid, atom, params, ws_prev)
+    elseif name == :superfluid_fraction
+        return _analyze_superfluid_fraction(psi, grid, atom, params, ws_prev)
     elseif name == :defect_density
         return _analyze_defect_density(psi, grid, atom, params, ws_prev)
     elseif name == :kibble_zurek_stats
@@ -114,7 +116,7 @@ function _run_analyzer(name::Symbol, psi, grid, atom, params; ws_prev=nothing,
         "winding_map, absorption_image, sg_tof, forward_image, " *
         "domain_analysis, skyrmion_density, " *
         "phase_contrast_image, momentum_distribution, vortex_detect, " *
-        "correlation_length, defect_density, kibble_zurek_stats, " *
+        "correlation_length, superfluid_fraction, defect_density, kibble_zurek_stats, " *
         "bragg_spectroscopy, droplet_profile, bogoliubov_dispersion, " *
         "bogoliubov_mode, skyrmion_detect, synthetic_dim, non_abelian_homotopy, " *
         "monopole_charge, majorana_order, winding_field, rosensweig_pattern, " *

--- a/src/workflow/validation/scalar_summary.jl
+++ b/src/workflow/validation/scalar_summary.jl
@@ -24,7 +24,7 @@ export run_scalar_summary, write_run_summary,
 const RUN_SUMMARY_FILENAME = "summary.json"
 # Bump when extraction logic changes so stale summaries (older extractor)
 # can be targeted for re-backfill via `_extractor_version`.
-const RUN_SUMMARY_EXTRACTOR_VERSION = "2"  # v2: + rotation-invariant mF
+const RUN_SUMMARY_EXTRACTOR_VERSION = "3"  # v3: + per-axis f_s (Leggett)
 
 # Run `f()`; on exception record "field: reason" in `errs` and return
 # `missing`. A `nothing` / non-finite result is treated as legitimately
@@ -51,6 +51,8 @@ wavefunction + metadata. Never throws. Keys appear only when extractable:
   energy, converged          — ground-state metadata / e_decomp / dynamics
   norm, Mz                   — computed from psi (deterministic)
   populations                — per-component |c_m|² fractions (Vector)
+  f_s_leggett                — per-axis superfluid fraction (Vector); present
+                               only when the cloud spans the periodic box
   norm_rel_drift,
   energy_rel_drift, Fz_drift — dynamics runs only
 
@@ -117,6 +119,38 @@ function run_scalar_summary(r::RunResult)
                 real(dot(z, sm.Fx * z))^2 + real(dot(z, sm.Fy * z))^2 +
                 real(dot(z, sm.Fz * z))^2,
             ) / F
+        end,
+    )
+
+    # Per-axis superfluid fraction, Leggett branch only: it is a closed form
+    # costing milliseconds, whereas the `:relaxed` solve is ~1.8 s at 128³ per
+    # axis — too heavy for a projection meant to be cheap enough to backfill
+    # over hundreds of runs.
+    #
+    # Present ONLY when the cloud spans the box along every axis. A trapped
+    # cloud surrounded by vacuum has no phase rigidity across the box, so its
+    # f_s ≈ 0 is geometry rather than a property of the state; writing that into
+    # every summary would put a column of zeros in front of a scan that could
+    # read them as signal. Absent is the honest value, and this file already
+    # keeps "absent" distinct from "errored".
+    bag["f_s_leggett"] = _try_field(
+        errs,
+        "f_s_leggett",
+        () -> begin
+            ndim = ndims(r.psi) - 1
+            n = total_density(r.psi, ndim)
+            vals = Float64[]
+            for d in 1:ndim
+                nbar = plane_averaged_density(n, d)
+                n_mean = sum(nbar) / length(nbar)
+                n_mean > 0 || return missing
+                minimum(nbar) > 1e-3 * n_mean || return missing
+                push!(
+                    vals,
+                    superfluid_fraction(n, r.grid; direction=d, warn_vacuum=false),
+                )
+            end
+            vals
         end,
     )
 

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -113,6 +113,7 @@ const FAST_TESTS = [
     "foundation/test_types_validation.jl",
     "analysis/test_currents.jl",
     "analysis/test_superfluid_fraction.jl",
+    "analysis/test_superfluid_fraction_gp_twist.jl",
     "hamiltonian/test_lhy_2d.jl",
     "analysis/test_bogoliubov_enhanced.jl",
     "hamiltonian/test_spinor_lhy.jl",

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -361,6 +361,7 @@ const FULL_EXTRA = [
     "workflow/test_calibration_drift.jl",
     "workflow/test_dynamics_knobs.jl",
     "gpu/test_cuda_equivalence.jl",
+    "gpu/test_superfluid_fraction_gpu.jl",
     "hamiltonian/test_tdhfb_gpu_phase5ab.jl",
     "hamiltonian/test_tdhfb_gpu_phase5c_expm.jl",
     "hamiltonian/test_tdhfb_gpu_phase5c_hf.jl",

--- a/test/analysis/test_superfluid_fraction.jl
+++ b/test/analysis/test_superfluid_fraction.jl
@@ -24,24 +24,37 @@ _fs_cosine(A) = sqrt(1 - A^2)
         for A in (0.0, 0.3, 0.6, 0.9)
             n = [1.0 + A * cos(k * x) for x in grid.x[1]]
             # The Leggett branch is a trapezoid sum of 1/n̄ over a period, which
-            # converges geometrically in the point count; the relaxed branch is
-            # a second-order finite-volume solve.
+            # converges geometrically in the point count.
             @test superfluid_fraction(n, grid) ≈ _fs_cosine(A) rtol = 1e-8
             @test superfluid_fraction(n, grid; method=:relaxed) ≈ _fs_cosine(A) rtol = 5e-3
         end
     end
 
-    @testset "relaxed branch is second-order in dx" begin
-        L = 10.0
+    @testset "relaxed converges to Leggett from above, second order" begin
+        # Axis-only modulation ⇒ no transverse rerouting ⇒ the two branches
+        # describe the same continuum number, and any gap is the relaxed
+        # branch's truncation error. Pinning both the sign (always above) and
+        # the order (dx²) is what lets a user tell discretisation from physics
+        # when the two disagree on a real state.
+        L = 7.0
         A = 0.9
         k = 2π / L
-        err = map((32, 64, 128)) do npt
+        gaps = map((32, 64, 128)) do npt
             grid = make_grid(GridConfig(npt, L))
             n = [1.0 + A * cos(k * x) for x in grid.x[1]]
-            abs(superfluid_fraction(n, grid; method=:relaxed) - _fs_cosine(A))
+            superfluid_fraction(n, grid; method=:relaxed) -
+            superfluid_fraction(n, grid; method=:leggett)
         end
-        @test err[1] / err[2] > 3.5
-        @test err[2] / err[3] > 3.5
+        @test all(gaps .> 0)                        # one-sided truncation error
+        @test gaps[1] / gaps[2] > 3.5               # second order
+        @test gaps[2] / gaps[3] > 3.5
+        @test gaps[3] < 1e-3                        # and small once resolved
+
+        # Same in 3D when only the flow axis is modulated.
+        grid3 = make_grid(GridConfig((64, 8, 8), (L, 4.0, 4.0)))
+        n3 = [1.0 + 0.8 * cos(k * x) for x in grid3.x[1], _ in grid3.x[2], _ in grid3.x[3]]
+        @test superfluid_fraction(n3, grid3; method=:relaxed) ≈
+            superfluid_fraction(n3, grid3; method=:leggett) rtol = 5e-3
     end
 
     @testset "f_s decreases monotonically with contrast" begin
@@ -100,6 +113,8 @@ _fs_cosine(A) = sqrt(1 - A^2)
             for d in 1:3
                 f_l = superfluid_fraction(n, grid; direction=d)
                 f_r = superfluid_fraction(n, grid; direction=d, method=:relaxed)
+                # Genuinely 3D structure, so rerouting dominates the relaxed
+                # branch's positive truncation error and the ordering shows.
                 @test 0.0 <= f_r <= f_l <= 1.0 + 1e-10
             end
         end
@@ -135,6 +150,43 @@ _fs_cosine(A) = sqrt(1 - A^2)
             (3 + 6 + 9 + 12) / 4]
         @test plane_averaged_density(n, 2) ≈ [2.0, 5.0, 8.0, 11.0]
         @test_throws ArgumentError plane_averaged_density(n, 3)
+    end
+
+    @testset "YAML analyzer face" begin
+        grid = make_grid(GridConfig((16, 16), (6.0, 6.0)))
+        kx = 2π / 6.0
+        psi = zeros(ComplexF64, 16, 16, 3)
+        for (i, x) in enumerate(grid.x[1]), j in 1:16
+            psi[i, j, 2] = sqrt(1.0 + 0.7 * cos(kx * x))
+        end
+
+        r = SpinorBEC._run_analyzer(
+            :superfluid_fraction, psi, grid, Rb87, Dict{String, Any}()
+        )
+        @test r.directions == [1, 2]
+        # Modulated along x only: axis 1 is impeded, axis 2 is free.
+        @test r.f_s_leggett[1] ≈ _fs_cosine(0.7) rtol = 1e-3
+        @test r.f_s_leggett[2] ≈ 1.0 atol = 1e-12
+        @test r.f_s_relaxed[2] ≈ 1.0 atol = 1e-12
+        @test all(0.0 .< r.f_s_relaxed .<= 1.0 + 1e-10)
+
+        # `method` selects a branch; the other comes back NaN, not silently 0.
+        r_l = SpinorBEC._run_analyzer(
+            :superfluid_fraction, psi, grid, Rb87,
+            Dict{String, Any}("method" => "leggett", "directions" => [1]),
+        )
+        @test r_l.directions == [1]
+        @test isfinite(r_l.f_s_leggett[1])
+        @test isnan(r_l.f_s_relaxed[1])
+
+        @test_throws ArgumentError SpinorBEC._run_analyzer(
+            :superfluid_fraction, psi, grid, Rb87,
+            Dict{String, Any}("method" => "bogus"),
+        )
+        @test_throws ArgumentError SpinorBEC._run_analyzer(
+            :superfluid_fraction, psi, grid, Rb87,
+            Dict{String, Any}("directions" => [3]),
+        )
     end
 
     @testset "argument validation" begin

--- a/test/analysis/test_superfluid_fraction_gp_twist.jl
+++ b/test/analysis/test_superfluid_fraction_gp_twist.jl
@@ -1,0 +1,135 @@
+# Type-B gate for `superfluid_fraction`: the rigid-density variational value vs
+# a direct twisted-boundary-condition GP minimisation.
+#
+# `superfluid_fraction` freezes the density and relaxes only the phase. The
+# obvious worry is that a real condensate also redistributes its density under
+# the twist, making the reported number a loose upper bound. It does not, at
+# the order that matters: the density response is O(q²), and because the
+# untwisted state is stationary its energy cost enters at O(q⁴), leaving f_s —
+# an O(q²) quantity — exact within mean field. This file checks that claim
+# numerically instead of asserting it.
+#
+# The reference below is written out longhand: its own imaginary-time
+# split-step, its own energy functional, no call into the production
+# propagator. Twisted BCs ψ(x+L) = e^{iθ}ψ(x) are gauged into ψ = e^{iqx}φ with
+# q = θ/L and φ periodic, so the twist appears only as k → k + q.
+
+using Test
+using SpinorBEC
+using FFTW
+
+function _gp_energy_twisted(phi, kx, V, g, q, dx)
+    phik = fft(phi)
+    npt = length(phi)
+    e_kin = 0.5 * sum(abs2.(phik) .* (kx .+ q) .^ 2) * dx / npt
+    e_pot = sum(V .* abs2.(phi)) * dx
+    e_int = 0.5 * g * sum(abs2.(phi) .^ 2) * dx
+    e_kin + e_pot + e_int
+end
+
+# Imaginary-time split-step ground state of the twisted 1D scalar GP.
+function _gp_twisted(; npt, L, V0, m_lat, g, q, dt=5e-3, n_steps=80_000, tol=1e-13)
+    dx = L / npt
+    x = collect(0:(npt - 1)) .* dx .- L / 2
+    kx = 2π .* fftfreq(npt, 1 / dx)
+    V = V0 .* cos.(2π * m_lat .* x ./ L)
+
+    phi = ones(ComplexF64, npt)
+    phi ./= sqrt(sum(abs2, phi) * dx)
+    kin = exp.(-0.5 * dt .* (kx .+ q) .^ 2)
+
+    E_prev = Inf
+    for step in 1:n_steps
+        @. phi *= exp(-0.5 * dt * (V + g * abs2(phi)))
+        phi = ifft(kin .* fft(phi))
+        @. phi *= exp(-0.5 * dt * (V + g * abs2(phi)))
+        phi ./= sqrt(sum(abs2, phi) * dx)
+        if step % 500 == 0
+            E = _gp_energy_twisted(phi, kx, V, g, q, dx)
+            abs(E - E_prev) < tol * max(1.0, abs(E)) && break
+            E_prev = E
+        end
+    end
+    (E=_gp_energy_twisted(phi, kx, V, g, q, dx), n=abs2.(phi))
+end
+
+# f_s = 2(E(q) − E(0)) / q², Richardson-extrapolated in q so the O(q²)
+# correction to the quadratic response cancels.
+function _fs_by_twist(; L, theta1=0.05, theta2=0.1, kwargs...)
+    E0 = _gp_twisted(; L, q=0.0, kwargs...).E
+    q1, q2 = theta1 / L, theta2 / L
+    f1 = 2 * (_gp_twisted(; L, q=q1, kwargs...).E - E0) / q1^2
+    f2 = 2 * (_gp_twisted(; L, q=q2, kwargs...).E - E0) / q2^2
+    (f=(4 * f1 - f2) / 3, dq=abs(f1 - f2))
+end
+
+@testset "Superfluid fraction vs twisted-BC GP (type B)" begin
+    L = 10.0
+    npt = 128
+    grid = make_grid(GridConfig(npt, L))
+
+    @testset "no lattice ⇒ f_s = 1 exactly" begin
+        # Sanity anchor for the reference itself: a uniform condensate carries
+        # the full rigid-flow energy, interactions or not.
+        for g in (0.0, 5.0)
+            r = _fs_by_twist(; L, npt, V0=0.0, m_lat=2, g)
+            @test r.f ≈ 1.0 rtol = 1e-6
+        end
+    end
+
+    @testset "rigid density is exact within mean field" begin
+        # Spans f_s over three and a half decades, from a weakly corrugated
+        # condensate to nearly isolated droplets.
+        cases = [
+            (V0=1.0, g=0.0), (V0=1.0, g=5.0), (V0=3.0, g=5.0), (V0=6.0, g=2.0)
+        ]
+        for c in cases
+            r = _fs_by_twist(; L, npt, m_lat=2, c.V0, c.g)
+            gs = _gp_twisted(; L, npt, m_lat=2, c.V0, c.g, q=0.0)
+
+            f_leggett = superfluid_fraction(gs.n, grid; method=:leggett)
+            f_relaxed = superfluid_fraction(gs.n, grid; method=:relaxed)
+
+            # 1D, so there is no transverse rerouting and the two branches
+            # describe the same number. `:leggett` is spectrally accurate and
+            # carries the claim; `:relaxed` adds its own one-sided O(dx²)
+            # error, larger in relative terms where f_s is small and the
+            # density is sharply peaked (see the refinement check below).
+            @test f_leggett ≈ r.f rtol = 5e-3
+            @test 0 <= (f_relaxed - r.f) / r.f < 5e-2
+            # The q-extrapolation has to be converged for the above to mean
+            # anything.
+            @test r.dq < 1e-3 * max(r.f, 1e-3)
+        end
+    end
+
+    @testset "the relaxed branch's residual is discretisation, not physics" begin
+        # Hardest case above (f_s ≈ 2e-2, sharply peaked). If the excess were a
+        # real rigid-density bias it would survive refinement; it should instead
+        # fall like dx².
+        V0, g = 3.0, 5.0
+        ref = _fs_by_twist(; L, npt=256, m_lat=2, V0, g).f
+        excess = map((64, 128, 256)) do np
+            gs = _gp_twisted(; L, npt=np, m_lat=2, V0, g, q=0.0)
+            g_np = make_grid(GridConfig(np, L))
+            superfluid_fraction(gs.n, g_np; method=:relaxed) - ref
+        end
+        @test all(excess .> 0)
+        @test excess[1] / excess[2] > 3.0
+        @test excess[2] / excess[3] > 3.0
+    end
+
+    @testset "a loose upper bound would have shown up as a one-sided gap" begin
+        # If density relaxation mattered at O(q²) the direct value would sit
+        # systematically BELOW the rigid-density one. Check the residuals are
+        # not one-sided at the 5e-3 level across the same cases.
+        residuals = map([
+            (V0=1.0, g=0.0), (V0=1.0, g=5.0), (V0=3.0, g=5.0), (V0=6.0, g=2.0)
+        ]) do c
+            r = _fs_by_twist(; L, npt, m_lat=2, c.V0, c.g)
+            gs = _gp_twisted(; L, npt, m_lat=2, c.V0, c.g, q=0.0)
+            (superfluid_fraction(gs.n, grid; method=:leggett) - r.f) / r.f
+        end
+        @test maximum(abs, residuals) < 5e-3
+    end
+end

--- a/test/gpu/test_superfluid_fraction_gpu.jl
+++ b/test/gpu/test_superfluid_fraction_gpu.jl
@@ -1,0 +1,50 @@
+# superfluid_fraction on a device array.
+#
+# Every loop in the implementation scalar-indexes, so a CuArray ψ would throw
+# under CUDA's scalar-indexing guard unless the entry point brings it home.
+# Analyzers get hosted by `_run_analyzer`, but the direct call is public API
+# and has to stand on its own. Gated on CUDA.functional(); a no-op on CPU-only
+# machines, load-bearing wherever a GPU runner exists.
+
+using SpinorBEC
+using Test
+
+@testset "superfluid_fraction on device arrays (gated)" begin
+    cuda_available = try
+        import CUDA
+        CUDA.functional()
+    catch
+        false
+    end
+
+    if !cuda_available
+        @info "CUDA not functional — superfluid_fraction GPU test skipped"
+        @test true
+        return nothing
+    end
+
+    grid = make_grid(GridConfig((32, 16, 16), (10.0, 6.0, 6.0)))
+    k = 2π / 10.0
+    A = 0.6
+    psi_h = zeros(ComplexF64, 32, 16, 16, 3)
+    for (i, x) in enumerate(grid.x[1]), j in 1:16, l in 1:16
+        psi_h[i, j, l, 2] = sqrt(1.0 + A * cos(k * x))
+    end
+    n_h = SpinorBEC.total_density(psi_h, 3)
+
+    psi_d = CUDA.CuArray(psi_h)
+    n_d = CUDA.CuArray(n_h)
+    # `cu` downcasts to Float32 — the mixed-precision (`dtype: f32`) path — so
+    # the entry point has to accept a Float32 density too, not only Float64.
+    psi_d32 = CUDA.cu(psi_h)
+
+    for method in (:leggett, :relaxed)
+        host = superfluid_fraction(psi_h, grid; method)
+        @test superfluid_fraction(psi_d, grid; method) ≈ host rtol = 1e-12
+        @test superfluid_fraction(n_d, grid; method) ≈ host rtol = 1e-12
+        @test superfluid_fraction(psi_d32, grid; method) ≈ host rtol = 1e-5
+    end
+
+    # The analytic anchor still has to hold through the device path.
+    @test superfluid_fraction(psi_d, grid) ≈ sqrt(1 - A^2) rtol = 1e-8
+end

--- a/test/workflow/validation/test_scalar_summary.jl
+++ b/test/workflow/validation/test_scalar_summary.jl
@@ -44,6 +44,39 @@ end
         @test haskey(s, "norm") && haskey(s, "Mz") && haskey(s, "populations")
     end
 
+    @testset "f_s_leggett appears only for box-spanning states" begin
+        # The default fixture puts all the weight in one voxel — a maximally
+        # disconnected "cloud". f_s would be 0 by geometry, so the key must be
+        # absent rather than a zero a scan could read as signal.
+        s = run_scalar_summary(_summary_fixture())
+        @test !haskey(s, "f_s_leggett")
+        @test !any(startswith.(s["extraction_error"], "f_s_leggett"))  # absent ≠ error
+
+        # A uniform state spans the box and is fully superfluid on every axis.
+        grid = make_grid(GridConfig((8, 8), (4.0, 4.0)))
+        atom = AtomSpecies("test", 1.0e-26, 1, 0.0, 0.0, 0.0)
+        psi = zeros(ComplexF64, 8, 8, 3)
+        psi[:, :, 1] .= 1.0 / 8
+        r = RunResult("/tmp/fake.jld2", psi, grid, atom, InteractionParams(Dict(0 => 1.0)))
+        s = run_scalar_summary(r)
+        @test haskey(s, "f_s_leggett")
+        @test length(s["f_s_leggett"]) == 2
+        @test all(≈(1.0; atol=1e-12), s["f_s_leggett"])
+
+        # Modulated along x only: axis 1 impeded by √(1−A²), axis 2 free.
+        A = 0.6
+        kx = 2π / 4.0
+        psi_m = zeros(ComplexF64, 8, 8, 3)
+        for (i, x) in enumerate(grid.x[1])
+            psi_m[i, :, 1] .= sqrt(1.0 + A * cos(kx * x)) / 8
+        end
+        s = run_scalar_summary(
+            RunResult("/tmp/fake.jld2", psi_m, grid, atom, InteractionParams(Dict(0 => 1.0)))
+        )
+        @test s["f_s_leggett"][1] ≈ sqrt(1 - A^2) rtol = 1e-2
+        @test s["f_s_leggett"][2] ≈ 1.0 atol = 1e-12
+    end
+
     @testset "with dynamics → drift keys present" begin
         dyn = DynamicsTimeSeries([0.0, 0.5, 1.0], [1.0, 1.0, 0.99],
             [-6.0, -5.9, -5.8], [-6.0, -5.95, -5.9])


### PR DESCRIPTION
Stacked on #99.

The metric landed in #99 with **no route into a production run** — no `analyze:` entry, no `Experiment` observable, and it threw on a device array. This adds the three faces, plus one discretisation fix the new tests forced out.

## Reachability

- **`superfluid_fraction` analyzer** (`spectroscopy.jl` + `_run_analyzer` branch). Per-axis; `method` ∈ `{leggett, relaxed, both}`; the unselected branch returns `NaN` rather than a silent `0`.
  ```yaml
  analyze:
    - superfluid_fraction: {}                          # all axes, both methods
    - superfluid_fraction: {directions: [1], method: leggett}
  ```
- **`superfluid_fraction(exp)` / `(exp, t)`** observables. Grid comes from the run's own `RunResult`, so the value is reproducible from the jld2 alone.
- **Device arrays.** Every loop scalar-indexes, so the entry point hosts first. The density face also widens `Float64` → `Real`, which the mixed-precision (`dtype: f32`) path needs; the solve still runs in `Float64`.

## Discretisation fix: face densities stay arithmetic

Harmonic face averaging was tried. It is the textbook choice for a discontinuous coefficient, and it makes $\sum 1/n_{\text{face}} = \sum 1/n$ hold exactly — but it breaks $\sum n_{\text{face}} = \sum n$, and *that* is the identity the $f_s$ ratio needs.

The disconnected-cloud test caught it immediately: a 21-cell blob in vacuum has 20 harmonic faces against 21 cells of mass, and reports $f_s = 1/21$ instead of the correct 0. Arithmetic faces supply the two half-weight edge faces that close the sum. Both the reasoning and the counterexample now live in the source comment so the "obvious" harmonic switch does not get made again.

## Corrected claim: the branch ordering is a continuum statement

That same experiment showed the ordering claim in #99 was too strong. `:leggett` is a spectrally accurate trapezoid sum; `:relaxed` is second-order with a **one-sided positive** truncation error. So at coarse `dx` the relaxed branch legitimately sits slightly *above* the bound — 1e-4 at 128 points / contrast 0.5, 8e-3 at 64 points / contrast 0.99.

A test now pins both the sign and the order of that gap, and the docstring carries the numbers, so a user can tell discretisation from transverse rerouting when the two branches disagree. Without this, someone would have read a coarse-grid excess as physics.

## Measured before optimising

`:relaxed` at 128³ is **1.8 s**, and the cost is flat in density contrast (0.21 s → 0.25 s going from contrast 0.2 to 0.99 at 64³). The FFT preconditioner this was expected to need is **not needed** — the planned optimisation is cancelled rather than written.

| grid | `:relaxed` |
|---|---|
| 32³ | 0.006 s |
| 64³ | 0.25 s |
| 96³ | 0.79 s |
| 128³ | 1.80 s |

## Tests

`analysis/test_superfluid_fraction.jl` 55/55 · `gpu/test_superfluid_fraction_gpu.jl` 7/7 on a live device (F64 and F32 paths) · tier membership 33/33 · fast tier 142/142.