### PR TITLE
feat(summary): summary.json carries per-axis superfluid fraction

### DIFF
--- a/src/workflow/validation/scalar_summary.jl
+++ b/src/workflow/validation/scalar_summary.jl
@@ -24,7 +24,7 @@ export run_scalar_summary, write_run_summary,
 const RUN_SUMMARY_FILENAME = "summary.json"
 # Bump when extraction logic changes so stale summaries (older extractor)
 # can be targeted for re-backfill via `_extractor_version`.
-const RUN_SUMMARY_EXTRACTOR_VERSION = "2"  # v2: + rotation-invariant mF
+const RUN_SUMMARY_EXTRACTOR_VERSION = "3"  # v3: + per-axis f_s (Leggett)
 
 # Run `f()`; on exception record "field: reason" in `errs` and return
 # `missing`. A `nothing` / non-finite result is treated as legitimately
@@ -51,6 +51,8 @@ wavefunction + metadata. Never throws. Keys appear only when extractable:
   energy, converged          — ground-state metadata / e_decomp / dynamics
   norm, Mz                   — computed from psi (deterministic)
   populations                — per-component |c_m|² fractions (Vector)
+  f_s_leggett                — per-axis superfluid fraction (Vector); present
+                               only when the cloud spans the periodic box
   norm_rel_drift,
   energy_rel_drift, Fz_drift — dynamics runs only
 
@@ -117,6 +119,38 @@ function run_scalar_summary(r::RunResult)
                 real(dot(z, sm.Fx * z))^2 + real(dot(z, sm.Fy * z))^2 +
                 real(dot(z, sm.Fz * z))^2,
             ) / F
+        end,
+    )
+
+    # Per-axis superfluid fraction, Leggett branch only: it is a closed form
+    # costing milliseconds, whereas the `:relaxed` solve is ~1.8 s at 128³ per
+    # axis — too heavy for a projection meant to be cheap enough to backfill
+    # over hundreds of runs.
+    #
+    # Present ONLY when the cloud spans the box along every axis. A trapped
+    # cloud surrounded by vacuum has no phase rigidity across the box, so its
+    # f_s ≈ 0 is geometry rather than a property of the state; writing that into
+    # every summary would put a column of zeros in front of a scan that could
+    # read them as signal. Absent is the honest value, and this file already
+    # keeps "absent" distinct from "errored".
+    bag["f_s_leggett"] = _try_field(
+        errs,
+        "f_s_leggett",
+        () -> begin
+            ndim = ndims(r.psi) - 1
+            n = total_density(r.psi, ndim)
+            vals = Float64[]
+            for d in 1:ndim
+                nbar = plane_averaged_density(n, d)
+                n_mean = sum(nbar) / length(nbar)
+                n_mean > 0 || return missing
+                minimum(nbar) > 1e-3 * n_mean || return missing
+                push!(
+                    vals,
+                    superfluid_fraction(n, r.grid; direction=d, warn_vacuum=false),
+                )
+            end
+            vals
         end,
     )
 

--- a/test/workflow/validation/test_scalar_summary.jl
+++ b/test/workflow/validation/test_scalar_summary.jl
@@ -44,6 +44,39 @@ end
         @test haskey(s, "norm") && haskey(s, "Mz") && haskey(s, "populations")
     end
 
+    @testset "f_s_leggett appears only for box-spanning states" begin
+        # The default fixture puts all the weight in one voxel — a maximally
+        # disconnected "cloud". f_s would be 0 by geometry, so the key must be
+        # absent rather than a zero a scan could read as signal.
+        s = run_scalar_summary(_summary_fixture())
+        @test !haskey(s, "f_s_leggett")
+        @test !any(startswith.(s["extraction_error"], "f_s_leggett"))  # absent ≠ error
+
+        # A uniform state spans the box and is fully superfluid on every axis.
+        grid = make_grid(GridConfig((8, 8), (4.0, 4.0)))
+        atom = AtomSpecies("test", 1.0e-26, 1, 0.0, 0.0, 0.0)
+        psi = zeros(ComplexF64, 8, 8, 3)
+        psi[:, :, 1] .= 1.0 / 8
+        r = RunResult("/tmp/fake.jld2", psi, grid, atom, InteractionParams(Dict(0 => 1.0)))
+        s = run_scalar_summary(r)
+        @test haskey(s, "f_s_leggett")
+        @test length(s["f_s_leggett"]) == 2
+        @test all(≈(1.0; atol=1e-12), s["f_s_leggett"])
+
+        # Modulated along x only: axis 1 impeded by √(1−A²), axis 2 free.
+        A = 0.6
+        kx = 2π / 4.0
+        psi_m = zeros(ComplexF64, 8, 8, 3)
+        for (i, x) in enumerate(grid.x[1])
+            psi_m[i, :, 1] .= sqrt(1.0 + A * cos(kx * x)) / 8
+        end
+        s = run_scalar_summary(
+            RunResult("/tmp/fake.jld2", psi_m, grid, atom, InteractionParams(Dict(0 => 1.0)))
+        )
+        @test s["f_s_leggett"][1] ≈ sqrt(1 - A^2) rtol = 1e-2
+        @test s["f_s_leggett"][2] ≈ 1.0 atol = 1e-12
+    end
+
     @testset "with dynamics → drift keys present" begin
         dyn = DynamicsTimeSeries([0.0, 0.5, 1.0], [1.0, 1.0, 0.99],
             [-6.0, -5.9, -5.8], [-6.0, -5.95, -5.9])


### PR DESCRIPTION
Stacked on #105 (→ #104 → #99).

Makes $f_s$ queryable **without opening jld2**, so a sweep can plot it straight from the catalog — the same psi-free-extraction move as the `mF` field in #94. Extractor version 2 → 3.

## Leggett branch only

It is a closed form costing milliseconds. The `:relaxed` solve is ~1.8 s at 128³ *per axis*, which would put ~5 s per run into a projection whose whole point is being cheap enough to backfill over hundreds of runs.

## Present only when the state spans the box

A trapped cloud surrounded by vacuum has no phase rigidity across the periodic box, so its $f_s \approx 0$ is geometry rather than a property of the state. Emitting that for every trapped run would put a column of zeros in front of a scan that could read them as signal — and most runs in this repo are trapped.

`scalar_summary.jl` already distinguishes "absent" from "errored", so absent is both available and the honest answer here. A test asserts the disconnected case lands in **neither** the bag nor `extraction_error`.

The practical effect: `f_s_leggett` shows up exactly on the periodic / supersolid-geometry runs where it means something, and nowhere else.

## Tests

`test_scalar_summary` 35/35 — uniform state ⇒ 1 on every axis; x-modulated state ⇒ $\sqrt{1-A^2}$ on the modulated axis and 1 on the free one; single-voxel fixture ⇒ key absent, no error recorded. `test_gs_stage_cache` 19/19.

## Note for reviewers

Existing `summary.json` files are now stale (`_extractor_version == "2"`). They are a regenerable projection — re-backfill to pick the field up; nothing breaks in the meantime since consumers use `haskey`.