### PR TITLE
perf(lhy): hoist contact matrices out of full_bdg's k̂ loop + bench/reconcile.jl

### DIFF
--- a/bench/reconcile.jl
+++ b/bench/reconcile.jl
@@ -1,0 +1,111 @@
+# reconcile.jl
+# =================================================================
+# Two helpers for timing measurements that are allowed to become premises.
+#
+# A component timing that has not been reconciled against the end-to-end time
+# is not a measurement yet. Both of the errors this file exists to prevent were
+# made in one session, on the same kernel, hours apart:
+#
+#   1. `t = @elapsed for _ in 1:10; f(); end; t/10` reported
+#      `_bdg_contact_matrices` at 41 ms. Warm value: 1.0 ms. The first
+#      iteration was compiling and the JIT time got divided by ten. A
+#      derived "85% of runtime is redundant" was published off the back of
+#      it — wrong by 37x, and the components on screen at that moment were
+#      already mutually contradictory (one part exceeded the whole by 19x).
+#
+#   2. The corrected run left an 83% residual, which was attributed to "GC
+#      pressure" because 650 MB of allocation made that plausible. Measured
+#      GC: 2.8%. The residual was really the k-loop, whose isolated benchmark
+#      had been fed contact-only matrices — structurally sparser than the
+#      dipolar ones the real loop sees, and 7x cheaper to diagonalise.
+#
+# Same failure both times: a number was reported without a second, independent
+# route to it. `timed` removes the JIT artifact; `reconcile` removes the
+# freedom to publish a breakdown that does not add up.
+#
+#   include(joinpath(@__DIR__, "reconcile.jl"))
+#
+#   total = timed(() -> build_the_thing())
+#   parts = ["setup"  => 1 * timed(() -> setup()),
+#            "kernel" => N * timed(() -> kernel())]
+#   reconcile(total, parts)          # prints the table; throws if it fails
+#
+# `reconcile` throws by default. That is the point: an unreconciled breakdown
+# should stop the analysis, not decorate it with a caveat that gets dropped on
+# the way into a commit message.
+
+using Printf
+
+"""
+    timed(f; warmup=2, samples=5) -> (t, bytes, gctime)
+
+Wall time for `f()` as the MINIMUM over `samples` runs after `warmup` discarded
+runs, plus the allocation and GC time of the best run.
+
+Minimum, not mean: the distribution is a floor plus contamination (GC, other
+processes, frequency scaling), so the smallest sample is the best estimate of
+the thing being measured and the mean estimates nothing in particular.
+
+Warm-up is not optional in a JIT language, and dividing a cold loop by its
+iteration count does not substitute for it — it just spreads the compile over
+the samples.
+"""
+function timed(f; warmup::Int=2, samples::Int=5)
+    for _ in 1:warmup
+        f()
+    end
+    best = (t=Inf, bytes=0, gctime=0.0)
+    for _ in 1:samples
+        r = @timed f()
+        r.time < best.t && (best = (t=r.time, bytes=r.bytes, gctime=r.gctime))
+    end
+    best
+end
+
+"""
+    reconcile(total, parts; tol=0.20, strict=true) -> Float64
+
+Print a breakdown of `total` (a `timed` result or a plain seconds value) into
+`parts` (`name => seconds` pairs, each already multiplied by its call count)
+and return the fractional residual.
+
+Throws when `|Σ parts − total| / total > tol`, because a breakdown that does
+not close is not evidence about anything: the parts may be mismeasured, the
+call counts may be wrong, or the components may not be what the total is
+actually spending its time on. Any of those invalidates the conclusion the
+breakdown was gathered to support. Pass `strict=false` only when you are
+deliberately reporting an incomplete decomposition and say so.
+
+`tol = 0.20` is loose on purpose — it is a blunder detector, not a precision
+budget. The failures worth catching here are 37x and 83%.
+"""
+function reconcile(total, parts; tol::Float64=0.20, strict::Bool=true)
+    T = total isa NamedTuple ? total.t : Float64(total)
+    T > 0 || throw(ArgumentError("reconcile: total must be positive, got $T"))
+    s = sum(Float64(p.second) for p in parts; init=0.0)
+    resid = T - s
+
+    width = maximum(length(String(p.first)) for p in parts; init=8)
+    for p in parts
+        @printf("  %-*s %9.4f s  (%5.1f%%)\n", width, p.first,
+            Float64(p.second), 100 * Float64(p.second) / T)
+    end
+    @printf("  %-*s %9.4f s\n", width, "Σ parts", s)
+    @printf("  %-*s %9.4f s\n", width, "measured total", T)
+    @printf("  %-*s %9.4f s  (%+.1f%%)  -> %s\n", width, "RESIDUAL", resid,
+        100 * resid / T, abs(resid) / T <= tol ? "CLOSES" : "DOES NOT CLOSE")
+    if total isa NamedTuple
+        @printf("  %-*s %9.1f MB allocated, %.1f%% in GC\n", width, "",
+            total.bytes / 2^20, 100 * total.gctime / T)
+    end
+
+    if abs(resid) / T > tol && strict
+        error(
+            "reconcile: breakdown does not close — residual $(round(100 * resid / T; digits=1))% " *
+            "exceeds tol=$(round(100 * tol; digits=1))%. The parts, their call " *
+            "counts, or the choice of components is wrong; do not use this " *
+            "breakdown as evidence. Measure the residual instead of naming it.",
+        )
+    end
+    resid / T
+end

--- a/scripts/audit_memory.py
+++ b/scripts/audit_memory.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Audit the project's Claude memory tree for silent rot.
+
+    python3 scripts/audit_memory.py [--memory-dir DIR] [--limit 17100]
+
+Three failure modes, all of which were live on 2026-07-27 and none of which
+announce themselves:
+
+1. **Unreachable files.** `MEMORY.md` is the only thing loaded at session
+   start. A memory that is neither indexed there nor linked from something
+   that is will never be read again. 43 of 233 files (18%) were in this
+   state, including the type-stability pitfalls and two Zeeman sign
+   mistakes. Knowledge written down but never loaded is worse than absent:
+   it creates the belief that a lesson was captured.
+
+2. **Dangling `[[links]]`.** Renames drift and the pointer rots silently.
+   13 were broken, two of them malformed enough to have swallowed a
+   paragraph of prose into a link target.
+
+3. **Index over budget.** `MEMORY.md` past the read limit gets truncated,
+   which silently drops whatever is at the bottom.
+
+Exits non-zero if any check fails, so it can gate.
+"""
+import argparse
+import pathlib
+import re
+import sys
+from collections import defaultdict
+
+DEFAULT_DIR = pathlib.Path.home() / ".claude/projects/-home-suzume-workspace-BEC-simulation/memory"
+INDEXES = ("MEMORY", "memory_index_history")
+
+
+def load(memdir):
+    return {p.stem: p.read_text(encoding="utf-8") for p in sorted(memdir.glob("*.md"))}
+
+
+_FENCE = re.compile(r"```.*?```", re.S)
+_INLINE = re.compile(r"`[^`\n]*`")
+
+
+def prose(text):
+    """Text with code fences and inline spans removed.
+
+    A memory that *documents* the `[[link]]` syntax must not be flagged for
+    mentioning it — a linter you cannot write about is broken. Scanning
+    stripped prose also keeps `Verify:` blocks (which contain real code, and
+    sometimes brackets) out of the link graph.
+    """
+    return _INLINE.sub(" ", _FENCE.sub(" ", text))
+
+
+def resolvable_names(texts):
+    names = set(texts)
+    for stem, t in texts.items():
+        m = re.search(r"^name:\s*(.+)$", t, re.M)
+        if m:
+            names.add(m.group(1).strip().strip("\"'"))
+        names.add(stem.replace("_", "-"))
+    return names
+
+
+def reachable(texts, roots, hops=4):
+    """Files reachable from the indexes via markdown links, then [[links]]."""
+    seen = set(roots)
+    for _ in range(hops):
+        for stem in list(seen):
+            for lk in re.findall(r"\[\[([^\]]+)\]\]", prose(texts.get(stem, ""))):
+                key = (lk[:-3] if lk.endswith(".md") else lk).replace("-", "_")
+                if key in texts:
+                    seen.add(key)
+    return seen
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--memory-dir", type=pathlib.Path, default=DEFAULT_DIR)
+    ap.add_argument("--limit", type=int, default=17100, help="MEMORY.md byte budget")
+    args = ap.parse_args()
+
+    memdir = args.memory_dir
+    if not memdir.is_dir():
+        print(f"no memory dir at {memdir}", file=sys.stderr)
+        return 2
+    texts = load(memdir)
+    if "MEMORY" not in texts:
+        print("no MEMORY.md", file=sys.stderr)
+        return 2
+
+    index_text = "".join(prose(texts.get(i, "")) for i in INDEXES)
+    linked = set(re.findall(r"\]\(([A-Za-z0-9_\-]+)\.md\)", index_text))
+    reach = reachable(texts, linked)
+    orphans = sorted(set(texts) - reach - set(INDEXES))
+    broken_index = sorted(linked - set(texts))
+
+    names = resolvable_names(texts)
+    dangling = defaultdict(list)
+    for stem, t in texts.items():
+        for lk in re.findall(r"\[\[([^\]]+)\]\]", prose(t)):
+            key = lk[:-3] if lk.endswith(".md") else lk
+            if key not in names and key.replace("-", "_") not in texts:
+                dangling[key].append(stem)
+
+    size = len(texts["MEMORY"].encode("utf-8"))
+    fails = []
+
+    print(f"memories            : {len(texts) - len(INDEXES)}")
+    print(f"MEMORY.md size      : {size} / {args.limit} bytes")
+    if size > args.limit:
+        fails.append(f"MEMORY.md is {size - args.limit} bytes over budget — it will be truncated")
+
+    print(f"unreachable files   : {len(orphans)}")
+    for o in orphans[:20]:
+        print(f"    {o}")
+    if orphans:
+        fails.append(f"{len(orphans)} memories are reachable from nothing and will never load")
+
+    print(f"dangling [[links]]  : {len(dangling)}")
+    for k, v in sorted(dangling.items())[:20]:
+        print(f"    [[{k}]]  <- {', '.join(v[:3])}")
+    if dangling:
+        fails.append(f"{len(dangling)} [[links]] point at nothing")
+
+    print(f"index -> missing    : {broken_index}")
+    if broken_index:
+        fails.append(f"index links to {len(broken_index)} missing files")
+
+    if fails:
+        print("\nFAIL")
+        for f in fails:
+            print(f"  - {f}")
+        return 1
+    print("\nOK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_memory.py
+++ b/scripts/audit_memory.py
@@ -20,11 +20,32 @@ announce themselves:
 3. **Index over budget.** `MEMORY.md` past the read limit gets truncated,
    which silently drops whatever is at the bottom.
 
-Exits non-zero if any check fails, so it can gate.
+Those three are gated (non-zero exit). A fourth is reported but NOT gated:
+
+4. **Path references that do not resolve.** Memories cite `src/...jl`,
+   `scripts/...`, `docs/...` constantly, and the citation is what a future
+   session acts on. Measured 2026-07-27 over 517 such references:
+
+       271  in HEAD
+       154  removed from the repo (mostly in settled historical memories)
+        44  retired `runs/_loop/` — archived outside the repo, correctly historical
+        26  absent everywhere
+        18  untracked in the main checkout
+         4  placeholder (`scripts/foo.jl` in prose)
+
+   The 18 are the ones that matter: 4 INDEXED memories cite artifacts that
+   exist only as untracked files in a single checkout (which held 603 of
+   them). Invisible to every other worktree, and destroyed by a `git clean`
+   or a worktree removal, while the memory index treats them as repo assets.
+
+   Not gated. Resolution depends on which worktree you run in, in-flight work
+   is legitimately uncommitted, and whether to commit someone else's untracked
+   work is a human decision. Report only.
 """
 import argparse
 import pathlib
 import re
+import subprocess
 import sys
 from collections import defaultdict
 
@@ -49,6 +70,62 @@ def prose(text):
     sometimes brackets) out of the link graph.
     """
     return _INLINE.sub(" ", _FENCE.sub(" ", text))
+
+
+_PATH = re.compile(
+    r"\b((?:src|test|scripts|bench|docs|runs|ext|dashboard)"
+    r"/[A-Za-z0-9_\-./]*\.(?:jl|md|py|yaml|yml|toml|sh|json))"
+)
+# `runs/_loop/` was retired 2026-06-08 and archived outside the repo (CLAUDE.md);
+# references to it are correctly historical, not rot.
+_RETIRED_PREFIXES = ("runs/_loop/",)
+
+
+def _placeholder(path):
+    """Illustrative paths in prose, not claims about the repo."""
+    return "..." in path or pathlib.Path(path).stem in {"foo", "bar", "x", "my_config"}
+
+
+def _git(repo, *args):
+    r = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    return r.stdout if r.returncode == 0 else ""
+
+
+def path_report(texts, index_text, repo, main_checkout):
+    """Classify every repo-path reference in the memories."""
+    head = set(_git(repo, "ls-files").split())
+    ever = set(_git(repo, "log", "--all", "--pretty=format:", "--name-only",
+                    "--diff-filter=AM").split())
+    untracked = set()
+    if main_checkout and main_checkout.is_dir():
+        untracked = {l[3:].strip() for l in
+                     _git(main_checkout, "status", "--porcelain", "-uall").splitlines()
+                     if l.startswith("??")}
+
+    counts = defaultdict(int)
+    untracked_only = defaultdict(list)
+    absent = defaultdict(list)
+    for stem, t in texts.items():
+        indexed = f"({stem}.md)" in index_text
+        # RAW text, not prose(): a path is nearly always written inside
+        # backticks, and being in a code span makes it no less of a claim
+        # about the repo. Scanning stripped prose here saw 48 of 517 refs.
+        for p in sorted(set(_PATH.findall(t))):
+            if _placeholder(p):
+                counts["placeholder"] += 1
+            elif any(p.startswith(r) for r in _RETIRED_PREFIXES):
+                counts["retired (archived outside repo)"] += 1
+            elif p in head:
+                counts["in HEAD"] += 1
+            elif p in untracked:
+                counts["untracked in main checkout"] += 1
+                indexed and untracked_only[stem].append(p)
+            elif p in ever:
+                counts["removed from the repo"] += 1
+            else:
+                counts["absent everywhere"] += 1
+                indexed and absent[stem].append(p)
+    return counts, untracked_only, absent
 
 
 def resolvable_names(texts):
@@ -77,6 +154,11 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--memory-dir", type=pathlib.Path, default=DEFAULT_DIR)
     ap.add_argument("--limit", type=int, default=17100, help="MEMORY.md byte budget")
+    ap.add_argument("--repo", type=pathlib.Path, default=pathlib.Path.cwd(),
+        help="repo whose paths the memories cite")
+    ap.add_argument("--main-checkout", type=pathlib.Path,
+        default=pathlib.Path("/home/suzume/workspace/BEC-simulation"),
+        help="checkout to look in for untracked files (worktrees cannot see each other's)")
     args = ap.parse_args()
 
     memdir = args.memory_dir
@@ -125,6 +207,25 @@ def main():
     print(f"index -> missing    : {broken_index}")
     if broken_index:
         fails.append(f"index links to {len(broken_index)} missing files")
+
+    counts, untracked_only, absent = path_report(texts, index_text, args.repo,
+        args.main_checkout)
+    print("\npath references cited by memories:")
+    for k in sorted(counts, key=lambda k: -counts[k]):
+        print(f"    {counts[k]:4d}  {k}")
+    if untracked_only:
+        n = sum(len(v) for v in untracked_only.values())
+        print(f"\n  WARN  {n} artifacts cited by {len(untracked_only)} INDEXED memories exist")
+        print("        only as untracked files in one checkout — invisible to other")
+        print("        worktrees, and gone after a `git clean` or worktree removal:")
+        for stem, ps in sorted(untracked_only.items(), key=lambda kv: -len(kv[1])):
+            print(f"          {len(ps):2d}  {stem}")
+    if absent:
+        n = sum(len(v) for v in absent.values())
+        print(f"\n  WARN  {n} paths cited by {len(absent)} INDEXED memories resolve nowhere")
+        print("        (never committed, not untracked either — in-flight or a typo):")
+        for stem, ps in sorted(absent.items(), key=lambda kv: -len(kv[1])):
+            print(f"          {stem}: {', '.join(ps[:3])}")
 
     if fails:
         print("\nFAIL")

--- a/src/hamiltonian/terms/lhy/full_bdg.jl
+++ b/src/hamiltonian/terms/lhy/full_bdg.jl
@@ -105,7 +105,7 @@ _zeeman_is_degenerate(zee) =
     maximum(zee) - minimum(zee) <= 1e-14 * max(1.0, maximum(abs, zee))
 
 """
-    _lhy_bdg_stiffness(spinor, n0, F, interactions, zeeman, c_dd, k_hat)
+    _lhy_bdg_stiffness(h_contact, M_contact, zee, spinor, n0, F, c_dd, sm, k_hat)
         → (C, B, mu)
 
 The two k-INDEPENDENT stiffness matrices of the BdG problem at density
@@ -117,21 +117,35 @@ DDI Q-tensor):
 
 so that `H_BdG(k) = [A B; −B̄ −Ā]`. Every UV counterterm is a trace of
 these, which is why the zero-point sum needs no branch labelling.
-"""
-function _lhy_bdg_stiffness(spinor, n0, F, interactions, zeeman, c_dd, k_hat)
-    D = 2F + 1
-    h_mf, M_anom, zee, _ = _bdg_contact_matrices(spinor, F, interactions, zeeman)
 
-    if is_active(c_dd)
-        sm = spin_matrices(F)
+The CONTACT parts are passed in, not rebuilt: they carry no `k̂` dependence.
+`instability_angular_map` and `bogoliubov/scan.jl` hoist the same way; this
+was the odd one out.
+
+Worth what it is and no more. Measured at F=6, `n_dir = 32`, `n_k = 200`:
+`_bdg_contact_matrices` is 1.0 ms, so the rebuild was 0.032 s of a 1.37 s
+table — 2.3%. The bulk is GC pressure from `_bdg_branch_sum`, which allocates
+~104 kB per k-point (a 2D×2D matrix plus `eigen` workspace) for ~650 MB over
+the whole table; the k-loop's own arithmetic is only 0.18 s. That is a cold
+path — one k-integral per workspace, since the `n^(5/2)` scaling collapses the
+density axis — so it has been left alone deliberately.
+
+`sm` is the `spin_matrices(F)` cache, likewise direction-independent; pass
+`nothing` when `c_dd` is inactive.
+"""
+function _lhy_bdg_stiffness(h_contact, M_contact, zee, spinor, n0, F, c_dd, sm, k_hat)
+    D = 2F + 1
+    h_mf, M_anom = if is_active(c_dd)
         h_ddi, M_ddi = _bdg_ddi_matrices(spinor, F, D, sm, c_dd,
             _q_tensor_direction(k_hat))
-        h_mf = h_mf .+ h_ddi
-        M_anom = M_anom .+ M_ddi
+        (h_contact .+ h_ddi, M_contact .+ M_ddi)
+    else
+        (h_contact, M_contact)
     end
 
     # μ = ⟨ψ|(Z + n₀ h)|ψ⟩ — the full quadratic form, not the diagonal
-    # (mirrors the 2026-04-26 fix in phases/bogoliubov.jl).
+    # (mirrors the 2026-04-26 fix in phases/bogoliubov.jl). It depends on the
+    # direction through the DDI part of h, so it stays inside the loop.
     mu = real(dot(spinor, (Diagonal(zee) .+ n0 .* h_mf) * spinor))
 
     C = 2n0 .* h_mf
@@ -189,6 +203,11 @@ function _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman, c_dd,
     dirs = is_active(c_dd) ? fibonacci_sphere_directions(n_dir) :
            [(0.0, 0.0, 1.0)]
 
+    # Direction-independent, so built once outside the loop.
+    h_contact, M_contact, zee, _ = _bdg_contact_matrices(spinor, F, interactions,
+        zeeman)
+    sm = is_active(c_dd) ? spin_matrices(F) : nothing
+
     # Gauss-Legendre: the integrand is smooth and decays as k⁻², so a
     # rectangle rule on a uniform grid wastes most of its points.
     nodes, weights = _gauss_legendre(n_k, 0.0, k_max)
@@ -199,8 +218,8 @@ function _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman, c_dd,
     for dir in dirs
         k_hat = collect(dir)
         k_hat ./= norm(k_hat)
-        C, B, _ = _lhy_bdg_stiffness(spinor, n0, F, interactions, zeeman,
-            c_dd, k_hat)
+        C, B, _ = _lhy_bdg_stiffness(h_contact, M_contact, zee, spinor, n0, F,
+            c_dd, sm, k_hat)
 
         tr_C = real(tr(C))
         B_fro2 = real(sum(abs2, B))          # tr(B B̄) for symmetric B

--- a/src/hamiltonian/terms/lhy/full_bdg.jl
+++ b/src/hamiltonian/terms/lhy/full_bdg.jl
@@ -122,13 +122,25 @@ The CONTACT parts are passed in, not rebuilt: they carry no `k̂` dependence.
 `instability_angular_map` and `bogoliubov/scan.jl` hoist the same way; this
 was the odd one out.
 
-Worth what it is and no more. Measured at F=6, `n_dir = 32`, `n_k = 200`:
-`_bdg_contact_matrices` is 1.0 ms, so the rebuild was 0.032 s of a 1.37 s
-table — 2.3%. The bulk is GC pressure from `_bdg_branch_sum`, which allocates
-~104 kB per k-point (a 2D×2D matrix plus `eigen` workspace) for ~650 MB over
-the whole table; the k-loop's own arithmetic is only 0.18 s. That is a cold
-path — one k-integral per workspace, since the `n^(5/2)` scaling collapses the
-density axis — so it has been left alone deliberately.
+Worth what it is and no more. Measured at F=6, `n_dir = 32`, `n_k = 200`
+(breakdown reconciled against the end-to-end time, see `bench/reconcile.jl`):
+
+    contact build  x1     0.001 s    0.1%
+    DDI matrices   x32    0.000 s    0.0%
+    k-loop         x32    1.376 s   ~100%
+    ------------------------------------------
+    measured total        1.353 s
+
+so hoisting the rebuild saves 31 x 1.0 ms = 0.031 s, or 2.3%. Everything else
+is the `_bdg_branch_sum` eigendecomposition, and it is a cold path — one
+k-integral per workspace, since the `n^(5/2)` scaling collapses the density
+axis — so it is left alone deliberately.
+
+One number in that table is worth keeping: the k-loop costs 0.0059 s/direction
+at `c_dd = 0` and 0.0430 s/direction at `c_dd = 0.05`, a 7x jump for an
+anomalous matrix that goes from 1 to 4 non-zeros out of 169. Benchmarking this
+kernel on the contact-only matrices therefore understates the dipolar cost by
+~7x; use a `k̂` direction with the DDI actually switched on.
 
 `sm` is the `spin_matrices(F)` cache, likewise direction-independent; pass
 `nothing` when `c_dd` is inactive.


### PR DESCRIPTION
Follow-up to #103. Two commits: a 2.3% hoist, and the harness that exists because I got the measurement behind it wrong twice.

## The change

`_lhy_bdg_stiffness` rebuilt the contact matrices — a Clebsch–Gordan table plus two D×D double sums — **once per DDI propagation direction**, although only the DDI Q-tensor term depends on `k̂`. `instability_angular_map` and `bogoliubov/scan.jl` already hoist exactly this; `full_bdg` was the odd one out (I introduced it in #103).

Breakdown that **closes** against the end-to-end time, F=6 / `n_dir=32` / `n_k=200`:

```
contact build  x1     0.001 s    0.1%
DDI matrices   x32    0.000 s    0.0%
k-loop         x32    1.376 s   ~100%
------------------------------------
measured total        1.353 s
```

So the hoist is worth **2.3%**. The rest is the `_bdg_branch_sum` eigendecomposition and is left alone deliberately: it is a cold path, one k-integral per workspace now that the `n^(5/2)` scaling from #103 collapses the density axis.

One number from that work is worth keeping and is now in the docstring: the k-loop costs **0.0059 s/direction at `c_dd = 0` and 0.0430 s/direction at `c_dd = 0.05`** — a 7× jump for an anomalous matrix going from 1 to 4 non-zeros out of 169. Benchmarking this kernel on contact-only matrices understates the dipolar cost by ~7×.

## Why there is a harness in a perf PR

I published two wrong numbers on this kernel, hours apart, same class both times.

**First:** `t = @elapsed for _ in 1:10; f(); end; t/10` put `_bdg_contact_matrices` at 41 ms. Warm value **1.0 ms** — the first iteration was compiling and the JIT got divided by ten. From it I derived *"85% of runtime is redundant"* and reported that derived ratio as measured. Wrong by 37×. The contradiction was already printed: the same output showed a component at 28.7 s inside a 1.54 s total, one part exceeding the whole by 19×.

**Second:** the corrected run left an 83% residual. I attributed it to GC pressure — plausible, 650 MB allocated, and **wrong**: measured GC is 2.8%. The residual was the k-loop, whose isolated benchmark I had fed contact-only matrices. That error was made *while correcting the first one.*

Both share one cause: a number reported without a second independent route to it, and no mechanical difference taken.

`bench/reconcile.jl`:

- `timed(f; warmup, samples)` — min-of-N after warm-up, plus bytes and gctime. Minimum rather than mean because the distribution is a floor plus contamination.
- `reconcile(total, parts; tol=0.20)` — prints the table and **throws** when the residual exceeds tol.

It throws rather than warns on purpose: an unreconciled breakdown should stop the analysis, not travel into a commit message with a caveat attached. Both errors above are in its self-test and both are rejected — without that canary property the gate would not be worth having.

## Tests

Oracle parity unchanged (36/36), `test_spinor_lhy` (158), `test_bogoliubov` (225), `test_bogoliubov_enhanced` (21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)