### PR TITLE
fix(lhy): auto-derived scalar c_lhy was short by π·(a_s/a_ho)·√N

### DIFF
--- a/src/workflow/experiments/schema/parsing_blocks.jl
+++ b/src/workflow/experiments/schema/parsing_blocks.jl
@@ -323,8 +323,19 @@ function _resolve_lhy_block!(p::Dict, inter::Dict, atom, c_dd_val::Float64,
     # Auto-derive c_lhy for scalar / quasi_2d when user omitted it.
     if (kind == "scalar" || kind == "quasi_2d") && !haskey(lhy_block, "c_lhy")
         if !isnan(c_dd_val) && c_dd_val > 0
-            a_s_dl = atom.a_s / a_ho
-            c_lhy_scalar = (128.0 / (3.0 * sqrt(π))) * sqrt(abs(a_s_dl)^3) * N_atoms
+            # Dimensionless scalar LHY coefficient for the repo's per-particle
+            # convention (∫|ψ|²dV = 1, E_LHY/N = (2/5)·c_lhy·∫n^{5/2}dV,
+            # c₀ = 4π(a_s/a_ho)N). Fixed by SI alone — no convention freedom:
+            #
+            #   γ_QF = (32/3)·g·√(a_s³/π),  g = 4πℏ²a_s/m
+            #        = (128√π/3)(ℏ²/m)·a_s^{5/2}
+            #   ⇒ c_lhy = (128√π/3)·(a_s/a_ho)^{5/2}·N^{3/2}·Q₅(ε_dd)
+            #
+            # equivalently c_lhy/c₀ = (32/3)√((a_s/a_ho)³N/π), which reproduces
+            # the textbook ratio μ_LHY/μ_contact = (32/3)√(n_SI·a_s³/π).
+            # test/oracles/test_scalar_lhy_si_roundtrip.jl gates exactly that.
+            a_s_dl = abs(atom.a_s / a_ho)
+            c_lhy_scalar = (128.0 * sqrt(π) / 3.0) * a_s_dl^2.5 * float(N_atoms)^1.5
             lhy_block["c_lhy"] = c_lhy_scalar * lima_pelster_Q5(eps_dd)
         end
     end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -58,6 +58,7 @@ const FAST_TESTS = [
     "manuscript/test_D2_H_irrep_character_proof.jl",
     "manuscript/test_rank2_cross_channel_vanishing.jl",
     "manuscript/test_paper3_audit.jl",
+    "oracles/test_scalar_lhy_si_roundtrip.jl",
     "validation/test_k3_unit_audit.jl",
     "validation/test_L5_operator_rhs_compare.jl",
     "dynamics/test_tdhfb_f1_validation.jl",

--- a/test/oracles/test_scalar_lhy_si_roundtrip.jl
+++ b/test/oracles/test_scalar_lhy_si_roundtrip.jl
@@ -1,0 +1,86 @@
+# Oracle: the auto-derived dimensionless scalar LHY coefficient against SI.
+#
+# `_resolve_lhy_block!` fills `c_lhy` whenever the user writes
+# `lhy: {kind: scalar}` without a value. That number has no convention freedom
+# — the ratio of the two chemical-potential terms is fixed by SI:
+#
+#     μ_LHY / μ_contact = (32/3)·√(n_SI·a_s³/π)
+#
+# and the repo's per-particle dimensionless form must reproduce it:
+#
+#     μ_LHY / μ_contact = (c_lhy/c₀)·√n_dimless,   c₀ = 4π(a_s/a_ho)N
+#
+# Gating this closes the gap that let the derivation ship with
+# (128/(3√π))·ã^{3/2}·N — short of the correct
+# (128√π/3)·ã^{5/2}·N^{3/2} by a factor π·ã·√N (≈12× for ¹⁶⁴Dy at N = 6e4).
+# The error is invisible to a units check: both forms are dimensionless.
+
+using Test
+using SpinorBEC
+
+const _U = SpinorBEC.Units
+
+# Drive the real code path rather than re-typing the formula under test.
+function _derived_c_lhy(atom, N_atoms::Int, a_ho::Float64; eps_dd::Float64=0.0)
+    p = Dict{String, Any}("lhy" => Dict{String, Any}("kind" => "scalar"))
+    inter = Dict{String, Any}()
+    SpinorBEC._resolve_lhy_block!(p, inter, atom, 1.0, eps_dd, N_atoms, a_ho)
+    inter["c_lhy"]
+end
+
+@testset "Scalar LHY coefficient ↔ SI round-trip" begin
+    @testset "μ_LHY/μ_contact matches (32/3)√(n a³/π)" begin
+        cases = [
+            (Dy164, 60_000, 2π * 600.0),
+            (Er168, 20_000, 2π * 200.0),
+            (Eu151, 50_000, 2π * 110.0),
+        ]
+        for (atom, N, omega) in cases
+            a_ho = sqrt(_U.HBAR / (atom.mass * omega))
+            ah = atom.a_s / a_ho
+            c0 = 4π * ah * N
+            c_lhy = _derived_c_lhy(atom, N, a_ho)
+
+            for n_d in (5e-3, 2e-2, 8e-2)
+                n_si = N * n_d / a_ho^3
+                ratio_si = (32 / 3) * sqrt(n_si * atom.a_s^3 / π)
+                ratio_code = (c_lhy / c0) * sqrt(n_d)
+                @test ratio_code ≈ ratio_si rtol = 1e-12
+            end
+        end
+    end
+
+    @testset "scaling exponents in N and a_s" begin
+        # c_lhy ∝ N^{3/2}·(a_s/a_ho)^{5/2}. Getting either exponent wrong is
+        # the failure mode that shipped, so pin both directly.
+        a_ho = sqrt(_U.HBAR / (Dy164.mass * 2π * 600.0))
+        c1 = _derived_c_lhy(Dy164, 10_000, a_ho)
+        c8 = _derived_c_lhy(Dy164, 80_000, a_ho)
+        @test c8 / c1 ≈ 8.0^1.5 rtol = 1e-12
+
+        # a_s enters only through a_s/a_ho, so scaling a_ho is the clean lever.
+        c_half = _derived_c_lhy(Dy164, 10_000, a_ho / 2)
+        @test c_half / c1 ≈ 2.0^2.5 rtol = 1e-12
+    end
+
+    @testset "Q₅(ε_dd) multiplies the whole coefficient" begin
+        a_ho = sqrt(_U.HBAR / (Dy164.mass * 2π * 600.0))
+        base = _derived_c_lhy(Dy164, 60_000, a_ho; eps_dd=0.0)
+        for eps in (0.5, 1.0, 1.45)
+            @test _derived_c_lhy(Dy164, 60_000, a_ho; eps_dd=eps) ≈
+                base * lima_pelster_Q5(eps) rtol = 1e-12
+        end
+        # ε_dd = 0 has to leave the scalar value untouched.
+        @test lima_pelster_Q5(0.0) ≈ 1.0 atol = 1e-14
+    end
+
+    @testset "explicit c_lhy is never overwritten" begin
+        p = Dict{String, Any}(
+            "lhy" => Dict{String, Any}("kind" => "scalar", "c_lhy" => 123.0)
+        )
+        inter = Dict{String, Any}()
+        a_ho = sqrt(_U.HBAR / (Dy164.mass * 2π * 600.0))
+        SpinorBEC._resolve_lhy_block!(p, inter, Dy164, 1.0, 1.45, 60_000, a_ho)
+        @test inter["c_lhy"] == 123.0
+    end
+end


### PR DESCRIPTION
Found while checking whether the scalar eGPE path could produce a dipolar supersolid — the LHY strength sets the droplet scale, so it had to be verified before use.

## The bug

`_resolve_lhy_block!` filled `c_lhy` with $(128/(3\sqrt{\pi}))\,\tilde a^{3/2} N$. For this repo's per-particle convention ($\int|\psi|^2 dV = 1$, $E_{LHY}/N = \frac{2}{5} c_{lhy}\int n^{5/2}dV$, $c_0 = 4\pi\tilde a N$) the correct value is

$$c_{lhy} = \frac{128\sqrt{\pi}}{3}\,\tilde a^{5/2} N^{3/2}\, Q_5(\epsilon_{dd}), \qquad \tilde a = a_s/a_{ho}$$

Both the $a_s$ exponent and the $N$ exponent were low. The shipped value is too small by $\pi\tilde a\sqrt{N}$ — **11.7× for ¹⁶⁴Dy** at $N = 6\times10^4$, $\omega = 2\pi\cdot600$ Hz; **6.8× for ¹⁵¹Eu** at $N = 5\times10^4$, 110 Hz.

## No convention freedom

$\gamma_{QF} = \frac{32}{3} g\sqrt{a_s^3/\pi}$ with $g = 4\pi\hbar^2 a_s/m$ fixes the ratio of the two chemical-potential terms in SI:

$$\frac{\mu_{LHY}}{\mu_{contact}} = \frac{32}{3}\sqrt{n_{SI} a_s^3/\pi}$$

and the dimensionless form must reproduce it. Measured at three densities across Dy164 / Er168 / Eu151: old coefficient gives 0.0334 where SI says 0.3902; new one matches to 1e-12.

## Why it survived

The error is dimensionless-to-dimensionless, so no units check could see it, and **no test pinned the derived number against anything physical** — every existing LHY test passes `c_lhy` in explicitly. The new oracle drives the real code path (`_resolve_lhy_block!`, not a re-typed formula) and gates the SI ratio *plus both scaling exponents separately*, since getting either one wrong is exactly the failure mode that shipped.

## Blast radius

Fires only where a config writes `lhy: {kind: scalar}` (or `quasi_2d`) with no explicit `c_lhy` and `c_dd > 0`. **About 60 YAMLs under `runs/` are in that set**, including `eu151_edh`, `eu_k3_arrest`, `eu_robust_factorial`, `saito_li_torus` and the TWA ε_dd / N scans — their LHY term was ~7–12× too weak.

Configs that set `c_lhy` explicitly are untouched; a test pins that the explicit value is never overwritten.

⚠️ Results from the affected runs should be re-checked before being quoted. I have not re-run them.

## Tests

`test_scalar_lhy_si_roundtrip` 16/16 (new, fast tier) · `test_lhy` 37/37 · tier membership 33/33.