### PR TITLE
chore(scripts): commit the Eu artifacts the memory index cites but the repo never had

### DIFF
--- a/docs/guides/eu_weak_field_gs_library.md
+++ b/docs/guides/eu_weak_field_gs_library.md
@@ -1,0 +1,64 @@
+# Weak-field ¹⁵¹Eu ground-state library (reuse guide)
+
+The pinned B-scan (`scripts/eu_bscan_pinned_continuation.jl`) produces a
+**reusable dataset of converged ground states** ψ(B) across 0–90 µG, not just
+animation frames. Each `frame_NNN/psi.jld2` is a self-describing state that
+seeds finer runs, dynamics, and analysis — so this region is computed once and
+reused, not re-solved every time.
+
+## Layout
+
+```
+figs/eu_bscan_pin_tight/          # canonical store (64³, tol=1e-5, pin b_x=2e-3)
+├── frame_001/ … frame_046/
+│   ├── psi.jld2                   # the converged GS ψ + full metadata
+│   ├── density_xy.csv fx_xy.csv … # z-midplane fields (animation)
+│   └── populations.csv
+├── frames.csv                     # frame ↔ B_uG + E, |∇E|, Fz, F⊥
+└── library.csv                    # physics-keyed index (built by eu_gs_library.jl)
+```
+
+Each `psi.jld2` carries: `psi`, `B_uG`, `pin_bx`, `grid_n_points`,
+`grid_box_size`, `atom_name`, `c0`, `c1`, `c_dd`, `E_total`, `grad_norm`,
+`converged`, `last_step` — and (new-schema runs) the full `load_state` keys
+(`t`, `step`, `zeeman_q`, `c_dict`, `c_lhy`, `dt`, `imaginary_time`).
+
+## Reuse recipes
+
+```julia
+using SpinorBEC
+include("scripts/eu_gs_library.jl")
+
+# 1. Discover — index all states (writes library.csv), sorted by B.
+lib = gs_library("figs/eu_bscan_pin_tight")
+
+# 2. Load the converged GS nearest a field.
+e = load_gs("figs/eu_bscan_pin_tight"; B_uG=50)     # e.psi (host array), e.meta
+```
+
+**Seed a finer / different run** (same grid → straight seed; different grid →
+`scripts/upsample_spinor.jl` first):
+
+```julia
+find_ground_state_lbfgs(; grid=g, atom=Eu151, interactions=..., c_dd=e.meta.c_dd,
+    zeeman=static_zeeman(Bz=..., Bx=e.meta.pin_bx), enable_ddi=true,
+    psi_init=e.psi, tol=1e-5)
+```
+
+**Feed a dynamics run** — upgrade the current run once, then use `load_state`:
+
+```julia
+make_load_state_compatible("figs/eu_bscan_pin_tight")   # add t/step/… in-place
+s = load_state("figs/eu_bscan_pin_tight/frame_020/psi.jld2")
+# s.psi, s.grid_n_points, s.c0, s.c1, s.c_dd, s.zeeman_p → make_workspace(psi_init=s.psi, …)
+```
+
+## Notes
+
+- **Never resume across a changed B-grid.** `frame_NNN ↔ B` depends on
+  `(BMAX, NB)`; point a new B-range at a FRESH output dir (the resume logic keys
+  on `frame_NNN/psi.jld2` presence, not on B).
+- The scan is itself resumable: re-running the same `BS_OUT` reloads existing
+  frames and continues from the first missing one.
+- `converged=-1` in the index = an older-schema file (pre-`converged` key); run
+  `make_load_state_compatible` to normalise, or just use `load_gs` (schema-tolerant).

--- a/scripts/eu_bscan_pinned_continuation.jl
+++ b/scripts/eu_bscan_pinned_continuation.jl
@@ -1,0 +1,230 @@
+# B-scan of the weak-field ¹⁵¹Eu (F=6) + DDI ground state with a FIXED
+# symmetry-breaking pin, warm-continued in B — the data source for a
+# "state vs magnetic field" animation.
+#
+# Physics: below ~60 µG the Eu+DDI GS lives on a soft Goldstone manifold
+# (broken axial U(1) e^{-iθ(L_z+F_z)}); un-pinned optimisation wanders and
+# the flower orientation is roundoff/seed-selected. We add ONE fixed
+# transverse pin b_x = ε (conjugate to the broken transverse-spin order),
+# held constant across every B, so the orientation is locked ⇒ the animation
+# does not flicker as B changes. A fixed absolute ε strengthens (relative to
+# p ∝ B) exactly as B → 0, i.e. where the pin is most needed.
+#
+# Efficiency: continuation. The anchor is the HIGH-B end (Zeeman-protected,
+# stiff, easy) via ITP→LBFGS; every lower-B cell warm-starts from its
+# higher-B neighbour and only needs a short LBFGS polish. The hard soft
+# manifold is reached gradually with a good seed each step.
+#
+# Env:
+#   BS_GRID=64  BS_BOX=24.0  BS_NB=101  BS_BMIN=0.0  BS_BMAX=100.0  (µG)
+#   BS_PIN_EPS=1e-3           fixed transverse pin b_x (dimensionless p-units)
+#   BS_ITP=2000  BS_LBFGS_ANCHOR=400  BS_LBFGS_CELL=120
+#   BS_NEWTON_ANCHOR=1  (Newton-polish the stiff anchor; OFF for soft cells)
+#   BS_SAVE_PSI=1       persist full ψ per frame (else only midplane CSVs)
+#   BS_OUT=figs/eu_bscan_pinned
+#   BS_SMOKE=1          grid16, NB5, itp150, lbfgs40 — every path in ≤2 min
+#
+#   [GPU]  LD_LIBRARY_PATH=/usr/lib/wsl/lib julia --project=. \
+#            scripts/eu_bscan_pinned_continuation.jl
+
+import CUDA
+using SpinorBEC
+using SpinorBEC: Units, eu151_preset, find_ground_state, find_ground_state_lbfgs,
+    init_psi, add_white_noise!, SpinSystem, static_zeeman, energy_decomposition,
+    component_populations, _spin_expectation_fields, pin_transverse_field,
+    CUDABackend, CPUBackend
+using DelimitedFiles: writedlm
+using JLD2: jldsave, jldopen
+using Printf
+
+geti(k, d) = haskey(ENV, k) ? parse(Float64, ENV[k]) : d
+const SMOKE = get(ENV, "BS_SMOKE", "") == "1"
+const NX    = SMOKE ? 16 : Int(geti("BS_GRID", 64))
+const BOX   = geti("BS_BOX", 24.0)
+const NB    = SMOKE ? 5 : Int(geti("BS_NB", 101))
+const BMIN  = geti("BS_BMIN", 0.0)     # µG
+const BMAX  = geti("BS_BMAX", 100.0)   # µG
+const EPS   = geti("BS_PIN_EPS", 1e-3) # fixed transverse pin b_x
+const ITP   = SMOKE ? 150 : Int(geti("BS_ITP", 2000))
+const LB_A  = SMOKE ? 40  : Int(geti("BS_LBFGS_ANCHOR", 400))
+const LB_C  = SMOKE ? 30  : Int(geti("BS_LBFGS_CELL", 120))
+# grad-norm early-stop target (driver.jl:187 breaks when |∇E| < tol). 1e-5 is
+# 4 orders below the un-pinned Goldstone floor (~0.05) and stops BEFORE the
+# near-convergence linesearch thrash (~1e-6 at 64³). Cells self-size: high-B
+# converge in few steps, soft low-B run up to the n_steps cap.
+const TOL   = geti("BS_TOL", 1e-5)
+# Re-polish mode: re-solve ONLY already-cached frames whose |∇E| exceeds RP_THRESH
+# (the soft low-B cells the fixed-pin main run leaves loose). BS_RP_RAMP set ⇒ use
+# the ε-ladder pin continuation (pin_transverse_field + epsilon_ramp, the PR#54
+# method that reaches ~1e-5 on the soft manifold); empty ⇒ just a higher-cap LBFGS
+# at the fixed pin. Warm-starts from each frame's own same-B cached ψ. Resumable:
+# a re-polished frame drops below RP_THRESH so a re-run skips it.
+const REPOLISH  = get(ENV, "BS_REPOLISH", "") == "1"
+const RP_THRESH = geti("BS_RP_THRESH", 1e-4)
+const RP_LBFGS  = SMOKE ? 60 : Int(geti("BS_RP_LBFGS", 400))
+const RP_RAMP   = let s = get(ENV, "BS_RP_RAMP", "")
+    isempty(s) ? Float64[] : sort(parse.(Float64, split(s, ",")); rev=true)
+end
+const NEWT_A = get(ENV, "BS_NEWTON_ANCHOR", "1") == "1"
+const SAVE_PSI = get(ENV, "BS_SAVE_PSI", "1") == "1"
+const OUT   = get(ENV, "BS_OUT", "figs/eu_bscan_pinned")
+mkpath(OUT)
+
+const TRAPZ = geti("BS_TRAP_Z", 1.1818)   # ω_z/ω_⊥ aspect ratio (demag prediction axis)
+const HAS_GPU = CUDA.functional()
+const BACKEND = HAS_GPU ? CUDABackend() : CPUBackend()
+const PRESET  = eu151_preset(; n_pts=(NX, NX, NX), box=(BOX, BOX, BOX),
+    trap_ratios=(1.0, 1.0, TRAPZ))
+const ATOM = PRESET.atom
+const SYS  = SpinSystem(ATOM.F)
+
+# Descending B (anchor = high field, then continue down into the soft manifold).
+const B_UG = collect(range(BMAX, BMIN; length=NB))
+
+@printf("B-scan pinned continuation: grid=%d^3 box=%.1f  B=%.1f→%.1f µG × %d pts  pin b_x=%.1e  tol=%.0e  %s%s%s\n",
+    NX, BOX, BMAX, BMIN, NB, EPS, TOL, HAS_GPU ? "CUDA" : "CPU", SMOKE ? " [SMOKE]" : "",
+    REPOLISH ? @sprintf(" [REPOLISH >%.0e cap=%d ramp=%s]", RP_THRESH, RP_LBFGS,
+        isempty(RP_RAMP) ? "none" : join(RP_RAMP, ",")) : "")
+flush(stdout)
+
+base_kw(p) = (; grid=PRESET.grid, atom=ATOM, interactions=PRESET.interactions,
+    potential=PRESET.potential, zeeman=static_zeeman(; Bz=p, Bx=EPS, q=0.0),
+    enable_ddi=true, c_dd=PRESET.c_dd, secular_ddi=false, backend=BACKEND)
+
+# density-weighted axial + transverse magnetisation (manifest scalars).
+function frame_scalars(psi)
+    dV = SpinorBEC.cell_volume(PRESET.grid)
+    dens3 = dropdims(sum(abs2, psi; dims=4); dims=4)
+    fx, fy, fz = _spin_expectation_fields(psi, PRESET.grid)
+    ntot = sum(dens3) * dV
+    (; fz_mean=sum(fz) * dV / ntot,
+       fperp_mean=sum(sqrt.(fx .^ 2 .+ fy .^ 2)) * dV / ntot)
+end
+
+# z-midplane field extraction for the animation frames.
+function dump_frame(dir, psi, energy, grad_norm, converged, last_step, p, b_ug)
+    mkpath(dir)
+    D = size(psi, 4)
+    kz = size(psi, 3) ÷ 2 + 1
+    dens3 = dropdims(sum(abs2, psi; dims=4); dims=4)
+    fx, fy, fz = _spin_expectation_fields(psi, PRESET.grid)
+    phase = angle.(@view psi[:, :, kz, D])          # dominant m=-F component
+    writedlm(joinpath(dir, "density_xy.csv"), dens3[:, :, kz])
+    writedlm(joinpath(dir, "fx_xy.csv"), fx[:, :, kz])
+    writedlm(joinpath(dir, "fy_xy.csv"), fy[:, :, kz])
+    writedlm(joinpath(dir, "fz_xy.csv"), fz[:, :, kz])
+    writedlm(joinpath(dir, "fperp_xy.csv"),
+        sqrt.(fx[:, :, kz] .^ 2 .+ fy[:, :, kz] .^ 2))
+    writedlm(joinpath(dir, "phase_xy.csv"), phase)
+    pops = component_populations(psi, PRESET.grid, SYS)
+    writedlm(joinpath(dir, "populations.csv"),
+        hcat(collect(pops.m_values), pops.populations))
+    # psi.jld2 written LAST = the completion marker the resume path checks for.
+    # Atomic (tmp+rename, same dir ⇒ same device, no EXDEV) so a SIGKILL mid-write
+    # can't leave a corrupt jld2 that resume would EOFError on.
+    if SAVE_PSI
+        tmp = joinpath(dir, "psi.jld2.tmp")
+        # Full load_state schema (t/step/zeeman_q/c_dict/c_lhy/dt/imaginary_time)
+        # so `load_state(pf)` + make_workspace(psi_init=…) consume these directly,
+        # PLUS reuse metadata (B_uG, pin_bx, E_total, grad_norm, converged, last_step).
+        jldsave(tmp;
+            psi=psi, t=0.0, step=0,
+            grid_n_points=PRESET.grid.config.n_points,
+            grid_box_size=PRESET.grid.config.box_size,
+            atom_name=ATOM.name,
+            c0=PRESET.interactions[0], c1=PRESET.interactions[1],
+            c_lhy=PRESET.interactions.c_lhy, c_dict=PRESET.interactions.c,
+            zeeman_p=p, zeeman_q=0.0, c_dd=PRESET.c_dd,
+            dt=0.002, imaginary_time=true,
+            B_uG=b_ug, pin_bx=EPS,
+            E_total=energy, grad_norm=grad_norm,
+            converged=converged, last_step=last_step)
+        mv(tmp, joinpath(dir, "psi.jld2"); force=true)
+    end
+    nothing
+end
+
+# --- scan (RESUMABLE) --------------------------------------------------------
+# Each completed frame writes psi.jld2 LAST. On (re)start we load any existing
+# frame's ψ as the warm seed and skip its solve; the first frame WITHOUT a
+# psi.jld2 is solved (anchored if no seed loaded yet, else warm-started from the
+# last loaded ψ) and the scan continues. ⇒ timeout-safe + re-run a frame by
+# deleting its dir + extend by adding points.
+manifest = Vector{NTuple{6, Float64}}()   # frame, B_uG, E, grad_norm, Fz, Fperp
+seed = nothing
+for (i, b_ug) in enumerate(B_UG)
+    global seed
+    dir = joinpath(OUT, @sprintf("frame_%03d", i))
+    pf = joinpath(dir, "psi.jld2")
+    p = Units.bfield_to_p(b_ug * 1e-6, ATOM.g_F, PRESET.omega_ref)  # µG→Gauss→p
+
+    # cached-frame gate: load any existing ψ; skip its solve UNLESS re-polishing a
+    # frame that is still above RP_THRESH.
+    cached = isfile(pf)
+    gN_cached = NaN
+    if cached
+        gN_cached = jldopen(pf, "r") do f
+            seed = Array{ComplexF64}(f["psi"]); f["grad_norm"]
+        end
+    end
+    if cached && !(REPOLISH && gN_cached > RP_THRESH)   # resume: reuse converged ψ
+        E = jldopen(pf, "r") do f; f["E_total"]; end
+        sc = frame_scalars(seed)
+        push!(manifest, (Float64(i), b_ug, E, gN_cached, sc.fz_mean, sc.fperp_mean))
+        @printf("[frame %03d  B=%.2f µG] RESUME (cached ψ)  E=%.5f |gradE|=%.2e\n",
+            i, b_ug, E, gN_cached)
+        flush(stdout)
+    else
+        kw = base_kw(p)
+        if REPOLISH && cached
+            # re-polish the loose cached frame from its own same-B ψ (already loaded
+            # into `seed`): ε-ladder pin continuation if RP_RAMP set, else higher-cap.
+            @printf("[frame %03d  B=%.2f µG] REPOLISH (|∇E|=%.2e → cap=%d %s) …\n",
+                i, b_ug, gN_cached, RP_LBFGS,
+                isempty(RP_RAMP) ? "fixed pin" : "ε-ladder")
+            flush(stdout)
+            gl = isempty(RP_RAMP) ?
+                find_ground_state_lbfgs(; kw..., psi_init=seed, n_steps=RP_LBFGS,
+                    tol=TOL, m_lbfgs=10, newton_polish=false, verbose=false) :
+                find_ground_state_lbfgs(; kw..., psi_init=seed, n_steps=RP_LBFGS,
+                    tol=TOL, m_lbfgs=10, newton_polish=false, verbose=false,
+                    pin=pin_transverse_field(; Bz=p, q=0.0), epsilon_ramp=RP_RAMP)
+        elseif seed === nothing
+            # anchor: symmetry-broken ITP seed. BS_ANCHOR_STATE picks the branch
+            # (:m_plus_F for the downsweep, :flower for the upsweep → hysteresis loop).
+            anchor_file = get(ENV, "BS_ANCHOR_FILE", "")
+            psi0 = isempty(anchor_file) ?
+                init_psi(PRESET.grid, SYS; state=Symbol(get(ENV, "BS_ANCHOR_STATE", "m_plus_F"))) :
+                jldopen(anchor_file, "r") do f; Array{ComplexF64}(f["psi"]); end
+            add_white_noise!(psi0, 0.02, 1, PRESET.grid)
+            @printf("[frame %03d  B=%.2f µG] anchor ITP %d …\n", i, b_ug, ITP)
+            flush(stdout)
+            gs = find_ground_state(; kw..., psi_init=psi0, dt=0.002, n_steps=ITP,
+                tol=1e-12, save_every=max(1, ITP ÷ 5), verbose=true)
+            seed = Array{ComplexF64}(gs.workspace.state.psi)
+            gl = find_ground_state_lbfgs(; kw..., psi_init=seed, n_steps=LB_A,
+                tol=TOL, m_lbfgs=10, newton_polish=NEWT_A, verbose=true)
+        else
+            # warm cell: LBFGS from the neighbouring-B ψ, early-stop at |∇E|<TOL
+            gl = find_ground_state_lbfgs(; kw..., psi_init=seed, n_steps=LB_C,
+                tol=TOL, m_lbfgs=10, newton_polish=false, verbose=false)
+        end
+        seed = Array{ComplexF64}(gl.workspace.state.psi)
+        HAS_GPU && CUDA.synchronize()
+        dump_frame(dir, seed, gl.energy, gl.grad_norm, gl.converged, gl.last_step, p, b_ug)
+        sc = frame_scalars(seed)
+        push!(manifest,
+            (Float64(i), b_ug, gl.energy, gl.grad_norm, sc.fz_mean, sc.fperp_mean))
+        @printf("[frame %03d  B=%.2f µG] E=%.5f |gradE|=%.2e (%d it%s)  Fz=%+.3f |F⊥|=%.3f\n",
+            i, b_ug, gl.energy, gl.grad_norm, gl.last_step,
+            gl.converged ? " ✓tol" : "", sc.fz_mean, sc.fperp_mean)
+        flush(stdout)
+    end
+    # rewrite manifest each frame so a killed job leaves a usable partial
+    open(joinpath(OUT, "frames.csv"), "w") do io
+        writedlm(io, ["frame" "B_uG" "E_total" "grad_norm" "Fz_mean" "Fperp_mean"])
+        writedlm(io, permutedims(reduce(hcat, collect.(manifest)), (2, 1)))
+    end
+end
+
+@printf("ALLDONE  %d frames → %s\n", length(manifest), OUT)

--- a/scripts/eu_gs_library.jl
+++ b/scripts/eu_gs_library.jl
@@ -1,0 +1,155 @@
+# Reusable ground-state library over a pinned Eu B-scan output dir.
+#
+# Every `frame_NNN/psi.jld2` produced by eu_bscan_pinned_continuation.jl is a
+# self-describing converged GS ψ(B). This module turns that directory into a
+# physics-keyed, discoverable dataset so the states SEED finer runs / dynamics /
+# analysis instead of being recomputed. Works on both the current-schema files
+# and older ones (missing keys default gracefully).
+#
+# Usage:
+#   using SpinorBEC
+#   include("scripts/eu_gs_library.jl")
+#   lib = gs_library("figs/eu_bscan_pin_tight")        # table + writes library.csv
+#   e   = load_gs("figs/eu_bscan_pin_tight"; B_uG=50)  # nearest-B: e.psi, e.meta
+#   # seed a run/dynamics from it:
+#   find_ground_state_lbfgs(; grid=g, atom=a, ..., psi_init=e.psi)   # same grid
+#   # or upsample first if the target grid differs (scripts/upsample_spinor.jl).
+#
+# `load_state(e.meta.path)` also works directly on new-schema files.
+
+using JLD2: jldopen
+using DelimitedFiles: writedlm
+using Printf
+
+_g(f, k, d) = haskey(f, k) ? f[k] : d
+_scalar(x) = x isa Tuple ? x[1] : x
+
+"""
+    gs_library(dir; write_csv=true) -> Vector{NamedTuple}
+
+Scan `dir/frame_*/psi.jld2`, return one metadata row per converged GS sorted by
+B_uG, and (default) write `dir/library.csv` as the human/tooling-readable index.
+"""
+function gs_library(dir::AbstractString; write_csv::Bool=true)
+    dirs = filter(isdir, readdir(dir; join=true))
+    rows = NamedTuple[]
+    for d in dirs
+        pf = joinpath(d, "psi.jld2")
+        isfile(pf) || continue
+        row = jldopen(pf, "r") do f
+            (; B_uG=_g(f, "B_uG", NaN),
+               grid=_scalar(f["grid_n_points"]), box=_scalar(f["grid_box_size"]),
+               pin_bx=_g(f, "pin_bx", NaN),
+               c0=_g(f, "c0", NaN), c1=_g(f, "c1", NaN), c_dd=_g(f, "c_dd", NaN),
+               E_total=_g(f, "E_total", NaN), grad_norm=_g(f, "grad_norm", NaN),
+               converged=_g(f, "converged", -1), last_step=_g(f, "last_step", -1),
+               path=pf)
+        end
+        push!(rows, row)
+    end
+    sort!(rows; by=r -> r.B_uG)
+    if write_csv && !isempty(rows)
+        open(joinpath(dir, "library.csv"), "w") do io
+            ks = collect(keys(rows[1]))
+            writedlm(io, reshape(String.(ks), 1, :))
+            for r in rows
+                writedlm(io, reshape(Any[getfield(r, k) for k in ks], 1, :))
+            end
+        end
+    end
+    rows
+end
+
+"""
+    load_gs(dir; B_uG, grid=nothing) -> (; psi, meta)
+
+Load the converged GS ψ nearest `B_uG` (optionally constrained to a `grid`).
+`psi` is a host `Array{ComplexF64}` ready to pass as `psi_init=`; `meta` is the
+library row (B_uG, grid, box, pin_bx, c0/c1/c_dd, E_total, grad_norm, …).
+"""
+function load_gs(dir::AbstractString; B_uG::Real, grid::Union{Nothing, Int}=nothing)
+    rows = gs_library(dir; write_csv=false)
+    grid !== nothing && (rows = filter(r -> r.grid == grid, rows))
+    isempty(rows) && error("no GS in $dir matching grid=$grid")
+    r = rows[argmin(abs.(getfield.(rows, :B_uG) .- B_uG))]
+    psi = jldopen(r.path, "r") do f
+        Array{ComplexF64}(f["psi"])
+    end
+    (; psi, meta=r)
+end
+
+"""
+    load_lib(; κ, B_uG, branch="dn", grid=32, lib="figs/eu_gs_library") -> (; psi, meta)
+
+Load a converged GS ψ from the MERGED library (built by scripts/eu_merge_library.jl)
+by physics key: nearest `B_uG` within the requested `(grid, κ, branch)`. This is the
+canonical way to reuse a state going forward — seed a run/dynamics/analysis with
+`psi_init=load_lib(; κ=1.8, B_uG=61).psi` instead of reaching into scattered dirs.
+`load_state(meta.path)` also works directly (files are load_state-schema).
+"""
+function load_lib(; κ::Real, B_uG::Real, branch::AbstractString="dn",
+                  grid::Int=32, lib::AbstractString="figs/eu_gs_library")
+    csv = joinpath(lib, "library.csv")
+    isfile(csv) || error("no merged library at $csv — run scripts/eu_merge_library.jl")
+    hdr = split(readline(csv), '\t')
+    col = Dict(h => i for (i, h) in enumerate(hdr))
+    cand = NamedTuple[]
+    for ln in readlines(csv)[2:end]
+        c = split(ln, '\t'); isempty(c[1]) && continue
+        (parse(Int, c[col["grid"]]) == grid &&
+         abs(parse(Float64, c[col["κ"]]) - κ) < 1e-3 &&
+         c[col["branch"]] == branch) || continue
+        push!(cand, (; B=parse(Float64, c[col["B"]]), path=String(c[col["path"]]),
+                       E=parse(Float64, c[col["E"]]), grad=parse(Float64, c[col["grad_norm"]])))
+    end
+    isempty(cand) && error("no library state for grid=$grid κ=$κ branch=$branch")
+    r = cand[argmin(abs.(getfield.(cand, :B) .- B_uG))]
+    psi = jldopen(r.path, "r") do f; Array{ComplexF64}(f["psi"]); end
+    (; psi, meta=r)
+end
+
+"""
+    make_load_state_compatible(dir) -> Int
+
+Upgrade older-schema `frame_*/psi.jld2` in-place (atomically) to the full
+`load_state` schema by adding any missing keys (t, step, zeeman_q, c_dict from
+c0/c1, c_lhy, dt, imaginary_time). Already-complete files are left untouched.
+Returns the number rewritten. Run AFTER a scan finishes so `load_state(pf)` and
+the whole make_workspace/dynamics/analysis pipeline consume the states directly.
+"""
+function make_load_state_compatible(dir::AbstractString)
+    n = 0
+    for d in filter(isdir, readdir(dir; join=true))
+        pf = joinpath(d, "psi.jld2")
+        isfile(pf) || continue
+        data = jldopen(pf, "r") do f
+            Dict(k => f[k] for k in keys(f))
+        end
+        haskey(data, "t") && haskey(data, "step") && continue   # already complete
+        get!(data, "t", 0.0); get!(data, "step", 0)
+        get!(data, "zeeman_q", 0.0); get!(data, "dt", 0.002)
+        get!(data, "imaginary_time", true); get!(data, "c_lhy", 0.0)
+        get!(data, "c_dict",
+            Dict{Int, Float64}(0 => get(data, "c0", NaN), 1 => get(data, "c1", NaN)))
+        tmp = pf * ".tmp"
+        jldopen(tmp, "w") do f
+            for (k, v) in data
+                f[k] = v
+            end
+        end
+        mv(tmp, pf; force=true)
+        n += 1
+    end
+    n
+end
+
+# CLI: `julia --project=. scripts/eu_gs_library.jl figs/eu_bscan_pin_tight`
+if abspath(PROGRAM_FILE) == @__FILE__
+    dir = length(ARGS) ≥ 1 ? ARGS[1] : "figs/eu_bscan_pin_tight"
+    lib = gs_library(dir)
+    @printf("indexed %d GS states → %s/library.csv\n", length(lib), dir)
+    for r in lib
+        @printf("  B=%6.2f µG  grid=%d  E=%.5f  |∇E|=%.2e  conv=%s\n",
+            r.B_uG, r.grid, r.E_total, r.grad_norm, string(r.converged))
+    end
+end

--- a/scripts/eu_merge_library.jl
+++ b/scripts/eu_merge_library.jl
@@ -1,0 +1,113 @@
+# Consolidate every scattered Eu B-scan output dir into ONE deduplicated,
+# physics-keyed library. Each frame_*/psi.jld2 is a self-describing converged GS;
+# the reusable atom is keyed by (grid, κ, B_uG, branch). When the same key was
+# computed multiple times (bequ/rc first attempts vs the final beq run), the
+# BEST-CONVERGED (min grad_norm) wins — superseded attempts drop out automatically.
+#
+# NON-DESTRUCTIVE: winners are HARD-LINKED into the library (same filesystem, zero
+# extra bytes), so the source dirs can later be reaped without losing data.
+#
+#   julia --project=. scripts/eu_merge_library.jl [figs] [figs/eu_gs_library]
+#
+# κ + branch are parsed from the source dir name (not stored in the jld2):
+#   *_dn_*, *down*, *beqd*      -> branch "dn" (m=−F anchor)
+#   *_up_*, *upsweep*, *bequ*, *rc_up*, *flower* -> branch "up"
+#   _k<κ>                       -> κ (default 1.1818 = the original Eu trap)
+
+using JLD2: jldopen
+using DelimitedFiles: writedlm
+using Printf
+
+_g(f, k, d) = haskey(f, k) ? f[k] : d
+_scalar(x) = x isa Tuple ? x[1] : x
+
+const SRC  = length(ARGS) >= 1 ? ARGS[1] : "figs"
+const DEST = length(ARGS) >= 2 ? ARGS[2] : "figs/eu_gs_library"
+
+function parse_kappa(name)
+    m = match(r"_k([0-9]+\.?[0-9]*)", name)
+    m === nothing ? 1.1818 : parse(Float64, m.captures[1])
+end
+function parse_branch(name)
+    n = lowercase(name)
+    (occursin("_dn", n) || occursin("down", n) || occursin("beqd", n)) && return "dn"
+    (occursin("_up", n) || occursin("upsweep", n) || occursin("bequ", n) ||
+     occursin("rc_up", n) || occursin("flower", n)) && return "up"
+    return "dn"  # m_plus_F-style default
+end
+
+# collect every psi.jld2 under SRC/<sweep>/frame_*/ (skip the library itself)
+rows = NamedTuple[]
+for sweep in readdir(SRC; join=true)
+    isdir(sweep) || continue
+    basename(sweep) == basename(DEST) && continue
+    startswith(basename(sweep), "eu_gs_library") && continue
+    κ = parse_kappa(basename(sweep)); br = parse_branch(basename(sweep))
+    for d in readdir(sweep; join=true)
+        pf = joinpath(d, "psi.jld2"); isfile(pf) || continue
+        r = jldopen(pf, "r") do f
+            (; grid=_scalar(_g(f, "grid_n_points", -1)),
+               B=round(_g(f, "B_uG", NaN); digits=1),
+               E=_g(f, "E_total", NaN), g=_g(f, "grad_norm", NaN),
+               conv=_g(f, "converged", -1), pin=_g(f, "pin_bx", NaN))
+        end
+        isnan(r.B) && continue
+        push!(rows, (; κ, br, r.grid, r.B, r.E, r.g, r.conv, r.pin,
+                       src=basename(sweep), path=pf))
+    end
+end
+
+# dedup by (grid, κ, B, branch): keep min grad_norm
+function dedup(rows)
+    best = Dict{Tuple{Int,Float64,Float64,String}, NamedTuple}()
+    ndup = 0
+    for r in rows
+        k = (r.grid, r.κ, r.B, r.br)
+        if !haskey(best, k) || (r.g < best[k].g)
+            haskey(best, k) && (ndup += 1)
+            best[k] = r
+        else
+            ndup += 1
+        end
+    end
+    best, ndup
+end
+best, ndup = dedup(rows)
+
+# hard-link winners into DEST/g<grid>/k<κ>/B<B>_<br>.jld2
+mkpath(DEST)
+manifest = NamedTuple[]
+for (k, r) in best
+    grid, κ, B, br = k
+    sub = joinpath(DEST, @sprintf("g%d", grid), @sprintf("k%s", κ))
+    mkpath(sub)
+    dst = joinpath(sub, @sprintf("B%03d_%s.jld2", round(Int, B), br))
+    isfile(dst) && rm(dst)
+    try
+        hardlink(r.path, dst)
+    catch
+        cp(r.path, dst; force=true)  # cross-device fallback
+    end
+    push!(manifest, (; grid, κ, B, branch=br, E=r.E, grad_norm=r.g,
+                       converged=r.conv, pin=r.pin, src=r.src, path=dst))
+end
+sort!(manifest; by=r -> (r.grid, r.κ, r.B, r.branch))
+
+open(joinpath(DEST, "library.csv"), "w") do io
+    ks = [:grid, :κ, :B, :branch, :E, :grad_norm, :converged, :pin, :src, :path]
+    writedlm(io, reshape(String.(ks), 1, :))
+    for r in manifest
+        writedlm(io, reshape(Any[getfield(r, k) for k in ks], 1, :))
+    end
+end
+
+@printf("scanned %d states, %d unique (grid,κ,B,branch), %d redundant dropped\n",
+    length(rows), length(best), ndup)
+@printf("library → %s/library.csv  (%d entries, hard-linked)\n", DEST, length(manifest))
+# per-grid summary
+grids = sort(unique(r.grid for r in manifest))
+for g in grids
+    gs = [r for r in manifest if r.grid == g]
+    ks = sort(unique(r.κ for r in gs))
+    @printf("  g%d: %d states, κ=%s\n", g, length(gs), join(ks, ","))
+end

--- a/scripts/homodyne_m5_alpha.jl
+++ b/scripts/homodyne_m5_alpha.jl
@@ -1,0 +1,53 @@
+# Evaporation efficiency α ≡ −dln(PSD)/dln(N) as the control variable for the m=-5
+# homodyne readout. At fixed load (N0,T0) and BEC-onset PSD = ζ(3), a ramp's N_BEC is
+# a monotone function of its run-averaged α:  N_BEC = N0·(ρ_load/ζ(3))^(1/α). Since the
+# m=-5 homodyne readout is detection-floor-dominated over the whole evaporation range
+# (SNR ∝ N), the readout sensitivity is set directly by α.
+#
+# Emits the (ds×fs) ramp ensemble {α=gamma_eff, N_BEC, N_final} and the nominal
+# trajectory's running α to figs/homodyne_m5_evap/; plot with viz_homodyne_m5_alpha.py.
+
+using SpinorBEC
+using DelimitedFiles
+
+const OUT = get(ENV, "HOMODYNE_OUT", "figs/homodyne_m5_evap")
+mkpath(OUT)
+
+d    = euv3_defaults()
+trap = euv3_evap_trap()
+p    = EvapParams(; a_s=d.a_s, tau_bg=d.tau_bg, K3=d.K3)
+base = euv3_evaporation_ramp()
+N0, T0 = d.N0, d.T0
+
+# --- ramp ensemble: capture efficiency α (gamma_eff) alongside N_BEC ---
+ds = collect(range(0.5, 3.0; length=34))
+fs = collect(range(0.3, 2.0; length=34))
+open(joinpath(OUT, "alpha_ensemble.csv"), "w") do io
+    println(io, "ds,fs,alpha,N_BEC,N_final,rho_load,reached")
+    for v1 in ds, v2 in fs
+        res = run_evaporation(trap, ramp_from_params([v1, v2, 1.0], base), p; N0=N0, T0=T0)
+        Nf   = isempty(res.N) ? N0 : res.N[end]
+        nbec = res.reached_bec ? res.N_BEC : NaN
+        rho0 = isempty(res.psd) ? NaN : res.psd[1]
+        println(io, join((v1, v2, res.gamma_eff, nbec, Nf, rho0,
+            res.reached_bec ? 1 : 0), ","))
+    end
+end
+
+# --- nominal trajectory: running α = −dln(ρ)/dln(N) from the load point ---
+r = run_euv3_evaporation()
+sm = evaporation_summary(r)
+n = length(r.t)
+α_run = fill(NaN, n)
+for i in 2:n
+    dlnN = log(r.N[i]) - log(r.N[1])
+    dlnρ = log(r.psd[i]) - log(r.psd[1])
+    α_run[i] = abs(dlnN) > 1e-9 ? -dlnρ / dlnN : NaN
+end
+open(joinpath(OUT, "alpha_trajectory.csv"), "w") do io
+    println(io, "t,N,psd,alpha_running")
+    writedlm(io, hcat(r.t, r.N, r.psd, α_run), ',')
+end
+
+println("nominal ramp: α=$(sm.gamma_eff)  N_BEC=$(sm.N_BEC)  ρ_load=$(r.psd[1])  ρ_BEC=1.202")
+println("wrote alpha CSVs to $(OUT)")

--- a/scripts/homodyne_m5_evap_readout.jl
+++ b/scripts/homodyne_m5_evap_readout.jl
@@ -1,0 +1,109 @@
+# Homodyne readout of the m=-5 spin component during the euv3 evaporation ramp.
+#
+# Physics. The m=-6 condensate (atom number N) is the local-oscillator reservoir.
+# A weak Raman pulse (pulse area θ, Δm=+1 via F_+) coherently injects a fraction of
+# it into m=-5 as a phase-reference amplitude a_LO = sinθ·√N. A pre-existing m=-5
+# signal a_s = √(εN)·e^{iφ} (ε = fixed small spin-dynamics/thermal fraction) then
+# interferes WITH IT inside the m=-5 channel:
+#
+#   N_meas = |a_LO + a_s e^{iφ}|² = sin²θ·N  +  εN  +  2 sinθ √ε · N cosφ
+#                                   └ carrier ┘ └DC┘  └─ homodyne fringe ─┘
+#
+# The homodyne term S_hom = 2 sinθ √ε · N is LINEAR in the small signal amplitude √ε
+# (vs the direct-imaging εN, quadratic in amplitude) and grows ∝ N. With a detection
+# floor σ_det (atoms), SNR_hom = S_hom/√(sin²θ·N + σ_det²) → 2√ε·√N at large N: the
+# strong LO carrier lifts the tiny m=-5 signal above the floor that buries direct
+# imaging. So a ramp that maximizes the final atom number ALSO maximizes the m=-5
+# homodyne sensitivity — the effect we visualize across the evaporation optimization.
+#
+# Emits CSVs to figs/homodyne_m5_evap/; render with scripts/viz_homodyne_m5_evap.py.
+# 0-D evaporation model is ms/run, so the (duration × final-power) surface is dense.
+
+using SpinorBEC
+using DelimitedFiles
+
+const OUT = get(ENV, "HOMODYNE_OUT", "figs/homodyne_m5_evap")
+mkpath(OUT)
+
+# --- homodyne readout model (phase-locked, cosφ = 1; best case) ---
+const EPS_M5 = parse(Float64, get(ENV, "HOMODYNE_EPS", "1e-3"))   # m=-5 signal fraction
+const THETA = parse(Float64, get(ENV, "HOMODYNE_THETA", "0.15")) # Raman pulse area [rad]
+const SIG_DET = parse(Float64, get(ENV, "HOMODYNE_SIGDET", "300")) # detection floor [atoms]
+
+carrier(N) = sin(THETA)^2 * N
+s_hom(N) = 2 * sin(THETA) * sqrt(EPS_M5) * N
+s_dir(N) = EPS_M5 * N
+snr_hom(N) = s_hom(N) / sqrt(carrier(N) + SIG_DET^2)
+snr_dir(N) = s_dir(N) / sqrt(s_dir(N) + SIG_DET^2)
+
+d = euv3_defaults()
+trap = euv3_evap_trap()
+p = EvapParams(; a_s=d.a_s, tau_bg=d.tau_bg, K3=d.K3)
+base = euv3_evaporation_ramp()
+N0, T0 = d.N0, d.T0
+
+println("euv3 defaults: N0=$(N0)  T0=$(T0*1e6) µK  K3=$(d.K3)")
+println("homodyne model: ε=$(EPS_M5)  θ=$(THETA) rad  σ_det=$(SIG_DET) atoms")
+
+# --- Panel A: signal & SNR vs atom number ---
+Ngrid = 10.0 .^ range(3.0, 6.4; length=240)
+A = hcat(Ngrid, s_hom.(Ngrid), s_dir.(Ngrid), snr_hom.(Ngrid), snr_dir.(Ngrid))
+open(joinpath(OUT, "signal_vs_N.csv"), "w") do io
+    println(io, "N,s_hom,s_dir,snr_hom,snr_dir")
+    writedlm(io, A, ',')
+end
+
+# --- Panel B: readout along the nominal euv3 evaporation trajectory ---
+r = run_euv3_evaporation()
+sm = evaporation_summary(r)
+println("nominal ramp: reached_bec=$(sm.reached_bec)  N_BEC=$(sm.N_BEC)  T_BEC=$(sm.T_BEC_uK) µK")
+B = hcat(r.t, r.N, r.T .* 1e6, r.psd, snr_hom.(r.N), snr_dir.(r.N))
+open(joinpath(OUT, "ramp_trajectory.csv"), "w") do io
+    println(io, "t,N,T_uK,psd,snr_hom,snr_dir")
+    writedlm(io, B, ',')
+end
+
+# --- Panel C: (duration_scale × final_power_scale) optimization surface ---
+ds = collect(range(0.5, 3.0; length=44))   # index 1 of ramp_from_params
+fs = collect(range(0.3, 2.0; length=44))   # index 2
+rows = Vector{NTuple{6, Float64}}()
+for v1 in ds, v2 in fs
+    ramp = ramp_from_params([v1, v2, 1.0], base)
+    res = run_evaporation(trap, ramp, p; N0=N0, T0=T0)
+    Nf = isempty(res.N) ? N0 : res.N[end]
+    nbec = res.reached_bec ? res.N_BEC : NaN
+    push!(rows, (v1, v2, Nf, nbec, res.reached_bec ? 1.0 : 0.0, snr_hom(Nf)))
+end
+open(joinpath(OUT, "opt_surface.csv"), "w") do io
+    println(io, "ds,fs,N_final,N_BEC,reached,snr_hom")
+    for row in rows
+        println(io, join(row, ","))
+    end
+end
+writedlm(joinpath(OUT, "opt_axes.csv"), [permutedims(ds); permutedims(fs)], ',')
+
+# --- Panel D: lab ramp vs monotone-optimized ramp ---
+r_lab = run_evaporation(trap, base, p; N0=N0, T0=T0)
+opt = optimize_ramp_monotone(trap, p, base; N0=N0, T0=T0, restarts=3)
+N_lab = isempty(r_lab.N) ? N0 : r_lab.N[end]
+N_opt = isempty(opt.result.N) ? N0 : opt.result.N[end]
+println("lab ramp:  N_final=$(N_lab)  N_BEC=$(r_lab.reached_bec ? r_lab.N_BEC : NaN)")
+println("opt ramp:  N_final=$(N_opt)  N_BEC=$(opt.N_BEC)")
+open(joinpath(OUT, "ramp_compare.csv"), "w") do io
+    println(io, "label,N_final,N_BEC,snr_hom")
+    println(io, "lab,$(N_lab),$(r_lab.reached_bec ? r_lab.N_BEC : NaN),$(snr_hom(N_lab))")
+    println(io, "optimized,$(N_opt),$(opt.N_BEC),$(snr_hom(N_opt))")
+end
+
+open(joinpath(OUT, "meta.csv"), "w") do io
+    println(io, "key,value")
+    println(io, "eps,$(EPS_M5)")
+    println(io, "theta,$(THETA)")
+    println(io, "sig_det,$(SIG_DET)")
+    println(io, "N0,$(N0)")
+    println(io, "T0_uK,$(T0*1e6)")
+    println(io, "t_BEC,$(sm.t_BEC_s)")
+    println(io, "N_BEC_nominal,$(sm.N_BEC)")
+end
+
+println("wrote CSVs to $(OUT)")

--- a/scripts/homodyne_m5_threshold.py
+++ b/scripts/homodyne_m5_threshold.py
@@ -1,0 +1,94 @@
+# Single-shot detectability threshold for the m=-5 Raman-homodyne readout.
+#
+# SNR_hom(N) = 2 sinθ √ε · N / √(sin²θ·N + σ_det²).  Invert SNR_hom = SNR_t for the
+# minimum atom number N_min that makes the m=-5 signal visible in ONE observation:
+#
+#   a²N² - SNR_t²·sin²θ·N - SNR_t²·σ_det² = 0,   a = 2 sinθ √ε
+#   ⇒ N_min = [SNR_t²·sin²θ + √(SNR_t⁴ sin⁴θ + 4 a² SNR_t² σ_det²)] / (2 a²)
+#
+#   HOMODYNE_OUT=figs/homodyne_m5_evap python scripts/homodyne_m5_threshold.py
+import os
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+OUT = os.environ.get("HOMODYNE_OUT", "figs/homodyne_m5_evap")
+
+meta = {}
+for line in open(f"{OUT}/meta.csv").read().splitlines()[1:]:
+    k, v = line.split(",")
+    meta[k] = float(v)
+EPS, THETA, SIGDET = meta["eps"], meta["theta"], meta["sig_det"]
+
+# euv3 endpoints (lab vs monotone-optimized) for reference lines
+endpoints = {}
+for row in open(f"{OUT}/ramp_compare.csv").read().splitlines()[1:]:
+    lab, nf, nb, sn = row.split(",")
+    endpoints[lab] = float(nf)
+
+
+def n_min(snr_t, theta=THETA, eps=EPS, sigdet=SIGDET):
+    s2 = np.sin(theta) ** 2
+    a2 = 4.0 * s2 * eps                      # a² = (2 sinθ √ε)²
+    disc = snr_t**4 * s2**2 + 4.0 * a2 * snr_t**2 * sigdet**2
+    return (snr_t**2 * s2 + np.sqrt(disc)) / (2.0 * a2)
+
+
+# --- console table ---
+print(f"model: ε={EPS:g}  θ={THETA:g} rad  σ_det={SIGDET:g} atoms")
+print(f"euv3 endpoints: lab N={endpoints.get('lab', float('nan')):.0f}  "
+      f"optimized N={endpoints.get('optimized', float('nan')):.0f}\n")
+print(f"{'criterion':<26}{'N_min (θ=0.15)':>16}{'N_min (θ=π/2, full)':>22}")
+labels = {1: "marginal (SNR=1)", 2: "single-shot visible (SNR=2)",
+          3: "clear (SNR=3)", 5: "high-confidence (SNR=5)"}
+for s in (1, 2, 3, 5):
+    print(f"{labels[s]:<26}{n_min(s):>16.0f}{n_min(s, theta=np.pi/2):>22.0f}")
+
+# --- figure ---
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5.6))
+fig.suptitle("m=-5 single-shot detectability: minimum atom number to see it in one observation",
+             fontsize=13, fontweight="bold")
+
+# Panel 1: N_min vs SNR threshold, for several Raman pulse areas
+snr = np.linspace(0.5, 6, 200)
+thetas = [(0.10, "weak θ=0.10"), (THETA, f"default θ={THETA:g}"),
+          (0.30, "θ=0.30"), (np.pi / 2, "full θ=π/2 (destructive)")]
+colors = plt.cm.viridis(np.linspace(0.15, 0.85, len(thetas)))
+for (th, lab), c in zip(thetas, colors):
+    lw = 3.0 if abs(th - THETA) < 1e-9 else 1.8
+    ax1.semilogy(snr, [n_min(s, theta=th) for s in snr], color=c, lw=lw, label=lab)
+for nlab, nval, col in [("lab ramp", endpoints.get("lab"), "0.45"),
+                        ("optimized ramp", endpoints.get("optimized"), "#d6336c")]:
+    if nval:
+        ax1.axhline(nval, color=col, lw=1.3, ls="--")
+        ax1.text(5.9, nval, f" {nlab}\n {nval:.0f}", color=col, fontsize=8,
+                 va="center", ha="right")
+for s in (2, 3):
+    ax1.axvline(s, color="0.7", lw=0.8, ls=":")
+ax1.set_xlabel("required SNR (single-shot visibility criterion)")
+ax1.set_ylabel("minimum atom number N_min")
+ax1.set_title("N_min vs visibility criterion — stronger pulse lowers the bar", fontsize=11)
+ax1.legend(loc="upper left", fontsize=9)
+ax1.grid(alpha=0.25, which="both")
+
+# Panel 2: N_min (single-shot visible, SNR=2) vs detection floor σ_det
+sig = np.logspace(1, 3.3, 200)   # 10 .. ~2000 atoms
+for (th, lab), c in zip(thetas, colors):
+    lw = 3.0 if abs(th - THETA) < 1e-9 else 1.8
+    ax2.loglog(sig, [n_min(2.0, theta=th, sigdet=sg) for sg in sig],
+               color=c, lw=lw, label=lab)
+ax2.axvline(SIGDET, color="0.5", lw=1.0, ls=":")
+ax2.text(SIGDET, ax2.get_ylim()[0] * 1.5, f" σ_det={SIGDET:g}", fontsize=8, color="0.4")
+if endpoints.get("lab"):
+    ax2.axhline(endpoints["lab"], color="0.45", lw=1.2, ls="--")
+    ax2.text(11, endpoints["lab"], " lab BEC", fontsize=8, color="0.45", va="bottom")
+ax2.set_xlabel("detection floor σ_det [atoms]")
+ax2.set_ylabel("N_min for single-shot visible (SNR=2)")
+ax2.set_title("threshold vs detection noise (at SNR=2)", fontsize=11)
+ax2.legend(loc="upper left", fontsize=9)
+ax2.grid(alpha=0.25, which="both")
+
+plt.tight_layout(rect=[0, 0, 1, 0.95])
+plt.savefig(f"{OUT}/threshold.png", dpi=130)
+print(f"\nwrote {OUT}/threshold.png")

--- a/scripts/submit_eu_bscan.sh
+++ b/scripts/submit_eu_bscan.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# TSUBAME (UGE) submit for the pinned Eu+DDI B-scan continuation (64³).
+# Bakes in the environment fixes learned 2026-07-08 (do not hand-write again):
+#   1. julia not on compute-node PATH  -> explicit $JULIA.
+#   2. julialauncher needs JULIAUP_DEPOT_PATH (login env only) -> export.
+#   3. node-local JULIA_DEPOT_PATH is empty each job -> shared depot (precompiled).
+#   4. GPU jobs silently fall back to CPU if CUDA driver missing -> hard guard.
+# No large dynamics snapshots here (GS states, ~55 MB/frame jld2 written directly
+# to figs/ on Lustre via IOStream, not the mmap snapshot path) — no scratch tweak.
+#
+# Submit:
+#   qsub -g tga-kozuma-kouhi scripts/submit_eu_bscan.sh
+# Override run size:
+#   qsub -g tga-kozuma-kouhi -v BS_NB=51,BS_LBFGS_CELL=100 scripts/submit_eu_bscan.sh
+#
+#$ -cwd
+#$ -N eu_bscan_pin
+#$ -l node_q=1
+#$ -l h_rt=24:00:00
+#$ -j y
+#$ -o logs/tsubame/eu_bscan.log
+set -euo pipefail
+
+REPO=/gs/fs/tga-kozuma-kouhi/uk07267/BEC-simulation
+cd "$REPO"
+mkdir -p logs/tsubame
+
+export JULIA_DEPOT_PATH=/gs/fs/tga-kozuma-kouhi/shared/.julia
+export JULIAUP_DEPOT_PATH=/gs/fs/tga-kozuma-kouhi/shared/.juliaup
+JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia
+
+source scripts/tsubame_setup.sh    # threads + CUDA module + node-local scratch
+
+# --- run parameters (override via `qsub -v`) ---
+export BS_GRID="${BS_GRID:-64}"
+export BS_BOX="${BS_BOX:-24.0}"
+export BS_NB="${BS_NB:-46}"          # 0..90 µG, ΔB=2 µG (≥90 µG not needed)
+export BS_BMIN="${BS_BMIN:-0.0}"
+export BS_BMAX="${BS_BMAX:-90.0}"
+export BS_PIN_EPS="${BS_PIN_EPS:-2e-3}"
+export BS_TOL="${BS_TOL:-1e-5}"      # grad-norm early-stop (4 orders below Goldstone floor)
+export BS_ITP="${BS_ITP:-1500}"
+export BS_NEWTON_ANCHOR="${BS_NEWTON_ANCHOR:-0}"   # Newton = 336 s/iter at 64³, useless on soft manifold
+export BS_LBFGS_ANCHOR="${BS_LBFGS_ANCHOR:-400}"   # cap; early-stops ~340 at |∇E|<1e-5
+export BS_LBFGS_CELL="${BS_LBFGS_CELL:-150}"       # cap; warm cells early-stop sooner
+export BS_SAVE_PSI="${BS_SAVE_PSI:-1}"
+export BS_OUT="${BS_OUT:-figs/eu_bscan_pinned}"
+
+echo "=== node $(hostname) $(date) grid=$BS_GRID box=$BS_BOX NB=$BS_NB B=$BS_BMAX..$BS_BMIN µG pin=$BS_PIN_EPS ==="
+$JULIA --project=. -e 'using CUDA; @assert CUDA.functional() "CUDA not functional — would silently run on CPU"; println("CUDA OK: ", CUDA.name(CUDA.device()))'
+$JULIA --project=. scripts/eu_bscan_pinned_continuation.jl
+echo "=== done $(date) — frames in $BS_OUT ==="

--- a/scripts/viz_eu_bscan_animation.py
+++ b/scripts/viz_eu_bscan_animation.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Animate the pinned weak-field ¹⁵¹Eu+DDI ground state vs magnetic field.
+
+Reads the per-frame CSVs from eu_bscan_pinned_continuation.jl and renders a
+4-panel animation sweeping B from high to low field:
+  1. density n(x,y)
+  2. transverse-spin |F⊥| (colour) + spin DIRECTION as UNIT arrows (normalised,
+     so they never overlap — length carries no info, only direction)
+  3. F_z(x,y)
+  4. m-population bar
+
+Physics regimes (labelled per frame): the radial spin texture ("flower") lives
+in the polarised regime B≳60 µG; below it the cloud depolarises and the pinned
+transverse spin becomes uniform (NOT a flower).
+
+  python scripts/viz_eu_bscan_animation.py [figs/eu_bscan_pin_tight] [out.mp4]
+Env BMAX (µG, default 90) drops the trivial high-field tail above that value.
+"""
+import os
+import sys
+import glob
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation, FFMpegWriter, PillowWriter
+
+D = sys.argv[1] if len(sys.argv) > 1 else "figs/eu_bscan_pin_tight"
+OUT = sys.argv[2] if len(sys.argv) > 2 else os.path.join(D, "eu_bscan.mp4")
+BMAX = float(os.environ.get("BMAX", "90"))
+FLOWER_B = 58.0   # radial flower texture lives above ~this field
+
+manifest = np.atleast_2d(
+    np.loadtxt(os.path.join(D, "frames.csv"), delimiter="\t", skiprows=1))
+all_frames = sorted(glob.glob(os.path.join(D, "frame_*")))
+pairs = [(fr, row[1]) for fr, row in zip(all_frames, manifest) if row[1] <= BMAX + 1e-9]
+if not pairs:
+    sys.exit(f"no frames with B <= {BMAX} µG under {D}")
+frames = [p[0] for p in pairs]
+b_ug = np.array([p[1] for p in pairs])
+print(f"{len(frames)} frames with B <= {BMAX} µG (of {len(all_frames)} computed)")
+
+
+def load(fr, name):
+    return np.loadtxt(os.path.join(fr, name), delimiter="\t")
+
+
+dmax = max(load(fr, "density_xy.csv").max() for fr in frames)
+fpmax = max(load(fr, "fperp_xy.csv").max() for fr in frames)
+fzabs = max(np.abs(load(fr, "fz_xy.csv")).max() for fr in frames)
+
+d0 = load(frames[0], "density_xy.csv")
+N = d0.shape[0]
+sk = max(1, N // 20)
+idx = np.arange(0, N, sk)
+GX, GY = np.meshgrid(idx, idx, indexing="ij")
+
+fig, ax = plt.subplots(1, 4, figsize=(19, 5.0))
+
+
+def regime(B):
+    if B >= FLOWER_B:
+        return "flower — radial spin texture", "#38b000"
+    if B >= 24:
+        return "transition — depolarising", "#f48c06"
+    return "uniform pinned — depolarised", "#9d4edd"
+
+
+def draw(i):
+    for a in ax:
+        a.clear()
+    fr = frames[i]
+    dens = load(fr, "density_xy.csv")
+    fx, fy = load(fr, "fx_xy.csv"), load(fr, "fy_xy.csv")
+    fz, fperp = load(fr, "fz_xy.csv"), load(fr, "fperp_xy.csv")
+    pops = load(fr, "populations.csv")
+    mask = dens > 0.08 * dmax
+    mag = np.hypot(fx, fy)
+    u = np.where(mask, fx / (mag + 1e-9), np.nan)
+    v = np.where(mask, fy / (mag + 1e-9), np.nan)
+
+    ax[0].imshow(dens.T, origin="lower", cmap="inferno", vmin=0, vmax=dmax)
+    ax[0].set_title("density  n(x,y)")
+
+    ax[1].imshow(fperp.T, origin="lower", cmap="magma", vmin=0, vmax=fpmax)
+    ax[1].quiver(GX, GY, u[::sk, ::sk], v[::sk, ::sk],
+                 color="cyan", scale=26, width=0.006, pivot="mid")
+    ax[1].set_title("transverse spin |F⊥| + direction (unit arrows)")
+
+    ax[2].imshow(fz.T, origin="lower", cmap="RdBu_r", vmin=-fzabs, vmax=fzabs)
+    ax[2].set_title("F_z density  (blue = spin-down / polarised)")
+
+    ax[3].bar(pops[:, 0], pops[:, 1], color="steelblue")
+    ax[3].set_ylim(0, 1)
+    ax[3].set_xlabel("m")
+    ax[3].set_title("populations")
+
+    for a in (ax[0], ax[1], ax[2]):
+        a.set_xticks([])
+        a.set_yticks([])
+
+    label, colour = regime(b_ug[i])
+    fig.suptitle(f"¹⁵¹Eu F=6 + DDI  pinned GS   B = {b_ug[i]:5.1f} µG    [{label}]",
+                 fontsize=15, color=colour)
+    return []
+
+
+anim = FuncAnimation(fig, draw, frames=len(frames), blit=False)
+fps = 10
+try:
+    if OUT.endswith(".gif"):
+        raise RuntimeError("gif requested")
+    anim.save(OUT, writer=FFMpegWriter(fps=fps, bitrate=4000))
+    print(f"wrote {OUT}")
+except Exception as e:
+    OUT = os.path.splitext(OUT)[0] + ".gif"
+    anim.save(OUT, writer=PillowWriter(fps=fps))
+    print(f"ffmpeg unavailable ({e}); wrote {OUT}")

--- a/scripts/viz_homodyne_m5_evap.py
+++ b/scripts/viz_homodyne_m5_evap.py
@@ -1,0 +1,143 @@
+# Render the m=-5 Raman-homodyne readout study produced by homodyne_m5_evap_readout.jl.
+#
+#   HOMODYNE_OUT=figs/homodyne_m5_evap python scripts/viz_homodyne_m5_evap.py
+#
+# Four panels:
+#   A  homodyne vs direct readout: signal & SNR vs atom number N (the headline)
+#   B  the readout riding the euv3 evaporation trajectory N(t), with BEC onset
+#   C  optimization surface: homodyne SNR over (duration × final-power) ramp transform
+#   D  lab ramp vs monotone-optimized ramp — atom number and homodyne SNR gain
+import os
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
+
+OUT = os.environ.get("HOMODYNE_OUT", "figs/homodyne_m5_evap")
+
+meta = {}
+for line in open(f"{OUT}/meta.csv").read().splitlines()[1:]:
+    k, v = line.split(",")
+    meta[k] = float(v)
+eps, theta, sig_det = meta["eps"], meta["theta"], meta["sig_det"]
+
+A = np.loadtxt(f"{OUT}/signal_vs_N.csv", delimiter=",", skiprows=1)
+N, s_hom, s_dir, snr_hom, snr_dir = A.T
+
+B = np.loadtxt(f"{OUT}/ramp_trajectory.csv", delimiter=",", skiprows=1)
+t, Nt, T_uK, psd, snr_hom_t, snr_dir_t = B.T
+
+S = np.loadtxt(f"{OUT}/opt_surface.csv", delimiter=",", skiprows=1)
+ax = np.loadtxt(f"{OUT}/opt_axes.csv", delimiter=",")
+ds, fs = ax[0], ax[1]
+nds, nfs = len(ds), len(fs)
+snr_grid = S[:, 5].reshape(nds, nfs)
+nbec_grid = S[:, 3].reshape(nds, nfs)
+
+C = open(f"{OUT}/ramp_compare.csv").read().splitlines()[1:]
+labels, Nfin, Nbec, snrc = [], [], [], []
+for row in C:
+    lab, nf, nb, sn = row.split(",")
+    labels.append(lab); Nfin.append(float(nf)); Nbec.append(float(nb)); snrc.append(float(sn))
+
+C_HOM, C_DIR = "#d6336c", "#1c7ed6"
+fig = plt.figure(figsize=(15, 10))
+fig.suptitle(
+    f"m=-5 Raman-homodyne readout across the euv3 evaporation ramp "
+    f"(ε={eps:g}, θ={theta:g} rad, σ_det={sig_det:g} atoms)",
+    fontsize=14, fontweight="bold")
+
+# --- Panel A: signal & SNR vs N ---
+axA = fig.add_subplot(2, 2, 1)
+axA.loglog(N, s_hom, color=C_HOM, lw=2.2, label="homodyne signal  2 sinθ√ε·N")
+axA.loglog(N, s_dir, color=C_DIR, lw=2.2, ls="--", label="direct signal  εN")
+axA.set_xlabel("atom number N (m=-6 reservoir)")
+axA.set_ylabel("m=-5 readout signal [atoms]", color="0.2")
+axA.grid(alpha=0.25, which="both")
+axB2 = axA.twinx()
+axB2.semilogx(N, snr_hom, color=C_HOM, lw=1.4, alpha=0.55)
+axB2.semilogx(N, snr_dir, color=C_DIR, lw=1.4, alpha=0.55, ls="--")
+axB2.set_ylabel("SNR  (faint lines)")
+axB2.axhline(1.0, color="0.5", lw=0.8, ls=":")
+# floor crossing for direct readout (SNR_dir = 1)
+above = np.where(snr_dir >= 1.0)[0]
+if len(above):
+    Ncross = N[above[0]]
+    axA.axvline(Ncross, color=C_DIR, lw=0.8, ls=":")
+    axA.text(Ncross, s_dir.min() * 3, f"direct SNR=1\n@N={Ncross:.0f}",
+             color=C_DIR, fontsize=8, ha="left")
+adv = float(np.nanmedian(s_hom / s_dir))
+axA.text(0.50, 0.06, f"homodyne / direct  ≈ ×{adv:.1f}\n(= 2 sinθ/√ε, amplitude gain)",
+         transform=axA.transAxes, fontsize=9, color=C_HOM,
+         bbox=dict(boxstyle="round", fc="white", ec=C_HOM, alpha=0.8))
+axA.set_title("A  homodyne is linear in the m=-5 amplitude → readable at low N", fontsize=11)
+axA.legend(loc="upper left", fontsize=9)
+
+# --- Panel B: readout along the evaporation trajectory ---
+axT = fig.add_subplot(2, 2, 2)
+axT.semilogy(t, Nt, color="0.25", lw=2.2, label="N(t) atom number")
+axT.set_xlabel("evaporation time t [s]")
+axT.set_ylabel("atom number N(t)", color="0.25")
+axT.grid(alpha=0.25, which="both")
+axS = axT.twinx()
+axS.plot(t, snr_hom_t, color=C_HOM, lw=2.0, label="homodyne SNR")
+axS.plot(t, snr_dir_t, color=C_DIR, lw=2.0, ls="--", label="direct SNR")
+axS.set_ylabel("m=-5 readout SNR")
+axS.axhline(1.0, color="0.5", lw=0.9, ls=":")
+axS.text(t[0], 1.0, " readable (SNR=1)", color="0.4", fontsize=8, va="bottom")
+axS.annotate(f"homodyne {snr_hom_t[-1]:.1f}\ndirect {snr_dir_t[-1]:.2f} (buried)",
+             xy=(t[-1], snr_hom_t[-1]), xytext=(t[-1] * 0.62, max(snr_hom_t) * 0.55),
+             fontsize=8.5, color=C_HOM,
+             arrowprops=dict(arrowstyle="->", color=C_HOM, lw=1.0))
+if "t_BEC" in meta and meta["t_BEC"] > 0:
+    axT.axvline(meta["t_BEC"], color="seagreen", lw=1.2, ls="-.")
+    axT.text(meta["t_BEC"], Nt.max(), " BEC onset", color="seagreen",
+             fontsize=8, va="top")
+l1, lab1 = axT.get_legend_handles_labels()
+l2, lab2 = axS.get_legend_handles_labels()
+axT.legend(l1 + l2, lab1 + lab2, loc="lower left", fontsize=9)
+axT.set_title("B  the readout rides the cooling trajectory in real time", fontsize=11)
+
+# --- Panel C: optimization surface ---
+axC = fig.add_subplot(2, 2, 3)
+sg = np.ma.masked_invalid(snr_grid.T)
+pcm = axC.pcolormesh(ds, fs, sg, shading="auto", cmap="magma")
+fig.colorbar(pcm, ax=axC, label="homodyne SNR at ramp end")
+# BEC-reached region contour
+ng = np.ma.masked_invalid(nbec_grid.T)
+if np.isfinite(nbec_grid).any():
+    axC.contour(ds, fs, np.isfinite(nbec_grid.T).astype(float),
+                levels=[0.5], colors="cyan", linewidths=1.2)
+# mark the optimum
+jmax = np.unravel_index(np.nanargmax(snr_grid), snr_grid.shape)
+axC.plot(ds[jmax[0]], fs[jmax[1]], "*", color="white", ms=16,
+         markeredgecolor="k", label="max SNR")
+axC.plot(1.0, 1.0, "o", color="cyan", ms=8, markeredgecolor="k", label="lab ramp")
+axC.set_xlabel("duration scale")
+axC.set_ylabel("final-power scale")
+axC.legend(loc="upper right", fontsize=8)
+axC.set_title("C  ramp that maximizes N also maximizes m=-5 SNR (∝√N)", fontsize=11)
+
+# --- Panel D: lab vs optimized ---
+axD = fig.add_subplot(2, 2, 4)
+x = np.arange(len(labels))
+w = 0.38
+nb_plot = [nb if np.isfinite(nb) else nf for nb, nf in zip(Nbec, Nfin)]
+b1 = axD.bar(x - w / 2, nb_plot, w, color="0.45", label="N (BEC / final)")
+axD.set_ylabel("atom number", color="0.3")
+axD.set_yscale("log")
+axDr = axD.twinx()
+b2 = axDr.bar(x + w / 2, snrc, w, color=C_HOM, label="homodyne SNR")
+axDr.set_ylabel("homodyne SNR", color=C_HOM)
+axD.set_xticks(x)
+axD.set_xticklabels(labels)
+for xi, nb, sn in zip(x, nb_plot, snrc):
+    axD.text(xi - w / 2, nb, f"{nb:.0f}", ha="center", va="bottom", fontsize=8)
+    axDr.text(xi + w / 2, sn, f"{sn:.0f}", ha="center", va="bottom", fontsize=8, color=C_HOM)
+gain = snrc[1] / snrc[0] if snrc[0] else float("nan")
+axD.set_title(f"D  optimized ramp: ×{gain:.1f} m=-5 homodyne SNR", fontsize=11)
+
+plt.tight_layout(rect=[0, 0, 1, 0.96])
+plt.savefig(f"{OUT}/homodyne_m5_evap.png", dpi=130)
+print(f"wrote {OUT}/homodyne_m5_evap.png")

--- a/scripts/viz_homodyne_m5_fringe.py
+++ b/scripts/viz_homodyne_m5_fringe.py
@@ -1,0 +1,109 @@
+# Single-shot m=-5 Raman-homodyne INTERFERENCE FRINGE vs atom number.
+#
+# The Raman beams carry an effective wavevector k_eff, so the LO injected from the
+# m=-6 BEC (a_LO = sinθ √n · e^{ik·x}) interferes with the co-located m=-5 signal
+# (a_s = √(εn) e^{iφ}) to produce SPATIAL fringes in the m=-5 column density:
+#
+#   n_{-5}(x) = (sin²θ+ε)·n(x)  +  2 sinθ √ε · n(x) · cos(k_eff·x − φ)
+#               └── pedestal ──┘     └──── homodyne fringe (∝ n) ────┘
+#
+# We simulate ONE shot (per-pixel Poisson atom shot noise + read noise) at several
+# atom numbers: the fringe amplitude rides on the BEC density, so it emerges from the
+# single-shot noise only once N is large enough — that is the "visible in one shot"
+# threshold, shown as the actual interferogram instead of an SNR number.
+#
+#   HOMODYNE_OUT=figs/homodyne_m5_evap python scripts/viz_homodyne_m5_fringe.py
+import os
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+OUT = os.environ.get("HOMODYNE_OUT", "figs/homodyne_m5_evap")
+
+meta = {}
+for line in open(f"{OUT}/meta.csv").read().splitlines()[1:]:
+    k, v = line.split(",")
+    meta[k] = float(v)
+EPS, THETA, SIGDET = meta["eps"], meta["theta"], meta["sig_det"]
+
+endpoints = {}
+for row in open(f"{OUT}/ramp_compare.csv").read().splitlines()[1:]:
+    lab, nf, nb, sn = row.split(",")
+    endpoints[lab] = float(nf)
+N_lab = endpoints.get("lab", 6.5e4)
+N_opt = endpoints.get("optimized", 1.1e5)
+
+# --- imaging model ---
+NPIX = 64
+R = 18.0                      # Thomas-Fermi radius [px]
+LAMBDA = 7.0                  # fringe period [px]  (~5 fringes across the cloud)
+PHI0 = 0.0                    # signal relative phase
+SIG_READ = 1.0               # per-pixel detection/read noise [atoms]
+PED = np.sin(THETA) ** 2 + EPS              # pedestal fraction
+AMP = 2 * np.sin(THETA) * np.sqrt(EPS)      # fringe-amplitude fraction
+VIS = AMP / PED                             # intrinsic fringe visibility
+
+x = np.arange(NPIX) - NPIX / 2 + 0.5
+X, Y = np.meshgrid(x, x)
+RR = X**2 + Y**2
+tf = np.clip(1.0 - RR / R**2, 0.0, None)    # 2D Thomas-Fermi paraboloid
+tf_norm = tf / tf.sum()                     # ∫ = 1
+
+
+def m5_image(N, seed):
+    rng = np.random.default_rng(seed)
+    env = N * tf_norm                                   # m=-6 BEC column [atoms/px]
+    fringe = PED + AMP * np.cos(2 * np.pi * X / LAMBDA - PHI0)
+    lam = np.clip(env * fringe, 0.0, None)              # mean m=-5 counts/px
+    shot = rng.poisson(lam).astype(float)
+    return shot + rng.normal(0.0, SIG_READ, lam.shape), lam
+
+
+Ns = [1.5e4, N_lab, N_opt, 3.0e5]
+tags = ["low N", "lab BEC", "optimized", "high N"]
+
+fig, axes = plt.subplots(2, 4, figsize=(16, 7.4),
+                         gridspec_kw={"height_ratios": [1.25, 1]})
+fig.suptitle(
+    f"m=-5 Raman-homodyne interference fringe — single shot vs atom number "
+    f"(θ={THETA:g}, ε={EPS:g}, intrinsic visibility {VIS:.0%})",
+    fontsize=13, fontweight="bold")
+
+for j, (N, tag) in enumerate(zip(Ns, tags)):
+    img, lam = m5_image(N, seed=10 + j)
+
+    # top: single-shot 2D m=-5 image
+    axi = axes[0, j]
+    vmax = max(lam.max() * 1.6, 1.0)
+    axi.imshow(img, origin="lower", cmap="inferno", vmin=0, vmax=vmax,
+               extent=[x[0], x[-1], x[0], x[-1]])
+    axi.set_title(f"{tag}:  N = {N:.0f}", fontsize=11)
+    axi.set_xticks([]); axi.set_yticks([])
+
+    # bottom: column-integrated fringe (the measured interference signal)
+    axp = axes[1, j]
+    prof = img.sum(axis=0)                       # integrate y → 1D fringe [atoms/col]
+    ideal = (N * tf_norm).sum(axis=0) * (PED + AMP * np.cos(2 * np.pi * x / LAMBDA - PHI0))
+    axp.plot(x, prof, color="0.25", lw=1.0, marker="o", ms=2.5, label="single shot")
+    axp.plot(x, ideal, color="#d6336c", lw=2.0, label="ideal fringe")
+    # single-shot fringe-amplitude SNR over the cloud
+    col_env = (N * tf_norm).sum(axis=0)
+    mask = col_env > 0.05 * col_env.max()
+    amp_col = AMP * col_env[mask]                                  # expected fringe amp
+    noise_col = np.sqrt(np.clip(PED * col_env[mask], 0, None) + SIG_READ**2 * NPIX)
+    snr_fr = np.sqrt(np.mean((amp_col / noise_col) ** 2))
+    axp.text(0.03, 0.92, f"fringe SNR ≈ {snr_fr:.1f}", transform=axp.transAxes,
+             fontsize=10, va="top",
+             color=("seagreen" if snr_fr >= 2 else "firebrick"),
+             bbox=dict(boxstyle="round", fc="white", alpha=0.8))
+    axp.set_xlabel("x [px]  (fringe axis)")
+    if j == 0:
+        axp.set_ylabel("m=-5 column density\n[atoms / column]")
+        axp.legend(loc="lower center", fontsize=8, ncol=2)
+    axp.grid(alpha=0.25)
+
+plt.tight_layout(rect=[0, 0, 1, 0.95])
+plt.savefig(f"{OUT}/homodyne_m5_fringe.png", dpi=130)
+print(f"wrote {OUT}/homodyne_m5_fringe.png")
+print(f"intrinsic visibility V = {VIS:.3f}  pedestal={PED:.4f}  amp={AMP:.4f}")

--- a/scripts/viz_homodyne_m5_gs.py
+++ b/scripts/viz_homodyne_m5_gs.py
@@ -1,0 +1,147 @@
+# Raman-homodyne interference of the GROUND-STATE m=-5 component (weak-field Eu+DDI).
+#
+# The converged weak-field Eu+DDI ground state is a DDI-textured spinor (NOT polarized
+# m=-6): m=-6 ≈ 22%, m=-5 ≈ 3.3% (figs/truegs_conv, |∇E|=7.6e-6). The m=-5 population
+# is the SIGNAL; m=-6 is the local-oscillator reservoir. A Raman pulse (area θ, Δm=+1)
+# injects sinθ√(N₋₆) into m=-5, where it interferes with the existing √(N₋₅):
+#
+#   N_meas = sin²θ·N₋₆ + N₋₅ + 2 sinθ √(N₋₅ N₋₆) cos(k·x − φ)
+#   N₋₅ = f₅·N,  N₋₆ = f₆·N   (f₅,f₆ from the ground-state spectrum)
+#
+# Visualizes the actual single-shot interferogram at the euv3 BEC atom number and the
+# minimum N for single-shot visibility, using the real ground-state populations.
+#
+#   HOMODYNE_OUT=figs/homodyne_m5_evap python scripts/viz_homodyne_m5_gs.py
+import os
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+OUT = os.environ.get("HOMODYNE_OUT", "figs/homodyne_m5_evap")
+GS = os.environ.get("GS_DIR", "figs/truegs_conv")     # converged GS (|∇E|=7.6e-6)
+
+# ground-state m populations
+ms, pops = [], []
+for line in open(f"{GS}/populations.csv").read().splitlines():
+    a, b = line.split()
+    ms.append(float(a)); pops.append(float(b))
+ms = np.array(ms); pops = np.array(pops)
+f5 = float(pops[ms == -5][0])
+f6 = float(pops[ms == -6][0])
+
+meta = {}
+for line in open(f"{OUT}/meta.csv").read().splitlines()[1:]:
+    k, v = line.split(",")
+    meta[k] = float(v)
+THETA, SIGDET = meta["theta"], meta["sig_det"]
+
+endpoints = {}
+for row in open(f"{OUT}/ramp_compare.csv").read().splitlines()[1:]:
+    lab, nf, nb, sn = row.split(",")
+    endpoints[lab] = float(nf)
+N_lab, N_opt = endpoints.get("lab", 6.5e4), endpoints.get("optimized", 1.1e5)
+
+st = np.sin(THETA)
+A = 2 * st * np.sqrt(f5 * f6)        # fringe coefficient: S_hom = A·N
+C = st**2 * f6 + f5                  # carried m=-5 pedestal coefficient
+
+
+def snr(N):
+    return A * N / np.sqrt(C * N + SIGDET**2)
+
+
+def n_min(snr_t):
+    disc = snr_t**4 * C**2 + 4 * A**2 * snr_t**2 * SIGDET**2
+    return (snr_t**2 * C + np.sqrt(disc)) / (2 * A**2)
+
+
+print(f"ground state {GS}:  f5(m=-5)={f5:.4f}  f6(m=-6)={f6:.4f}")
+print(f"homodyne θ={THETA:g}, σ_det={SIGDET:g}: SNR(lab N={N_lab:.0f})={snr(N_lab):.1f}, "
+      f"SNR(opt N={N_opt:.0f})={snr(N_opt):.1f}")
+for s in (1, 2, 3, 5):
+    print(f"  N_min(SNR={s}) = {n_min(s):.0f}")
+
+# --- imaging model for the single-shot interferogram ---
+NPIX, R, LAMBDA, SIG_READ = 64, 18.0, 7.0, 1.0
+x = np.arange(NPIX) - NPIX / 2 + 0.5
+Xg, Yg = np.meshgrid(x, x)
+tf = np.clip(1.0 - (Xg**2 + Yg**2) / R**2, 0.0, None)
+tf /= tf.sum()
+PED = st**2 * f6 + f5                       # pedestal fraction of total N
+AMP = 2 * st * np.sqrt(f5 * f6)             # fringe amplitude fraction
+
+
+def shot(N, seed):
+    rng = np.random.default_rng(seed)
+    fr = PED + AMP * np.cos(2 * np.pi * Xg / LAMBDA)
+    lam = np.clip(N * tf * fr, 0.0, None)
+    return rng.poisson(lam) + rng.normal(0, SIG_READ, lam.shape)
+
+
+fig = plt.figure(figsize=(15, 9))
+fig.suptitle(
+    f"Ground-state m=-5 Raman-homodyne interference (weak-field Eu+DDI, B=10µG;  "
+    f"f₅={f5:.1%}, f₆={f6:.1%}, θ={THETA:g})", fontsize=13, fontweight="bold")
+
+# Panel A: ground-state m spectrum
+axA = fig.add_subplot(2, 2, 1)
+colors = ["#adb5bd"] * len(ms)
+colors[int(np.where(ms == -5)[0][0])] = "#d6336c"
+colors[int(np.where(ms == -6)[0][0])] = "#1c7ed6"
+axA.bar(ms, pops, color=colors, edgecolor="k", lw=0.4)
+axA.set_xlabel("magnetic sublevel m")
+axA.set_ylabel("population fraction")
+axA.set_title("A  converged GS spectrum — DDI-textured, NOT polarized", fontsize=11)
+axA.text(-5, f5, f" m=-5\n {f5:.1%}\n (signal)", color="#d6336c", fontsize=9, va="bottom")
+axA.text(-6, f6, f"m=-6\n{f6:.1%}\n(LO)", color="#1c7ed6", fontsize=9, va="bottom", ha="center")
+axA.text(0.97, 0.95, f"un-converged 32³ (|∇E|=0.009)\noverestimates m=-5 at 9.5%",
+         transform=axA.transAxes, fontsize=7.5, ha="right", va="top", color="0.45",
+         style="italic")
+
+# Panel B: single-shot 2D interferogram at euv3 BEC N
+axB = fig.add_subplot(2, 2, 2)
+img = shot(N_lab, seed=7)
+axB.imshow(img, origin="lower", cmap="inferno", extent=[x[0], x[-1], x[0], x[-1]])
+axB.set_title(f"B  single-shot m=-5 interferogram @ euv3 BEC (N={N_lab:.0f})", fontsize=11)
+axB.set_xticks([]); axB.set_yticks([])
+
+# Panel C: column fringe profile at lab vs low N
+axC = fig.add_subplot(2, 2, 3)
+for N, tag, col in [(N_lab, f"euv3 BEC N={N_lab:.0f}", "#d6336c"),
+                    (8e3, "N=8000", "#1c7ed6")]:
+    prof = shot(N, seed=3).sum(axis=0)
+    ideal = (N * tf).sum(axis=0) * (PED + AMP * np.cos(2 * np.pi * x / LAMBDA))
+    axC.plot(x, prof, color=col, lw=0.9, marker="o", ms=2.5, alpha=0.6,
+             label=f"{tag}  (SNR≈{snr(N):.1f})")
+    axC.plot(x, ideal, color=col, lw=2.0)
+axC.set_xlabel("x [px]  (fringe axis)")
+axC.set_ylabel("m=-5 column density [atoms/col]")
+axC.set_title("C  the interference signal: crisp at BEC N, noisy at low N", fontsize=11)
+axC.legend(loc="upper right", fontsize=8)
+axC.grid(alpha=0.25)
+
+# Panel D: single-shot threshold with the real GS m=-5
+axD = fig.add_subplot(2, 2, 4)
+snr_axis = np.linspace(0.5, 8, 200)
+axD.semilogy(snr_axis, [n_min(s) for s in snr_axis], color="#d6336c", lw=2.6,
+             label=f"GS m=-5 (f₅={f5:.1%})")
+# placeholder ε=1e-3 comparison
+A0 = 2 * st * np.sqrt(1e-3)
+C0 = st**2 + 1e-3
+nmin0 = lambda s: (s**2 * C0 + np.sqrt(s**4 * C0**2 + 4 * A0**2 * s**2 * SIGDET**2)) / (2 * A0**2)
+axD.semilogy(snr_axis, [nmin0(s) for s in snr_axis], color="0.6", lw=1.6, ls="--",
+             label="placeholder ε=10⁻³")
+for nlab, nval, c in [("lab BEC", N_lab, "0.3"), ("optimized", N_opt, "seagreen")]:
+    axD.axhline(nval, color=c, lw=1.2, ls=":")
+    axD.text(7.8, nval, f" {nlab} {nval:.0f}", color=c, fontsize=8, va="center", ha="right")
+axD.axvline(2, color="0.7", lw=0.8, ls=":")
+axD.set_xlabel("required SNR (single-shot criterion)")
+axD.set_ylabel("minimum atom number N_min")
+axD.set_title(f"D  with real GS m=-5, single-shot visible at N≳{n_min(2):.0f}", fontsize=11)
+axD.legend(loc="lower right", fontsize=9)
+axD.grid(alpha=0.25, which="both")
+
+plt.tight_layout(rect=[0, 0, 1, 0.95])
+plt.savefig(f"{OUT}/homodyne_m5_gs.png", dpi=130)
+print(f"\nwrote {OUT}/homodyne_m5_gs.png")


### PR DESCRIPTION
`scripts/audit_memory.py` (in #107) found **four indexed memories citing 18 artifacts that existed only as untracked files in a single checkout** — that checkout held 603 untracked files. Invisible to every other worktree, destroyed by a `git clean` or a worktree removal, while the memory index treats them as repo assets. Code belongs in the repo; that is the standing convention.

## What lands (12 of the 18)

All 12–32 days old, belonging to settled project arcs:

| file | |
|---|---|
| `scripts/eu_gs_library.jl` | the most-cited of the lot — **three separate memories** point at it |
| `scripts/eu_merge_library.jl` | |
| `scripts/eu_bscan_pinned_continuation.jl` | pinned weak-field B-scan |
| `scripts/submit_eu_bscan.sh`, `scripts/viz_eu_bscan_animation.py` | |
| `docs/guides/eu_weak_field_gs_library.md` | reuse guide for the ψ(B) dataset |
| `scripts/homodyne_m5_{alpha,evap_readout}.jl`, `homodyne_m5_threshold.py`, `viz_homodyne_m5_{evap,fringe,gs}.py` | m=−5 Raman-homodyne readout |

## What is deliberately left out (6)

Five belong to `project_eu_adiabatic_protocol_2026_07_27` and were **modified 0.4–2.7 hours ago by a session that is running right now** (`eu_adiabatic_ramp_protocol.jl`, `eu_adiabatic_window.jl`, `run_eu_adiabatic_ramp.sh`, `viz_eu_adiabatic_ramp.py`, plus `eu_gs_library.jl` which is included here anyway). Committing mid-edit files would fight that session. `scripts/eu_transition_order.py` is not on disk yet.

Those should be committed by whoever finishes them.

## Method — several worktrees are live

Files were **copied out** of the main checkout and never staged there. Verified after: its index stays clean (`git diff --cached` empty) and its untracked count unchanged at 603, so a concurrent `git add -u` in that tree cannot pick up anything of mine. Once this merges, those paths become tracked with identical content and simply stop showing as untracked.

## Verified before committing

- gitleaks clean; no secrets, tokens or absolute home paths
- not `.gitignore`d (they were genuinely untracked, not deliberately excluded)
- all 5 Julia files parse (`Meta.parseall`)
- all 5 Python files parse (`ast.parse`)
- `bash -n` passes on the shell script
- **no behaviour change** — nothing under `src/` or `test/`, nothing imported by the package, so no test can move

## Caveat

If the session owning the main checkout later commits these same paths from there, expect a trivial add/add conflict — content is byte-identical (`cp -p`), so it resolves by taking either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)