### PR TITLE
fix(scalar-egpe): energy functional was missing the LHY term; add seeds

### DIFF
--- a/src/hamiltonian/coefficients.jl
+++ b/src/hamiltonian/coefficients.jl
@@ -413,7 +413,7 @@ function _gauss_legendre(n::Int, a::Float64, b::Float64)
     (nodes, weights)
 end
 
-export lima_pelster_Q5, compute_c_lhy_with_ddi
+export lima_pelster_Q5, compute_c_lhy_with_ddi, scalar_lhy_coefficient
 
 """
     lima_pelster_Q5(eps_dd) → Float64
@@ -449,4 +449,30 @@ Apply the Lima-Pelster DDI correction to a scalar LHY coefficient:
 """
 function compute_c_lhy_with_ddi(c_lhy_scalar::Float64, eps_dd::Float64)
     c_lhy_scalar * lima_pelster_Q5(eps_dd)
+end
+
+"""
+    scalar_lhy_coefficient(a_s_over_a_ho, N_atoms; eps_dd=0.0) → Float64
+
+Dimensionless scalar (Lee-Huang-Yang / quantum-fluctuation) coefficient in this
+repo's per-particle convention: with `∫|ψ|² dV = 1` and `c₀ = 4π(a_s/a_ho)N`,
+
+    E_LHY/N = (2/5)·c_lhy·∫n^{5/2} dV,     μ_LHY = c_lhy·n^{3/2}
+
+Derived from `γ_QF = (32/3)·g·√(a_s³/π)` with `g = 4πℏ²a_s/m`, i.e.
+`γ_QF = (128√π/3)(ℏ²/m)a_s^{5/2}`, which in these units is
+
+    c_lhy = (128√π/3)·(a_s/a_ho)^{5/2}·N^{3/2}·Q₅(ε_dd)
+
+Equivalently `c_lhy/c₀ = (32/3)√((a_s/a_ho)³N/π)`, which reproduces the SI
+ratio `μ_LHY/μ_contact = (32/3)√(n_SI·a_s³/π)` — the statement with no
+convention freedom, gated by `test/oracles/test_scalar_lhy_si_roundtrip.jl`.
+
+Single declaration point: the YAML `lhy: {kind: scalar}` auto-derivation and
+the scalar-eGPE `gamma_lhy` both read it, so the two paths cannot drift.
+"""
+function scalar_lhy_coefficient(a_s_over_a_ho::Real, N_atoms::Real; eps_dd::Real=0.0)
+    ah = abs(Float64(a_s_over_a_ho))
+    n = Float64(N_atoms)
+    (128.0 * sqrt(π) / 3.0) * ah^2.5 * n^1.5 * lima_pelster_Q5(Float64(eps_dd))
 end

--- a/src/solvers/scalar_egpe.jl
+++ b/src/solvers/scalar_egpe.jl
@@ -334,18 +334,77 @@ function scalar_energies(ws::ScalarSimWS{T, N}, B_hat::SVector{3, T}) where {T, 
     compute_tilted_dipole_potential!(ws, B_hat)
     E_trap = zero(T);
     E_contact = zero(T);
-    E_dd = zero(T)
+    E_dd = zero(T);
+    E_lhy = zero(T)
     g = ws.g_contact
+    γ = ws.gamma_lhy
     @inbounds for I in eachindex(ws.psi)
         ρ = ws.rho[I]
         E_trap += ρ * ws.V_trap[I]
         E_contact += ρ * ρ * g / 2
         E_dd += ρ * ws.V_dd[I] / 2
+        # E_LHY = (2/5)·γ·∫ρ^{5/2}: the functional whose δ/δψ̄ is the γ·ρ^{3/2}ψ
+        # the diagonal propagator already applies. Omitting it (pre-2026-07-27)
+        # left the reported energy inconsistent with the state ITP converges to,
+        # so the total could rise along an imaginary-time trajectory.
+        if γ != zero(T)
+            E_lhy += (2 / 5) * γ * ρ * ρ * sqrt(ρ)
+        end
     end
     E_trap *= dV;
     E_contact *= dV;
-    E_dd *= dV
-    (E_kin, E_trap, E_contact, E_dd, E_kin + E_trap + E_contact + E_dd)
+    E_dd *= dV;
+    E_lhy *= dV
+    (
+        E_kin=E_kin, E_trap=E_trap, E_contact=E_contact, E_dd=E_dd, E_lhy=E_lhy,
+        total=E_kin + E_trap + E_contact + E_dd + E_lhy,
+    )
+end
+
+# --- Symmetry-breaking seeds ---
+#
+# ITP started from a uniform state stays uniform: the unmodulated solution is a
+# stationary point, so a density wave never nucleates however unstable it is.
+# A supersolid ground state has to be seeded.
+
+"""
+    seed_scalar_noise!(ws; amplitude, seed=nothing)
+
+Multiply ψ by `1 + amplitude·ξ` with ξ uniform in [-1, 1) per voxel, then
+renormalise. Broadband, so ITP selects the wavelength itself — use this when the
+modulation period is the answer rather than an input.
+"""
+function seed_scalar_noise!(
+    ws::ScalarSimWS{T, N}; amplitude::Real, seed::Union{Nothing, Integer}=nothing
+) where {T, N}
+    rng = seed === nothing ? Random.default_rng() : Random.MersenneTwister(seed)
+    a = T(amplitude)
+    @inbounds for I in eachindex(ws.psi)
+        ws.psi[I] *= one(T) + a * (2 * rand(rng, T) - one(T))
+    end
+    normalize_scalar!(ws)
+    nothing
+end
+
+"""
+    seed_scalar_mode!(ws; k, amplitude, axis=1)
+
+Multiply ψ by `1 + amplitude·cos(k·x_axis)`, then renormalise. Deterministic
+single-wavelength seed: use it to test a specific period (e.g. the roton
+wavelength) or to reproduce a published droplet count.
+"""
+function seed_scalar_mode!(
+    ws::ScalarSimWS{T, N}; k::Real, amplitude::Real, axis::Int=1
+) where {T, N}
+    1 <= axis <= N || throw(ArgumentError("axis $axis outside 1:$N"))
+    kk = T(k);
+    a = T(amplitude)
+    x = ws.grid.x[axis]
+    @inbounds for I in CartesianIndices(ws.psi)
+        ws.psi[I] *= one(T) + a * cos(kk * x[I[axis]])
+    end
+    normalize_scalar!(ws)
+    nothing
 end
 
 """z-component of orbital angular momentum L_z = -i ⟨ψ|x∂_y - y∂_x|ψ⟩.

--- a/src/workflow/experiments/schema/parsing_blocks.jl
+++ b/src/workflow/experiments/schema/parsing_blocks.jl
@@ -334,9 +334,7 @@ function _resolve_lhy_block!(p::Dict, inter::Dict, atom, c_dd_val::Float64,
             # equivalently c_lhy/c₀ = (32/3)√((a_s/a_ho)³N/π), which reproduces
             # the textbook ratio μ_LHY/μ_contact = (32/3)√(n_SI·a_s³/π).
             # test/oracles/test_scalar_lhy_si_roundtrip.jl gates exactly that.
-            a_s_dl = abs(atom.a_s / a_ho)
-            c_lhy_scalar = (128.0 * sqrt(π) / 3.0) * a_s_dl^2.5 * float(N_atoms)^1.5
-            lhy_block["c_lhy"] = c_lhy_scalar * lima_pelster_Q5(eps_dd)
+            lhy_block["c_lhy"] = scalar_lhy_coefficient(atom.a_s / a_ho, N_atoms; eps_dd)
         end
     end
     # Normalise to internal fields for downstream consumers.

--- a/test/rotating_basis/test_scalar_egpe_smoke.jl
+++ b/test/rotating_basis/test_scalar_egpe_smoke.jl
@@ -87,9 +87,10 @@ end
     Bhat = SVector{3, Float64}(0.0, 0.0, 1.0)
     SpinorBEC.find_ground_state_scalar!(ws, 3000, 0.005; B_hat=Bhat)
     e = SpinorBEC.scalar_energies(ws, Bhat)
-    @test isapprox(e[1], 0.75; atol=2e-2)    # E_kin
-    @test isapprox(e[2], 0.75; atol=2e-2)    # E_trap
-    @test isapprox(e[5], 1.5; atol=2e-2)     # total
+    @test isapprox(e.E_kin, 0.75; atol=2e-2)
+    @test isapprox(e.E_trap, 0.75; atol=2e-2)
+    @test isapprox(e.total, 1.5; atol=2e-2)
+    @test e.E_lhy == 0.0                     # gamma_lhy = 0 here
 end
 
 @testset "scalar_egpe energy ↔ Hψ FD identity (contact + DDI)" begin
@@ -98,6 +99,10 @@ end
     # built from the SAME pieces the propagator uses. Exercises the contact
     # AND dipolar nonlinear terms (the ½'s in g|ψ|⁴/2 and ρV_dd/2 cancel the
     # modulus-derivative 2). g=c_dd≠0 so the interaction terms are live.
+    #
+    # gamma_lhy≠0 since 2026-07-27: the propagator applied γρ^{3/2} while
+    # scalar_energies omitted (2/5)γ∫ρ^{5/2}, so energy and gradient described
+    # different functionals. With γ live this FD identity is what catches it.
     n = 16
     L = 8.0
     grid = SpinorBEC.make_grid(GridConfig((n, n, n), (L, L, L)))
@@ -105,7 +110,8 @@ end
         0.5 * (grid.x[1][I[1]]^2 + grid.x[2][I[2]]^2 + grid.x[3][I[3]]^2)
         for I in CartesianIndices((n, n, n))
     ]
-    ws = SpinorBEC.make_scalar_ws(grid, V; g_contact=5.0, c_dd=1.0, F=6.0)
+    ws = SpinorBEC.make_scalar_ws(grid, V; g_contact=5.0, c_dd=1.0, F=6.0,
+        gamma_lhy=3.0)
     dV = prod(grid.dx)
     Bhat = SVector{3, Float64}(0.0, 0.0, 1.0)
 
@@ -121,7 +127,7 @@ end
         copyto!(ws.psi, ψ)
         SpinorBEC.compute_tilted_dipole_potential!(ws, Bhat)
         ws.rho .= abs2.(ws.psi)                 # scalar_energies reads ws.rho
-        SpinorBEC.scalar_energies(ws, Bhat)[5]
+        SpinorBEC.scalar_energies(ws, Bhat).total
     end
 
     copyto!(ws.psi, base)
@@ -131,10 +137,77 @@ end
     ws.fft_fwd * kin
     kin .*= 0.5 .* ws.grid.k_squared
     ws.fft_inv * kin
-    Hψ = kin .+ (ws.V_trap .+ ws.g_contact .* abs2.(ws.psi) .+ ws.V_dd) .* ws.psi
+    ρ = abs2.(ws.psi)
+    Hψ =
+        kin .+
+        (ws.V_trap .+ ws.g_contact .* ρ .+ ws.V_dd .+ ws.gamma_lhy .* ρ .* sqrt.(ρ)) .*
+        ws.psi
     inner = 2 * real(sum(conj.(δ) .* Hψ)) * dV
 
     ε = 1e-6
     fd = (Eval(base .+ ε .* δ) - Eval(base .- ε .* δ)) / (2ε)
     @test isapprox(fd, inner; rtol=1e-3)
+end
+
+@testset "scalar_egpe uniform box: E and μ analytic with LHY live" begin
+    # No trap, periodic box ⇒ the ground state is uniform at ρ = 1/V and both
+    # scalars are closed-form in the repo's per-particle convention:
+    #   E/N = (1/2)c₀ρ + (2/5)γρ^{3/2}      (the energy functional)
+    #   μ    = c₀ρ + γρ^{3/2}                (what ITP norm decay reports)
+    # Two independent expressions, so this gates the energy face against the
+    # propagator face rather than against itself. The pre-fix code passed the μ
+    # half and failed the E half.
+    n = 12
+    L = 6.0
+    grid = SpinorBEC.make_grid(GridConfig((n, n, n), (L, L, L)))
+    V = zeros(Float64, n, n, n)
+    c0 = 40.0
+    γ = 25.0
+    ws = SpinorBEC.make_scalar_ws(grid, V; g_contact=c0, c_dd=0.0, F=6.0, gamma_lhy=γ)
+    Vbox = L^3
+    ρ = 1 / Vbox
+    ws.psi .= sqrt(ρ) + 0im
+    SpinorBEC.normalize_scalar!(ws)
+    Bhat = SVector{3, Float64}(0.0, 0.0, 1.0)
+
+    e = SpinorBEC.scalar_energies(ws, Bhat)
+    @test e.E_contact ≈ 0.5 * c0 * ρ rtol = 1e-12
+    @test e.E_lhy ≈ (2 / 5) * γ * ρ^1.5 rtol = 1e-12
+    @test e.E_kin ≈ 0.0 atol = 1e-20
+    @test e.total ≈ 0.5 * c0 * ρ + (2 / 5) * γ * ρ^1.5 rtol = 1e-12
+
+    μ = SpinorBEC.find_ground_state_scalar!(ws, 200, 1e-3; B_hat=Bhat)
+    @test μ ≈ c0 * ρ + γ * ρ^1.5 rtol = 1e-6
+end
+
+@testset "scalar_egpe seeds break the uniform stationary point" begin
+    n = 16
+    L = 8.0
+    grid = SpinorBEC.make_grid(GridConfig((n, n, n), (L, L, L)))
+    ws = SpinorBEC.make_scalar_ws(
+        grid, zeros(Float64, n, n, n); g_contact=10.0, c_dd=0.0, F=6.0
+    )
+    ws.psi .= 1.0 + 0im
+    SpinorBEC.normalize_scalar!(ws)
+    flat = maximum(abs2, ws.psi) - minimum(abs2, ws.psi)
+    @test flat < 1e-20                       # uniform: ITP would never modulate
+
+    SpinorBEC.seed_scalar_mode!(ws; k=2 * 2π / L, amplitude=0.1, axis=1)
+    @test SpinorBEC.scalar_norm(ws) ≈ 1.0 atol = 1e-12
+    # Two full periods along x, flat in y and z.
+    line = [abs2(ws.psi[i, 1, 1]) for i in 1:n]
+    @test maximum(line) - minimum(line) > 1e-4
+    @test all(abs2(ws.psi[1, j, 1]) ≈ abs2(ws.psi[1, 1, 1]) for j in 1:n)
+
+    ws.psi .= 1.0 + 0im
+    SpinorBEC.normalize_scalar!(ws)
+    SpinorBEC.seed_scalar_noise!(ws; amplitude=0.05, seed=1234)
+    @test SpinorBEC.scalar_norm(ws) ≈ 1.0 atol = 1e-12
+    @test maximum(abs2, ws.psi) - minimum(abs2, ws.psi) > 1e-6
+    # Deterministic under a fixed seed.
+    n1 = copy(abs2.(ws.psi))
+    ws.psi .= 1.0 + 0im
+    SpinorBEC.normalize_scalar!(ws)
+    SpinorBEC.seed_scalar_noise!(ws; amplitude=0.05, seed=1234)
+    @test abs2.(ws.psi) ≈ n1 rtol = 1e-14
 end


### PR DESCRIPTION
Stacked on #108. Two blockers found while scoping the 3D dipolar supersolid ground state — both in the scalar eGPE path, which was a skeleton with a smoke test only.

## 1. `scalar_energies` omitted $E_{LHY}$

The diagonal propagator has applied $\gamma\rho^{3/2}$ all along, but the functional summed only kinetic + trap + contact + dd. Energy and gradient therefore described **different functionals**: the reported total was not the quantity ITP minimises, so it could rise along an imaginary-time trajectory and no relative energy between two candidate states was trustworthy. That is fatal for a supersolid, where the whole question is which of several modulated states is lower.

Added $E_{LHY} = \frac{2}{5}\gamma\int\rho^{5/2}$.

**The gate.** The existing FD identity test (central difference of $E_{total}$ vs $2\,\mathrm{Re}\langle\delta|H\psi\rangle dV$) now runs with `gamma_lhy = 3.0` instead of `0`, which is what turns it into a gate on this. Canaried — with the LHY energy term removed:

```
with_lhy=true    fd= 0.10305055  inner= 0.10305054  rel=1.2e-07  PASS
with_lhy=false   fd=-0.06606396  inner= 0.10305054  rel=1.6e+00  FAIL
```

164 % relative, derivative flips sign. Load-bearing, not vacuous.

A second test pins the closed forms in a uniform periodic box — $E/N = \frac12 c_0\rho + \frac25\gamma\rho^{3/2}$ against the functional, $\mu = c_0\rho + \gamma\rho^{3/2}$ against the ITP norm decay. Two independent expressions, so the energy face is checked against the propagator face and not against itself.

`scalar_energies` now returns a NamedTuple `(E_kin, E_trap, E_contact, E_dd, E_lhy, total)`. Positional access was already ambiguous, and adding a term would have silently shifted `[5]` from `total` to `E_lhy`.

## 2. No symmetry-breaking seed existed

ITP from a uniform state stays uniform — the unmodulated solution is a stationary point, so a density wave never nucleates however unstable it is, and a supersolid ground state is simply unreachable.

- `seed_scalar_noise!(ws; amplitude, seed)` — broadband, ITP selects the wavelength itself. Use when the modulation period is the answer.
- `seed_scalar_mode!(ws; k, amplitude, axis)` — deterministic single-$k$, for testing a specific period or reproducing a published droplet count.

Both renormalise. The noise seed is deterministic under a given seed and a test pins that.

## Single declaration point for the coefficient

Extracts the #108 fix into `scalar_lhy_coefficient(a_s/a_ho, N; eps_dd)` in `hamiltonian/coefficients.jl`, so the YAML auto-derivation and the scalar-eGPE `gamma_lhy` read one declaration and cannot drift.

## Tests

`test_scalar_egpe_smoke` 23/23 · `test_scalar_lhy_si_roundtrip` 16/16 · fast tier 142/142.

Next: the tube-geometry $\epsilon_{dd}$ scan against Roccuzzo & Ancilotto, PRA 99, 041601(R) (2019) — ¹⁶⁴Dy, $N = 6\times10^4$, $\omega_y = \omega_z = 2\pi\cdot600$ Hz, PBC along $x$, 11 droplets at $\epsilon_{dd} = 1.45$.