### PR TITLE
chore(scripts): classify run output and retired loop machinery in the memory audit

### DIFF
--- a/scripts/audit_memory.py
+++ b/scripts/audit_memory.py
@@ -76,9 +76,26 @@ _PATH = re.compile(
     r"\b((?:src|test|scripts|bench|docs|runs|ext|dashboard)"
     r"/[A-Za-z0-9_\-./]*\.(?:jl|md|py|yaml|yml|toml|sh|json))"
 )
-# `runs/_loop/` was retired 2026-06-08 and archived outside the repo (CLAUDE.md);
-# references to it are correctly historical, not rot.
+# Correctly-historical references, not rot:
+#   runs/_loop/  — the first autonomous loop, retired 2026-06-08 and archived
+#                  outside the repo (CLAUDE.md).
+#   scripts/{loop,judge,scheduler,resource_probe,cleanup_branches}
+#                — the same loop's machinery, moved to
+#                  BEC-simulation-archive/loop_machinery_2026_06_08/.
 _RETIRED_PREFIXES = ("runs/_loop/",)
+_RETIRED_FILES = frozenset((
+    "scripts/loop.sh", "scripts/judge.py", "scripts/scheduler.py",
+    "scripts/resource_probe.py", "scripts/cleanup_branches.sh",
+    "scripts/otel_query.py", "scripts/tests/test_judge_in_operator.py",
+))
+
+# `runs/` holds RUN OUTPUT, content-addressed and routinely pruned (the data
+# lives on TSUBAME, the repo keeps figures and code). A memory naming a jld2 /
+# summary.json / per-point file under runs/ is recording what a run produced,
+# not asserting that the file is still there — so an absent one is expected,
+# not drift. Only `runs/**/*.yaml` is a config, i.e. real input worth checking.
+def _is_run_output(path):
+    return path.startswith("runs/") and not path.endswith((".yaml", ".yml"))
 
 
 def _placeholder(path):
@@ -113,10 +130,12 @@ def path_report(texts, index_text, repo, main_checkout):
         for p in sorted(set(_PATH.findall(t))):
             if _placeholder(p):
                 counts["placeholder"] += 1
-            elif any(p.startswith(r) for r in _RETIRED_PREFIXES):
+            elif any(p.startswith(r) for r in _RETIRED_PREFIXES) or p in _RETIRED_FILES:
                 counts["retired (archived outside repo)"] += 1
             elif p in head:
                 counts["in HEAD"] += 1
+            elif _is_run_output(p):
+                counts["run output (pruned by design)"] += 1
             elif p in untracked:
                 counts["untracked in main checkout"] += 1
                 indexed and untracked_only[stem].append(p)


### PR DESCRIPTION
Follow-up to the auditor added in #107. It reported **17 unresolvable path references across 13 indexed memories**. Checking each one, **only four were real drift** — the rest were the audit not knowing two legitimate categories.

## What the audit was miscounting

| category | count | why it is not rot |
|---|---|---|
| `runs/**` (excluding `*.yaml`) | 14 | **Run output** — content-addressed and routinely pruned, with data on TSUBAME while the repo keeps figures and code. A memory naming a `jld2` or a per-point file records *what a run produced*, not a claim the file is still there. `runs/**/*.yaml` stays checked, since those are inputs. |
| `scripts/{loop,judge,scheduler,resource_probe,cleanup_branches,otel_query}` | 8 | The **retired autonomous loop's machinery**, moved to `BEC-simulation-archive/loop_machinery_2026_06_08/` alongside `runs/_loop/`, which the audit already recognised. |

Counting these as correct is what makes the remaining warnings worth reading: **17 → 1**, and that one lives in a memory the index does not reach.

```
305  in HEAD
 52  retired (archived outside repo)
 14  run output (pruned by design)
  4  placeholder
  4  untracked in main checkout   <- project_eu_adiabatic_protocol, in-flight
  1  absent everywhere
```

## The four real drifts (fixed in the memory tree, not in this repo)

| memory said | actually |
|---|---|
| `src/validation/reference_rhs_scalar.jl` | `src/validation/reference_rhs/scalar.jl` |
| `src/analysis/rotating_basis.jl` | `src/workflow/experiments/analyzers/rotating_basis.jl` |
| `scripts/inspect_config.jl` | `scripts/cli.jl inspect` |
| `scripts/validation/run_validation_suite.jl` | `scripts/validation/run_validation_matrix.jl` |

Plus one reference to a file that **never existed on any ref**: `src/hamiltonian/terms/operator_interface.jl`, a proposed interface whose job shipped as the **HamTerm protocol** instead. That memory now carries a note at the top saying so, rather than reading as a map of the tree — a stale design doc that looks like a description is worse than one that admits it is intent.

## One thing worth knowing if you extend this

A memory that documents a path as *gone* gets flagged for naming it — the same self-reference problem the `[[links]]` scan had, and it caught two of my own fixes. Handled by writing those as bare filenames rather than paths, on the grounds that a path-shaped token in a memory *is* a claim about the tree.

(I also mis-transcribed one path while fixing them — wrote `test/test_L5_...` for `test/validation/test_L5_...` — and the audit caught it on the next run. Working as intended.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)