### PR TITLE
feat(lhy): warn when a textured state meets a single-spinor LHY table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,7 @@ NOT bugs — don't "fix".
 - **`spin_rotating_frame_omega ≠ 0` requires `secular_ddi=true`** (enforced via `ArgumentError`). Full DDI's off-diagonal components Larmor-average to zero only in secular limit.
 - **`even_c_extra(F; c2, c4, c6, …)` is canonical** — hand-written `[c2, c4, c6]` silently misindexes for F ≥ 3.
 - CUDA-Graph in `ext/SpinorBECCUDAExt/gpu_graph.jl` disabled (replay drift, 4× slower); `split_step_captured!` itself was deleted 2026-05-22.
+- **Spinor LHY tables are built for ONE spinor and applied at every voxel** — `:full_bdg` takes the peak-density spinor, the closed forms assume their own fixed ansatz. Exact for a uniform state; measured ~5% in ε_LHY on converged weak-field Eu textures, with a sign that FLIPS along a B-scan (so it does not cancel in a comparison). Only the magnitude of ⟨F⟩ matters — a pure direction texture (flower / spin vortex / skyrmion, all |⟨F⟩|/F = 1) is free, since ε_LHY is an SO(3) scalar for contact and moves 0.25% under the DDI. `make_workspace` warns above a |⟨F⟩|/F spread of 0.3 (`test/workflow/test_lhy_texture_warning.jl`). Spatially-varying LHY is not implemented.
 - **Tensor c2/c4 not in `energy_gradient!`** — LBFGS warns, falls back to ITP. `[KNOWN-LIMIT]`.
 - **TDHFB has no YAML pipeline integration.** `dynamics.tdhfb` does NOT exist. Engine parallel-track to GP; do not wire in without explicit ask.
 

--- a/src/workflow/initialization/make_workspace.jl
+++ b/src/workflow/initialization/make_workspace.jl
@@ -560,12 +560,18 @@ rotating the spinor leaves ε_LHY invariant to machine precision for contact
 direction texture (flower, spin vortex, skyrmion; all `|⟨F⟩|/F` = 1 everywhere)
 costs nothing. Varying the MAGNITUDE costs ~20% between `|⟨F⟩|/F` = 1 and 0.
 """
-function _lhy_texture_spread(psi_init, F::Int)
-    psi_init === nothing && return (0.0, 1.0, 1.0)
-    N = ndims(psi_init) - 1
-    D = size(psi_init, N + 1)
+_lhy_texture_spread(::Nothing, ::Int) = (0.0, 1.0, 1.0)
+
+# `Val(N)` comes from the ARRAY'S type parameter, never from `ndims(x)` —
+# CLAUDE.md "Type stability boundaries". Taking `N = ndims(psi_init) - 1` as a
+# runtime Int made `ntuple(..., N)` uninferrable and the whole function
+# returned `Tuple{Any,Any,Any}`, inside `make_workspace`, which is precisely
+# the path that documentation warns turns into a multi-minute JIT hang.
+function _lhy_texture_spread(psi_init::AbstractArray{<:Complex, M}, F::Int) where {M}
+    N = M - 1
+    D = size(psi_init, M)
     D == 2F + 1 || return (0.0, 1.0, 1.0)
-    n_pts = ntuple(d -> size(psi_init, d), N)
+    n_pts = ntuple(d -> size(psi_init, d), Val(N))
 
     # SUBSAMPLED on a stride. This is a threshold decision on a smooth field,
     # not a physical observable, and `make_workspace` runs per scan point —
@@ -579,7 +585,9 @@ function _lhy_texture_spread(psi_init, F::Int)
     # diagonal), threaded and already gated. Restating it as explicit 13×13
     # matrix-vector products cost 0.31 s and 695 MB at 96³.
     stride = max(1, floor(Int, (prod(n_pts) / 8000)^(1 / N)))
-    fx, fy, fz = spin_density_vector(psi_init, spin_matrices(F), N)
+    # `spin_matrices(F)` is `SpinMatrices{D}` with D only known at runtime,
+    # so the call's return type has to be narrowed at this boundary.
+    fx, fy, fz = spin_density_vector(psi_init, spin_matrices(F), N)::NTuple{3, Array{Float64, N}}
     sampled = CartesianIndices(ntuple(d -> 1:stride:n_pts[d], N))
 
     nmax = 0.0

--- a/src/workflow/initialization/make_workspace.jl
+++ b/src/workflow/initialization/make_workspace.jl
@@ -542,10 +542,93 @@ end
 
 _lhy_g_dict(atom::AtomSpecies, ws::InteractionParams) = c_to_g(atom.F, ws)
 
+"""
+    _lhy_texture_spread(psi_init, F) -> (spread, peak_f, mean_f)
+
+How far the state is from having ONE spinor. Returns the `n^(5/2)`-weighted
+spread of `|⟨F⟩|/F` over the cloud (the weight `ε_LHY ∝ n^(5/2)` actually
+carries), plus the value at the density peak and the weighted mean.
+
+Every spinor LHY table in this file is built for a single spinor and then
+applied at every voxel: `:full_bdg` takes the peak spinor, and the closed forms
+assume their own fixed ansatz outright. That is exact when the state is uniform
+and an approximation when it is not.
+
+Only the SHAPE of the local spinor matters, not its direction. Measured at F=6:
+rotating the spinor leaves ε_LHY invariant to machine precision for contact
+(it is an SO(3) scalar) and to 0.25% with the DDI at ε_dd ~ 0.05 — so a pure
+direction texture (flower, spin vortex, skyrmion; all `|⟨F⟩|/F` = 1 everywhere)
+costs nothing. Varying the MAGNITUDE costs ~20% between `|⟨F⟩|/F` = 1 and 0.
+"""
+function _lhy_texture_spread(psi_init, F::Int)
+    psi_init === nothing && return (0.0, 1.0, 1.0)
+    N = ndims(psi_init) - 1
+    D = size(psi_init, N + 1)
+    D == 2F + 1 || return (0.0, 1.0, 1.0)
+    sm = spin_matrices(F)
+    Fx, Fy, Fz = Matrix{ComplexF64}(sm.Fx), Matrix{ComplexF64}(sm.Fy),
+    Matrix{ComplexF64}(sm.Fz)
+    n = dropdims(sum(abs2, psi_init; dims=N + 1); dims=N + 1)
+    nmax = maximum(n)
+    nmax <= 0 && return (0.0, 1.0, 1.0)
+    cut = 1e-6 * nmax
+    z = Vector{ComplexF64}(undef, D)
+    wsum = 0.0
+    mean_f = 0.0
+    peak_f = 1.0
+    lo, hi = Inf, -Inf
+    for I in CartesianIndices(size(n))
+        n[I] < cut && continue
+        for c in 1:D
+            z[c] = psi_init[I, c]
+        end
+        nz = norm(z)
+        nz < 1e-14 && continue
+        z ./= nz
+        f = sqrt(real(dot(z, Fx * z))^2 + real(dot(z, Fy * z))^2 +
+                 real(dot(z, Fz * z))^2) / F
+        w = n[I]^2.5
+        wsum += w
+        mean_f += w * f
+        lo = min(lo, f)
+        hi = max(hi, f)
+        n[I] == nmax && (peak_f = f)
+    end
+    wsum <= 0 && return (0.0, 1.0, 1.0)
+    (hi - lo, peak_f, mean_f / wsum)
+end
+
+# Above this spread in |⟨F⟩|/F the single-spinor table is worth flagging.
+# Measured on converged weak-field Eu ground states (pinned B-scan,
+# figs/eu_bscan_pin_tight): spread 0.0 gives 0.00% error, 0.375 gives -1.5%,
+# 0.89 gives -4.5%, 0.90 gives +4.9% — and the sign FLIPS across the scan, so
+# it does not cancel in a B-comparison. 0.3 is where it leaves the noise.
+const _LHY_TEXTURE_WARN = 0.3
+
+function _warn_lhy_texture(mode::Symbol, psi_init, F::Int)
+    spread, peak_f, mean_f = _lhy_texture_spread(psi_init, F)
+    spread <= _LHY_TEXTURE_WARN && return nothing
+    what = if mode === :full_bdg
+        "built from the peak-density spinor (|⟨F⟩|/F = $(round(peak_f; digits=3)))"
+    else
+        "built for the fixed :$mode ansatz"
+    end
+    @warn "LHY table is $what and then applied at every voxel, but this state " *
+        "is textured in |⟨F⟩|/F: spread $(round(spread; digits=3)) across the " *
+        "cloud, n^(5/2)-weighted mean $(round(mean_f; digits=3)). Measured on " *
+        "converged weak-field Eu ground states that costs up to ~5% in ε_LHY, " *
+        "with a sign that flips along a B-scan (so it does not cancel in a " *
+        "comparison). Direction textures are free — only the magnitude of " *
+        "⟨F⟩ matters. Treat LHY here as good to ~5%, or keep the state " *
+        "uniform." maxlog=1
+    nothing
+end
+
 # Catch-all: unknown / unsupported mode → nothing (caller falls through).
 _build_spinor_lhy(::Val, atom, ws, psi_init, c_dd, enable_ddi) = nothing
 
 function _build_spinor_lhy(::Val{:polar_two_channel}, atom, ws, psi_init, c_dd, enable_ddi)
+    _warn_lhy_texture(:polar_two_channel, psi_init, atom.F)
     compute_spinor_lhy_polar_two_channel(;
         F=atom.F, c0=ws[0], c1=ws[1],
         c_dd=enable_ddi && !isnan(c_dd) ? c_dd : 0.0,
@@ -553,6 +636,7 @@ function _build_spinor_lhy(::Val{:polar_two_channel}, atom, ws, psi_init, c_dd, 
 end
 
 function _build_spinor_lhy(::Val{:full_bdg}, atom, ws, psi_init, c_dd, enable_ddi)
+    _warn_lhy_texture(:full_bdg, psi_init, atom.F)
     spinor_init = psi_init !== nothing ? _extract_spinor(psi_init) : _default_spinor(atom.F)
     compute_spinor_lhy_table(;
         spinor=spinor_init, F=atom.F, interactions=ws,
@@ -564,6 +648,7 @@ end
 # :full_bdg. Restricted to polar spinors (ζ_α = δ_{α,0}); for post-quench /
 # mixed states fall back to :full_bdg.
 function _build_spinor_lhy(::Val{:polar_contact}, atom, ws, psi_init, c_dd, enable_ddi)
+    _warn_lhy_texture(:polar_contact, psi_init, atom.F)
     compute_spinor_lhy_polar_contact(;
         F=atom.F, g_dict=_lhy_g_dict(atom, ws), n_max=_lhy_n_max(psi_init))
 end
@@ -572,6 +657,7 @@ end
 # m=+F: ε = (8/15π²)(g_{2F}n)^(5/2). For uniform g_S this matches scalar
 # Lima-Pelster; for realistic per-S a_S it differs.
 function _build_spinor_lhy(::Val{:fm_contact}, atom, ws, psi_init, c_dd, enable_ddi)
+    _warn_lhy_texture(:fm_contact, psi_init, atom.F)
     compute_spinor_lhy_fm_contact(;
         F=atom.F, g_dict=_lhy_g_dict(atom, ws), n_max=_lhy_n_max(psi_init))
 end
@@ -584,6 +670,7 @@ end
 # Direct callers that already have scalar eps_dd should use
 # `compute_spinor_lhy_fm_dipolar(; eps_dd)`.
 function _build_spinor_lhy(::Val{:fm_dipolar}, atom, ws, psi_init, c_dd, enable_ddi)
+    _warn_lhy_texture(:fm_dipolar, psi_init, atom.F)
     g_dict = _lhy_g_dict(atom, ws)
     c_dd_eff = enable_ddi && !isnan(c_dd) ? c_dd : 0.0
     g_2F = get(g_dict, 2 * atom.F, 0.0)
@@ -619,6 +706,7 @@ end
 end
 
 function _build_spinor_lhy(::Val{:polar_dipolar}, atom, ws, psi_init, c_dd, enable_ddi)
+    _warn_lhy_texture(:polar_dipolar, psi_init, atom.F)
     g_dict = _lhy_g_dict(atom, ws)
     c_dd_eff = enable_ddi && !isnan(c_dd) ? c_dd : 0.0
     delta_1 = delta_polar(atom.F, 1, g_dict)
@@ -641,6 +729,7 @@ end
 #   them through their own builder, not this branch.
 # See: src/hamiltonian/terms/lhy/icosahedral.jl
 function _build_spinor_lhy(::Val{:icosahedral}, atom, ws, psi_init, c_dd, enable_ddi)
+    _warn_lhy_texture(:icosahedral, psi_init, atom.F)
     atom.F == 6 || throw(ArgumentError(
         ":icosahedral spinor_lhy is F=6 only (got F=$(atom.F))"))
     compute_spinor_lhy_icosahedral(;

--- a/src/workflow/initialization/make_workspace.jl
+++ b/src/workflow/initialization/make_workspace.jl
@@ -565,34 +565,54 @@ function _lhy_texture_spread(psi_init, F::Int)
     N = ndims(psi_init) - 1
     D = size(psi_init, N + 1)
     D == 2F + 1 || return (0.0, 1.0, 1.0)
-    sm = spin_matrices(F)
-    Fx, Fy, Fz = Matrix{ComplexF64}(sm.Fx), Matrix{ComplexF64}(sm.Fy),
-    Matrix{ComplexF64}(sm.Fz)
-    n = dropdims(sum(abs2, psi_init; dims=N + 1); dims=N + 1)
-    nmax = maximum(n)
+    n_pts = ntuple(d -> size(psi_init, d), N)
+
+    # SUBSAMPLED on a stride. This is a threshold decision on a smooth field,
+    # not a physical observable, and `make_workspace` runs per scan point —
+    # CLAUDE.md calls it the hot path for every pipeline step. Full-grid cost
+    # was 26% of a 64³ workspace build and 69% of a 32³ one, to answer a
+    # yes/no question. The stride targets ~8000 samples, which holds the guard
+    # under ~1% while leaving the verdict unchanged on the converged
+    # weak-field Eu states it was calibrated on (spread 0.921 either way).
+    #
+    # `spin_density_vector` is the O(D) ladder form (F± tridiagonal, Fz
+    # diagonal), threaded and already gated. Restating it as explicit 13×13
+    # matrix-vector products cost 0.31 s and 695 MB at 96³.
+    stride = max(1, floor(Int, (prod(n_pts) / 8000)^(1 / N)))
+    fx, fy, fz = spin_density_vector(psi_init, spin_matrices(F), N)
+    sampled = CartesianIndices(ntuple(d -> 1:stride:n_pts[d], N))
+
+    nmax = 0.0
+    @inbounds for I in sampled
+        nsum = 0.0
+        for c in 1:D
+            nsum += abs2(psi_init[I, c])
+        end
+        nmax = max(nmax, nsum)
+    end
     nmax <= 0 && return (0.0, 1.0, 1.0)
     cut = 1e-6 * nmax
-    z = Vector{ComplexF64}(undef, D)
+
     wsum = 0.0
     mean_f = 0.0
     peak_f = 1.0
     lo, hi = Inf, -Inf
-    for I in CartesianIndices(size(n))
-        n[I] < cut && continue
+    @inbounds for I in sampled
+        nsum = 0.0
         for c in 1:D
-            z[c] = psi_init[I, c]
+            nsum += abs2(psi_init[I, c])
         end
-        nz = norm(z)
-        nz < 1e-14 && continue
-        z ./= nz
-        f = sqrt(real(dot(z, Fx * z))^2 + real(dot(z, Fy * z))^2 +
-                 real(dot(z, Fz * z))^2) / F
-        w = n[I]^2.5
+        nsum < cut && continue
+        # fx/fy/fz are DENSITY-weighted (⟨ψ|F|ψ⟩, not normalised), so dividing
+        # by the local density gives the per-spinor |⟨F⟩| the LHY table cares
+        # about — see CLAUDE.md, |F/n|² is a density-weighted average.
+        f = sqrt(fx[I]^2 + fy[I]^2 + fz[I]^2) / (nsum * F)
+        w = nsum^2.5
         wsum += w
         mean_f += w * f
         lo = min(lo, f)
         hi = max(hi, f)
-        n[I] == nmax && (peak_f = f)
+        nsum == nmax && (peak_f = f)
     end
     wsum <= 0 && return (0.0, 1.0, 1.0)
     (hi - lo, peak_f, mean_f / wsum)
@@ -609,13 +629,14 @@ function _warn_lhy_texture(mode::Symbol, psi_init, F::Int)
     spread, peak_f, mean_f = _lhy_texture_spread(psi_init, F)
     spread <= _LHY_TEXTURE_WARN && return nothing
     what = if mode === :full_bdg
-        "built from the peak-density spinor (|⟨F⟩|/F = $(round(peak_f; digits=3)))"
+        "built from the peak-density spinor (|⟨F⟩|/F ≈ $(round(peak_f; digits=2)))"
     else
         "built for the fixed :$mode ansatz"
     end
     @warn "LHY table is $what and then applied at every voxel, but this state " *
-        "is textured in |⟨F⟩|/F: spread $(round(spread; digits=3)) across the " *
-        "cloud, n^(5/2)-weighted mean $(round(mean_f; digits=3)). Measured on " *
+        "is textured in |⟨F⟩|/F: spread ≈ $(round(spread; digits=2)) across the " *
+        "cloud, n^(5/2)-weighted mean ≈ $(round(mean_f; digits=2)) (sampled on " *
+        "a stride, so indicative not exact). Measured on " *
         "converged weak-field Eu ground states that costs up to ~5% in ε_LHY, " *
         "with a sign that flips along a B-scan (so it does not cancel in a " *
         "comparison). Direction textures are free — only the magnitude of " *

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -34,6 +34,7 @@ const FAST_TESTS = [
     "workflow/test_calibration_edge_cases.jl",
     "workflow/test_loss_block_edge_cases.jl",
     "workflow/test_dynamics_lhy_plumbing.jl",
+    "workflow/test_lhy_texture_warning.jl",
     "workflow/test_b_block_normalize.jl",
     "workflow/test_waveform_inner_duration.jl",
     "workflow/validation/test_run_result.jl",

--- a/test/workflow/test_lhy_texture_warning.jl
+++ b/test/workflow/test_lhy_texture_warning.jl
@@ -1,0 +1,101 @@
+# Gate: every spinor LHY table is built for ONE spinor and applied at every
+# voxel. That is exact for a uniform state and an approximation otherwise, and
+# nothing used to say so.
+#
+# The measurement that sets the threshold (converged weak-field Eu ground
+# states, figs/eu_bscan_pin_tight, F=6, c0=10, c1=-0.02, comparing the shipped
+# single-spinor table against a per-voxel LDA over the full n^(5/2) weight):
+#
+#     |⟨F⟩|/F spread   ε_LHY error
+#          0.00          +0.00%
+#          0.375         -1.48%
+#          0.892         -4.48%
+#          0.901         +4.87%
+#
+# The sign FLIPS along the scan, so it does not cancel in a B-comparison —
+# which is the reason this warns rather than being left as a docstring caveat.
+#
+# Only the magnitude of ⟨F⟩ matters. A pure DIRECTION texture is free: ε_LHY is
+# an SO(3) scalar for contact (invariant to machine precision, measured across
+# the full canting family) and moves 0.25% with the DDI at ε_dd ≈ 0.05.
+
+using Test
+using LinearAlgebra
+using SpinorBEC
+using SpinorBEC: _lhy_texture_spread, _warn_lhy_texture, _LHY_TEXTURE_WARN
+
+@testset "LHY single-spinor texture warning" begin
+    F = 6
+    grid = make_grid(GridConfig((16, 16, 16), (8.0, 8.0, 8.0)))
+    sys = SpinSystem(F)
+
+    @testset "direction textures are uniform in |⟨F⟩| ⇒ no warning" begin
+        # flower / radial_spin_vortex / skyrmion rotate a fully polarised
+        # spinor in space. |⟨F⟩|/F = 1 everywhere, so the single-spinor table
+        # is exact and must stay silent.
+        for st in (:m_plus_F, :m_minus_F, :flower, :radial_spin_vortex,
+            :chiral_spin_vortex, :polar)
+            psi = init_psi(grid, sys; state=st)
+            spread, _, _ = _lhy_texture_spread(psi, F)
+            @test spread < 1e-6
+            @test spread <= _LHY_TEXTURE_WARN
+            @test _warn_lhy_texture(:full_bdg, psi, F) === nothing
+        end
+    end
+
+    @testset "a magnitude texture is detected and reported" begin
+        # Build one directly: |⟨F⟩|/F running from 1 at the centre to 0 outside,
+        # which is the shape a converged weak-field Eu ground state develops.
+        n = 16
+        psi = zeros(ComplexF64, n, n, n, 2F + 1)
+        c = (n + 1) / 2
+        for i in 1:n, j in 1:n, k in 1:n
+            r = sqrt((i - c)^2 + (j - c)^2 + (k - c)^2) / (n / 2)
+            amp = exp(-2r^2)
+            x = clamp(r, 0.0, 1.0)                 # 0 at centre → 1 at edge
+            psi[i, j, k, 1] = amp * (1 - x)        # m = +F
+            psi[i, j, k, F + 1] = amp * x          # m = 0
+        end
+        spread, peak_f, mean_f = _lhy_texture_spread(psi, F)
+        @test spread > _LHY_TEXTURE_WARN
+        @test peak_f > mean_f                      # peak is more polarised
+        @test 0.0 <= mean_f <= 1.0
+        @test_logs (:warn, r"textured in \|⟨F⟩\|/F") match_mode = :any begin
+            _warn_lhy_texture(:full_bdg, psi, F)
+        end
+        # The closed forms assume their own fixed ansatz, so they are at least
+        # as exposed — they must warn too, with wording naming the ansatz.
+        @test_logs (:warn, r"fixed :polar_contact ansatz") match_mode = :any begin
+            _warn_lhy_texture(:polar_contact, psi, F)
+        end
+    end
+
+    @testset "degenerate inputs do not throw" begin
+        @test _lhy_texture_spread(nothing, F) == (0.0, 1.0, 1.0)
+        @test _lhy_texture_spread(zeros(ComplexF64, 4, 4, 4, 2F + 1), F) ==
+            (0.0, 1.0, 1.0)
+        # component count not matching 2F+1 ⇒ abstain rather than mis-measure
+        @test _lhy_texture_spread(ones(ComplexF64, 4, 4, 4, 3), F) == (0.0, 1.0, 1.0)
+    end
+
+    @testset "make_workspace warns through the real path" begin
+        # The warning has to be reachable from where users actually build a
+        # workspace, not just from the helper.
+        atom = resolve_atom(:Eu151)
+        g = make_grid(GridConfig((12, 12, 12), (8.0, 8.0, 8.0)))
+        psi = zeros(ComplexF64, 12, 12, 12, 2F + 1)
+        for i in 1:12, j in 1:12, k in 1:12
+            r = sqrt((i - 6.5)^2 + (j - 6.5)^2 + (k - 6.5)^2) / 6
+            amp = exp(-2r^2)
+            psi[i, j, k, 1] = amp * (1 - clamp(r, 0, 1))
+            psi[i, j, k, F + 1] = amp * clamp(r, 0, 1)
+        end
+        @test_logs (:warn, r"applied at every voxel") match_mode = :any begin
+            make_workspace(; grid=g, atom=atom,
+                interactions=InteractionParams(Dict(0 => 10.0, 1 => -0.02)),
+                potential=HarmonicTrap((1.0, 1.0, 1.0)),
+                sim_params=SimParams(; dt=0.001, n_steps=1),
+                psi_init=psi, spinor_lhy=:polar_contact)
+        end
+    end
+end

--- a/test/workflow/test_lhy_texture_warning.jl
+++ b/test/workflow/test_lhy_texture_warning.jl
@@ -70,6 +70,24 @@ using SpinorBEC: _lhy_texture_spread, _warn_lhy_texture, _LHY_TEXTURE_WARN
         end
     end
 
+    @testset "type-stable — it runs inside make_workspace" begin
+        # CLAUDE.md "Type stability boundaries": Workspace has 23+ type
+        # parameters and widening that reaches `make_workspace` shows up as a
+        # multi-minute JIT hang with no stack trace. This guard sits on that
+        # path, so its inference is part of its contract, not a nicety.
+        #
+        # It failed here first: `N = ndims(psi) - 1` as a runtime Int made
+        # `ntuple(..., N)` uninferrable and the function returned
+        # Tuple{Any,Any,Any}. Val(N) now comes from the array's type parameter.
+        for M in (2, 3, 4)                       # 1D, 2D, 3D grids
+            psi = randn(ComplexF64, ntuple(_ -> 4, M - 1)..., 2F + 1)
+            @inferred _lhy_texture_spread(psi, F)
+            @inferred _warn_lhy_texture(:full_bdg, psi, F)
+        end
+        @inferred _lhy_texture_spread(nothing, F)
+        @test @inferred(_lhy_texture_spread(nothing, F)) == (0.0, 1.0, 1.0)
+    end
+
     @testset "degenerate inputs do not throw" begin
         @test _lhy_texture_spread(nothing, F) == (0.0, 1.0, 1.0)
         @test _lhy_texture_spread(zeros(ComplexF64, 4, 4, 4, 2F + 1), F) ==


### PR DESCRIPTION
Every spinor LHY table is built for **one** spinor and then applied at every voxel — `:full_bdg` takes the peak-density spinor via `_extract_spinor`, and the closed forms assume their own fixed ansatz without looking at the state at all. Exact when the state is uniform, an approximation otherwise, and nothing said so.

I measured it before deciding what to do about it.

## Only the magnitude of ⟨F⟩ matters

`ε_LHY` is an SO(3) scalar for contact, so **rotating** the spinor leaves it invariant to machine precision across the whole canting family; the DDI breaks that by **0.25%** at ε_dd ≈ 0.05. Varying `|⟨F⟩|/F` from 1 to 0 costs **~20%**.

So every direction texture in `state_zoo` — flower, radial/chiral spin vortex, skyrmion, all `|⟨F⟩|/F = 1` everywhere — is **free**. That is why this has never bitten.

## Converged states are a different matter

On the pinned weak-field Eu B-scan (`figs/eu_bscan_pin_tight`), `|⟨F⟩|/F` develops real spatial structure as B falls, and the peak value diverges from the `n^(5/2)`-weighted mean the energy actually carries (**0.640 vs 0.799** at frame_046). Shipped single-spinor table vs a per-voxel LDA over the full weight:

| `\|⟨F⟩\|/F` spread | ε_LHY error |
|---|---|
| 0.00 | +0.00% |
| 0.375 | −1.48% |
| 0.892 | **−4.48%** |
| 0.901 | **+4.87%** |

~5%, and **the sign flips along the scan** — so it does not cancel in a B-comparison, which is the worst shape for a scan hunting a transition. That is what makes it worth surfacing rather than leaving as a docstring caveat.

## What this does *not* do

It does not build spatially-varying LHY. 5% does not justify that redesign, and **no config in the repo currently combines a spinor LHY kind with a textured state** — all 20 use `initial_state: m_minus_F`, uniform. This is a **latent trap, not a live error**.

But the active weak-field Eu arcs are exactly the textures that would spring it, and the original framing of the LHY work called this the common bottleneck. So `make_workspace` warns above a `|⟨F⟩|/F` spread of 0.3 (the threshold is where the error leaves the noise, from the table above), naming the measured cost, and CLAUDE.md records the limitation.

## Method note, because the first answer was wrong

The first pass sampled the **top 140 voxels by `n^(5/2)` weight** and reported 0.5%. That covers 7–9% of the weight and — worse — selects precisely the uniform high-density core while missing the varying halo. **Biased toward "no error" by construction.**

The coverage figure was printed alongside the result, which is how it was caught. Redone by binning on `|⟨F⟩|/F` so 100% of the weight is covered; the within-bin spread (~2%) is reported as the method's own uncertainty rather than hidden.

## Tests

`test/workflow/test_lhy_texture_warning.jl` (27): direction textures stay silent, a magnitude texture is detected and reported (both for `:full_bdg` and for a closed form, with wording that names the ansatz), degenerate inputs abstain rather than mis-measure, and the warning is reachable through a real `make_workspace` call rather than only from the helper.

Fast tier: 145 files, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)