### PR TITLE
ci: docs-only PRs were permanently unmergeable — gate steps, not the workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    # Docs/markdown-only changes touch no Julia code, so skip the whole
-    # workflow (test + oracles + format + bench). ~30 % of commits are
-    # markdown-only (README / docs / CLAUDE.md / memory notes). `main` is not
-    # branch-protected, so there are no required status checks to leave hanging
-    # in "expected". A commit touching any non-`.md` file (incl. this workflow,
-    # any `.jl`, Project/Manifest) still runs everything — paths-ignore only
-    # skips when EVERY changed file matches.
-    paths-ignore: ["**/*.md"]
   pull_request:
     branches: [main]
-    paths-ignore: ["**/*.md"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,9 +15,69 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
+# Markdown-only changes touch no Julia code, so the expensive steps are worth
+# skipping (~30 % of commits are markdown-only: README / docs / CLAUDE.md /
+# memory notes). This used to be a workflow-level `paths-ignore: ["**/*.md"]`.
+#
+# That broke once `main` gained branch protection with three required checks.
+# `paths-ignore` stops the workflow from being CREATED at all, so the three
+# required contexts never appear and sit "expected" forever — a docs-only PR
+# becomes permanently unmergeable. Observed on #123: 0 check-runs on the head
+# SHA, combined status `pending`, `mergeable=MERGEABLE`,
+# `mergeStateStatus=BLOCKED`, and `gh pr merge --admin` refused.
+#
+# So the jobs now always run and always report their context; only the costly
+# STEPS are gated on `needs.changes.outputs.code`. Step-level rather than
+# job-level gating on purpose: a job skipped by a job-level `if` reports the
+# conclusion "skipped", and whether that satisfies a required check is a
+# GitHub-side semantic we would rather not depend on. A job that runs and
+# succeeds needs no such assumption. The price is one runner start (~15 s) per
+# job per docs-only commit, against a full test run saved.
 jobs:
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+          fi
+          # A new branch or a force-push can leave `before` as the null SHA.
+          # Run everything rather than guess: the failure mode of guessing is a
+          # silent green on untested code.
+          if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            echo "base $base unavailable - running everything"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(git diff --name-only "$base" "$head")
+          echo "changed files:"
+          echo "$files"
+          # Any file not ending in .md means code. An empty diff also lands
+          # here (the empty line does not end in .md), which is the safe way
+          # round.
+          if printf '%s\n' "$files" | grep -qv '\.md$'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "markdown only - skipping the expensive steps"
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Test (Julia 1.12, tier=fast)
+    needs: changes
     runs-on: ubuntu-latest
     # FAST tier parallelised across the runner's cores (SPINORBEC_TEST_WORKERS
     # =auto): the files are split into one independent julia process per CPU
@@ -47,9 +98,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
+        if: needs.changes.outputs.code == 'true'
         with:
           version: "1.12"
       - uses: julia-actions/cache@v2
+        if: needs.changes.outputs.code == 'true'
         with:
           # Share ONE depot cache across the per-PR `test` + `oracles` jobs: same
           # Project/Manifest/Julia/OS ⇒ byte-identical depot. The action's
@@ -64,7 +117,9 @@ jobs:
           # depot.
           cache-name: julia-cache;workflow=${{ github.workflow }}
       - uses: julia-actions/julia-buildpkg@v1
+        if: needs.changes.outputs.code == 'true'
       - uses: julia-actions/julia-runtest@v1
+        if: needs.changes.outputs.code == 'true'
         with:
           # Coverage instrumentation forces re-precompile of every package
           # because the precompile cache is keyed on compile flags. We don't
@@ -74,6 +129,7 @@ jobs:
 
   oracles:
     name: Oracle gates (tier=oracles)
+    needs: changes
     runs-on: ubuntu-latest
     # The sign-bug-proof / validation oracle gates live in the `ci` tier, which
     # only runs nightly — so a PR could break one and merge green. It happened:
@@ -89,27 +145,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
+        if: needs.changes.outputs.code == 'true'
         with:
           version: "1.12"
       - uses: julia-actions/cache@v2
+        if: needs.changes.outputs.code == 'true'
         with:
           # Shared with the `test` job — see the rationale on that job's cache step.
           cache-name: julia-cache;workflow=${{ github.workflow }}
       - uses: julia-actions/julia-buildpkg@v1
+        if: needs.changes.outputs.code == 'true'
       - uses: julia-actions/julia-runtest@v1
+        if: needs.changes.outputs.code == 'true'
         with:
           coverage: false
 
   format:
     name: JuliaFormatter check
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
+        if: needs.changes.outputs.code == 'true'
         with:
           version: "1.12"
       - name: Install JuliaFormatter
+        if: needs.changes.outputs.code == 'true'
         # Pin the version so CI and the .githooks/pre-commit check agree.
         # An unpinned add floats to whatever is newest and silently reflows
         # the repo when JuliaFormatter changes its blue style between
@@ -117,6 +180,7 @@ jobs:
         # + `format("test/")` reformat (devs must run the same version).
         run: julia -e 'using Pkg; Pkg.add(name="JuliaFormatter", version="2.5.0")'
       - name: Check formatting
+        if: needs.changes.outputs.code == 'true'
         run: |
           julia -e '
             using JuliaFormatter
@@ -132,7 +196,11 @@ jobs:
   bench:
     name: Benchmark
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: changes
+    if: >-
+      needs.changes.outputs.code == 'true'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Found while trying to merge #123 (docs-only). It is not a conflict — it cannot be merged at all, and neither can any future markdown-only PR.

## The failure

`paths-ignore: ["**/*.md"]` skips the whole workflow for markdown-only changes. The workflow comment states the assumption that made that safe:

> `main` is not branch-protected, so there are no required status checks to leave hanging in "expected".

`main` now has three required checks. `paths-ignore` stops the workflow from being **created**, so those contexts never appear and stay `expected` forever:

```
check-runs on head SHA : 0
combined status        : pending (0 statuses)
mergeable              : MERGEABLE      ← no conflict
mergeStateStatus       : BLOCKED
gh pr merge --admin    : "3 of 3 required status checks are expected"
```

Waiting does not help — there is nothing queued to finish, and nothing to re-run. #101 (also docs-only) merged normally at 17:00Z, so the protection was added after that.

## The fix

The three required jobs always run and always report their context. Only the **expensive steps** are gated, on a new `changes` job that diffs the push / PR range and sets `code=true` unless every changed file ends in `.md`.

**Step-level rather than job-level gating, on purpose.** A job skipped by a job-level `if` reports the conclusion `skipped`, and whether that satisfies a required check is a GitHub-side semantic. A job that runs and succeeds needs no such assumption. The price is one runner start (~15 s) per job on a docs-only commit, against a full test run saved — the ~30 % markdown-only commit rate the original optimisation targeted is still served.

`changes` fails **safe**: if the base SHA is unavailable (new branch, force-push, null `before`) it runs everything, because the failure mode of guessing is a silent green on untested code. An empty diff likewise runs everything.

`bench` keeps its main-push-only condition, now ANDed with the same flag.

## Verification

This PR touches `.github/workflows/ci.yml`, a non-`.md` file, so it exercises the `code=true` path and its own checks must go green before merge. The `code=false` path gets exercised by #123 immediately afterwards — I will confirm the three contexts report there before calling this done.

Structurally checked already: YAML parses; `changes` has no dependencies; the three required jobs and `bench` depend on it; and the gates sit **inside** their steps rather than as bare list items — the first attempt inserted them as standalone `- if:` entries, which parses fine and gates nothing.