### PR TITLE
fix(inspect): the preflight failed configs that run fine

### DIFF
--- a/src/workflow/experiments/inspect.jl
+++ b/src/workflow/experiments/inspect.jl
@@ -224,6 +224,35 @@ function _inspect_loaded(raw::AbstractDict, path::String;
     normalised = deepcopy(raw_dict)
     warnings = ConfigWarning[]
 
+    # `dealias:` is a real top-level block, but it never reaches the schema:
+    # the runner pops it and applies it to global Refs (run_registry.jl), and
+    # strict validation rejects every top-level key it does not recognise. So
+    # inspecting a config without popping it first reported a schema ERROR for
+    # a config that runs fine — on ~20 of them, including ones already run on
+    # TSUBAME. A preflight that fails valid configs is worse than none: this
+    # severity feeds the autopilot gate.
+    #
+    # Applied rather than merely popped, because `auto_dt` tightens `dt` in the
+    # pipeline and inspect should report the dt the run will actually use. The
+    # Refs are restored immediately — inspect stays a read-only operation.
+    try
+        was_enabled, was_k_cut = apply_dealias_block!(normalised)
+        restore_dealias_refs!(was_enabled, was_k_cut)
+    catch e
+        push!(
+            warnings,
+            ConfigWarning(
+                :dealias_block_invalid, :error, 0,
+                "dealias block rejected",
+                sprint(showerror, e),
+                "Fix the `dealias:` block; the runner will throw on it too.",
+                Dict{String, Any}("exception" => string(typeof(e))),
+            ),
+        )
+        return ConfigInspection(path, raw_dict, normalised,
+            StepInspection[], warnings)
+    end
+
     # Run the same normalize+validate pass as load_config.
     try
         _normalize_and_validate!(normalised; strict)

--- a/src/workflow/experiments/inspect_checks.jl
+++ b/src/workflow/experiments/inspect_checks.jl
@@ -51,6 +51,7 @@ const DROP_ALLOWLIST = DropRule[
     DropRule("calibration_history", nothing, "popped after interpolation"),
     DropRule("target_date", nothing, "consumed by calibration interpolation"),
     DropRule("dealias", nothing, "popped, applied via global Ref"),
+    DropRule("units", nothing, "popped by units_block after lab-unit conversion"),
     DropRule("use", nothing, "template/mixin reference"),
     DropRule("mixins", nothing, "template/mixin reference"),
     # B-block split: theta/phi may legitimately move to B_direction when
@@ -373,12 +374,6 @@ function _compat_polar_two_channel_lhy(params, _kind)
     return string(get(lhy, "kind", "")) == "polar_two_channel"
 end
 
-function _compat_full_bdg_f6_polar(params, _kind)
-    lhy = get(params, "lhy", nothing)
-    lhy isa AbstractDict || return false
-    return string(get(lhy, "kind", "")) == "full_bdg"
-end
-
 function _compat_spin_rotating_omega_secular(params, _kind)
     srfo = get(params, "spin_rotating_frame_omega", 0)
     srfo isa Real && srfo != 0 || return false
@@ -408,14 +403,18 @@ const COMPAT_TABLE = CompatRule[
         "FM use FMContactLHY / FMDipolarLHY; F=6 icosahedral uses " *
         "IcosahedralLHY. Polar at F=2 is fine.",
     ),
-    CompatRule(
-        :full_bdg_f6_polar, :warn,
-        "FullBdGLHY at F=6 polar emits ~3000× spurious offset",
-        _compat_full_bdg_f6_polar,
-        "Memory: full_bdg_F6_polar_broken.md. Runtime emits a @warn " *
-        "but the magnitude is large enough to render results unusable.",
-        "Use PolarContactLHY / PolarDipolarLHY at F=6 polar instead.",
-    ),
+    # `:full_bdg_f6_polar` DELETED 2026-07-28. It warned that FullBdGLHY emits a
+    # ~3000× spurious offset at F=6 polar. That offset was a UV counterterm
+    # subtracting ε_k twice — divergent at EVERY F and phase, not an F=6 polar
+    # property — and it was fixed on 2026-07-27; full_bdg now matches all three
+    # closed forms to ~1e-4. The rule outlived the bug and steered users away
+    # from the one general-spinor LHY path.
+    #
+    # Its predicate also fired on ANY `kind: full_bdg`, never checking F or the
+    # polar ansatz its own name claimed. The genuine remaining caveat —
+    # scheme-dependence when the mean field is dynamically UNSTABLE — is a
+    # property of the converged state, not of the config, so it stays a runtime
+    # @warn and cannot become a preflight rule.
     CompatRule(
         :spin_rotating_omega_secular_required, :error,
         "spin_rotating_frame_omega ≠ 0 requires secular_ddi=true",

--- a/test/workflow/test_inspect_config.jl
+++ b/test/workflow/test_inspect_config.jl
@@ -205,6 +205,58 @@ using SpinorBEC
             ins.warnings)
     end
 
+    @testset "runner-consumed top-level blocks are not schema errors" begin
+        # `dealias:` and `units:` are real top-level blocks that the RUNNER pops
+        # before validation — `dealias` onto global Refs, `units` after lab-unit
+        # conversion. Inspect used to validate the raw dict, so it reported a
+        # schema ERROR for ~20 configs that run fine, several already run on
+        # TSUBAME. A preflight that fails valid configs is worse than none:
+        # this severity feeds the autopilot gate.
+        src = """
+        units: {B: Gauss}
+        dealias: {enabled: true, k_cut: 5.0}
+        pipeline:
+          - ground_state:
+              atom: Eu151
+              grid: {n: [8, 8, 8], box: [4.0, 4.0, 4.0]}
+              potential: {type: harmonic, omega: [1.0, 1.0, 1.0]}
+              interactions: {N_atoms: 1000, omega_ref: 691.1504}
+              lhy: {kind: full_bdg}
+              B: {Bz: "0.01 Gauss"}
+              n_steps: 10
+              tol: 1.0e-6
+        """
+        ins = SpinorBEC.inspect_config_string(src)
+        @test !any(w -> w.kind === :normalize_failed, ins.warnings)
+        @test !any(w -> w.kind === :input_resolved_drop &&
+                        occursin("units", w.title), ins.warnings)
+        # ...and inspecting must not leak the dealias Refs into the session.
+        @test SpinorBEC.DEALIAS_2_3_ENABLED[] == false
+
+        # `kind: full_bdg` is no longer flagged. The ~3000× offset that rule
+        # warned about was a UV counterterm bug, fixed 2026-07-27; full_bdg is
+        # the general-spinor path and matches the closed forms to ~1e-4.
+        @test !any(w -> w.kind === :full_bdg_f6_polar, ins.warnings)
+    end
+
+    @testset "a malformed dealias block is still an error" begin
+        # Popping it must not mean ignoring it — the runner throws on this.
+        src = """
+        dealias: {enabled: true, no_such_key: 1}
+        pipeline:
+          - ground_state:
+              atom: Eu151
+              grid: {n: [8, 8, 8], box: [4.0, 4.0, 4.0]}
+              potential: {type: harmonic, omega: [1.0, 1.0, 1.0]}
+              interactions: {N_atoms: 1000, omega_ref: 691.1504}
+              n_steps: 10
+              tol: 1.0e-6
+        """
+        ins = SpinorBEC.inspect_config_string(src)
+        @test any(w -> w.kind === :dealias_block_invalid && w.severity === :error,
+            ins.warnings)
+    end
+
     # --- run_yaml audit hook (W4 + opt-out) -----------------------------
     #
     # The hook lives in `_run_yaml_impl`; we exercise it via run_yaml with


### PR DESCRIPTION
`inspect` reported a schema **ERROR** for ~20 committed configs — several of them already run on TSUBAME.

```
ERROR [config] normalize_and_validate failed
  ArgumentError: Unknown top-level YAML key(s) ["dealias"] — typo?
```

`dealias:` is a real top-level block. The runner pops it onto global Refs (`run_registry.jl:260`) *before* validating; inspect validated the raw dict, and strict validation rejects every top-level key it does not recognise. A preflight that fails valid configs is worse than none — this severity feeds the autopilot gate (`:block` → `killed_bug`).

Found while preflighting a new config; confirmed by inspecting `config_texture_bscan.yaml`, which has already produced results on TSUBAME.

## Fix

Inspect now **applies** the block and restores the Refs immediately, rather than merely popping it: `auto_dt` tightens `dt` in the pipeline, and inspect should report the dt the run will actually use. Inspect stays read-only. A malformed block is still an error, now `:dealias_block_invalid`.

## Two more of the same class, in the same gate

- **`units:` missing from `DROP_ALLOWLIST`.** It is popped by `units_block` after lab-unit conversion, so every lab-units config got a false "key not present after normalize" warning — two lines above an `:info` reporting the conversion that key had just performed.

- **`:full_bdg_f6_polar` deleted.** It warned that `FullBdGLHY` emits a ~3000× spurious offset at F=6 polar. That offset was a UV counterterm subtracting ε_k twice — divergent at **every** F and phase, not an F=6 polar property — and was fixed 2026-07-27; `full_bdg` now matches all three closed forms to ~1e-4. The rule outlived the bug and steered users off the only general-spinor LHY path, which is the one currently being selected for the Eu phase-diagram recompute.

  Its predicate also fired on **any** `kind: full_bdg`, never checking F or the polar ansatz its own name claimed. The genuine remaining caveat — scheme-dependence when the mean field is dynamically **unstable** — is a property of the converged state, not of the config, so it stays a runtime `@warn` and cannot become a preflight rule.

## Gates

Two testsets in `test_inspect_config.jl`: a config carrying both blocks inspects clean **and does not leak the dealias Refs into the session**; a malformed dealias block is still an error. 29/29. Fast tier: 149 files, all passed.

## Not in this PR

`docs/manuscript/thesis/appendices/AppendixB_spinorbec_api.md` and `docs/research_notes/eu_collapse_lhy_insufficient.md` still deprecate `full_bdg` on the authority of a memory file (`full_bdg_F6_polar_broken.md`) that no longer exists. Same staleness, different surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)