### PR TITLE
feat(lhy): the SpatialLHY propagator now carries the polarisation term

### DIFF
--- a/docs/reference/yaml_schema_reference.md
+++ b/docs/reference/yaml_schema_reference.md
@@ -272,11 +272,12 @@ rather than returning nothing.
 
 Two caveats for `spatial`:
 
-- The propagator applies only the diagonal $\partial\varepsilon/\partial n$. The
-  polarisation piece of $\delta E/\delta\bar\psi$ is a spin operator, which the
-  LBFGS gradient carries and the diagonal split-step cannot — a measured 2.3%
-  difference, so ITP and LBFGS minimise slightly different functionals here
-  (issue #131).
+- The polarisation piece of $\delta E/\delta\bar\psi$ is a spin operator, which
+  a diagonal split-step cannot carry. It is applied as its own substep
+  (`apply_spatial_lhy_spin_step!`, a per-voxel rotation about the local
+  $\langle F\rangle$ axis), so the propagator and the LBFGS gradient agree. Runs
+  predating issue #131 had ITP minimising a functional 2.3% away from the one
+  LBFGS minimised.
 - Expect `full_bdg`'s dynamic-instability warning. A bin's representative
   spinor is lifted out of the cloud and is not a solution of the *uniform*
   mean-field problem at its own density; the warning is about that fictitious

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -58,6 +58,7 @@ include("hamiltonian/terms/lhy/icosahedral.jl")
 include("hamiltonian/terms/lhy/modes_round45.jl")
 include("hamiltonian/terms/lhy/dispatch.jl")
 include("hamiltonian/terms/lhy/full_bdg.jl")
+include("hamiltonian/terms/lhy/spatial_spin_step.jl")
 include("hamiltonian/terms/lhy/spatial.jl")
 include("hamiltonian/integrator/absorbing_boundary.jl")
 

--- a/src/hamiltonian/integrator/split_step.jl
+++ b/src/hamiltonian/integrator/split_step.jl
@@ -577,6 +577,16 @@ function _outer_operators_fwd!(
         )
     end
 
+    # The spin half of a spatially-varying LHY (issue #131). No-op for every
+    # other LHY — `_lhy_needs_spin` is a compile-time trait, so nothing else
+    # pays for it. Mirrored in the reverse half below to keep Strang symmetric.
+    if _lhy_needs_spin(ws.lhy)
+        @timeit_debug TIMER "spatial_lhy_spin" apply_spatial_lhy_spin_step!(
+            ws.state.psi, ws.lhy, ws.spin_matrices, dt_outer, ndim;
+            imaginary_time, psi_mf,
+        )
+    end
+
     c2 = get_cn(ip, 2)
     if is_active(c2)
         @timeit_debug TIMER "singlet_pair" apply_singlet_pair_step!(
@@ -643,6 +653,13 @@ function _outer_operators_bwd!(
     if is_active(c2)
         @timeit_debug TIMER "singlet_pair" apply_singlet_pair_step!(
             ws.state.psi, ip, ws.spin_matrices.system.F, dt_outer, ndim; imaginary_time, psi_mf
+        )
+    end
+
+    if _lhy_needs_spin(ws.lhy)
+        @timeit_debug TIMER "spatial_lhy_spin" apply_spatial_lhy_spin_step!(
+            ws.state.psi, ws.lhy, ws.spin_matrices, dt_outer, ndim;
+            imaginary_time, psi_mf,
         )
     end
 

--- a/src/hamiltonian/terms/lhy/lhy_term.jl
+++ b/src/hamiltonian/terms/lhy/lhy_term.jl
@@ -266,15 +266,16 @@ The first term is `_lhy_V(n, p, lhy)·ψ`, the diagonal potential the propagator
 applies. The second is not diagonal — `ŝ = ⟨F⟩/|⟨F⟩|` — so it exists only here.
 Verified against a finite difference of `_lhy_energy(::SpatialLHY)` to 8e-10.
 
-**The propagator omits the second term**, because its diagonal step has no place
-to put a spin operator. Measured on a random F=6 spinor with the ~20% `e₁(p)`
-variation `spatial.jl` reports at F=6, the omission is **2.3%** of the gradient
-norm; `test_lhy_gradient_all_modes.jl` pins that number so it cannot drift
-unnoticed. ITP and LBFGS therefore minimise slightly different functionals for
-`SpatialLHY` alone — LBFGS the true energy, ITP the diagonal approximation to
-it. Closing the gap belongs in the propagator — issue #131, which needs a
-per-voxel spin substep — not in a gradient that would then stop being the
-energy's derivative.
+The diagonal propagator step has no place to put a spin operator, so until issue
+#131 it simply omitted the second term — a measured **2.3%** of the gradient
+norm on a random F=6 spinor with the ~20% `e₁(p)` variation `spatial.jl` reports
+at F=6, which left ITP and LBFGS minimising different functionals for this one
+mode. `apply_spatial_lhy_spin_step!` now applies it as its own substep, a
+per-voxel rotation about the local ⟨F⟩ axis, and
+`test_spatial_lhy_spin_substep.jl` pins that the propagator and this gradient
+agree. `test_lhy_gradient_all_modes.jl` still pins the 2.3% as a statement about
+the DIAGONAL potential in isolation — which is what keeps the substep's
+contribution measured rather than assumed.
 
 `ŝ·F` uses the ladder form, from the SAME `fp_coeffs` and component convention
 as `_local_polarisation`: `(F₊ψ)_c = fp[c+1]·ψ_{c+1}`, `(F₋ψ)_c = fp[c]·ψ_{c-1}`,

--- a/src/hamiltonian/terms/lhy/spatial_spin_step.jl
+++ b/src/hamiltonian/terms/lhy/spatial_spin_step.jl
@@ -1,0 +1,115 @@
+# spatial_spin_step.jl
+# =================================================================
+# The spin half of the spatially-varying LHY, as a propagator substep.
+#
+# `SpatialLHY` has ε = n^(5/2) e₁(p) with p = |⟨F⟩|/F, so ψ enters through the
+# POLARISATION as well as the density:
+#
+#     δε/δψ̄ = (5/2) n^(3/2) e₁(p) ψ  +  c [ (ŝ·F)ψ/F − p ψ ],
+#     c = n^(3/2) e₁′(p),   ŝ = ⟨F⟩/|⟨F⟩|
+#
+# The first term is `_lhy_V(n, p, lhy)` and the diagonal step applies it. The
+# second is a SPIN operator — a diagonal step has nowhere to put it — so before
+# this file the propagator simply omitted it while the LBFGS gradient carried it
+# (issue #131). Measured on a random F=6 spinor with the ~20 % e₁(p) variation
+# `spatial.jl` reports at F=6, the omission was 2.3 % of the gradient norm, and
+# it is the physically interesting part: the force driving the spinor toward the
+# polarisation that minimises e₁, i.e. the reason to make the LHY spatial.
+#
+# It costs no new machinery, because the operator is a rotation:
+#
+#     A = (c/F)(ŝ·F) − c p
+#     exp(−dt·A) = exp(+dt·c·p) · exp(−dt·(φ·F)),     φ = (c/F)·ŝ
+#
+# a per-voxel scalar times a per-voxel spin rotation about the local ⟨F⟩ axis —
+# exactly the Euler 5-stage `_apply_ddi_rotation!` already performs for the DDI,
+# on CPU and GPU alike. Its convention was verified rather than read off:
+# real time it applies exp(−i·dt·(φ·F)), imaginary time exp(−dt·(φ·F)).
+
+export apply_spatial_lhy_spin_step!
+
+"""
+    apply_spatial_lhy_spin_step!(psi, lhy::SpatialLHY, sm, dt_frac, ndim;
+                                 imaginary_time=false, psi_mf=psi)
+
+Apply `exp(∓dt·A)` with `A = (c/F)(ŝ·F) − c·p`, the piece of `δε_LHY/δψ̄` the
+diagonal step cannot carry. See the file header for the derivation.
+
+`psi_mf` supplies the mean field (density, ⟨F⟩) — the same frozen-coefficient
+convention every other nonlinear substep here uses, so a Strang sandwich stays
+second order. Voxels with no density, no polarisation, or a flat `e₁` on their
+interval contribute nothing and are skipped.
+"""
+function apply_spatial_lhy_spin_step!(
+    psi::AbstractArray{<:Complex},
+    lhy::SpatialLHY,
+    sm::SpinMatrices{D},
+    dt_frac::Float64,
+    ndim::Int;
+    imaginary_time::Bool=false,
+    psi_mf::AbstractArray{<:Complex}=psi,
+) where {D}
+    n_pts = ntuple(d -> size(psi, d), ndim)
+    Ns = prod(n_pts)
+    F = lhy.F
+    fp = lhy.fp_coeffs
+    RT = real(eltype(psi))
+
+    P = reshape(psi_mf, Ns, D)
+    phi_x = zeros(RT, n_pts...)
+    phi_y = zeros(RT, n_pts...)
+    phi_z = zeros(RT, n_pts...)
+    shift = zeros(RT, n_pts...)
+    fx = reshape(phi_x, Ns)
+    fy = reshape(phi_y, Ns)
+    fz = reshape(phi_z, Ns)
+    sh = reshape(shift, Ns)
+
+    any_active = false
+    @inbounds for i in 1:Ns
+        n = 0.0
+        szl = 0.0
+        for c in 1:D
+            a = abs2(P[i, c])
+            n += a
+            szl += (F - (c - 1)) * a
+        end
+        n < 1e-30 && continue
+        sp = zero(ComplexF64)
+        for c in 2:D
+            sp += fp[c] * conj(P[i, c - 1]) * P[i, c]
+        end
+        smag = sqrt(abs2(sp) + szl * szl)
+        smag < 1e-30 && continue
+        p = smag / (n * F)
+        de1 = _lhy_de1_dp(lhy, clamp(p, 0.0, 1.0))
+        de1 == 0.0 && continue
+        c_coef = n * sqrt(n) * de1
+        # φ = (c/F)·ŝ, with ŝ = (Re S₊, Im S₊, S_z)/|S| — the same component
+        # convention `_local_polarisation` uses to build |S| in the first place.
+        g = c_coef / (F * smag)
+        fx[i] = RT(g * real(sp))
+        fy[i] = RT(g * imag(sp))
+        fz[i] = RT(g * szl)
+        sh[i] = RT(c_coef * p)
+        any_active = true
+    end
+    any_active || return nothing
+
+    _apply_ddi_rotation!(psi, phi_x, phi_y, phi_z, sm, dt_frac, ndim; imaginary_time)
+
+    # The `−c·p` half of A: spin-independent, so a per-voxel scalar. Sign is
+    # `+dt·c·p` in the exponent because A carries it with a minus.
+    dt_t = RT(dt_frac)
+    idx = ntuple(_ -> Colon(), ndim)
+    scale = imaginary_time ? exp.(shift .* dt_t) : cis.(shift .* dt_t)
+    for c in 1:D
+        view(psi, idx..., c) .*= scale
+    end
+    nothing
+end
+
+# Every other LHY has no spin dependence, so the substep is a no-op they never
+# pay for — `_lhy_needs_spin` is the compile-time trait that decides.
+apply_spatial_lhy_spin_step!(::AbstractArray, ::Any, ::SpinMatrices, ::Float64,
+    ::Int; kwargs...) = nothing

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -127,6 +127,7 @@ const FAST_TESTS = [
     "hamiltonian/test_tabulated_lhy_propagator_parity.jl",
     "hamiltonian/test_lhy_energy_convention.jl",
     "hamiltonian/test_spatial_lhy.jl",
+    "hamiltonian/test_spatial_lhy_spin_substep.jl",
     "hamiltonian/test_lhy_gradient_all_modes.jl",
     "hamiltonian/test_spinor_lhy_validation.jl",
     "hamiltonian/test_icosahedral_lhy.jl",

--- a/test/hamiltonian/test_lhy_gradient_all_modes.jl
+++ b/test/hamiltonian/test_lhy_gradient_all_modes.jl
@@ -115,8 +115,11 @@ end
         @test norm(g) > 1.0
         @test norm(g .- fd) / norm(fd) < 1e-7     # measured 8.3e-10
 
-        # The diagonal-only gradient — what the propagator applies — and by how
-        # much it falls short. Pinned so the discrepancy cannot silently grow.
+        # The diagonal-only gradient, and by how much it falls short. Since
+        # issue #131 the propagator also applies the spin piece
+        # (`apply_spatial_lhy_spin_step!`), so this is no longer what the
+        # propagator does — it is the measurement that makes that substep's
+        # contribution a number rather than an assumption.
         P = reshape(psi, prod(npts), _D)
         fp = ntuple(c -> fp_ladder_coeff(_F, _F - (c - 1)), Val(_D))
         diag = zeros(ComplexF64, prod(npts), _D)

--- a/test/hamiltonian/test_spatial_lhy_spin_substep.jl
+++ b/test/hamiltonian/test_spatial_lhy_spin_substep.jl
@@ -1,0 +1,165 @@
+# Gate: the SpatialLHY propagator now carries the polarisation term (issue #131).
+#
+# `ε = n^(5/2) e₁(p)` depends on ψ through p = |⟨F⟩|/F as well as through n, so
+#
+#     δε/δψ̄ = (5/2)n^(3/2)e₁(p)·ψ  +  c[(ŝ·F)ψ/F − p·ψ],   c = n^(3/2)e₁′(p)
+#
+# The diagonal step applies the first term. The second is a SPIN operator, and
+# the propagator simply omitted it — a measured 2.3 % of the gradient norm —
+# while the LBFGS gradient carried it in full. ITP and LBFGS were therefore
+# minimising different functionals for this one mode.
+#
+# `apply_spatial_lhy_spin_step!` closes it, as a rotation:
+#
+#     A = (c/F)(ŝ·F) − c·p,   exp(−dt·A) = exp(+dt·c·p)·exp(−dt·(φ·F)),
+#     φ = (c/F)·ŝ
+#
+# The decisive check is not that the substep is self-consistent but that the
+# propagator and the gradient now agree: one imaginary-time step of the FULL
+# LHY (diagonal + this substep) must move ψ along −δE/δψ̄.
+
+using Test
+using LinearAlgebra: norm
+using Random
+using SpinorBEC
+using SpinorBEC: apply_spatial_lhy_spin_step!, _lhy_de1_dp, _lhy_V, _grad_lhy!,
+    _lhy_needs_spin, fp_ladder_coeff, _local_polarisation, total_density
+
+const _F = 2
+const _D = 5
+
+function _lhy(; var=0.20)
+    ps = collect(range(0.0, 1.0; length=9))
+    SpatialLHY(ps, [0.5 * (1 - var * p^2) for p in ps], _F,
+        [fp_ladder_coeff(_F, _F - (c - 1)) for c in 1:_D])
+end
+
+_ws(l) = (; interactions=InteractionParams(Dict(0 => 10.0, 1 => 0.1)), lhy=l)
+
+# The full local LHY operator applied for a time dt: diagonal V_LHY plus the
+# spin substep. This is what the propagator does, assembled here directly so
+# the test does not depend on the whole split-step sandwich.
+function _full_lhy_step(psi, lhy, sm, dt, imaginary_time)
+    q = copy(psi)
+    mf = copy(psi)
+    n_pts = size(psi)[1:3]
+    Ns = prod(n_pts)
+    P = reshape(mf, Ns, _D)
+    fp = ntuple(c -> lhy.fp_coeffs[c], Val(_D))
+    Q = reshape(q, Ns, _D)
+    for i in 1:Ns
+        s = sum(abs2, @view P[i, :])
+        s < 1e-30 && continue
+        p = _local_polarisation(P, i, s, lhy.F, fp, Val(_D))
+        v = _lhy_V(s, p, lhy)
+        f = imaginary_time ? exp(-v * dt) : cis(-v * dt)
+        for c in 1:_D
+            Q[i, c] *= f
+        end
+    end
+    apply_spatial_lhy_spin_step!(q, lhy, sm, dt, 3; imaginary_time, psi_mf=mf)
+    q
+end
+
+@testset "SpatialLHY propagator carries the polarisation term" begin
+    sm = spin_matrices(_F)
+    Random.seed!(20260728)
+    psi = 0.5 .* randn(ComplexF64, 3, 3, 3, _D)
+    lhy = _lhy()
+
+    @testset "the substep alone == exp(-dt A), both time directions" begin
+        # Pinned against an explicit matrix exponential of the operator it
+        # claims to be, so the rotation identity cannot silently rot.
+        Ns = 27
+        P = reshape(psi, Ns, _D)
+        i = 1
+        nn = sum(abs2, @view P[i, :])
+        szl = sum((_F - (c - 1)) * abs2(P[i, c]) for c in 1:_D)
+        sp = sum(lhy.fp_coeffs[c] * conj(P[i, c - 1]) * P[i, c] for c in 2:_D)
+        smag = sqrt(abs2(sp) + szl^2)
+        p = smag / (nn * _F)
+        cc = nn * sqrt(nn) * _lhy_de1_dp(lhy, clamp(p, 0.0, 1.0))
+        @test cc != 0.0
+        sh = [real(sp), imag(sp), szl] ./ smag
+        A =
+            (cc / _F) * (sh[1] * Matrix(sm.Fx) + sh[2] * Matrix(sm.Fy) +
+                         sh[3] * Matrix(sm.Fz)) - cc * p * Matrix(one(sm.Fz))
+
+        for it in (false, true)
+            q = copy(psi)
+            apply_spatial_lhy_spin_step!(q, lhy, sm, 0.03, 3;
+                imaginary_time=it, psi_mf=copy(psi))
+            U = it ? exp(-0.03 * A) : exp(-im * 0.03 * A)
+            want = U * [psi[1, 1, 1, c] for c in 1:_D]
+            got = [q[1, 1, 1, c] for c in 1:_D]
+            @test maximum(abs.(got .- want)) < 1e-13
+        end
+    end
+
+    @testset "propagator now agrees with the gradient" begin
+        # THE point of #131. One imaginary-time step of the full LHY moves psi
+        # along -dE/dpsibar; before the substep existed this was 2.3% off.
+        dt = 1e-6
+        q = _full_lhy_step(psi, lhy, sm, dt, true)
+        moved = (psi .- q) ./ dt                       # ≈ δE/δψ̄
+        g = zeros(ComplexF64, size(psi))
+        _grad_lhy!(g, psi, _ws(lhy), total_density(psi, 3), size(psi)[1:3], _D, Val(3))
+        @test norm(g) > 1e-6
+        @test norm(moved .- g) / norm(g) < 1e-4        # dt-limited, not systematic
+    end
+
+    @testset "the diagonal step ALONE is 2.3% short — the gap #131 closed" begin
+        # Same comparison with the substep removed. Pins that the term being
+        # added is real and of the measured size, so a no-op substep cannot
+        # pass the test above by accident.
+        dt = 1e-6
+        Ns = 27
+        q = copy(psi)
+        P = reshape(psi, Ns, _D)
+        Q = reshape(q, Ns, _D)
+        fp = ntuple(c -> lhy.fp_coeffs[c], Val(_D))
+        for i in 1:Ns
+            s = sum(abs2, @view P[i, :])
+            s < 1e-30 && continue
+            v = _lhy_V(s, _local_polarisation(P, i, s, lhy.F, fp, Val(_D)), lhy)
+            for c in 1:_D
+                Q[i, c] *= exp(-v * dt)
+            end
+        end
+        moved = (psi .- q) ./ dt
+        g = zeros(ComplexF64, size(psi))
+        _grad_lhy!(g, psi, _ws(lhy), total_density(psi, 3), size(psi)[1:3], _D, Val(3))
+        gap = norm(moved .- g) / norm(g)
+        @test 0.01 < gap < 0.05
+    end
+
+    @testset "real time is norm-preserving" begin
+        # A is Hermitian, so the real-time step must be unitary. Catches a
+        # dropped conjugate or a sign flip in the scalar half, which the
+        # imaginary-time comparison above is much less sensitive to.
+        q = _full_lhy_step(psi, lhy, sm, 0.05, false)
+        @test isapprox(sum(abs2, q), sum(abs2, psi); rtol=1e-12)
+    end
+
+    @testset "flat e1 makes the substep an exact no-op" begin
+        # e₁′ ≡ 0 ⇒ no polarisation force. Guards against the substep adding a
+        # spurious rotation on states it should not touch.
+        flat = SpatialLHY(collect(range(0.0, 1.0; length=9)), fill(0.5, 9), _F,
+            [fp_ladder_coeff(_F, _F - (c - 1)) for c in 1:_D])
+        for it in (false, true)
+            q = copy(psi)
+            apply_spatial_lhy_spin_step!(q, flat, sm, 0.05, 3;
+                imaginary_time=it, psi_mf=copy(psi))
+            @test q == psi
+        end
+    end
+
+    @testset "non-spatial LHY never pays for it" begin
+        @test !_lhy_needs_spin(ScalarLHY(0.5))
+        @test !_lhy_needs_spin(NoLHY())
+        @test _lhy_needs_spin(lhy)
+        q = copy(psi)
+        apply_spatial_lhy_spin_step!(q, ScalarLHY(0.5), sm, 0.05, 3)
+        @test q == psi
+    end
+end

--- a/test/oracles/test_path_coverage.jl
+++ b/test/oracles/test_path_coverage.jl
@@ -108,7 +108,7 @@ const PATH_COVERAGE = [
     # cloud's own local spinors. The wiring gate covers the builder, the
     # uniform-cloud fallback to `:full_bdg`, and the resolver's knobs; the
     # table itself is `hamiltonian/test_spatial_lhy.jl` and its gradient
-    # (which alone carries the polarisation term — issue #131) is
+    # (whose polarisation term the propagator also carries since #131) is
     # `hamiltonian/test_lhy_gradient_all_modes.jl`.
     (axis=:lhy_kind, value="spatial", status=:gated,
         ref="workflow/test_lhy_block_wiring.jl"),


### PR DESCRIPTION
Closes #131.

## The gap

`ε = n^(5/2) e₁(p)` depends on ψ through the polarisation `p = |⟨F⟩|/F` as well
as through the density:

$$\frac{\delta \varepsilon}{\delta \bar\psi} = \tfrac{5}{2} n^{3/2} e_1(p)\,\psi \;+\; n^{3/2} e_1'(p)\Big[\tfrac{1}{F}(\hat s\cdot \mathbf F)\psi - p\,\psi\Big]$$

The diagonal step applies the first term. The second is a **spin operator**, so
a diagonal step has nowhere to put it — the propagator simply omitted it, a
measured **2.3%** of the gradient norm, while the LBFGS gradient has carried it
in full since #132. ITP and LBFGS were minimising different functionals for this
one mode.

That omitted piece is also the physically interesting one: it is the force
driving the spinor toward the polarisation that minimises `e₁` — i.e. the reason
to make the LHY spatially varying at all.

## The fix needs no new machinery

The operator is a rotation:

```
A = (c/F)(ŝ·F) − c·p,        c = n^{3/2} e₁′(p)
exp(−dt·A) = exp(+dt·c·p) · exp(−dt·(φ·F)),      φ = (c/F)·ŝ
```

— a per-voxel scalar times a per-voxel spin rotation about the local ⟨F⟩ axis,
which is exactly the Euler 5-stage `_apply_ddi_rotation!` already performs for
the DDI, CPU and GPU alike.

Its sign convention was **verified numerically rather than read off the source**:
`exp(−i·dt·φ·F)` in real time and `exp(−dt·φ·F)` in imaginary time, both to
3e-16 against an explicit matrix exponential. That mattered — a sign error here
would have been a plausible-looking 2× energy shift rather than an obvious
failure.

Placed in **both halves** of the inner V sandwich, mirrored around
`spin_mixing`, so Strang symmetry is preserved. `_lhy_needs_spin` is a
compile-time trait, so every other LHY compiles the substep away and pays
nothing.

## Gates — `test/hamiltonian/test_spatial_lhy_spin_substep.jl` (13 assertions)

| check | result |
|---|---|
| substep alone == `exp(−dt·A)`, both time directions, vs explicit matrix exponential | 1e-13 |
| **propagator and gradient now agree** — one IT step moves ψ along `−δE/δψ̄` | 1e-4 (dt-limited) |
| the diagonal step **alone** is still 1–5% short | so a no-op substep cannot pass the above by accident |
| real time is norm-preserving (A is Hermitian) | 1e-12 |
| flat `e₁` ⇒ exact no-op | `q == psi` |
| non-spatial LHY untouched | `q == psi` |

The third row is the one that makes this a gate rather than a self-comparison:
without it, deleting the substep body would leave the "propagator agrees with
gradient" test passing only if the gradient were also wrong.

`test_lhy_gradient_all_modes.jl` keeps its 2.3% pin, now framed as a statement
about the **diagonal potential in isolation** rather than about the propagator —
which is what keeps this substep's contribution a measured number rather than an
assumption.

## Verification

- oracles tier: **63 files, all passed**
- fast tier: **155 files, all passed**

## Note

Commits are unsigned — the 1Password SSH agent is still unavailable in this
session and @anko9801 asked to proceed. Happy to amend once it is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)