### PR TITLE
feat(summary): stamp the producing commit, and make staleness queryable

### DIFF
--- a/src/workflow/validation/scalar_summary.jl
+++ b/src/workflow/validation/scalar_summary.jl
@@ -18,7 +18,8 @@
 
 import JSON
 
-export run_scalar_summary, write_run_summary,
+export run_scalar_summary,
+    write_run_summary, summary_provenance,
     RUN_SUMMARY_FILENAME, RUN_SUMMARY_EXTRACTOR_VERSION
 
 const RUN_SUMMARY_FILENAME = "summary.json"
@@ -41,6 +42,32 @@ function _try_field(errs::Vector{String}, field::AbstractString, f)
     end
 end
 
+# Commit that produced a summary, so staleness is queryable rather than guessed.
+#
+# The need was measured, not anticipated: re-running eu_k3_lhy_control in current
+# code gave peak_max 0.005775 where the stored May row said 0.007487, and the
+# classification moved `delay` → `marginal_arrest`. That reads as a dramatic
+# effect of the c_lhy fix (#108) and is not one — an A/B in identical code showed
+# the coefficient accounts for 2 % of it and the rest is accumulated code change.
+# Without a recorded commit there is no way to ask which stored verdicts predate
+# which fix, so the only options were re-run everything or trust nothing.
+#
+# Best-effort by design: a summary must still be written when git is unavailable
+# (a tarball, a container, a compute node with no .git). `nothing` then, and the
+# key is simply absent — the same "absent ≠ errored" contract as every other
+# field here.
+function _repo_commit()
+    try
+        root = dirname(dirname(dirname(dirname(@__DIR__))))   # src/workflow/validation → repo
+        out = readchomp(Cmd(`git -C $root rev-parse HEAD`; ignorestatus=true))
+        occursin(r"^[0-9a-f]{40}$", out) || return nothing
+        dirty = !isempty(readchomp(Cmd(`git -C $root status --porcelain`; ignorestatus=true)))
+        dirty ? out * "-dirty" : out
+    catch
+        nothing
+    end
+end
+
 """
     run_scalar_summary(r::RunResult) -> Dict{String, Any}
 
@@ -55,6 +82,10 @@ wavefunction + metadata. Never throws. Keys appear only when extractable:
                                only when the cloud spans the periodic box
   norm_rel_drift,
   energy_rel_drift, Fz_drift — dynamics runs only
+
+The writer additionally stamps `_extractor_version`, `_source`, `_extracted_at`
+and `_repo_commit` (absent when git is unavailable; `-dirty`-suffixed when the
+working tree differs from HEAD).
 
 Always includes `extraction_error` (Vector{String}, empty when clean), so
 extraction failure is a first-class, queryable facet rather than a silent
@@ -213,6 +244,12 @@ function write_run_summary(run_dir::AbstractString, jld2_path::AbstractString;
     bag["_extractor_version"] = RUN_SUMMARY_EXTRACTOR_VERSION
     bag["_source"] = String(source)
     bag["_extracted_at"] = string(now())
+    # `-dirty` suffix when the working tree differs from HEAD: a summary produced
+    # from uncommitted code is not reproducible from the hash alone, and saying so
+    # is more useful than a hash that lies.
+    let c = _repo_commit()
+        c === nothing || (bag["_repo_commit"] = c)
+    end
 
     isdir(run_dir) || mkpath(run_dir)
     path = joinpath(run_dir, RUN_SUMMARY_FILENAME)
@@ -220,4 +257,41 @@ function write_run_summary(run_dir::AbstractString, jld2_path::AbstractString;
         JSON.print(io, bag, 2)
     end
     return path
+end
+
+"""
+    summary_provenance(run_dir) -> NamedTuple
+
+`(commit, dirty, extractor_version, extracted_at, stamped)` for a run's
+`summary.json`. `stamped == false` means the summary predates commit stamping —
+which is *not* the same as "current": it means the question cannot be answered
+from the file and the run has to be re-run to know.
+
+Use it to triage a stored suite before quoting it:
+
+```julia
+for d in readdir("runs"; join=true)
+    p = summary_provenance(d)
+    p.stamped || println("unknown vintage: ", d)
+end
+```
+"""
+function summary_provenance(run_dir::AbstractString)
+    path = joinpath(run_dir, RUN_SUMMARY_FILENAME)
+    absent = (commit=nothing, dirty=false, extractor_version=nothing,
+        extracted_at=nothing, stamped=false)
+    isfile(path) || return absent
+    d = try
+        JSON.parsefile(path)
+    catch
+        return absent
+    end
+    c = get(d, "_repo_commit", nothing)
+    c isa AbstractString || return (commit=nothing, dirty=false,
+        extractor_version=get(d, "_extractor_version", nothing),
+        extracted_at=get(d, "_extracted_at", nothing), stamped=false)
+    dirty = endswith(c, "-dirty")
+    (commit=dirty ? c[1:(end - 6)] : c, dirty=dirty,
+        extractor_version=get(d, "_extractor_version", nothing),
+        extracted_at=get(d, "_extracted_at", nothing), stamped=true)
 end

--- a/src/workflow/validation/scalar_summary.jl
+++ b/src/workflow/validation/scalar_summary.jl
@@ -58,7 +58,16 @@ end
 # field here.
 function _repo_commit()
     try
-        root = dirname(dirname(dirname(dirname(@__DIR__))))   # src/workflow/validation → repo
+        root = pkgdir(@__MODULE__)
+        root === nothing && return nothing
+        # `git -C` walks UP until it finds a repository, so a wrong `root` does
+        # not fail — it silently answers for an ANCESTOR repo. That is how the
+        # first version of this function stamped the parent checkout's HEAD when
+        # run from a worktree under `.claude/worktrees/` (path arithmetic was one
+        # `dirname` too deep, and CI, whose checkout has no git ancestor, was what
+        # exposed it). So verify the repo we reached is the package's own.
+        top = readchomp(Cmd(`git -C $root rev-parse --show-toplevel`; ignorestatus=true))
+        isdir(top) && realpath(top) == realpath(root) || return nothing
         out = readchomp(Cmd(`git -C $root rev-parse HEAD`; ignorestatus=true))
         occursin(r"^[0-9a-f]{40}$", out) || return nothing
         dirty = !isempty(readchomp(Cmd(`git -C $root status --porcelain`; ignorestatus=true)))

--- a/test/workflow/validation/test_scalar_summary.jl
+++ b/test/workflow/validation/test_scalar_summary.jl
@@ -121,4 +121,52 @@ end
             @test any(startswith.(String.(s["extraction_error"]), "open_result"))
         end
     end
+    @testset "provenance stamp: commit, dirty flag, and honest absence" begin
+        mktempdir() do dir
+            jld = joinpath(dir, "point_001.jld2")
+            jldopen(jld, "w") do f
+                local p = zeros(ComplexF64, 8, 8, 3)
+                p[1, 1, 1] = 1.0 + 0im
+                f["psi"] = p
+                f["grid_n_points"] = [8, 8]
+                f["grid_box_size"] = [4.0, 4.0]
+                f["energy"] = -6.0
+            end
+            write_run_summary(dir, jld; source="finish_hook")
+            s = JSON.parsefile(joinpath(dir, SpinorBEC.RUN_SUMMARY_FILENAME))
+            # The repo this test runs in is a git checkout, so the stamp is there.
+            @test haskey(s, "_repo_commit")
+            c = s["_repo_commit"]
+            @test occursin(r"^[0-9a-f]{40}(-dirty)?$", c)
+
+            pr = summary_provenance(dir)
+            @test pr.stamped
+            @test length(pr.commit) == 40
+            @test pr.dirty == endswith(c, "-dirty")
+            @test pr.extractor_version == SpinorBEC.RUN_SUMMARY_EXTRACTOR_VERSION
+        end
+    end
+
+    @testset "provenance of an unstamped or missing summary is not 'current'" begin
+        # A summary written before stamping cannot be retro-dated. The query must
+        # say so rather than imply the run matches HEAD — that distinction is the
+        # whole point of the field.
+        mktempdir() do dir
+            @test summary_provenance(dir).stamped == false        # no file at all
+            @test summary_provenance(dir).commit === nothing
+
+            open(joinpath(dir, SpinorBEC.RUN_SUMMARY_FILENAME), "w") do io
+                JSON.print(io, Dict("energy" => -1.0, "_extractor_version" => "2"), 2)
+            end
+            pr = summary_provenance(dir)
+            @test pr.stamped == false
+            @test pr.commit === nothing
+            @test pr.extractor_version == "2"                     # still readable
+        end
+        # Corrupt JSON must not throw out of a triage loop.
+        mktempdir() do dir
+            write(joinpath(dir, SpinorBEC.RUN_SUMMARY_FILENAME), "{not json")
+            @test summary_provenance(dir).stamped == false
+        end
+    end
 end

--- a/test/workflow/validation/test_scalar_summary.jl
+++ b/test/workflow/validation/test_scalar_summary.jl
@@ -134,16 +134,36 @@ end
             end
             write_run_summary(dir, jld; source="finish_hook")
             s = JSON.parsefile(joinpath(dir, SpinorBEC.RUN_SUMMARY_FILENAME))
-            # The repo this test runs in is a git checkout, so the stamp is there.
-            @test haskey(s, "_repo_commit")
-            c = s["_repo_commit"]
-            @test occursin(r"^[0-9a-f]{40}(-dirty)?$", c)
+            # Assert the VALUE against an independently obtained HEAD, not just
+            # that the key exists. `haskey` alone passed while the first version
+            # of the stamp was recording an ANCESTOR repo's commit (git -C walks
+            # up), which is exactly the lying hash the -dirty flag exists to
+            # avoid. Skip only where git genuinely is not available.
+            root = pkgdir(SpinorBEC)
+            head = try
+                readchomp(Cmd(`git -C $root rev-parse HEAD`; ignorestatus=true))
+            catch
+                ""
+            end
+            if occursin(r"^[0-9a-f]{40}$", head)
+                @test haskey(s, "_repo_commit")
+                c = s["_repo_commit"]
+                @test occursin(r"^[0-9a-f]{40}(-dirty)?$", c)
+                @test startswith(c, head)          # the package's OWN HEAD
+            else
+                @info "git unavailable — commit stamp is absent by design"
+                @test !haskey(s, "_repo_commit")
+            end
 
             pr = summary_provenance(dir)
-            @test pr.stamped
-            @test length(pr.commit) == 40
-            @test pr.dirty == endswith(c, "-dirty")
             @test pr.extractor_version == SpinorBEC.RUN_SUMMARY_EXTRACTOR_VERSION
+            if occursin(r"^[0-9a-f]{40}$", head)
+                @test pr.stamped
+                @test pr.commit == head
+                @test pr.dirty == endswith(s["_repo_commit"], "-dirty")
+            else
+                @test pr.stamped == false
+            end
         end
     end
 


### PR DESCRIPTION
Addresses the open item from `docs/validation/superfluidity_knowledge_state.md` §3: *"the stored results under `runs/` are stale against current `main`, and nothing has audited which verdicts still hold."*

## Measured need, not anticipated

Re-running `eu_k3_lhy_control` in current code gave peak_max **0.005775** where the stored May row says **0.007487**, and the classification moved `delay` → `marginal_arrest`.

That reads as a dramatic effect of the `c_lhy` fix (#108). It is not one — an A/B in *identical* code showed the coefficient accounts for **2 %** of the difference and the rest is accumulated code change since May. I nearly reported the original verdict as an artifact of the bug.

With no recorded commit there was no way to ask *which stored verdicts predate which fix*, so the only options were re-run everything or trust nothing.

## What it adds

`summary.json` now carries `_repo_commit`, with a `-dirty` suffix when the working tree differs from HEAD. A summary produced from uncommitted code is not reproducible from the hash alone, and saying so beats a hash that lies.

`summary_provenance(run_dir)` → `(commit, dirty, extractor_version, extracted_at, stamped)`.

The **`stamped` flag is the load-bearing part**: `false` means the summary predates stamping — which is *not* the same as "current". It means the question cannot be answered from the file and the run has to be repeated to know. Tests pin that distinction, plus that a missing file and corrupt JSON both return unstamped rather than throwing out of a triage loop.

```julia
for d in readdir("runs"; join=true)
    summary_provenance(d).stamped || println("unknown vintage: ", d)
end
```

## Best-effort by design

Git may be unavailable — a tarball, a container, a compute node without `.git`. Then the key is simply absent, the same "absent is not errored" contract as every other field in this file. A summary must still get written.

## Census of what exists today

**230 `summary.json` files** under `runs/` across this worktree and the main checkout. **0 stamped.**

Retro-dating is impossible, so those stay unknown-vintage — the stamp only helps from here. That census is itself the argument for the field: 230 stored verdicts whose vintage cannot be established.

## Tests

`test_scalar_summary` 47/47 · fast tier 154/154.