### PR TITLE
fix(dealias): the k_cut mask assumed L=12 on every axis — carry the real box

### DIFF
--- a/src/foundation/types/ddi_loss.jl
+++ b/src/foundation/types/ddi_loss.jl
@@ -22,6 +22,11 @@ mutable struct DDIParams{N, AQ <: AbstractArray{<:AbstractFloat, N}}
     Q_yy::AQ
     Q_yz::AQ
     Q_zz::AQ
+    # Real-space box length per axis. Q_αβ = k̂_α k̂_β − δ_αβ/3 is scale-free,
+    # so the box cannot be recovered from the tensors — it is carried here
+    # because the Orszag F-filter's physical `DEALIAS_K_CUTOFF[]` is
+    # meaningless without it (see `_get_orszag_mask`).
+    box_size::NTuple{N, Float64}
 end
 
 struct DDIBuffers{N, RP, IRP, AR <: AbstractArray, AC <: AbstractArray}

--- a/src/hamiltonian/integrator/dealias.jl
+++ b/src/hamiltonian/integrator/dealias.jl
@@ -106,12 +106,16 @@ mode: pick `k_cut` below the smallest grid's Nyquist so every grid
 yields the same effective physics window.
 
 Usage:
-    SpinorBEC.DEALIAS_K_CUTOFF[] = 11.0   # for L=12 box, gives same
-                                          # bandwidth as N=64 default
+    SpinorBEC.DEALIAS_K_CUTOFF[] = 11.0   # on an L=12 box, the same
+                                          # bandwidth as the N=64 default
     SpinorBEC.DEALIAS_K_CUTOFF[] = nothing  # back to (n_d ÷ 3) default
 
 The cutoff is per-axis (|k_x| and |k_y| and |k_z| each ≤ k_cut),
-matching the (n_d ÷ 3) default's per-axis structure.
+matching the (n_d ÷ 3) default's per-axis structure. Being stated in
+physical k, it is meaningful only against a box: the same number is a
+different fraction of the band on a different `box_size`, so the box
+travels to the mask builder from the `Grid` (ψ filter) and from
+`DDIParams.box_size` (F filter) rather than being assumed.
 """
 const DEALIAS_K_CUTOFF = Ref{Union{Nothing, Float64}}(nothing)
 
@@ -121,22 +125,29 @@ const DEALIAS_K_CUTOFF = Ref{Union{Nothing, Float64}}(nothing)
 const _ORSZAG_MASK_CACHE = Dict{Tuple, Any}()
 
 """
-    _get_orszag_mask(n_pts::NTuple{N,Int}) -> Array{Float64,N}
+    _get_orszag_mask(n_pts::NTuple{N,Int}, box::NTuple{N,Float64}) -> Array{Float64,N}
 
 Return a cached real-valued mask of shape `n_pts`. Value 1.0 at modes
 that should be KEPT, 0.0 at modes that should be zeroed. Per axis the
 cutoff is `n_d ÷ 3`: any axis index with `min(i-1, n-i+1) > n_d ÷ 3`
 zeros the full slab along that axis.
+
+`box` is the physical box length per axis. It is unused by the default
+`n_d ÷ 3` rule (that cutoff lives in index space and is box-independent)
+and load-bearing for the `DEALIAS_K_CUTOFF[]` override, which is stated
+in physical k and therefore only means something against a box.
 """
-function _get_orszag_mask(n_pts::NTuple{N, Int}) where {N}
-    _get_orszag_mask(n_pts, DEALIAS_K_CUTOFF[])
+function _get_orszag_mask(n_pts::NTuple{N, Int}, box::NTuple{N, Float64}) where {N}
+    _get_orszag_mask(n_pts, DEALIAS_K_CUTOFF[], box)
 end
 
 function _get_orszag_mask(n_pts::NTuple{N, Int},
-    k_cut_override::Union{Nothing, Float64}) where {N}
-    # The cache key includes k_cut_override so the mask rebuilds when
-    # DEALIAS_K_CUTOFF[] changes.
-    key = (n_pts, k_cut_override)
+    k_cut_override::Union{Nothing, Float64},
+    box::NTuple{N, Float64}) where {N}
+    # The cache key includes k_cut_override and the box so the mask rebuilds
+    # when DEALIAS_K_CUTOFF[] changes or the same grid shape is used on a
+    # different box.
+    key = (n_pts, k_cut_override, box)
     haskey(_ORSZAG_MASK_CACHE, key) && return _ORSZAG_MASK_CACHE[key]::Array{Float64, N}
     mask = ones(Float64, n_pts)
     if k_cut_override === nothing
@@ -155,15 +166,11 @@ function _get_orszag_mask(n_pts::NTuple{N, Int},
             end
         end
     else
-        # Fixed physical-k cutoff: zero modes with |k_d| > k_cut_override.
-        # Assume box L = 12.0 (the L4 verification suite box). This is a
-        # diagnostic mode; physical-k threading from the Grid is deferred
-        # to a follow-up commit (would require passing grid info through
-        # the filter call chain).
-        L_assumed = 12.0
+        # Fixed physical-k cutoff: zero modes with |k_d| > k_cut_override,
+        # where |k_d| is measured against the ACTUAL box length on that axis.
         for d in 1:N
             n = n_pts[d]
-            dk = 2π / L_assumed
+            dk = 2π / box[d]
             for i in 1:n
                 k_idx = i - 1 <= n ÷ 2 ? (i - 1) : (i - 1 - n)
                 k_val = abs(k_idx) * dk
@@ -181,7 +188,7 @@ function _get_orszag_mask(n_pts::NTuple{N, Int},
 end
 
 """
-    apply_orszag_2_3_filter!(psi, fft_plans, n_components, ndim)
+    apply_orszag_2_3_filter!(psi, fft_plans, n_components, ndim, box)
 
 Apply the Orszag 2/3-rule k-space filter to `psi` in place. Per axis,
 zeros all Fourier modes with `|k_idx| > n_d ÷ 3`. Cost per call:
@@ -200,9 +207,10 @@ function apply_orszag_2_3_filter!(
     fft_plans::FFTPlans,
     n_components::Int,
     ndim::Int,
-)
+    box::NTuple{M, Float64},
+) where {M}
     n_pts = ntuple(d -> size(psi, d), ndim)
-    mask = _get_orszag_mask(n_pts)
+    mask = _get_orszag_mask(n_pts, box)
     # Match the device of `psi` (CPU Array → CPU mask; CuArray → device mask).
     # The mask is per-grid-shape cached; we promote to device via similar+copy.
     mask_dev = _to_psi_device(psi, mask)
@@ -248,7 +256,7 @@ function _get_orszag_F_filter_resources(F_pad_template::AbstractArray{T, N},
 end
 
 """
-    apply_orszag_2_3_F_filter!(F_pad, n_pts) -> nothing
+    apply_orszag_2_3_F_filter!(F_pad, n_pts, box) -> nothing
 
 Apply the Orszag 2/3-rule k-space filter to the first `n_pts` entries
 of the bilinear spin-density buffer `F_pad`. The remainder (the
@@ -259,11 +267,11 @@ Call once per spin component (Fx, Fy, Fz) after the bilinear
 `_compute_spin_density!` and before the rfft convolution.
 """
 function apply_orszag_2_3_F_filter!(
-    F_pad::AbstractArray{T, N}, n_pts::NTuple{N, Int}
+    F_pad::AbstractArray{T, N}, n_pts::NTuple{N, Int}, box::NTuple{N, Float64}
 ) where {T <: Real, N}
-    _check_safe_k_cut(n_pts)
+    _check_safe_k_cut(n_pts, box)
     buf, plans = _get_orszag_F_filter_resources(F_pad, n_pts)
-    mask = _get_orszag_mask(n_pts)
+    mask = _get_orszag_mask(n_pts, box)
     mask_dev = _to_psi_device(buf, mask)
     idx = ntuple(d -> 1:n_pts[d], N)
     @views buf .= F_pad[idx...]
@@ -280,19 +288,21 @@ Runtime check: if `DEALIAS_K_CUTOFF[]` exceeds the safe boundary
 bilinear aliasing — the result will be contaminated and (per L4
 k-scan data) non-monotonic in `k_cut`. Emit a single `@warn` on first
 violation so the user sees it without spam.
+
+The binding axis is the one with the smallest `k_Nyq_d = π·n_d/L_d`,
+which is a property of the RATIO `n_d/L_d` — not of `n_d` alone. A
+long axis with many points can still be the loose one.
 """
-function _check_safe_k_cut(n_pts::NTuple{N, Int}) where {N}
+function _check_safe_k_cut(n_pts::NTuple{N, Int}, box::NTuple{N, Float64}) where {N}
     k_cut = DEALIAS_K_CUTOFF[]
     k_cut === nothing && return nothing
-    # Use the smallest axis as the binding constraint; per-axis cutoff
-    # in physical k is the same across axes for cubic boxes (assumed
-    # L=12 here; see DEALIAS_K_CUTOFF docstring for the box assumption).
-    n_min = minimum(n_pts)
-    k_safe = safe_k_cut_boundary(n_min, 12.0)
+    d_bind = argmin(ntuple(d -> n_pts[d] / box[d], N))
+    k_safe = safe_k_cut_boundary(n_pts[d_bind], box[d_bind])
     if k_cut > k_safe + 1e-9
         @warn "DEALIAS_K_CUTOFF[] = $k_cut exceeds safe boundary $(round(k_safe; digits=4)) " *
-            "(= 2·k_Nyq/3 at n=$n_min, L=12); F-filter cannot fully suppress bilinear " *
-            "aliasing — answer will be contaminated. Reduce k_cut or use a larger grid." maxlog=1
+            "(= 2·k_Nyq/3 on the binding axis $d_bind: n=$(n_pts[d_bind]), " *
+            "L=$(box[d_bind])); F-filter cannot fully suppress bilinear aliasing — " *
+            "answer will be contaminated. Reduce k_cut or use a larger grid." maxlog=1
     end
     nothing
 end

--- a/src/hamiltonian/integrator/split_step.jl
+++ b/src/hamiltonian/integrator/split_step.jl
@@ -81,7 +81,7 @@ function split_step!(ws::Workspace{N}) where {N}
 
     if DEALIAS_2_3_ENABLED[]
         @timeit_debug TIMER "dealias" apply_orszag_2_3_filter!(
-            ws.state.psi, ws.fft_plans, n_comp, N
+            ws.state.psi, ws.fft_plans, n_comp, N, ws.grid.config.box_size
         )
     end
 
@@ -360,7 +360,7 @@ function split_step_midpoint!(ws::Workspace{N}; dt::Float64=ws.sim_params.dt) wh
 
     if DEALIAS_2_3_ENABLED[]
         @timeit_debug TIMER "dealias" apply_orszag_2_3_filter!(
-            ws.state.psi, ws.fft_plans, n_comp, N
+            ws.state.psi, ws.fft_plans, n_comp, N, ws.grid.config.box_size
         )
     end
 

--- a/src/hamiltonian/terms/ddi/convolution.jl
+++ b/src/hamiltonian/terms/ddi/convolution.jl
@@ -59,7 +59,7 @@ function _make_ddi_params_quasi2d(
         U(l_z),
     )
 
-    DDIParams(c_dd, Q_xx, Q_xy, Q_xz, Q_yy, Q_yz, Q_zz)
+    DDIParams(c_dd, Q_xx, Q_xy, Q_xz, Q_yy, Q_yz, Q_zz, grid.config.box_size)
 end
 
 function _make_ddi_params_full(
@@ -120,7 +120,7 @@ function _make_ddi_params_full(
         trunc_radius,
     )
 
-    DDIParams(C_dd, Q_xx, Q_xy, Q_xz, Q_yy, Q_yz, Q_zz)
+    DDIParams(C_dd, Q_xx, Q_xy, Q_xz, Q_yy, Q_yz, Q_zz, grid.config.box_size)
 end
 
 function _ddi_params_to_device(ddi::DDIParams, backend::CPUBackend)
@@ -136,6 +136,7 @@ function _ddi_params_to_device(ddi::DDIParams, backend::AbstractBackend)
         _to_device(backend, ddi.Q_yy),
         _to_device(backend, ddi.Q_yz),
         _to_device(backend, ddi.Q_zz),
+        ddi.box_size,
     )
 end
 
@@ -181,9 +182,9 @@ function _compute_and_convolve_ddi!(
     # Full Orszag 2/3 rule companion (see dealias.jl + ddi_padded.jl). Filter
     # bilinear F to (2/3)·k_Nyq to suppress aliased fold-back into low-k F.
     if DEALIAS_2_3_ENABLED[]
-        apply_orszag_2_3_F_filter!(bufs.Fx_r, n_pts)
-        apply_orszag_2_3_F_filter!(bufs.Fy_r, n_pts)
-        apply_orszag_2_3_F_filter!(bufs.Fz_r, n_pts)
+        apply_orszag_2_3_F_filter!(bufs.Fx_r, n_pts, ddi.box_size)
+        apply_orszag_2_3_F_filter!(bufs.Fy_r, n_pts, ddi.box_size)
+        apply_orszag_2_3_F_filter!(bufs.Fz_r, n_pts, ddi.box_size)
     end
 
     rp = bufs.rfft_plans

--- a/src/hamiltonian/terms/ddi/ddi_padded.jl
+++ b/src/hamiltonian/terms/ddi/ddi_padded.jl
@@ -158,9 +158,9 @@ function _compute_and_convolve_ddi_padded!(
     # rule. The first n_pts entries of F_pad are modified; the
     # convolution-pad (the rest) stays zero.
     if DEALIAS_2_3_ENABLED[]
-        apply_orszag_2_3_F_filter!(ctx.Fx_pad, n_pts)
-        apply_orszag_2_3_F_filter!(ctx.Fy_pad, n_pts)
-        apply_orszag_2_3_F_filter!(ctx.Fz_pad, n_pts)
+        apply_orszag_2_3_F_filter!(ctx.Fx_pad, n_pts, ddi.box_size)
+        apply_orszag_2_3_F_filter!(ctx.Fy_pad, n_pts, ddi.box_size)
+        apply_orszag_2_3_F_filter!(ctx.Fz_pad, n_pts, ddi.box_size)
     end
 
     rp = ctx.rfft_plans

--- a/src/hamiltonian/terms/ddi/ddi_term.jl
+++ b/src/hamiltonian/terms/ddi/ddi_term.jl
@@ -76,7 +76,7 @@ function _ddi_energy_from_gpu(psi_host, sm::SpinMatrices{D}, ddi_gpu, ddi_bufs_g
 
     ddi_host = DDIParams(ddi_gpu.C_dd, _to_host(ddi_gpu.Q_xx), _to_host(ddi_gpu.Q_xy),
         _to_host(ddi_gpu.Q_xz), _to_host(ddi_gpu.Q_yy), _to_host(ddi_gpu.Q_yz),
-        _to_host(ddi_gpu.Q_zz))
+        _to_host(ddi_gpu.Q_zz), ddi_gpu.box_size)
     rfft_plans = make_rfft_plans(n_pts)
     Fx_rk = rfft_plans.forward * Fx_r
     Fy_rk = similar(Fx_rk);

--- a/src/solvers/ground_state/itp_loop.jl
+++ b/src/solvers/ground_state/itp_loop.jl
@@ -74,7 +74,8 @@ function _run_itp_loop!(
     # even after the dynamics filter is applied; see L4 cross-grid probe
     # 2026-05-24).
     if DEALIAS_2_3_ENABLED[]
-        apply_orszag_2_3_filter!(ws.state.psi, ws.fft_plans, n_comp_ws, N_dim)
+        apply_orszag_2_3_filter!(ws.state.psi, ws.fft_plans, n_comp_ws, N_dim,
+            ws.grid.config.box_size)
     end
 
     # Open: V(dt/2)
@@ -87,7 +88,8 @@ function _run_itp_loop!(
             on_step !== nothing && on_step(ws, step, n_steps)
 
             if DEALIAS_2_3_ENABLED[]
-                apply_orszag_2_3_filter!(ws.state.psi, ws.fft_plans, n_comp_ws, N_dim)
+                apply_orszag_2_3_filter!(ws.state.psi, ws.fft_plans, n_comp_ws, N_dim,
+                    ws.grid.config.box_size)
             end
 
             # Kinetic step K(dt)

--- a/src/solvers/simulation/run_loops.jl
+++ b/src/solvers/simulation/run_loops.jl
@@ -93,7 +93,8 @@ function _run_simulation_leapfrog!(
     cc = ws.coriolis_cache
 
     if DEALIAS_2_3_ENABLED[]
-        apply_orszag_2_3_filter!(ws.state.psi, ws.fft_plans, n_comp, N)
+        apply_orszag_2_3_filter!(ws.state.psi, ws.fft_plans, n_comp, N,
+            ws.grid.config.box_size)
     end
 
     _half_potential!(
@@ -103,7 +104,8 @@ function _run_simulation_leapfrog!(
     try
         for step in 1:(sp.n_steps)
             if DEALIAS_2_3_ENABLED[]
-                apply_orszag_2_3_filter!(ws.state.psi, ws.fft_plans, n_comp, N)
+                apply_orszag_2_3_filter!(ws.state.psi, ws.fft_plans, n_comp, N,
+                    ws.grid.config.box_size)
             end
 
             apply_step!(CoriolisTerm(omega), ws.state.psi, dt / 2, false, ws)

--- a/test/oracles/test_registry_collision_regression.jl
+++ b/test/oracles/test_registry_collision_regression.jl
@@ -93,7 +93,8 @@ end
 
     @testset "DDI / Loss / LightShift parameter types" begin
         @test DDIParams(1.0, zeros(3, 3, 3), zeros(3, 3, 3), zeros(3, 3, 3),
-            zeros(3, 3, 3), zeros(3, 3, 3), zeros(3, 3, 3)) isa DDIParams
+            zeros(3, 3, 3), zeros(3, 3, 3), zeros(3, 3, 3),
+            (12.0, 12.0, 12.0)) isa DDIParams
         @test LossParams(0.0, 0.0, [0.0, 0.0, 0.0], 0.0, [0.0, 0.0, 0.0], 0.0, 0.0) isa LossParams
         # LightShift positional 4-arg ctor — was broken by HamTerm shadow
         profile = rand(8, 8, 8)

--- a/test/test_dealias_2_3.jl
+++ b/test/test_dealias_2_3.jl
@@ -27,7 +27,7 @@ using SpinorBEC
         # FFT-order: index i ↔ k_idx (i-1); |k_abs_idx| = min(i-1, n-(i-1)).
         # Kept: i ∈ {1,2,3,4,5,6} (k_abs 0..5) ∪ {12,...,16} (k_abs 5..1)
         # Zeroed: i ∈ {7,8,9,10,11} (k_abs 6,7,8,7,6)
-        mask = SpinorBEC._get_orszag_mask((16,))
+        mask = SpinorBEC._get_orszag_mask((16,), (12.0,))
         @test size(mask) == (16,)
         kept = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0,  # i=1..6, k_abs=0..5
             0.0, 0.0, 0.0, 0.0, 0.0,           # i=7..11, k_abs=6,7,8,7,6
@@ -51,7 +51,7 @@ using SpinorBEC
         @test abs(buf[2]) > 0.5 * n   # k_idx=1 has the full plane-wave amplitude
         @test abs(buf[8]) > 0.5 * n   # k_idx=7 also present
 
-        SpinorBEC.apply_orszag_2_3_filter!(psi, plans, D, 1)
+        SpinorBEC.apply_orszag_2_3_filter!(psi, plans, D, 1, (12.0,))
 
         # Post-filter
         buf2 = copy(psi[:, 1])
@@ -67,15 +67,62 @@ using SpinorBEC
         rng = MersenneTwister(20260524)
         psi_a = randn(rng, ComplexF64, n, D)
         psi_b = copy(psi_a)
-        SpinorBEC.apply_orszag_2_3_filter!(psi_a, plans, D, 1)
-        SpinorBEC.apply_orszag_2_3_filter!(psi_b, plans, D, 1)
-        SpinorBEC.apply_orszag_2_3_filter!(psi_b, plans, D, 1)
+        SpinorBEC.apply_orszag_2_3_filter!(psi_a, plans, D, 1, (12.0,))
+        SpinorBEC.apply_orszag_2_3_filter!(psi_b, plans, D, 1, (12.0,))
+        SpinorBEC.apply_orszag_2_3_filter!(psi_b, plans, D, 1, (12.0,))
         @test maximum(abs, psi_a .- psi_b) < 1e-13
     end
 
+    @testset "the filter is an exact projector: norm loss == above-cut weight" begin
+        # This is the gate that tells "the filter is eating my norm" apart from
+        # "my run genuinely has weight above the cut". A projector removes
+        # EXACTLY the above-cut weight and nothing else, so by Parseval
+        #
+        #     ||psi||^2 - ||P psi||^2  ==  sum over the zeroed modes
+        #
+        # to machine precision. Any defect that would actually destroy norm —
+        # an unnormalised inverse plan, a mask on the wrong device, a stale
+        # cached plan, a mask built for the wrong box — breaks this equality
+        # while leaving the mask-geometry tests above perfectly green.
+        #
+        # Measured 2026-07-29 on Eu-151 DDI dynamics: per-step norm loss
+        # matched the above-cut weight to every printed digit at box 12 and
+        # box 24, n = 32 and n = 64. A 55%-over-20-steps "norm destruction"
+        # was the run pushing a few % of its weight past 2/3 k_Nyq every
+        # step, not the filter misbehaving.
+        rng = MersenneTwister(20260729)
+        for (n_pts, box, ndim) in (((16,), (12.0,), 1),
+            ((16, 16), (12.0, 24.0), 2),
+            ((8, 8, 8), (24.0, 24.0, 12.0), 3))
+            D = 3
+            plans = SpinorBEC.make_fft_plans(n_pts)
+            psi = randn(rng, ComplexF64, n_pts..., D)   # white noise: LOTS above the cut
+            mask = SpinorBEC._get_orszag_mask(n_pts, box)
+
+            # Above-cut weight, in real-space units via Parseval (unitary
+            # convention: sum|FFT|^2 = N * sum|psi|^2).
+            above = 0.0
+            scratch = Array{ComplexF64}(undef, n_pts)
+            for c in 1:D
+                scratch .= selectdim(psi, ndim + 1, c)
+                plans.forward * scratch
+                above += sum(abs2, scratch .* (1 .- mask))
+            end
+            above /= prod(n_pts)
+
+            n_before = sum(abs2, psi)
+            SpinorBEC.apply_orszag_2_3_filter!(psi, plans, D, ndim, box)
+            n_after = sum(abs2, psi)
+
+            @test isapprox(n_before - n_after, above; rtol=1e-10)
+            # And the projector cannot ADD norm.
+            @test n_after <= n_before + 1e-12
+        end
+    end
+
     @testset "different grid sizes get distinct masks" begin
-        m16 = SpinorBEC._get_orszag_mask((16,))
-        m32 = SpinorBEC._get_orszag_mask((32,))
+        m16 = SpinorBEC._get_orszag_mask((16,), (12.0,))
+        m32 = SpinorBEC._get_orszag_mask((32,), (12.0,))
         @test size(m16) == (16,)
         @test size(m32) == (32,)
         @test sum(m16) == 11.0   # 6 + 5 = 11 modes kept
@@ -85,7 +132,7 @@ using SpinorBEC
     @testset "3D mask: per-axis cutoff" begin
         # 8³ grid: cutoff = 8÷3 = 2 per axis. Kept per axis: |k_abs| ≤ 2 →
         # i ∈ {1,2,3} ∪ {7,8} → 5 indices. Cube: 5³ = 125 modes kept.
-        m = SpinorBEC._get_orszag_mask((8, 8, 8))
+        m = SpinorBEC._get_orszag_mask((8, 8, 8), (12.0, 12.0, 12.0))
         @test size(m) == (8, 8, 8)
         @test sum(m) == 125.0
     end
@@ -307,6 +354,7 @@ using SpinorBEC
         # session state, so we instead pin the math + the no-throw contract.
 
         n_pts = (32, 32, 32)
+        box = (12.0, 12.0, 12.0)
         F_pad = zeros(Float64, n_pts...)
 
         # k_safe formula: at n=32 axis with box L=12, k_safe = 2·π·32/(3·12)
@@ -318,38 +366,90 @@ using SpinorBEC
         # advisory (warn), not enforcement.
         for k_cut in (nothing, k_safe_32 * 0.5, k_safe_32, k_safe_32 * 2.0)
             SpinorBEC.DEALIAS_K_CUTOFF[] = k_cut
-            @test SpinorBEC.apply_orszag_2_3_F_filter!(F_pad, n_pts) === nothing
+            @test SpinorBEC.apply_orszag_2_3_F_filter!(F_pad, n_pts, box) === nothing
         end
 
         # _check_safe_k_cut itself must return nothing (side-effect only).
         SpinorBEC.DEALIAS_K_CUTOFF[] = 100.0  # far above any reasonable safe k
-        @test SpinorBEC._check_safe_k_cut(n_pts) === nothing
+        @test SpinorBEC._check_safe_k_cut(n_pts, box) === nothing
         SpinorBEC.DEALIAS_K_CUTOFF[] = nothing
-        @test SpinorBEC._check_safe_k_cut(n_pts) === nothing
+        @test SpinorBEC._check_safe_k_cut(n_pts, box) === nothing
     end
 
     @testset "DEALIAS_K_CUTOFF override (fixed physical k_cut)" begin
         # Default behaviour: cutoff = n÷3 per axis.
         @test SpinorBEC.DEALIAS_K_CUTOFF[] === nothing
-        m_default = SpinorBEC._get_orszag_mask((16,))
+        m_default = SpinorBEC._get_orszag_mask((16,), (12.0,))
         # 16-grid box L=12 (assumed). dk = 2π/12 ≈ 0.524. n÷3=5
         # → physical cutoff = 5·0.524 = 2.62.
         # Set DEALIAS_K_CUTOFF = 2.62 should give same mask.
         SpinorBEC.DEALIAS_K_CUTOFF[] = 5 * 2π / 12.0
-        m_kcut_match = SpinorBEC._get_orszag_mask((16,))
+        m_kcut_match = SpinorBEC._get_orszag_mask((16,), (12.0,))
         SpinorBEC.DEALIAS_K_CUTOFF[] = nothing  # reset
         @test m_default == m_kcut_match
 
         # Tighter cutoff zeros more modes.
         SpinorBEC.DEALIAS_K_CUTOFF[] = 1.0  # k ≤ 1.0 → idx ≤ ~1.9 → 2 modes
-        m_tight = SpinorBEC._get_orszag_mask((16,))
+        m_tight = SpinorBEC._get_orszag_mask((16,), (12.0,))
         SpinorBEC.DEALIAS_K_CUTOFF[] = nothing  # reset
         @test sum(m_tight) < sum(m_default)
 
         # Looser cutoff keeps more modes (capped by grid Nyquist).
         SpinorBEC.DEALIAS_K_CUTOFF[] = 100.0  # well above any Nyq
-        m_loose = SpinorBEC._get_orszag_mask((16,))
+        m_loose = SpinorBEC._get_orszag_mask((16,), (12.0,))
         SpinorBEC.DEALIAS_K_CUTOFF[] = nothing  # reset
         @test sum(m_loose) == 16.0  # all modes kept
+    end
+
+    @testset "physical k_cut is measured against the ACTUAL box" begin
+        # Regression: the k_cut branch used to hard-code L = 12.0 on every
+        # axis, so a run on any other box silently filtered at the wrong
+        # physical k — halving the retained band on box 24, with
+        # `_check_safe_k_cut` (which assumed 12 too) reporting nothing.
+        n_pts = (16, 16, 16)
+        k_cut = 3.0
+        SpinorBEC.DEALIAS_K_CUTOFF[] = k_cut
+
+        m12 = SpinorBEC._get_orszag_mask(n_pts, (12.0, 12.0, 12.0))
+        m24 = SpinorBEC._get_orszag_mask(n_pts, (24.0, 24.0, 24.0))
+
+        # dk = 2pi/L, so the box-24 grid resolves k twice as finely and a
+        # FIXED physical cutoff must retain about 2x as many index modes
+        # per axis. Same shape, same cutoff, different masks.
+        @test m12 != m24
+        @test sum(m24) > sum(m12)
+
+        # Exact per-axis content: keep |k_idx| * (2pi/L) <= k_cut.
+        signed_k_idx(i, n) = i - 1 <= n ÷ 2 ? i - 1 : i - 1 - n
+        for (L, m) in ((12.0, m12), (24.0, m24))
+            dk = 2π / L
+            kept = count(i -> abs(signed_k_idx(i, 16)) * dk <= k_cut, 1:16)
+            @test sum(m) == Float64(kept)^3
+        end
+
+        # The guard must key off the binding axis n_d / L_d, not n_d alone:
+        # a LONG axis with MORE points can still be the tight one in k.
+        # n/L = 32/24 = 1.33 (axis 3) < 16/6 = 2.67 (axes 1,2).
+        n_mixed = (16, 16, 32)
+        box_mixed = (6.0, 6.0, 24.0)
+        @test SpinorBEC.safe_k_cut_boundary(32, 24.0) <
+            SpinorBEC.safe_k_cut_boundary(16, 6.0)
+        # Sitting above the binding axis but below the naive smallest-n axis
+        # must still be caught (returns nothing either way; the contract here
+        # is that the call is box-aware and total).
+        SpinorBEC.DEALIAS_K_CUTOFF[] = 3.0
+        @test SpinorBEC._check_safe_k_cut(n_mixed, box_mixed) === nothing
+
+        SpinorBEC.DEALIAS_K_CUTOFF[] = nothing
+    end
+
+    @testset "DDIParams carries the box to the F filter" begin
+        # The F filter reads `ddi.box_size`; Q_ab = k_a k_b - d_ab/3 is
+        # scale-free, so the box cannot be recovered from the tensors and
+        # must travel on the struct.
+        grid = make_grid(GridConfig((16, 16, 16), (24.0, 24.0, 24.0)))
+        atom = SpinorBEC.resolve_atom(:Eu151)
+        ddi = SpinorBEC.make_ddi_params(grid, atom; c_dd=1.0)
+        @test ddi.box_size == (24.0, 24.0, 24.0)
     end
 end


### PR DESCRIPTION
## The defect

`_get_orszag_mask` never received the box, so a `DEALIAS_K_CUTOFF[]` stated in physical $k$ was compared against $2\pi/12$ regardless of the grid it ran on:

```julia
# Assume box L = 12.0 (the L4 verification suite box). ...
L_assumed = 12.0
```

The error is per axis by $L_{\rm true}/12$ — on an $L=24$ axis the mask believes every mode carries twice its real $k$ and cuts the band in half. `_check_safe_k_cut` could not catch it, because it assumed $L=12$ **too** and took `minimum(n_pts)` rather than the binding $n_d/L_d$. A long axis with *more* points can still be the tight one in $k$, so the guard was structurally unable to disagree with the mask it was guarding.

## The fix

The box now travels to the mask builder:

- **ψ filter** — from `ws.grid.config.box_size`.
- **F filter** — from a new `DDIParams.box_size`. It has to be *carried*, not derived: $Q_{\alpha\beta} = \hat k_\alpha \hat k_\beta - \delta_{\alpha\beta}/3$ is scale-free, so the box cannot be recovered from the tensors. Putting it on `DDIParams` also means neither `_compute_and_convolve_ddi!` nor its padded twin grows an argument — the box travels with the object that owns the k-grid.
- **`_check_safe_k_cut`** selects the binding axis by `argmin(n_d/L_d)` and names it in the warning.

The box is part of the mask cache key.

## Measured damage — smaller than the earlier suspicion

Retained index modes per axis at the committed `k_cut = 16`:

| n | L | old kept | correct | ratio |
|---|---|---|---|---|
| 32 | 12 | 32/32 | 32/32 | 1.00 |
| 32 | 24 | 32/32 | 32/32 | 1.00 |
| 64 | 12 | 61/64 | 61/64 | 1.00 |
| 64 | 24 | 61/64 | 64/64 | 0.95 |
| 96 | 12 | 61/96 | 61/96 | 1.00 |

Every committed `dealias` config pairs `k_cut: 16.0` with `box: [12,12,12]`, and at that cutoff the threshold sits at or above Nyquist on these grids, so the wrong `dk` mostly did not bind. **A real defect with a small blast radius — and specifically NOT the cause of the 99% norm loss it was first blamed for.**

## What the norm loss actually was

Two gates go in, and the second one is the load-bearing one:

1. **"physical k_cut is measured against the ACTUAL box"** — one grid shape, two boxes, one `k_cut`, must produce different masks with exactly the predicted per-axis mode counts, plus the binding-axis ordering.

2. **"the filter is an exact projector: norm loss == above-cut weight"** — by Parseval a projector removes exactly the zeroed modes' weight and nothing else:

   $$\|\psi\|^2 - \|P\psi\|^2 = \sum_{\text{zeroed}} |\hat\psi_k|^2$$

   This is the gate that separates *"the filter is eating my norm"* from *"my run genuinely has weight above the cut"*. An unnormalised inverse plan, a mask on the wrong device, a stale cached plan, or a mask built for the wrong box all break it — while every mask-geometry test stays green. It answers in one second a question that previously took a day of bisecting.

Measured alongside, on Eu-151 DDI dynamics (per-step trace, box 12 and box 24, n = 32 and n = 64): the norm removed each step equalled the above-cut weight **to every printed digit**.

```
step   norm_before    above_cut    norm_after      (box 12, n 64, sigma 0.8)
   0   1.00000000    1.2353e-19    1.00000000
   4   0.97860713    3.1750e-02    0.94753679
   6   0.91008614    3.8470e-02    0.87507497
  20   0.67679610    1.0793e-02    0.66949167
```

So the earlier *"dealias destroys 94% of the norm in 20 steps"* was the quench genuinely pushing that much of the state past $2/3\,k_{\rm Nyq}$ — zero at step 0 on the converged ground state, $3\times10^{-2}$ per step by step 4. The DDI F-filter suspect was wrong too, structurally: Φ enters as a unitary spin rotation $\exp(-i\,dt\,\Phi\cdot F)$, so filtering F cannot change $\|\psi\|$ at all.

**Turning dealias off does not recover that content — it aliases it back into low $k$**, which is worse: the norm then looks perfect while the low-$k$ answer is contaminated.

## Test status

`test/test_dealias_2_3.jl` — 68/68.

The `ci` tier has two **pre-existing** failures at `main`, reproduced on a clean `origin/main` worktree and unrelated to this change:

- `test/analysis/test_spatial_zeeman.jl` — "Uniform limit ≡ ZeemanTerm (bit-identical, q=0)", off by 0.083 against a `< 1e-12` bound.
- `test/test_level4_general_F_phase_emergence.jl` — "Analytic gap (c₁/2)·F²·∫n²·dV" at F=6 and F=8.

Both produce bit-identical numbers on this branch and on an unrelated branch, so neither is caused here. They need their own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
