### PR TITLE
fix: the two red ci gates on main — a missing IT overflow guard and a tolerance fitted to a failing expansion

### DIFF
--- a/src/foundation/types/spatial_zeeman.jl
+++ b/src/foundation/types/spatial_zeeman.jl
@@ -396,6 +396,31 @@ function apply_spatial_zeeman_step!(
         end
     end
 
+    # IT overflow guard for the rotation, matching what the diagonal fast path
+    # and `_spatial_q_halfstep!` already do — without it this branch was the one
+    # place in the function that propagated `exp(-dt·H)` unshifted, so a large
+    # |B| overflowed here and nowhere else.
+    #
+    # With q split off, the rotated operator is H_rot(r) = -(B(r)·F), whose
+    # eigenvalues are -|B(r)|·m. The guard subtracts the GLOBAL minimum over
+    # (voxel, m), = -max_r|B(r)|·F, so the surviving factor exp(+dt·gshift) is
+    # one spatially-CONSTANT scalar. That distinction is the whole point of the
+    # "no per-voxel shift" note in `_apply_euler_spin_rotation`: a per-voxel
+    # shift is a density reweighting that survives normalization and biases the
+    # ITP fixed point, while a global one factors out of it exactly.
+    if imaginary_time
+        b_max = 0.0
+        @inbounds for I in CartesianIndices(n_pts)
+            b2 = bx[I]^2 + by[I]^2 + bz[I]^2
+            b2 > b_max && (b_max = b2)
+        end
+        gshift = -sqrt(b_max) * F
+        if gshift != 0.0
+            scale = exp(dtf * gshift)
+            @inbounds psi .*= scale
+        end
+    end
+
     has_q && _spatial_q_halfstep!(psi, q, m_vals, dtf / 2, imaginary_time, n_pts, Val(D))
     nothing
 end

--- a/test/test_level4_general_F_phase_emergence.jl
+++ b/test/test_level4_general_F_phase_emergence.jl
@@ -3,7 +3,7 @@
 # Universal claims (any F ≥ 1, c_extra = 0):
 #   c₁ > 0 → polar/nematic class is the GS (|⟨F⟩| = 0)
 #   c₁ < 0 → ferromagnetic class is the GS (|⟨F⟩| = max within constraint)
-#   E_FM_up - E_polar = (c₁/2)·F²·∫n²·dV
+#   E_FM_up - E_polar = E_GP(c₁F²+c₀) - E_GP(c₀); to first order (c₁/2)·F²·∫n²·dV
 #   Bogoliubov polar:  stable at c₁>0,  unstable at c₁<0 (spin mode)
 #
 # F-specific (with c_extra = 0):
@@ -76,46 +76,97 @@ const F_CASES = [
         @test info_f.spin_order > 0.99
     end
 
-    @testset "Analytic gap (c₁/2)·F²·∫n²·dV at F=$Fval" for (Fval, atom, label) in F_CASES
+    # The FM/polar gap, stated EXACTLY rather than to first order.
+    #
+    # Polar (m=0 only) has ⟨F⟩ = 0 and FM-up (m=+F) has |⟨F⟩| = F·n, so with
+    # c_extra = 0 BOTH are single-component GP problems that differ only in
+    # their coupling:
+    #
+    #     polar : g = c₀              FM-up : g = c₀ + c₁F²
+    #
+    # Hence  E_FM − E_polar = E_GP(c₀ + c₁F²) − E_GP(c₀)  identically, with no
+    # small parameter anywhere.
+    #
+    # The familiar closed form (c₁/2)·F²·∫n²·dV is the FIRST-ORDER
+    # (Hellmann–Feynman, dE/dg = ½∫n²) term of that difference, so its accuracy
+    # is controlled by c₁F²/c₀ — NOT by F. This file used to hold c₁ = ±0.2
+    # fixed while sweeping F, which drives c₁F²/c₀ from 0.04 (F=1) to 2.56
+    # (F=8); at F=6, c₀ + c₁F² = −2.2 actually changes sign. The resulting
+    # 15–47% drift was then absorbed into an F-dependent rtol fitted to the
+    # failure, which is how a first-order formula got mistaken for an F-scaling
+    # law. Measured errors of the old one-endpoint form: 0.9% (F=1), 4.5%
+    # (F=3), 24% (F=6), 47% (F=8).
+    #
+    # Both claims are now pinned separately and tightly.
+    @testset "FM/polar gap is exactly E_GP(c₀+c₁F²) − E_GP(c₀) at F=$Fval" for (
+            Fval, atom, label
+        ) in
+                                                                               F_CASES
+
         grid = make_grid(GridConfig{1}((16,), (8.0,)))
 
-        function _itp(c1, seed)
-            find_ground_state(;
-                grid, atom,
-                interactions=InteractionParams(Dict(0 => 5.0, 1 => c1)),
-                potential=HarmonicTrap((1.0,)),
-                n_steps=400, dt=0.005, tol=1e-8,
-                initial_state=seed,
-            )
-        end
+        _itp(c0, c1, seed) = find_ground_state(;
+            grid, atom,
+            interactions=InteractionParams(Dict(0 => c0, 1 => c1)),
+            potential=HarmonicTrap((1.0,)),
+            n_steps=400, dt=0.005, tol=1e-8,
+            initial_state=seed,
+        )
 
-        # Density profile from polar (m=0 only — least perturbed by c₁).
-        r_polar = _itp(0.2, :polar)
-        psi_polar = Array(r_polar.workspace.state.psi)
-        n_dens = dropdims(sum(abs2, psi_polar; dims=2); dims=2)
-        n_sq_int = sum(n_dens .^ 2) * cell_volume(grid)
-
-        # The two seeds yield slightly different density profiles
-        # (FM-up at high F shifts the cloud width because c₁·F² is
-        # a non-negligible energy). For F=6: 36× spin-energy → ~10%
-        # density-profile shift. Use F-dependent tolerance.
-        rtol_gap = Fval <= 2 ? 0.05 : 0.15
-
+        c0 = 5.0
         for c1 in (0.2, -0.2)
-            r_polar = _itp(c1, :polar)
-            r_fm = _itp(c1, :m_plus_F)
-            psi_polar = Array(r_polar.workspace.state.psi)
-            n_dens = dropdims(sum(abs2, psi_polar; dims=2); dims=2)
-            n_sq_int = sum(n_dens .^ 2) * cell_volume(grid)
+            g_eff = c0 + c1 * Fval^2
 
-            gap_predicted = (c1 / 2) * Fval^2 * n_sq_int
-            gap_measured = r_fm.energy - r_polar.energy
+            gap_measured = _itp(c0, c1, :m_plus_F).energy - _itp(c0, c1, :polar).energy
+            gap_exact = _itp(g_eff, 0.0, :polar).energy - _itp(c0, 0.0, :polar).energy
 
-            # Sign must match exactly.
-            @test sign(gap_predicted) == sign(gap_measured)
-            # Magnitude within F-dependent tolerance.
-            @test isapprox(gap_predicted, gap_measured;
-                rtol=rtol_gap, atol=1e-3)
+            @test sign(gap_measured) == sign(c1)
+            # Exact identity — the only slack is ITP convergence (observed
+            # ≤ 1.5e-4 across F = 1…8, including the g_eff < 0 cases).
+            @test isapprox(gap_measured, gap_exact; rtol=1e-3, atol=1e-6)
+        end
+    end
+
+    @testset "Universal F² scaling: gap is F-independent at fixed c₁F²" begin
+        # The actual F-scaling claim, isolated. Holding the expansion parameter
+        # c₁F² fixed makes the whole problem F-independent, so BOTH the closed
+        # form and the measured gap must be the same number at every F — the
+        # code has to get the F² in the spin energy exactly right to reproduce
+        # it from c₁ = 0.2 (F=1) through c₁ = 0.003125 (F=8), a 64× spread.
+        # Any error in the F² power shows up immediately, with no tolerance
+        # fitting and no density-profile back-reaction to hide behind.
+        grid = make_grid(GridConfig{1}((16,), (8.0,)))
+        c0 = 5.0
+
+        for c1_F2 in (0.2, -0.2)
+            gaps = Float64[]
+            for (Fval, atom, label) in F_CASES
+                c1 = c1_F2 / Fval^2
+                _itp(seed) = find_ground_state(;
+                    grid, atom,
+                    interactions=InteractionParams(Dict(0 => c0, 1 => c1)),
+                    potential=HarmonicTrap((1.0,)),
+                    n_steps=400, dt=0.005, tol=1e-8,
+                    initial_state=seed,
+                )
+                r_polar = _itp(:polar)
+                r_fm = _itp(:m_plus_F)
+
+                psi_polar = Array(r_polar.workspace.state.psi)
+                n_dens = dropdims(sum(abs2, psi_polar; dims=2); dims=2)
+                n_sq_int = sum(n_dens .^ 2) * cell_volume(grid)
+
+                gap_predicted = (c1 / 2) * Fval^2 * n_sq_int
+                gap_measured = r_fm.energy - r_polar.energy
+                push!(gaps, gap_measured)
+
+                @test sign(gap_predicted) == sign(gap_measured)
+                # ONE tolerance for every F — the expansion parameter is now
+                # fixed at 0.04, where the first-order form is good to ~1%.
+                @test isapprox(gap_predicted, gap_measured; rtol=0.02, atol=1e-6)
+            end
+            # F-independence itself: same physics ⇒ same number.
+            @test maximum(abs, gaps .- gaps[1]) < 1e-6 * abs(gaps[1]) + 1e-9
         end
     end
 


### PR DESCRIPTION
The `ci` tier was red at `main` (9159486d) on two independent gates. Both reproduce on a clean `origin/main` worktree, so neither was caused by an open branch. With these two commits, `SpinorBEC (243 files across 10 workers, tier=ci): all passed`.

---

## 1. `apply_spatial_zeeman_step!` skipped the IT overflow guard on its transverse branch

The function applied **three different imaginary-time conventions** depending on which branch a field happened to take:

| branch | IT shift |
|---|---|
| diagonal fast path (`bx ≡ by ≡ 0`) | global min over (voxel, m) |
| `_spatial_q_halfstep!` | global min over (voxel, m) |
| **transverse Euler rotation** | **none** |

So switching on a transverse component silently dropped the guard — in the one branch where $|B|$ can be largest — and made the function disagree with the uniform `ZeemanTerm`, which subtracts `minimum(real, eigvals(Hermitian(M)))` per CLAUDE.md's *"ITP Zeeman shift"* convention. That disagreement is what `test_spatial_zeeman.jl` had been red on.

**Neither side was computing wrong physics.** Measured on the fixture ($b = (0.3, -0.2, 0.5)$, $dt = 0.05$, $F=1$):

- real time already agreed to **1.3e-15**;
- imaginary time differed by a **pure global scalar** of 1.0313019880 — ratio standard deviation 2e-15 across every voxel and every $m$ — which is exactly $\exp(+|b|F\,dt)$;
- against an independently constructed $\exp(-dt\,(-b\!\cdot\!F))$, the spatial path was exact and `ZeemanTerm` carried the guard.

With $q$ split off, the rotated operator is $H_{\rm rot}(r) = -(B(r)\cdot F)$ with eigenvalues $-|B(r)|\,m$, so the guard subtracts the global minimum over (voxel, $m$), $-\max_r|B(r)|\cdot F$.

**Global** is the operative word. The "do NOT apply a per-voxel shift" note in `_apply_euler_spin_rotation` is about a shift that *varies in space* — that is a density reweighting which survives normalization and biases the ITP fixed point. A spatially constant one factors out of normalization exactly, which is why both sibling branches already used it.

Physics unchanged: the shift is a global scalar, so every normalized ITP result is identical. `test_spatial_zeeman.jl` 9/9.

---

## 2. `test_level4_general_F_phase_emergence.jl` fitted its tolerance to the failure

The gate asserted

$$E_{\rm FM} - E_{\rm polar} = \tfrac{c_1}{2}F^2\int n^2\,dV$$

sweeping F = 1…8 with `c1 = ±0.2` **held fixed**, and carried

```julia
rtol_gap = Fval <= 2 ? 0.05 : 0.15   # "F-dependent tolerance"
```

blaming a "density-profile shift". It was red at F=6 and F=8 anyway.

That closed form is the **first-order** (Hellmann–Feynman, $dE/dg = \tfrac12\int n^2$) term of the gap, and its expansion parameter is $c_1F^2/c_0$ — **not** $F$. Holding $c_1$ fixed drives it from 0.04 (F=1) to 2.56 (F=8); at F=6 the effective coupling $c_0 + c_1F^2 = -2.2$ **changes sign**. Measured error of the one-endpoint form:

| F | $c_1F^2/c_0$ | error |
|---|---|---|
| 1 | 0.04 | 0.9 % |
| 3 | 0.36 | 4.5 % |
| 6 | 1.44 | 24 % |
| 8 | 2.56 | 47 % |

So the tolerance was fitted to the breakdown of an approximation, and the gate read as *"the F² scaling holds to 15 %"* when the F² scaling is in fact exact and the 15 % was the expansion failing.

### The exact statement

With `c_extra = 0`, polar (m=0) has $\langle F\rangle = 0$ and FM-up (m=+F) has $|\langle F\rangle| = F n$, so **both are single-component GP problems** differing only in coupling — $c_0$ versus $c_0 + c_1F^2$. Hence

$$E_{\rm FM} - E_{\rm polar} = E_{\rm GP}(c_0 + c_1F^2) - E_{\rm GP}(c_0)$$

with no small parameter. Verified: `E_FM(c0,c1)` equals `E_polar(c0+c1F², 0)` to 1e-5…1e-6 at every F, and the gap identity holds to 2e-5 including both `g_eff < 0` cases. (The both-endpoint trapezoid rule is a large improvement over the one-endpoint rectangle — 2.4 % vs 24 % at F=6 — but still 8–10 % once `g_eff` goes negative. Only the exact form is clean everywhere.)

### Two gates replace the fitted one

1. **The exact identity**, one `rtol = 1e-3` for every F, slack set by ITP convergence alone.
2. **The F² scaling claim, isolated** by holding $c_1F^2 = \pm 0.2$ **fixed**. That makes the problem F-independent, so the closed form and the measured gap must both be the *same number* from `c1 = 0.2` (F=1) to `c1 = 0.003125` (F=8) — a 64× spread in `c1` that only cancels if the F² power is exactly right. Measured: 0.90 % and 0.05 % error, identical at every F, and the gaps agree to < 1e-6 relative.

This is a strictly sharper gate than the original: no fudge factor, and no density-profile back-reaction for an F² error to hide behind. 115/115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
