### PR TITLE
fix(io): persist the couplings a run used, so results can be re-verified

### DIFF
--- a/src/workflow/experiments/pipeline/run_registry.jl
+++ b/src/workflow/experiments/pipeline/run_registry.jl
@@ -560,6 +560,8 @@ function _run_yaml_scan(data::Dict, scan::OverrideScan, run_dir, env; verbose=tr
                         f["env/$k"] = v
                     end
                     _save_units_metadata!(f, patched)
+                    haskey(result, :workspace) &&
+                        _save_interactions_metadata!(f, result.workspace)
                     _save_analyzer_results!(f, result)
                 end
                 _move_scratch_to_final(tmp_file, psi_file)
@@ -730,6 +732,7 @@ function _run_yaml_single(data::Dict, run_dir, env, index, run_name; verbose=tru
                 f["env/$k"] = v
             end
             _save_units_metadata!(f, data)
+            haskey(result, :workspace) && _save_interactions_metadata!(f, result.workspace)
             _save_analyzer_results!(f, result)
         end
         _move_scratch_to_final(tmp_file, psi_file)

--- a/src/workflow/experiments/runtime/runtime_io.jl
+++ b/src/workflow/experiments/runtime/runtime_io.jl
@@ -35,6 +35,54 @@ function _save_units_metadata!(f, data::Dict)
 end
 
 """
+    _save_interactions_metadata!(f, ws)
+
+Persist the interaction couplings the run ACTUALLY used, so a result can be
+re-verified later.
+
+A result file recorded its outputs — the energy decomposition, the dynamics
+series — but not the inputs that produced them, and `open_result` filled the
+gap with `compute_interaction_params(atom; N_atoms)`. That fallback returns SI
+couplings (c₀ ≈ 1e-46) where the run used dimensionless ones, silently, so
+rebuilding a workspace from a stored result gave a Hamiltonian with essentially
+no interactions. Recomputing a 2026-05 LHY run that way produced E_LHY = 1e-121
+against a stored 1301 — the discrepancy is what exposed this.
+
+`c_lhy` is the scalar coefficient only; a spinor LHY table is reproduced from
+`lhy_kind` plus these couplings, which is why the kind is recorded beside them.
+"""
+function _save_interactions_metadata!(f, ws)
+    ip = ws.interactions
+    f["interactions_c0"] = ip[0]
+    f["interactions_c1"] = ip[1]
+    f["interactions_c_lhy"] = ip.c_lhy
+    # Even-rank tensor channels, as a Pair vector — the shape
+    # `_extract_interactions` already knows how to read.
+    #
+    # These do NOT survive in `ws.interactions`: `make_workspace` moves every
+    # channel above c1 into `tensor_cache` and leaves `interactions` holding
+    # only c0/c1. Reading the couplings off `interactions` alone therefore
+    # records a c2/c4 run as if it had none — so the cache is the source here,
+    # with `interactions` as the fallback for the paths that keep them inline.
+    f["interactions_c_high_rank"] = [k => ip[k] for k in sort(collect(keys(ip.c))) if k >= 2]
+
+    # The tensor channels get their OWN key, deliberately. `make_workspace`
+    # moves every channel above c1 into `tensor_cache`, but what it stores
+    # there are **g_S pair-channel couplings**, not c_k tensor couplings — a
+    # c₂ of 0.25 lands as g₂ = −0.1178. Writing those into
+    # `interactions_c_high_rank` would relabel g_S as c_k and reconstruct a
+    # different Hamiltonian while looking perfectly healthy.
+    if ws.tensor_cache !== nothing
+        tc = ws.tensor_cache
+        f["tensor_g_channels"] = [S => g for (S, g) in zip(tc.active_channels, tc.g_values)]
+    end
+    # The spinor LHY table is not a coupling and cannot be reconstructed from
+    # `c_lhy`; without the kind, a re-verification silently gets no LHY at all.
+    f["lhy_kind"] = ws.lhy === nothing ? "none" : String(nameof(typeof(ws.lhy)))
+    nothing
+end
+
+"""
 Persist pipeline analyzer outputs under `analyze/<name>/<field>` so phase
 diagrams can be reconstructed from disk without re-running simulations.
 

--- a/src/workflow/validation/open_result.jl
+++ b/src/workflow/validation/open_result.jl
@@ -190,14 +190,32 @@ function _extract_interactions(data::Dict, atom::AtomSpecies)
     end
 
     # Fallback: derive from units/* metadata via compute_interaction_params.
+    #
+    # This is a GUESS, not the run's couplings, and it is not a small one: for a
+    # 2026-05 Eu run it returns c₀ ≈ 9.7e-47 where the run used a dimensionless
+    # c₀ of order 10. Rebuilding a workspace from that gives a Hamiltonian with
+    # essentially no interactions — a recomputed E_LHY of 1e-121 against a
+    # stored 1301, which reads as a catastrophic physics failure rather than as
+    # missing metadata. It used to happen silently.
+    #
+    # Files written after `_save_interactions_metadata!` landed carry
+    # `interactions_*` and never reach here.
     N_atoms = Int(get(data, "units/N_atoms", 1))
     omega_ref = Float64(get(data, "units/omega_ref_rad_s", 1.0))
     if N_atoms > 0 && omega_ref > 0
         try
-            return compute_interaction_params(atom; N_atoms, dims=3)
-        catch
-            # silent: empty Dict is a safe default
+            ip = compute_interaction_params(atom; N_atoms, dims=3)
+            @warn "result has no `interactions_*`; couplings GUESSED from units/* " *
+                "metadata. They are not the ones the run used — do not rebuild a " *
+                "workspace from this and compare energies." c0_guess=ip[0] maxlog=1
+            return ip
+        catch err
+            @warn "result has no `interactions_*` and the units/* fallback failed; " *
+                "interactions are EMPTY" exception=err maxlog=1
         end
+    else
+        @warn "result has no `interactions_*` and no units/* metadata; " *
+            "interactions are EMPTY" maxlog=1
     end
     InteractionParams(Dict{Int, Float64}())
 end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -36,6 +36,7 @@ const FAST_TESTS = [
     "workflow/test_dynamics_lhy_plumbing.jl",
     "workflow/test_lhy_texture_warning.jl",
     "workflow/test_lhy_block_wiring.jl",
+    "workflow/test_interactions_roundtrip.jl",
     "workflow/test_b_block_normalize.jl",
     "workflow/test_waveform_inner_duration.jl",
     "workflow/validation/test_run_result.jl",

--- a/test/workflow/test_interactions_roundtrip.jl
+++ b/test/workflow/test_interactions_roundtrip.jl
@@ -1,0 +1,124 @@
+# Gate: a result file carries the couplings the run actually used.
+#
+# Result files recorded their OUTPUTS — energy decomposition, dynamics series —
+# but not the INPUTS that produced them. `open_result` filled the gap with
+# `compute_interaction_params(atom; N_atoms)`, which returns SI couplings
+# (c₀ ≈ 1e-46) where the run used dimensionless ones, and did so silently.
+#
+# Rebuilding a workspace from a stored 2026-05 Eu LHY run that way gave a
+# recomputed E_LHY of 1e-121 against a stored 1301. That reads as a
+# catastrophic physics failure; it was missing metadata. A post-hoc audit of a
+# run was simply not possible, which is how three LHY defects went unnoticed in
+# stored artifacts.
+#
+# Two halves, both gated here: the writer persists the couplings, and the
+# fallback — when an OLD file has none — now says so out loud.
+
+using Test
+using JLD2
+using SpinorBEC
+using SpinorBEC: _save_interactions_metadata!, _extract_interactions
+
+const _F = 2
+const _D = 5
+
+function _ws_with(; c_lhy=0.0, kind=nothing, extra=Dict{Int, Float64}())
+    grid = make_grid(GridConfig((8, 8, 8), (10.0, 10.0, 10.0)))
+    c = merge(Dict(0 => 12.5, 1 => -0.375), extra)
+    inter = InteractionParams(c; c_lhy=c_lhy)
+    sp = SimParams(; dt=0.005, n_steps=1, imaginary_time=true)
+    atom = AtomSpecies("t", 1.0, _F, 100.0, 95.0, 1.0)
+    make_workspace(; grid, atom, interactions=inter, sim_params=sp, spinor_lhy=kind)
+end
+
+# `open_result` reads a flat Dict keyed by JLD2 path; mirror that here so the
+# test exercises the real extractor rather than a reimplementation of it.
+function _roundtrip(ws)
+    mktempdir() do dir
+        p = joinpath(dir, "r.jld2")
+        jldopen(p, "w") do f
+            _save_interactions_metadata!(f, ws)
+        end
+        data = jldopen(p, "r") do f
+            Dict{String, Any}(k => f[k] for k in keys(f))
+        end
+        (data, _extract_interactions(data, ws.atom))
+    end
+end
+
+@testset "result files carry the couplings the run used" begin
+    @testset "c0 / c1 / c_lhy round-trip exactly" begin
+        ws = _ws_with(; c_lhy=0.875)
+        data, ip = _roundtrip(ws)
+        @test ip[0] == 12.5
+        @test ip[1] == -0.375
+        @test ip.c_lhy == 0.875
+        # ...and the values came from the file, not from a lucky fallback.
+        @test haskey(data, "interactions_c0")
+        @test data["interactions_c0"] == 12.5
+    end
+
+    @testset "tensor channels are recorded as g_S, under their own key" begin
+        # `make_workspace` moves everything above c1 into `tensor_cache`, and
+        # what it holds are g_S PAIR-CHANNEL couplings, not c_k tensor ones:
+        # c₂ = 0.25 is stored as g₂ = −0.1178. They therefore get a separate
+        # key — writing them into `interactions_c_high_rank` would relabel
+        # g_S as c_k and rebuild a different Hamiltonian that looks healthy.
+        ws = _ws_with(; extra=Dict(2 => 0.25, 4 => -0.125))
+        @test ws.tensor_cache !== nothing
+        @test ws.interactions[2] == 0.0          # the reason a separate key is needed
+        data, ip = _roundtrip(ws)
+        g = Dict(data["tensor_g_channels"])
+        @test haskey(g, 2) && haskey(g, 4)
+        @test g[2] != 0.25                       # g_S, not c_k -- not interchangeable
+        @test ip[2] == 0.0                       # and NOT smuggled in as c2
+    end
+
+    @testset "the LHY kind is recorded, not just c_lhy" begin
+        # A spinor LHY table cannot be reconstructed from `c_lhy` — it is 0.0
+        # for every tabulated mode. Without the kind, re-verification silently
+        # rebuilds with NO LHY, which is exactly the shape of the #125 defect.
+        ws = _ws_with(; kind=:polar_contact)
+        data, _ = _roundtrip(ws)
+        @test data["lhy_kind"] == "PolarContactLHY"
+        @test ws.interactions.c_lhy == 0.0      # the point: c_lhy alone says nothing
+
+        plain = _ws_with()
+        d2, _ = _roundtrip(plain)
+        @test d2["lhy_kind"] == "none"
+    end
+
+    @testset "an old file with no interactions_* WARNS" begin
+        # The failure that made this necessary was silent. A guess presented as
+        # the run's couplings is worse than an error, so the fallback must be
+        # audible; `@test_logs` fails if the warning stops being emitted.
+        atom = AtomSpecies("t", 1.0, _F, 100.0, 95.0, 1.0)
+        old = Dict{String, Any}("units/N_atoms" => 1000,
+            "units/omega_ref_rad_s" => 628.3)
+        ip = @test_logs (:warn,) match_mode = :any _extract_interactions(old, atom)
+        # And it really is a different number — this is the 1e-46-vs-10 gap.
+        @test ip[0] != 12.5
+
+        # No units either: the defaults (N_atoms=1, omega_ref=1) still send it
+        # down the guess branch, so what matters is that it stays audible.
+        empty_ip = @test_logs (:warn,) match_mode = :any _extract_interactions(
+            Dict{String, Any}(), atom)
+        @test empty_ip[0] != 12.5
+    end
+
+    @testset "a file WITH interactions_* stays silent" begin
+        # The warning must not fire on healthy files, or it trains you to
+        # ignore it.
+        ws = _ws_with(; c_lhy=0.5)
+        mktempdir() do dir
+            p = joinpath(dir, "r.jld2")
+            jldopen(p, "w") do f
+                _save_interactions_metadata!(f, ws)
+            end
+            data = jldopen(p, "r") do f
+                Dict{String, Any}(k => f[k] for k in keys(f))
+            end
+            @test_logs _extract_interactions(data, ws.atom)
+        end
+    end
+end


### PR DESCRIPTION
## The gap

A result file recorded its **outputs** — energy decomposition, dynamics series
— but not the **inputs** that produced them. `open_result` filled that gap with
`compute_interaction_params(atom; N_atoms)`, which returns SI couplings where
the run used dimensionless ones, and did so **silently**:

| | c₀ | recomputed E_LHY |
|---|---|---|
| stored (2026-05 Eu icosahedral run) | ~10 | **1301** |
| rebuilt via the fallback | 9.7e-47 | **1e-121** |

So rebuilding a workspace from a stored result gave a Hamiltonian with
essentially no interactions, and the recomputed energy read as a catastrophic
physics failure rather than as missing metadata.

**Post-hoc audit of a run was simply not possible.** That is why three LHY
defects (#125, the 2.5× energy, #132) were invisible in stored artifacts and
had to be found by reading code instead.

Found while trying to re-derive `E_LHY` for the four CPU runs in
`runs/eu_k3_lhy*` — the re-derivation is what hit the wall.

## Writer

`_save_interactions_metadata!`, wired into both save paths in `run_registry`:

- `interactions_c0` / `c1` / `c_lhy` / `c_high_rank`
- **`lhy_kind`** — a spinor LHY table cannot be reconstructed from `c_lhy`,
  which is `0.0` for *every* tabulated mode. Without the kind, a
  re-verification silently rebuilds with **no LHY at all** — the exact shape of
  the #125 defect.
- **`tensor_g_channels`** — deliberately its own key. `make_workspace` moves
  everything above `c1` into `tensor_cache`, but what it holds there are **g_S
  pair-channel couplings, not c_k tensor couplings**: `c₂ = 0.25` is stored as
  `g₂ = −0.1178`. Writing those into `interactions_c_high_rank` would relabel
  g_S as c_k and reconstruct a *different* Hamiltonian while looking perfectly
  healthy. I wrote that version first — the round-trip test caught it.

## Reader

The fallback now **warns** instead of substituting a guess in silence. A guess
presented as the run's couplings is worse than an error. It stays quiet on
files that carry the real values, so the warning doesn't train you to ignore
it.

## Gate — `test/workflow/test_interactions_roundtrip.jl`, 18 assertions

- exact round-trip of `c0` / `c1` / `c_lhy`, and the values provably came from
  the file rather than from a lucky fallback;
- tensor channels recorded as g_S under their own key and **not** smuggled in
  as `c2`;
- `lhy_kind` present, alongside `c_lhy == 0` for a table — the assertion that
  states *why* the kind is needed;
- the fallback audible on an old file, and **silent** on a healthy one.

## Scope

Existing result files predate this and still carry no `interactions_*`. They
now say so out loud rather than yielding 1e-47 couplings. Re-deriving `E_LHY`
for those older runs needs the couplings recovered from their `config.yaml`,
which is separate work.

## Verification

- fast tier: **156 files, all passed**
- oracles tier: **63 files, all passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)