### PR TITLE
docs(validation): every stored runs/ result predates every physics correction

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ docs/
 | F=6 phase boundary scan | `research_notes/F6_phase_boundaries.md` |
 | Eu collapse + LHY ablation | `research_notes/eu_collapse_lhy_insufficient.md` |
 | Superfluidity / dipolar supersolids — known vs unknown | `validation/superfluidity_knowledge_state.md` |
+| Whether a stored `runs/` result can still be quoted | `validation/stored_results_vintage_audit.md` |
 | Dipolar supersolid tube (type-C reproduction) | `validation/dipolar_supersolid_tube.md` |
 | Closed-form theory derivations | `theory/*.md` |
 

--- a/docs/manuscript/four_figure_spec_2026_05_26.md
+++ b/docs/manuscript/four_figure_spec_2026_05_26.md
@@ -1,5 +1,10 @@
 # Thesis / manuscript 4-figure spec — 2026-05-26
 
+> **Vintage note.** The `runs/` results this document cites predate every
+> physics correction merged after 2026-06-02 — including a quadratic Zeeman
+> that was 11× too large for Eu until 2026-07-08. See
+> [`stored_results_vintage_audit.md`](../validation/stored_results_vintage_audit.md) before quoting a number from here.
+
 Companion to `docs/validation/weekly_presentation_outline.md` (which
 specifies the **6-slide presentation** view).  This document specifies
 the **manuscript / thesis** view of the same body of work: a 4-figure

--- a/docs/research_notes/eu_collapse_lhy_insufficient.md
+++ b/docs/research_notes/eu_collapse_lhy_insufficient.md
@@ -1,5 +1,10 @@
 # Eu F=6 EdH post-quench collapse: LHY-insufficiency negative result
 
+> **Vintage note.** The `runs/` results this document cites predate every
+> physics correction merged after 2026-06-02 — including a quadratic Zeeman
+> that was 11× too large for Eu until 2026-07-08. See
+> [`stored_results_vintage_audit.md`](../validation/stored_results_vintage_audit.md) before quoting a number from here.
+
 **Status**: ablation complete, conclusion confirmed across 5 LHY treatments **Date**: 2026-05-07 **Code path**: `runs/eu151_edh_postfix_local/`, post-Bug-4-fix Julia `main`
 
 ## TL;DR

--- a/docs/validation/day_inventory_2026_05_26.md
+++ b/docs/validation/day_inventory_2026_05_26.md
@@ -1,5 +1,10 @@
 # Day inventory — 2026-05-26
 
+> **Vintage note.** The `runs/` results this document cites predate every
+> physics correction merged after 2026-06-02 — including a quadratic Zeeman
+> that was 11× too large for Eu until 2026-07-08. See
+> [`stored_results_vintage_audit.md`](stored_results_vintage_audit.md) before quoting a number from here.
+
 End-of-day manifest of artifacts produced during the
 2026-05-26 BEC-simulation validation session. Provides a single
 audit point: commit hash, environment, paths, cell census, and the

--- a/docs/validation/self_contained_validation_report.md
+++ b/docs/validation/self_contained_validation_report.md
@@ -1,5 +1,10 @@
 # Self-contained validation report
 
+> **Vintage note.** The `runs/` results this document cites predate every
+> physics correction merged after 2026-06-02 — including a quadratic Zeeman
+> that was 11× too large for Eu until 2026-07-08. See
+> [`stored_results_vintage_audit.md`](stored_results_vintage_audit.md) before quoting a number from here.
+
 **As of 2026-05-26.** Replaces the Ueda-comparison-gated framing
 documented in `validation_ladder_2026_05_22.md` (Level 10). See
 `docs/validation/ueda_status.md` for the BLOCKED_EXTERNAL declaration.

--- a/docs/validation/stored_results_vintage_audit.md
+++ b/docs/validation/stored_results_vintage_audit.md
@@ -1,0 +1,98 @@
+# Stored `runs/` results: every one predates every physics correction
+
+**As of 2026-07-29.** Audit of whether the results stored under `runs/` can be
+quoted as current evidence. They cannot.
+
+This is not a list of suspect cases. It is a single fact with a date.
+
+## The measurement
+
+230 `summary.json` files exist under `runs/` (this worktree plus the main
+checkout). **Zero carry a producing commit** — the stamp only landed in #139, so
+none can be retro-dated. Using file mtime as the only available proxy for
+vintage:
+
+| | |
+|---|---|
+| stored summaries | 230 |
+| stamped with a commit | 0 |
+| newest summary | **2026-06-02** |
+| oldest | 2026-05-25 |
+| summaries predating **all** the corrections below | **230 of 230** |
+
+## The corrections they predate
+
+Physics-affecting fixes merged after 2026-06-02, i.e. after the newest stored
+result. Each changes numbers a spinor Eu run would produce:
+
+| merged | correction |
+|---|---|
+| 2026-06-15 | ITP spin-rotation Stage-3 density bias (c₁ + DDI) — changes ground states |
+| 2026-06-22 | Strang / Yoshida order under DDI restored via midpoint mean-field — the integrator was first-order with DDI |
+| 2026-06-22 | LBFGS driven to its true gradient floor |
+| **2026-07-08** | **Eu quadratic Zeeman was 11× too large** — affects every Eu run with a field |
+| 2026-07-27 | `full_bdg` LHY UV counterterm (ε_k subtracted twice) |
+| 2026-07-27 | scalar `c_lhy` short by π(a_s/a_ho)√N |
+| 2026-07-28 | tabulated LHY dropped on the broadcast path; its energy 2.5× too large |
+
+The quadratic-Zeeman one alone is disqualifying for any Eu result that used a
+field: $q$ was wrong by an order of magnitude, and $q$ sets the m-level
+structure.
+
+## What follows
+
+**No stored `runs/` summary is quotable as current evidence.** They are not
+"slightly stale" and they are not auditable — auditing would need a per-run
+comparison against current code, which costs the same as re-running. The A/B on
+`eu_k3_lhy_control` measured what that gap looks like in one case: peak_max
+0.007487 → 0.005775 and the collapse class moving `delay` → `marginal_arrest`,
+of which the `c_lhy` fix accounts for only 2 %.
+
+So a claim resting on a stored run has to be re-derived, not re-checked.
+
+### Documents that cite stored runs
+
+Highest counts first — these are where such claims live and where a reader is
+most likely to pick one up:
+
+| citations | file |
+|---|---|
+| 12 | `validation/self_contained_validation_report.md` |
+| 12 | `validation/day_inventory_2026_05_26.md` |
+| 11 | `manuscript/four_figure_spec_2026_05_26.md` |
+| 10 | `manuscript/thesis/chapters/Ch5_TWA_chaotic_dynamics_integrated.md` |
+| 9 | `manuscript/shared/figures.md` |
+| 7 | `manuscript/klaus_quench_protocol_spec_2026_05_26.md` |
+| 6 | `research_notes/eu_collapse_lhy_insufficient.md` |
+
+All of these do carry a date — `self_contained_validation_report.md` opens with
+"As of 2026-05-26" and `eu_collapse_lhy_insufficient.md` with "Date: 2026-05-07".
+That is the honest form and it was checked rather than assumed.
+
+The residual hazard is narrower: **a date does not tell a reader what changed
+since it.** Someone reading "2026-05-26" has no way to know that the Eu
+quadratic Zeeman was 11× too large until July, or that the DDI integrator was
+first-order until late June. So each of these files now carries a one-line
+pointer here, which is the part a date cannot supply.
+
+## What is *not* affected
+
+- Everything gated by a test in a tier. Those run against current code on every
+  push, which is the point of the tier system.
+- The results produced during 2026-07-27/28 and recorded in
+  [`dipolar_supersolid_tube.md`](dipolar_supersolid_tube.md) and
+  [`superfluidity_knowledge_state.md`](superfluidity_knowledge_state.md). Those
+  post-date the corrections and their figures ship with the scripts that made
+  them.
+- Claims that turn on a coefficient identity rather than a run — e.g. the SI
+  round-trip oracles, $Q_5$ closed forms, $a_{dd}$ values.
+
+## Recommended order
+
+1. **Do not re-run 230 suites.** Most were exploratory. Re-derive only what a
+   live document actually claims.
+2. Start with the two undated documents above, since they read as current.
+3. New runs are self-dating: `summary_provenance(run_dir)` reports the producing
+   commit and whether the tree was dirty. A summary with `stamped == false` means
+   the question cannot be answered from the file — treat it as this audit treats
+   all 230.


### PR DESCRIPTION
Started as a triage of the 230 unknown-vintage summaries #139 turned up. It did not need to be a triage — there is one fact.

Docs only.

## The measurement

| | |
|---|---|
| stored `summary.json` files | **230** |
| stamped with a producing commit | **0** (the stamp only landed in #139) |
| newest summary | **2026-06-02** |
| predating **all** corrections below | **230 of 230** |

## The corrections they predate

Physics-affecting fixes merged *after* the newest stored result:

| merged | correction |
|---|---|
| 2026-06-15 | ITP spin-rotation Stage-3 density bias (c₁ + DDI) — changes ground states |
| 2026-06-22 | Strang / Yoshida order under DDI restored via midpoint mean-field — the integrator was **first-order** with DDI |
| 2026-06-22 | LBFGS driven to its true gradient floor |
| **2026-07-08** | **Eu quadratic Zeeman was 11× too large** |
| 2026-07-27 | `full_bdg` LHY UV counterterm (ε_k subtracted twice) |
| 2026-07-27 | scalar `c_lhy` short by $\pi(a_s/a_{ho})\sqrt N$ |
| 2026-07-28 | tabulated LHY dropped on the broadcast path; its energy 2.5× too large |

The quadratic-Zeeman one alone disqualifies any Eu result that used a field: $q$ sets the m-level structure and it was wrong by an order of magnitude.

## Why this is not an audit item

These are not "slightly stale" and not auditable — auditing would need a per-run comparison against current code, which costs the same as re-running. The `eu_k3_lhy_control` A/B measured the size of the gap in one case: peak_max 0.007487 → 0.005775 with the collapse class moving `delay` → `marginal_arrest`, of which `c_lhy` accounts for **2 %**.

A claim resting on a stored run has to be **re-derived, not re-checked**.

The recommendation is explicitly **not** to re-run 230 suites. Most were exploratory; re-derive only what a live document actually claims, starting with the highest-citation files.

## A correction to my own first draft

I wrote that `self_contained_validation_report.md` and `eu_collapse_lhy_insufficient.md` were "undated" and therefore the hazard. Checking them, **both carry dates** — "As of 2026-05-26" and "Date: 2026-05-07". I asserted before verifying.

The real residual hazard is narrower and worth stating precisely: **a date does not tell a reader what changed since it.** Nobody reading "2026-05-26" can know the Eu quadratic Zeeman was 11× off until July, or that the DDI integrator was first-order until late June.

So the four highest-citation dated documents now carry a one-line vintage note pointing at the audit — the part a date cannot supply.

## What is not affected

- Anything gated by a test in a tier: those run against current code on every push.
- The 2026-07-27/28 results in `dipolar_supersolid_tube.md` and `superfluidity_knowledge_state.md` — they postdate the corrections and ship with the scripts that made them.
- Claims resting on a coefficient identity rather than a run (SI round-trip oracles, $Q_5$ closed forms, $a_{dd}$ values).