### PR TITLE
fix(spgpe): measure projector outflow in k-space, not as a norm difference

### DIFF
--- a/src/solvers/projected_gp.jl
+++ b/src/solvers/projected_gp.jl
@@ -14,11 +14,22 @@ export apply_projected_gp!, projected_gp_callback
 # to `run_simulation!` / `find_ground_state`.
 
 """
-    apply_projected_gp!(ws, k_cut; smooth=false) -> Nothing
+    apply_projected_gp!(ws, k_cut; smooth=false) -> Float64
 
 Zero out all Fourier components of ψ with |k| > k_cut. Works on GPU or CPU
 via the existing FFT plans. `smooth=true` replaces the hard mask with a
 cosine-tapered cutoff over [k_cut, 1.1·k_cut] for smoother artefacts.
+
+Returns the weight the projector REMOVED, in atom-number units (`∫|ψ|²dV`),
+accumulated in k-space while the transform is already in hand.
+
+That is the definition of the quantity, and it is also the only way to measure
+it accurately. Differencing `∫|ψ|²` across the call instead costs a
+catastrophic cancellation between two nearly equal O(N) sums, and — since the
+projector is an FFT round-trip rather than a literal no-op — leaves the
+round-trip error, ~1e-15 relative, as the floor. Measured here the floor is the
+residual amplitude in already-masked modes, ~1e-16 *squared*, so re-projecting
+an already-projected field returns ~1e-30 rather than ~1e-15.
 """
 function apply_projected_gp!(
     ws::Workspace{N}, k_cut::Real;
@@ -38,33 +49,60 @@ function apply_projected_gp!(
     k_squared = _to_device(ws.backend, ws.grid.k_squared)
     T = real(eltype(psi))
 
-    if smooth
-        k_taper_sq = (1.1 * k_cut)^2
-    end
+    # Hoisted, and concrete. Assigning these inside the `if smooth` branches put
+    # them in a `Core.Box`, and closing over `T` (a Type) is not isbits either —
+    # both make the mapreduce closure a non-bitstype kernel argument on CUDA.
+    k_cut_sq_t = T(k_cut_sq)
+    k_taper_sq_t = smooth ? T((1.1 * k_cut)^2) : k_cut_sq_t
+    zero_t = zero(k_cut_sq_t)
+    one_t = one(k_cut_sq_t)
+    half_t = T(0.5)
+    pi_t = T(π)
+    inv_span = smooth ? one_t / (k_taper_sq_t - k_cut_sq_t) : zero_t
 
+    removed_k = 0.0
     for c in 1:D
         idx = _component_slice(N, n_pts, c)
         psi_c = view(psi, idx...)
         fft_buf .= psi_c
         plans.forward * fft_buf
         if smooth
-            # Cosine-tapered high-pass suppression
-            k_taper_sq_t = T(k_taper_sq)
-            k_cut_sq_t = T(k_cut_sq)
+            # Cosine-tapered high-pass suppression. Suppressed weight is
+            # |f|²(1 − w²), with w the amplitude taper.
+            removed_k += Float64(
+                mapreduce(
+                    (f, k2) -> begin
+                        w = if k2 <= k_cut_sq_t
+                            one_t
+                        elseif k2 >= k_taper_sq_t
+                            zero_t
+                        else
+                            half_t * (one_t + cos(pi_t * (k2 - k_cut_sq_t) * inv_span))
+                        end
+                        abs2(f) * (one_t - w * w)
+                    end,
+                    +, fft_buf, k_squared; init=zero_t,
+                ),
+            )
             @. fft_buf *= ifelse(
-                k_squared <= k_cut_sq_t, one(T),
-                ifelse(k_squared >= k_taper_sq_t, zero(T),
-                    T(0.5) * (one(T) + cos(T(π) * (k_squared - k_cut_sq_t) /
-                                  (k_taper_sq_t - k_cut_sq_t)))),
+                k_squared <= k_cut_sq_t, one_t,
+                ifelse(k_squared >= k_taper_sq_t, zero_t,
+                    half_t * (one_t + cos(pi_t * (k_squared - k_cut_sq_t) * inv_span))),
             )
         else
-            k_cut_sq_t = T(k_cut_sq)
+            removed_k += Float64(
+                mapreduce(
+                    (f, k2) -> k2 <= k_cut_sq_t ? zero_t : abs2(f),
+                    +, fft_buf, k_squared; init=zero_t,
+                ),
+            )
             @. fft_buf *= (k_squared <= k_cut_sq_t)
         end
         plans.inverse * fft_buf
         psi_c .= fft_buf
     end
-    nothing
+    # Parseval: the forward plan is unnormalised, so sum|F|² = prod(n)·sum|ψ|².
+    removed_k / prod(n_pts) * cell_volume(ws.grid)
 end
 
 """

--- a/src/solvers/spgpe.jl
+++ b/src/solvers/spgpe.jl
@@ -318,10 +318,7 @@ function apply_spgpe_step!(
     # the C region for the I region. Measuring this after the noise instead would
     # conflate it with noise truncation, which is a per-step effect two to three
     # orders of magnitude larger and would swamp it.
-    dV = cell_volume(ws.grid)
-    n0 = real(sum(abs2, ws.state.psi))
-    apply_projected_gp!(ws, r.k_cut)
-    cutoff_outflow = (n0 - real(sum(abs2, ws.state.psi))) * dV
+    cutoff_outflow = apply_projected_gp!(ws, r.k_cut)
 
     if r.gamma > 0
         _spgpe_number_damping!(ws, r.gamma, r.mu, r.T, dt_f; seed=seed, noise=noise)
@@ -336,9 +333,7 @@ function apply_spgpe_step!(
     # literal P{…} of Eq. (4). What it removes here is the part of the fresh
     # noise that landed above the cutoff; that is bookkeeping of the injection,
     # NOT a physical outflow, so it is reported separately from `cutoff_outflow`.
-    n_before = real(sum(abs2, ws.state.psi))
-    apply_projected_gp!(ws, r.k_cut)
-    noise_truncated = (n_before - real(sum(abs2, ws.state.psi))) * dV
+    noise_truncated = apply_projected_gp!(ws, r.k_cut)
     merge(r, (; cutoff_outflow, noise_truncated))
 end
 

--- a/test/dynamics/test_spgpe.jl
+++ b/test/dynamics/test_spgpe.jl
@@ -393,13 +393,19 @@ end
     ws = flowing_state!(scalar_ws())
     n0 = norm_sq(ws)
 
-    # (a) cutoff held fixed, noise off ⇒ nothing leaves by either route. The
-    # outflow is EXACTLY zero (the field is already projected at this cutoff, so
-    # the mask removes nothing bit-for-bit), which is the sharp statement.
+    # (a) cutoff held fixed, noise off ⇒ nothing leaves by either route.
+    #
+    # `== 0.0` is NOT available here and asserting it was wrong: the projector is
+    # an FFT round-trip, not a literal no-op. What IS available is a floor 16
+    # orders below the old one. The outflow is accumulated in k-space as the
+    # weight of the masked modes, so its floor is the residual amplitude left in
+    # already-masked modes SQUARED (~1e-31), where differencing ∫|ψ|² across the
+    # call floored at the FFT round-trip error itself (~1e-15) — and could come
+    # out NEGATIVE, which is meaningless for "atoms that left".
     still = SPGPEReservoir(; T=0.0, mu=1.0, a_s=0.01, k_cut=5.0, gamma=0.01, M=0.0)
     apply_spgpe_step!(ws, still, 0.002; t=0.0, noise=false)          # settle
     r = apply_spgpe_step!(ws, still, 0.002; t=0.0, noise=false)
-    @test r.cutoff_outflow == 0.0
+    @test 0.0 <= r.cutoff_outflow < 1e-25 * n0
     @test r.noise_truncated < 1e-12 * n0        # only FFT round-off
 
     # (b) cutoff SHRINKS, noise still off ⇒ the swept band leaves, and it is
@@ -412,14 +418,16 @@ end
     @test r2.cutoff_outflow > 1e-3 * n0
     @test r2.noise_truncated < 1e-5 * r2.cutoff_outflow
 
-    # (c) noise on at a FIXED cutoff ⇒ truncation is large, outflow exactly zero.
+    # (c) noise on at a FIXED cutoff ⇒ truncation is large, outflow at the floor.
     # This is the case that made the first combined diagnostic meaningless: it
     # reported 1.4e7 "atoms leaving the C region" when the cutoff-driven flow was
     # identically nothing.
     noisy = SPGPEReservoir(; T=5.0, mu=1.0, a_s=0.01, k_cut=2.0, gamma=0.01, M=0.0)
     r3 = apply_spgpe_step!(ws, noisy, 0.002; t=0.0, seed=5, noise=true)
     @test r3.noise_truncated > 1e-3 * n0
-    @test r3.cutoff_outflow == 0.0
+    @test 0.0 <= r3.cutoff_outflow < 1e-25 * n0
+    # The separation is the point: 20+ decades between the two channels.
+    @test r3.cutoff_outflow < 1e-20 * r3.noise_truncated
 end
 
 @testset "SPGPE full step composes and stays finite" begin


### PR DESCRIPTION
`main` went red on `test/dynamics/test_spgpe.jl` after #140 landed:

```
Expression: r.cutoff_outflow == 0.0
 Evaluated:  2.5292268279741847e-15 == 0.0
 Evaluated: -2.5292268279741847e-15 == 0.0
```

## The test's premise was wrong

Its comment claimed the projector *"removes nothing bit-for-bit"* when the cutoff has not moved. But `apply_projected_gp!` is an **FFT round-trip**, not a literal no-op — it perturbs ψ at ~1e-16 relative whatever the mask does. Differencing $\int|\psi|^2$ across the call therefore measures the round-trip error: a catastrophic cancellation between two nearly equal $O(N)$ sums, floored by the FFT error itself.

The tell is the second value: **negative**. "Atoms that left the C region" came out below zero, which is meaningless.

## The fix

`apply_projected_gp!` now returns the weight it removed, accumulated in k-space while the transform is already in hand. That is the *definition* of the quantity rather than a proxy for it, it is non-negative by construction, and its floor becomes the residual amplitude in already-masked modes **squared** instead of the round-trip error:

| | before | after |
|---|---|---|
| `cutoff_outflow` at a fixed cutoff | 2.5e-15 | **5.5e-31** |

16 decades. `apply_spgpe_step!` uses the returned value for both `cutoff_outflow` and `noise_truncated`, which also drops two full reductions over ψ per step.

The test now asserts what is true:

```julia
@test 0.0 <= r.cutoff_outflow < 1e-25 * n0
@test r3.cutoff_outflow < 1e-20 * r3.noise_truncated   # the separation it exists for
```

`== 0.0` is not available without short-circuiting the projection, and pretending otherwise is what put a floating-point equality on an FFT round-trip in the first place.

## Two CUDA traps on the way

The `mapreduce` closure captured `T` (a `Type`, not isbits) and `k_cut_sq_t` (assigned inside *both* `if smooth` branches, so Julia put it in a `Core.Box`). Either one makes it a non-bitstype kernel argument:

```
KernelError: passing non-bitstype argument
  .T is of type Type{Float64} which is not isbits.
  .k_cut_sq_t is of type Core.Box which is not isbits.
```

Both hoisted and made concrete. `test/gpu/test_projected_gp_parity.jl` passes on RTX 5070 Ti.

## Why this reached `main` — worth fixing separately

Branch protection requires `Test (Julia 1.12, tier=fast)` and `Oracle gates (tier=oracles)`. `test/dynamics/test_spgpe.jl` is registered in the **`ci`** tier, so **the gate that caught this never ran on #140**. The required-check set does not cover the `ci` tier at all — every `ci`-only test can land red today. I hit this only because I ran the tier locally after merging.

## Verification

`SPINORBEC_TEST_TIER=ci`: **249 files across 10 workers, all passed** (local, WSL2 CPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
