### PR TITLE
fix(lhy): the closed-form spinor tables were exactly N_atoms too large

### DIFF
--- a/src/hamiltonian/terms/lhy/dispatch.jl
+++ b/src/hamiltonian/terms/lhy/dispatch.jl
@@ -64,6 +64,7 @@ function compute_spinor_lhy_polar_two_channel(;
     c_dd::Float64=0.0,
     n_max::Float64=100.0,
     n_points::Int=200,
+    n_atoms::Int=1,
 )
     F >= 1 || throw(ArgumentError("F must be ≥ 1 (got F=$F)"))
 
@@ -73,7 +74,7 @@ function compute_spinor_lhy_polar_two_channel(;
     density_coef = is_active(c0) ? abs(c0)^(5 / 2) * Q5 : 0.0
     spin_coef = is_active(c1) ? 2.0 * F * abs(c1)^(5 / 2) : 0.0
 
-    _tabulate_lhy(PolarTwoChannelLHY; n_max, n_points) do n
+    _tabulate_lhy(PolarTwoChannelLHY; n_max, n_points, n_atoms) do n
         prefactor * (density_coef + spin_coef) * n^2 * sqrt(n)
     end
 end
@@ -103,9 +104,10 @@ function compute_spinor_lhy_polar_contact(;
     g_dict,
     n_max::Float64=100.0,
     n_points::Int=200,
+    n_atoms::Int=1,
 )
     coefs = build_polar_lhy_coefs(F, g_dict)
-    _tabulate_lhy(n -> lhy_energy_polar(n, coefs), PolarContactLHY; n_max, n_points)
+    _tabulate_lhy(n -> lhy_energy_polar(n, coefs), PolarContactLHY; n_max, n_points, n_atoms)
 end
 
 """
@@ -122,10 +124,11 @@ function compute_spinor_lhy_polar_dipolar(;
     eps_tilde_dd::Float64,
     n_max::Float64=100.0,
     n_points::Int=200,
+    n_atoms::Int=1,
 )
     coefs = build_polar_lhy_coefs(F, g_dict)
     _tabulate_lhy(n -> lhy_energy_polar_dipolar(n, coefs, eps_tilde_dd),
-        PolarDipolarLHY; n_max, n_points)
+        PolarDipolarLHY; n_max, n_points, n_atoms)
 end
 
 """
@@ -142,10 +145,11 @@ function compute_spinor_lhy_fm_dipolar(;
     eps_dd::Real,
     n_max::Float64=100.0,
     n_points::Int=200,
+    n_atoms::Int=1,
 )
     coefs = build_fm_lhy_coefs(F, g_dict)
     _tabulate_lhy(n -> lhy_energy_fm_dipolar(n, coefs, eps_dd),
-        FMDipolarLHY; n_max, n_points)
+        FMDipolarLHY; n_max, n_points, n_atoms)
 end
 
 """
@@ -164,9 +168,10 @@ function compute_spinor_lhy_fm_contact(;
     g_dict,
     n_max::Float64=100.0,
     n_points::Int=200,
+    n_atoms::Int=1,
 )
     coefs = build_fm_lhy_coefs(F, g_dict)
-    _tabulate_lhy(n -> lhy_energy_fm(n, coefs), FMContactLHY; n_max, n_points)
+    _tabulate_lhy(n -> lhy_energy_fm(n, coefs), FMContactLHY; n_max, n_points, n_atoms)
 end
 
 """
@@ -186,13 +191,14 @@ function compute_spinor_lhy_icosahedral(;
     g_dict,
     n_max::Float64=100.0,
     n_points::Int=200,
+    n_atoms::Int=1,
 )
     F == 6 || throw(
         ArgumentError(
             "compute_spinor_lhy_icosahedral is F=6 only (got F=$F); the I_h closed " *
             "form is specific to the F=6 even-S channel structure"),
     )
-    _tabulate_lhy(n -> epsilon_LHY_F6_Ih(n, g_dict), IcosahedralLHY; n_max, n_points)
+    _tabulate_lhy(n -> epsilon_LHY_F6_Ih(n, g_dict), IcosahedralLHY; n_max, n_points, n_atoms)
 end
 
 """
@@ -268,14 +274,29 @@ end
 # loop. Keeping the derivative path in ONE place means a future change to
 # the finite-difference scheme can't silently drift between modes.
 function _tabulate_lhy(energy_fn, ::Type{ResultT};
-    n_max::Float64, n_points::Int) where {ResultT}
+    n_max::Float64, n_points::Int, n_atoms::Int=1) where {ResultT}
     n_points >= 3 || throw(ArgumentError("n_points must be >= 3"))
     n_max > 0 || throw(ArgumentError("n_max must be positive"))
+    n_atoms >= 1 || throw(ArgumentError("n_atoms must be >= 1"))
     densities = collect(range(0.0, n_max; length=n_points))
     energy = zeros(Float64, n_points)
     for (i, n) in enumerate(densities)
         n < 1e-30 && continue
-        energy[i] = energy_fn(n)
+        # The closed forms are ε = (8/15π²)(g n)^(5/2) with `n` the PHYSICAL
+        # density and `g` the SI coupling. Here `n = |ψ|²` is normalised to
+        # ∫|ψ|²dV = 1 and `g` comes from the dimensionless `c₀ = 4π(a_s/a_ho)N`,
+        # which already carries N. Carrying it twice at the 5/2 power leaves the
+        # tabulated energy a factor **N too large**:
+        #
+        #     (2/5)·c_lhy = (8/15π²)·c₀^(5/2) / N      [scalar Lima-Pelster]
+        #
+        # Measured in the uniform-g_S limit, `fm/scalar` and `polar/scalar` were
+        # EXACTLY N for N = 1e3, 3e4, 1e5. On a 2026-05 Eu run that made E_LHY
+        # 96% of the total energy — impossible for a beyond-mean-field term; the
+        # SI-anchored scalar path gives 0.05% for the same state.
+        #
+        # V = dε/dn, so dividing ε here divides the tabulated V too.
+        energy[i] = energy_fn(n) / n_atoms
     end
     ResultT(densities, _numerical_derivative(densities, energy))
 end

--- a/src/hamiltonian/terms/lhy/full_bdg.jl
+++ b/src/hamiltonian/terms/lhy/full_bdg.jl
@@ -131,6 +131,7 @@ function compute_spinor_lhy_table(;
     c_dd::Float64=0.0,
     n_max::Float64=100.0,
     n_points::Int=100,
+    n_atoms::Int=1,
     rtol::Float64=1e-4,
     k_max::Union{Nothing, Float64}=nothing,
     n_k::Union{Nothing, Int}=nothing,
@@ -158,7 +159,7 @@ function compute_spinor_lhy_table(;
         return FullBdGLHY(densities, (2.5 * eps_1) .* densities .^ 1.5)
     end
 
-    _tabulate_lhy(FullBdGLHY; n_max, n_points) do n0
+    _tabulate_lhy(FullBdGLHY; n_max, n_points, n_atoms) do n0
         _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman,
             c_dd, k_max, n_k, n_dir; rtol)
     end

--- a/src/hamiltonian/terms/lhy/spatial.jl
+++ b/src/hamiltonian/terms/lhy/spatial.jl
@@ -53,6 +53,7 @@ function compute_spatial_lhy(;
     n_bins::Int=12,
     rtol::Float64=1e-4,
     min_spread::Float64=0.05,
+    n_atoms::Int=1,
 ) where {M}
     n_bins >= 2 || throw(ArgumentError("n_bins must be ≥ 2"))
     N = M - 1
@@ -66,8 +67,11 @@ function compute_spatial_lhy(;
 
     e1 = similar(ps)
     for i in eachindex(reps)
-        e1[i] = _lhy_bdg_energy_density(reps[i], 1.0, F, interactions, zeeman,
-            c_dd, nothing, nothing, nothing; rtol)
+        # Same 1/N as `_tabulate_lhy`: the closed/BdG forms are in physical
+        # units, the repo's n = |ψ|² is normalised to 1 and c₀ already carries N.
+        e1[i] =
+            _lhy_bdg_energy_density(reps[i], 1.0, F, interactions, zeeman,
+                c_dd, nothing, nothing, nothing; rtol) / n_atoms
     end
     SpatialLHY(ps, e1, F, [fp_ladder_coeff(F, F - (c - 1)) for c in 1:D])
 end

--- a/src/workflow/experiments/schema/parsing_blocks.jl
+++ b/src/workflow/experiments/schema/parsing_blocks.jl
@@ -348,10 +348,15 @@ function _resolve_lhy_block!(p::Dict, inter::Dict, atom, c_dd_val::Float64,
     # start but normalised nowhere, so `_build_spinor_lhy` never saw them and a
     # user's `n_points: 4000` silently stayed 200. They ride in one internal
     # slot as an `LHYTableOpts`, which is what `make_workspace` takes.
+    # `n_atoms` is NOT a table knob — it is the unit conversion. The closed
+    # forms are ε = (8/15π²)(g n)^(5/2) in physical units; here n is normalised
+    # to ∫|ψ|²dV = 1 and c₀ = 4π(a_s/a_ho)N already carries N, so the tabulated
+    # energy needs a 1/N or it comes out exactly N times too large.
     p["lhy_opts"] = LHYTableOpts(;
         n_max=haskey(lhy_block, "n_max") ? Float64(lhy_block["n_max"]) : NaN,
         n_points=Int(get(lhy_block, "n_points", 200)),
-        n_bins=Int(get(lhy_block, "n_bins", 12)))
+        n_bins=Int(get(lhy_block, "n_bins", 12)),
+        n_atoms=max(1, Int(get(get(p, "interactions", Dict()), "N_atoms", 1))))
     return nothing
 end
 

--- a/src/workflow/initialization/make_workspace.jl
+++ b/src/workflow/initialization/make_workspace.jl
@@ -51,9 +51,10 @@ struct LHYTableOpts
     n_max::Float64
     n_points::Int
     n_bins::Int
+    n_atoms::Int
 end
-LHYTableOpts(; n_max::Float64=NaN, n_points::Int=200, n_bins::Int=12) =
-    LHYTableOpts(n_max, n_points, n_bins)
+LHYTableOpts(; n_max::Float64=NaN, n_points::Int=200, n_bins::Int=12,
+    n_atoms::Int=1) = LHYTableOpts(n_max, n_points, n_bins, n_atoms)
 
 function make_workspace(;
     grid::Grid{N, T},
@@ -714,7 +715,7 @@ function _build_spinor_lhy(::Val{:spatial}, atom, ws, psi_init, c_dd, enable_ddi
     tbl = compute_spatial_lhy(;
         psi_init, F=atom.F, interactions=ws,
         c_dd=enable_ddi && !isnan(c_dd) ? c_dd : 0.0,
-        n_bins=opts.n_bins)
+        n_bins=opts.n_bins, n_atoms=opts.n_atoms)
     tbl === nothing ? _full_bdg() : tbl
 end
 
@@ -723,7 +724,7 @@ function _build_spinor_lhy(::Val{:polar_two_channel}, atom, ws, psi_init, c_dd, 
     compute_spinor_lhy_polar_two_channel(;
         F=atom.F, c0=ws[0], c1=ws[1],
         c_dd=enable_ddi && !isnan(c_dd) ? c_dd : 0.0,
-        n_max=_lhy_n_max(psi_init, opts), n_points=opts.n_points)
+        n_max=_lhy_n_max(psi_init, opts), n_points=opts.n_points, n_atoms=opts.n_atoms)
 end
 
 function _build_spinor_lhy(::Val{:full_bdg}, atom, ws, psi_init, c_dd, enable_ddi, opts)
@@ -732,7 +733,7 @@ function _build_spinor_lhy(::Val{:full_bdg}, atom, ws, psi_init, c_dd, enable_dd
     compute_spinor_lhy_table(;
         spinor=spinor_init, F=atom.F, interactions=ws,
         c_dd=enable_ddi && !isnan(c_dd) ? c_dd : 0.0,
-        n_max=_lhy_n_max(psi_init, opts), n_points=opts.n_points)
+        n_max=_lhy_n_max(psi_init, opts), n_points=opts.n_points, n_atoms=opts.n_atoms)
 end
 
 # F-generic polar contact LHY (paper #1, contact-only). ~1000× faster than
@@ -742,7 +743,7 @@ function _build_spinor_lhy(::Val{:polar_contact}, atom, ws, psi_init, c_dd, enab
     _warn_lhy_texture(:polar_contact, psi_init, atom.F)
     compute_spinor_lhy_polar_contact(;
         F=atom.F, g_dict=_lhy_g_dict(atom, ws), n_max=_lhy_n_max(psi_init, opts),
-        n_points=opts.n_points)
+        n_points=opts.n_points, n_atoms=opts.n_atoms)
 end
 
 # FM-phase contact LHY (paper #2 contact-only piece). Single-mode collapse at
@@ -752,7 +753,7 @@ function _build_spinor_lhy(::Val{:fm_contact}, atom, ws, psi_init, c_dd, enable_
     _warn_lhy_texture(:fm_contact, psi_init, atom.F)
     compute_spinor_lhy_fm_contact(;
         F=atom.F, g_dict=_lhy_g_dict(atom, ws), n_max=_lhy_n_max(psi_init, opts),
-        n_points=opts.n_points)
+        n_points=opts.n_points, n_atoms=opts.n_atoms)
 end
 
 # Stage C scalar reduction: FM single-mode contact LHY × Lima-Pelster Q_5(eps_dd).
@@ -770,7 +771,7 @@ function _build_spinor_lhy(::Val{:fm_dipolar}, atom, ws, psi_init, c_dd, enable_
     eps_dd = abs(g_2F) > 1e-12 ? abs(c_dd_eff) * atom.F^2 / (3.0 * abs(g_2F)) : 0.0
     compute_spinor_lhy_fm_dipolar(;
         F=atom.F, g_dict=g_dict, eps_dd=eps_dd, n_max=_lhy_n_max(psi_init, opts),
-        n_points=opts.n_points)
+        n_points=opts.n_points, n_atoms=opts.n_atoms)
 end
 
 # F-generic polar contact + DDI LHY (paper #1 with dipolar extension).
@@ -807,7 +808,7 @@ function _build_spinor_lhy(::Val{:polar_dipolar}, atom, ws, psi_init, c_dd, enab
     eps_tilde_dd = abs(delta_1) > 1e-12 ? abs(c_dd_eff) / abs(delta_1) : 0.0
     compute_spinor_lhy_polar_dipolar(;
         F=atom.F, g_dict=g_dict, eps_tilde_dd=eps_tilde_dd,
-        n_max=_lhy_n_max(psi_init, opts), n_points=opts.n_points)
+        n_max=_lhy_n_max(psi_init, opts), n_points=opts.n_points, n_atoms=opts.n_atoms)
 end
 
 # F=6 I_h closed form (Stage D). Universal `c_0^(5/2) + 3|λ_spin|^(5/2)` with
@@ -828,5 +829,5 @@ function _build_spinor_lhy(::Val{:icosahedral}, atom, ws, psi_init, c_dd, enable
         ":icosahedral spinor_lhy is F=6 only (got F=$(atom.F))"))
     compute_spinor_lhy_icosahedral(;
         F=atom.F, g_dict=_lhy_g_dict(atom, ws), n_max=_lhy_n_max(psi_init, opts),
-        n_points=opts.n_points)
+        n_points=opts.n_points, n_atoms=opts.n_atoms)
 end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -314,6 +314,9 @@ const CI_EXTRA = [
     # is gated" was true while three of its faces were broken at once.
     # Driven by LHY_SCHEMA["kind"].enum, so a new mode cannot ship ungated.
     "oracles/test_lhy_mode_face_coverage.jl",
+    # Magnitude sibling of the above: the closed forms had a consistency oracle
+    # and no SI anchor, and were exactly N_atoms too large in that gap.
+    "oracles/test_lhy_magnitude_si_anchor.jl",
     # Directional / parity gates pinning the ungated physics-duplication
     # clusters the 2026-06-07 redundancy audit upheld as drift-risks
     # (vortex / monopole sign, manuscript spinors vs SSoT, init_psi vs

--- a/test/oracles/test_lhy_magnitude_si_anchor.jl
+++ b/test/oracles/test_lhy_magnitude_si_anchor.jl
@@ -1,0 +1,133 @@
+# Magnitude oracle: every tabulated LHY mode, anchored to SI — not to itself.
+#
+# The closed forms had a CONSISTENCY oracle and no MAGNITUDE oracle.
+# `test_lhy_full_bdg_closed_form_parity.jl` asserts
+#
+#     uniform g_S  ⇒  ε = (8/15π²)(g n)^(5/2)
+#
+# which is the closed form agreeing with its own algebraic statement. It passes
+# whatever the units are. Meanwhile the only SI-anchored check in the tree,
+# `test_scalar_lhy_si_roundtrip.jl`, covers the SCALAR path alone.
+#
+# In that gap the whole tabulated family was **exactly N_atoms too large**:
+# `ε = (8/15π²)(g n)^(5/2)` is written for a PHYSICAL density and an SI coupling,
+# but here `n = |ψ|²` is normalised to `∫|ψ|²dV = 1` and
+# `c₀ = 4π(a_s/a_ho)N` already carries N. Counting N twice inside a 5/2 power is
+# not a subtle error: on a 2026-05 ¹⁵¹Eu run it made E_LHY **96% of the total
+# energy**, which is impossible for a beyond-mean-field correction — the scalar
+# path gives 0.08% for the same state.
+#
+# The anchor used here is the scalar Lima-Pelster coefficient, which IS tied to
+# SI by `μ_LHY/μ_contact = (32/3)√(n_SI a_s³/π)`. In the uniform-g_S limit every
+# closed form must reduce to it exactly. That is a statement about MAGNITUDE and
+# it is the one the family was missing.
+
+using Test
+using SpinorBEC
+using SpinorBEC: scalar_lhy_coefficient, _lhy_V, LHYTableOpts
+
+const _F = 6
+const _NPTS = 8000          # central-difference table; 4e-7 residual at this size
+
+# Physically sensible (a_s/a_ho, N) triples spanning three decades of N, so the
+# check cannot pass by coincidence at one atom number.
+const _CASES = ((1_000, 0.02), (30_000, 0.0071127), (100_000, 0.001))
+
+# V_LHY = dε/dn of ε = (2/5)·c_lhy·n^(5/2) is c_lhy·n^(3/2).
+_scalar_V(n, a_over_aho, N) = scalar_lhy_coefficient(a_over_aho, N) * n * sqrt(n)
+
+@testset "tabulated LHY magnitude is anchored to SI, not to itself" begin
+    n_eval = 0.004
+
+    @testset "uniform g_S ⇒ every closed form == scalar Lima-Pelster" begin
+        for (N, ah) in _CASES
+            c0 = 4π * ah * N
+            g = Dict(S => c0 for S in 0:2:(2_F))
+            want = _scalar_V(n_eval, ah, N)
+            @test want > 0
+
+            builders = (
+                "fm_contact" => compute_spinor_lhy_fm_contact(;
+                    F=_F, g_dict=g, n_max=0.05, n_points=_NPTS, n_atoms=N),
+                "polar_contact" => compute_spinor_lhy_polar_contact(;
+                    F=_F, g_dict=g, n_max=0.05, n_points=_NPTS, n_atoms=N),
+            )
+            for (label, tbl) in builders
+                @testset "$label N=$N" begin
+                    @test isapprox(_lhy_V(n_eval, tbl), want; rtol=1e-5)
+                end
+            end
+        end
+    end
+
+    @testset "the N-fold error is what this catches" begin
+        # Without the 1/N the table is larger by EXACTLY N — measured at
+        # 1e3, 3e4, 1e5 before the fix. Pinning the factor makes a regression
+        # read as "N too large" rather than as a vague tolerance failure.
+        for (N, ah) in _CASES
+            c0 = 4π * ah * N
+            g = Dict(S => c0 for S in 0:2:(2_F))
+            unfixed = compute_spinor_lhy_fm_contact(;
+                F=_F, g_dict=g, n_max=0.05, n_points=_NPTS, n_atoms=1)
+            fixed = compute_spinor_lhy_fm_contact(;
+                F=_F, g_dict=g, n_max=0.05, n_points=_NPTS, n_atoms=N)
+            @test isapprox(_lhy_V(n_eval, unfixed) / _lhy_V(n_eval, fixed), N; rtol=1e-9)
+        end
+    end
+
+    @testset "LHY stays a CORRECTION at a physical gas parameter" begin
+        # The blunt sanity check the family never had: a beyond-mean-field term
+        # that is most of the energy is not a correction, whatever the algebra
+        # says. Before the 1/N it was 96% of the total on a real Eu run.
+        #
+        # The state has to be a PHYSICAL cloud. `init_psi`'s default is a narrow
+        # blob whose peak density is ~37x the converged Eu run's, and E_LHY goes
+        # as n^(5/2), so a share measured on it says nothing — it reads 90% even
+        # with the fix in. Build a Gaussian at the run's actual peak density
+        # (n ~ 3.7e-3, gas parameter n_SI a_s^3 ~ 4e-5) instead.
+        N = 30_000
+        n_pts, box = (24, 24, 24), (12.0, 12.0, 12.0)
+        grid = make_grid(GridConfig(n_pts, box))
+        atom = Eu151
+        a_ho = sqrt(SpinorBEC.Units.HBAR / (atom.mass * 628.3))
+        c0 = 4π * (atom.a_s / a_ho) * N
+        ip = InteractionParams(Dict(0 => c0, 1 => -0.005 * c0))
+        sp = SimParams(; dt=0.005, n_steps=1, imaginary_time=true)
+        D = 2 * _F + 1
+
+        sigma = 2.58                       # peak = (2π σ²)^(-3/2) ≈ 3.7e-3
+        psi = zeros(ComplexF64, n_pts..., D)
+        xs = [(i - 1) * box[1] / n_pts[1] - box[1] / 2 for i in 1:n_pts[1]]
+        for I in CartesianIndices(n_pts)
+            r2 = xs[I[1]]^2 + xs[I[2]]^2 + xs[I[3]]^2
+            psi[I, 1] = exp(-r2 / (4 * sigma^2))
+        end
+        dV = prod(box) / prod(n_pts)
+        psi ./= sqrt(sum(abs2, psi) * dV)
+        peak = maximum(sum(abs2, psi; dims=4))
+        @test 1e-3 < peak < 1e-2           # the regime this claim is about
+
+        # SI prediction AT THE PEAK: μ_LHY/μ_MF = (32/3)√(n_SI a_s³/π).
+        # The measured energy ratio is density-weighted over the whole cloud, so
+        # it must sit BELOW the peak value but within the same order — that is a
+        # physics bound, not a tuned threshold.
+        gas_param = N * peak * (atom.a_s / a_ho)^3
+        si_peak = (32 / 3) * sqrt(gas_param / π)
+        @test 1e-5 < gas_param < 1e-4       # the dilute regime this claim needs
+
+        for kind in (:icosahedral, :polar_contact, :fm_contact)
+            ws = make_workspace(; grid, atom, interactions=ip, sim_params=sp,
+                psi_init=psi, spinor_lhy=kind, lhy_opts=LHYTableOpts(; n_atoms=N))
+            ed = energy_decomposition(ws)
+            ratio = abs(ed.lhy) / abs(ed.density)
+            @testset "$kind" begin
+                @test isfinite(ed.lhy)
+                # Percent-level, and a fraction of the peak prediction.
+                # Measured: 2.26% (icosahedral / polar_contact), 1.37% (fm),
+                # against si_peak = 3.9%. Without the 1/N this was 96% of the
+                # TOTAL energy — off the top of this bound by orders.
+                @test 0.2 < ratio / si_peak < 1.0
+            end
+        end
+    end
+end


### PR DESCRIPTION
## The bug

`ε = (8/15π²)(g n)^(5/2)` is written for a **physical** density and an **SI**
coupling. Here `n = |ψ|²` is normalised to `∫|ψ|²dV = 1`, and the coupling comes
from the dimensionless `c₀ = 4π(a_s/a_ho)N` — which already carries N. Counting
N twice inside a 5/2 power left every tabulated LHY mode a factor **N too
large**.

The scalar path states the correct relation:

$$\tfrac{2}{5}\,c_{\rm lhy} \;=\; \tfrac{8}{15\pi^2}\,\frac{c_0^{5/2}}{N}$$

Measured in the uniform-`g_S` limit, `fm/scalar` and `polar/scalar` came out
**exactly N**:

| N | fm/scalar | polar/scalar |
|---|---|---|
| 1,000 | 1000.0 | 1000.0 |
| 30,000 | 30000.0 | 30000.0 |
| 100,000 | 100000.0 | 100000.0 |

## What it did to a real run

`runs/LHY_icosahedral_K0_*` (¹⁵¹Eu, N = 30000):

| | E_LHY | E_tot | share |
|---|---|---|---|
| before | 861.6 | 897.8 | **96.0%** |
| after | 0.0287 | 36.2 | **0.079%** |

96% of the total energy is impossible for a beyond-mean-field correction. After
the fix the LHY/mean-field ratio is **2.26%**, against the SI prediction
`(32/3)√(n·a_s³/π) = 3.9%` at the peak — the measured value is density-weighted
over the cloud, so sitting below the peak is correct.

## The fix

One line at the single shared point, `_tabulate_lhy`:

```julia
energy[i] = energy_fn(n) / n_atoms
```

`V = dε/dn`, so dividing ε divides the tabulated V too. `full_bdg` and
`SpatialLHY` build their tables outside that helper and get the same `1/N`
individually. `n_atoms` reaches all eight builders through `LHYTableOpts`, set
from `interactions.N_atoms` in `_resolve_lhy_block!`.

## Why no gate caught it

`test_lhy_full_bdg_closed_form_parity.jl:68` asserts

> uniform `g_S` ⇒ `ε = (8/15π²)(g n)^(5/2)`

which is the closed form agreeing with **its own algebraic statement**. It
passes whatever the units are. The one SI-anchored check in the tree,
`test_scalar_lhy_si_roundtrip.jl`, covers the **scalar path alone**.

The closed-form family had a **consistency oracle and no magnitude oracle** —
the same gap that hid the quasi-2D factor of 2 (#136), with a much larger blast
radius.

### New gate — `test/oracles/test_lhy_magnitude_si_anchor.jl`, 20 assertions

- uniform `g_S` ⇒ every closed form equals the SI-anchored scalar coefficient,
  at three atom numbers spanning three decades (**1.0000004**);
- the unfixed/fixed ratio is **exactly N**, so a regression reads as "N too
  large" rather than as a vague tolerance failure;
- on a cloud at a physical gas parameter (`n_SI·a_s³ ≈ 4e-5`) the LHY stays a
  correction, bounded **against the SI prediction** rather than against a tuned
  threshold.

One trap worth recording: the default `init_psi` is a narrow blob whose peak
density is ~37× a converged Eu cloud's, and `E_LHY ∝ n^(5/2)`, so a share
measured on it reads **90% even with the fix in**. The test builds its own
Gaussian at the run's actual peak density.

## Scope

**Every stored result using a tabulated LHY has an E_LHY N times too large.**
Combined with the pre-`69ee9a67` `n·V` energy convention, this is what made the
2026-05 `eu_k3_lhy` stored values 1.51× the current ones (2.49 × 0.609).

The propagator used the same tables, so **dynamics are affected too**, not just
the reported energy.

## Verification

- fast tier: **159 files, all passed**
- oracles tier: one failure, `test_spin_chain_fusion_parity.jl`, **unrelated and
  pre-existing** — it contains no LHY reference and fails identically with these
  changes stashed, under `--check-bounds=yes` (the runner's flag; it disables
  `@inbounds` and changes the SIMD reduction order the bit-exactness assertion
  depends on). It passes standalone at 1/4/8 threads either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)