### PR TITLE
fix(barnett): survive a full group volume — redirect results and the Julia depot

### DIFF
--- a/runs/eu_barnett_redo/run_core.jl
+++ b/runs/eu_barnett_redo/run_core.jl
@@ -23,7 +23,13 @@ using JLD2, FFTW, Printf, LinearAlgebra
 
 const CELL  = get(ENV, "BR_CELL", "plus")
 const SMOKE = get(ENV, "SMOKE", "0") == "1"
-const OUT   = joinpath(@__DIR__, "data")
+# Output root. Defaults to the run directory, but BR_OUT can send results
+# somewhere off the group volume. That is not a nicety: the group Lustre area is
+# shared with two other users holding ~900 GB between them, and when it filled,
+# a production cell died with a Bus error -- JLD2 mmaps its output, so a full
+# filesystem is SIGBUS rather than a clean write error. $HOME is a separate
+# 25 GB quota on the same Lustre, so BR_OUT=$HOME/... survives a full /gs/fs.
+const OUT   = get(ENV, "BR_OUT", joinpath(@__DIR__, "data"))
 mkpath(OUT)
 
 CELL in ("plus", "minus", "zero", "plus_nodd") ||

--- a/runs/eu_barnett_redo/tsubame_core.sh
+++ b/runs/eu_barnett_redo/tsubame_core.sh
@@ -37,8 +37,13 @@ REPO="${BR_REPO:-$PWD}"
 cd "$REPO"
 echo "REPO=$REPO  branch=$(git branch --show-current 2>/dev/null)  HEAD=$(git rev-parse --short HEAD 2>/dev/null)"
 
-export JULIA_DEPOT_PATH=/gs/fs/tga-kozuma-kouhi/shared/.julia
-export JULIAUP_DEPOT_PATH=/gs/fs/tga-kozuma-kouhi/shared/.juliaup
+# The shared depot lives on the group volume. When that volume is full, Julia
+# cannot write precompile output and dies with an LLVM "IO failure on output
+# stream: Disk quota exceeded" -- so the depot has to be overridable too, not
+# just the results. `JULIA_DEPOT_PATH=$HOME/.julia` runs entirely off the
+# separate 25 GB home quota.
+export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH:-/gs/fs/tga-kozuma-kouhi/shared/.julia}"
+export JULIAUP_DEPOT_PATH="${JULIAUP_DEPOT_PATH:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup}"
 export BR_CELL="${BR_CELL:-plus}"
 
 source scripts/tsubame_setup.sh    # node-local NVMe SPINORBEC_SCRATCH_DIR — KEEP IT.


### PR DESCRIPTION
## What

Two environment overrides so a run does not die when the shared group volume is
full. Defaults are unchanged.

| var | effect |
|---|---|
| `BR_OUT` | output root for ledgers and frames (default: the run directory) |
| `JULIA_DEPOT_PATH` / `JULIAUP_DEPOT_PATH` | now respected if pre-set, instead of being overwritten |

## Why

The group Lustre area (`/gs/fs/tga-kozuma-kouhi`, 1000 GB) is shared. It is
currently at 1010 GB, with ~900 GB held by two other users whose run
directories are mode 755 — `rm` from this account is Permission denied, so this
is not something the job owner can clear.

Two distinct failures came out of that, both silent in different ways:

1. **A production cell died with `Bus error (core dumped)`.** JLD2 mmaps its
   output, so a full filesystem is SIGBUS rather than a clean write error. The
   other three cells in the batch finished normally, which is how it hid — the
   batch looked 3/4 successful rather than blocked.

2. **`git fetch` and Julia precompile both failed with
   `Disk quota exceeded`**, the latter as
   `LLVM ERROR: IO failure on output stream`. A job submitted after a failed
   fetch runs the *previous* commit, which is worse than not running: it
   produces plausible output from the wrong code.

`$HOME` is a separate 25 GB quota on the same Lustre (1.1 GB used). With both
overrides the whole pipeline — checkout, depot, results — runs off it and is
independent of the group volume. The study's real output is small: 95 KB of
ledger CSV per cell, with `BR_FRAMES` controlling the psi snapshots that are
only needed for the vortex figure.

## Test

- `SMOKE=1 BR_OUT=<tmp> BR_FRAMES=2` writes to the redirected root; ledger and
  frames land there, physics numbers unchanged.
- Submitted on TSUBAME with code, depot and output all under `$HOME` after the
  group volume filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)