### PR TITLE
docs(barnett): /gs/bs/work is the better escape from a full group volume

### DIFF
--- a/runs/eu_barnett_redo/run_core.jl
+++ b/runs/eu_barnett_redo/run_core.jl
@@ -27,8 +27,12 @@ const SMOKE = get(ENV, "SMOKE", "0") == "1"
 # somewhere off the group volume. That is not a nicety: the group Lustre area is
 # shared with two other users holding ~900 GB between them, and when it filled,
 # a production cell died with a Bus error -- JLD2 mmaps its output, so a full
-# filesystem is SIGBUS rather than a clean write error. $HOME is a separate
-# 25 GB quota on the same Lustre, so BR_OUT=$HOME/... survives a full /gs/fs.
+# filesystem is SIGBUS rather than a clean write error.
+#
+# Preferred destination: /gs/bs/work/<n>/<user>, which is a per-user area on a
+# DIFFERENT filesystem (40 PB, no per-user block quota). $HOME also works and is
+# a separate quota too, but it is only 25 GB -- fine for the ledger CSVs, not for
+# a depot plus snapshots.
 const OUT   = get(ENV, "BR_OUT", joinpath(@__DIR__, "data"))
 mkpath(OUT)
 

--- a/runs/eu_barnett_redo/tsubame_core.sh
+++ b/runs/eu_barnett_redo/tsubame_core.sh
@@ -40,8 +40,14 @@ echo "REPO=$REPO  branch=$(git branch --show-current 2>/dev/null)  HEAD=$(git re
 # The shared depot lives on the group volume. When that volume is full, Julia
 # cannot write precompile output and dies with an LLVM "IO failure on output
 # stream: Disk quota exceeded" -- so the depot has to be overridable too, not
-# just the results. `JULIA_DEPOT_PATH=$HOME/.julia` runs entirely off the
-# separate 25 GB home quota.
+# just the results.
+#
+# Escape routes, both on filesystems separate from /gs/fs:
+#   /gs/bs/work/<n>/<user>   per-user, 40 PB, no per-user block quota  <- preferred
+#   $HOME                    separate quota but only 25 GB
+# A depot needs ~5 GB and must be instantiated ONCE before the first job
+# (`Pkg.instantiate(); Pkg.precompile()`), or the run dies with
+# "Package CUDA ... is required but does not seem to be installed".
 export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH:-/gs/fs/tga-kozuma-kouhi/shared/.julia}"
 export JULIAUP_DEPOT_PATH="${JULIAUP_DEPOT_PATH:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup}"
 export BR_CELL="${BR_CELL:-plus}"


### PR DESCRIPTION
Follow-up to #160.

#160 added `BR_OUT` and a settable `JULIA_DEPOT_PATH`, and pointed both at `$HOME`. That works but `$HOME` is **25 GB** — fine for the 95 KB ledger CSVs, not for a ~5 GB depot plus snapshots.

`/gs/bs/work/<n>/<user>` is a per-user area on a **different filesystem**: 40 PB with 33 PB free and no per-user block quota (`lfs quota` reports limit 0). Verified owned and writable.

Docs only — no behaviour change. Also records the trap that cost a submitted job: a redirected depot must be instantiated once (`Pkg.instantiate(); Pkg.precompile()`) or the run dies with `Package CUDA ... is required but does not seem to be installed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)