### PR TITLE
fix(barnett): named production geometries — qsub -v cannot carry a tuple

### DIFF
--- a/runs/eu_barnett_redo/tsubame_core.sh
+++ b/runs/eu_barnett_redo/tsubame_core.sh
@@ -46,6 +46,16 @@ export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH:-/gs/fs/tga-kozuma-kouhi/shared/.jul
 export JULIAUP_DEPOT_PATH="${JULIAUP_DEPOT_PATH:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup}"
 export BR_CELL="${BR_CELL:-plus}"
 
+# Optional named geometry. `qsub -v` splits values on commas, so BR_N / BR_BOX
+# tuples CANNOT be passed through -v -- they silently expand into several bogus
+# variables and the job runs the default geometry. Use BR_VARIANT=<name> from
+# variants.sh instead.
+if [ -n "${BR_VARIANT:-}" ]; then
+  source runs/eu_barnett_redo/variants.sh
+  br_select_prod "$BR_VARIANT"
+  echo "variant=$BR_VARIANT n=$BR_N box=$BR_BOX dt=$BR_DT"
+fi
+
 source scripts/tsubame_setup.sh    # node-local NVMe SPINORBEC_SCRATCH_DIR — KEEP IT.
 
 JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia

--- a/runs/eu_barnett_redo/variants.sh
+++ b/runs/eu_barnett_redo/variants.sh
@@ -30,6 +30,26 @@ declare -A BR_VARIANTS=(
   [trunc]="64,64,28|28,28,12|1|1.0e-3|0"     # image-free AND a real-space cutoff on the kernel
 )
 
+# PRODUCTION geometries (full stage lengths, unlike the probe entries above).
+# The dx-convergence series was measured at stir = 10; at the production stir of
+# 30 the same dx = 0.22 leaks 67.7% of the conversion against 15.9% at stir 10,
+# so the series does NOT extrapolate and the production resolution is unsettled.
+# `prod_dx175` is the same protocol at finer dx to test exactly that.
+declare -A BR_PROD_VARIANTS=(
+  [prod_dx22]="128,128,80|28.0,28.0,18.0|0|1.0e-3|NaN"    # current production, dx 0.22
+  [prod_dx175]="160,160,100|28.0,28.0,18.0|0|1.0e-3|NaN"  # dx 0.175, 2x the cells
+)
+
+# Export geometry for a PRODUCTION variant. Exists because `qsub -v` splits on
+# commas, so a tuple like BR_N=128,128,80 cannot be passed through -v at all --
+# it silently becomes several bogus variables. Pass BR_VARIANT=<name> instead.
+br_select_prod() {
+  local tag=$1
+  [[ -n "${BR_PROD_VARIANTS[$tag]:-}" ]] || { echo "unknown prod variant: $tag" >&2; return 1; }
+  IFS='|' read -r BR_N BR_BOX BR_PAD BR_DT BR_TRUNC <<<"${BR_PROD_VARIANTS[$tag]}"
+  export BR_N BR_BOX BR_PAD BR_DT BR_TRUNC BR_TAG="_$tag"
+}
+
 # Export BR_N / BR_BOX / BR_PAD / BR_DT / BR_TRUNC for one variant name.
 br_select_variant() {
   local tag=$1


### PR DESCRIPTION
`qsub -v` splits values on commas, so `BR_N=160,160,100` never reaches the job as one variable — it silently expands into several bogus ones and the job runs the **default** geometry while appearing to run the requested one. Nothing errors; the output just quietly describes a different simulation.

This already bit the probe path once (58317795, "qsub -v eats the commas") and I repeated it on the production path today.

`BR_VARIANT=<name>` now selects a geometry from `variants.sh` on the production submit script too, the same mechanism the probe path uses.

## Two production entries

| variant | grid | dx |
|---|---|---|
| `prod_dx22` | 128×128×80, box 28×28×18 | 0.22 (current) |
| `prod_dx175` | 160×160×100, box 28×28×18 | 0.175 |

## Why prod_dx175

The dx-convergence series was measured at **stir = 10**, where dx = 0.22 leaked 15.9% of the conversion and all three of stir output, conversion and leak converged:

| dx | J_z at quench start | leak | conversion | leak/conv |
|---|---|---|---|---|
| 0.44 | 7.754 | 6.265 | 0.851 | 736% |
| 0.29 | 12.207 | 2.985 | 1.406 | 212% |
| 0.22 | 12.495 | 0.230 | 1.447 | 15.9% |

At the **production stir of 30**, the same dx = 0.22 leaks **67.7%**. So the series does not extrapolate across stage length — longer stirring develops more grid-scale structure, which is exactly the mechanism the leak was traced to — and the production resolution is **not settled**. `prod_dx175` runs the full protocol at finer dx to test whether the conversion has converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)