### PR TITLE
feat(bscan): a direction knob, so the "up" branch can be generated at all

### DIFF
--- a/scripts/eu_bscan_pinned_continuation.jl
+++ b/scripts/eu_bscan_pinned_continuation.jl
@@ -17,6 +17,10 @@
 #
 # Env:
 #   BS_GRID=64  BS_BOX=24.0  BS_NB=101  BS_BMIN=0.0  BS_BMAX=100.0  (µG)
+#   BS_TRAP_Z=1.1818          trap aspect ω_z/ω_⊥ — this is κ
+#   BS_DIR=down|up            continuation direction; `up` + BS_ANCHOR_STATE=flower
+#                             is the branch a hysteresis loop needs at κ ≥ 1.0
+#   BS_ANCHOR_STATE=m_plus_F  seed for the first (anchor) cell
 #   BS_PIN_EPS=1e-3           fixed transverse pin b_x (dimensionless p-units)
 #   BS_ITP=2000  BS_LBFGS_ANCHOR=400  BS_LBFGS_CELL=120
 #   BS_NEWTON_ANCHOR=1  (Newton-polish the stiff anchor; OFF for soft cells)
@@ -78,11 +82,31 @@ const PRESET  = eu151_preset(; n_pts=(NX, NX, NX), box=(BOX, BOX, BOX),
 const ATOM = PRESET.atom
 const SYS  = SpinSystem(ATOM.F)
 
-# Descending B (anchor = high field, then continue down into the soft manifold).
-const B_UG = collect(range(BMAX, BMIN; length=NB))
+# Scan direction. The anchor is always the FIRST cell, so the direction picks
+# which spinodal the continuation walks toward — and therefore which branch this
+# run produces.
+#
+#   down (default)  anchor at HIGH field, continue into the soft low-B manifold.
+#                   Pairs with BS_ANCHOR_STATE=m_plus_F → the "dn" branch, which
+#                   loses stability at the LOWER spinodal.
+#   up              anchor at LOW field, continue upward. Pairs with
+#                   BS_ANCHOR_STATE=flower → the "up" branch, which is stable at
+#                   weak field and loses stability at the UPPER spinodal.
+#
+# Both branches at one κ are what a hysteresis loop is made of, so a first-order
+# claim needs BOTH — the direction was hard-coded to `down` until 2026-07-29,
+# which is why the library had no "up" branch at any κ ≥ 1.0.
+const DIR = let d = lowercase(get(ENV, "BS_DIR", "down"))
+    d in ("down", "up") || error("BS_DIR must be `down` or `up`, got `$d`")
+    d
+end
+const B_UG = DIR == "down" ? collect(range(BMAX, BMIN; length=NB)) :
+             collect(range(BMIN, BMAX; length=NB))
 
-@printf("B-scan pinned continuation: grid=%d^3 box=%.1f  B=%.1f→%.1f µG × %d pts  pin b_x=%.1e  tol=%.0e  %s%s%s\n",
-    NX, BOX, BMAX, BMIN, NB, EPS, TOL, HAS_GPU ? "CUDA" : "CPU", SMOKE ? " [SMOKE]" : "",
+@printf("B-scan pinned continuation: grid=%d^3 box=%.1f κ=%.4f  B=%.1f→%.1f µG × %d pts (%s, anchor=%s)  pin b_x=%.1e  tol=%.0e  %s%s%s\n",
+    NX, BOX, TRAPZ, first(B_UG), last(B_UG), NB, DIR,
+    get(ENV, "BS_ANCHOR_STATE", "m_plus_F"),
+    EPS, TOL, HAS_GPU ? "CUDA" : "CPU", SMOKE ? " [SMOKE]" : "",
     REPOLISH ? @sprintf(" [REPOLISH >%.0e cap=%d ramp=%s]", RP_THRESH, RP_LBFGS,
         isempty(RP_RAMP) ? "none" : join(RP_RAMP, ",")) : "")
 flush(stdout)


### PR DESCRIPTION
## The defect

`eu_bscan_pinned_continuation.jl` hard-coded

```julia
const B_UG = collect(range(BMAX, BMIN; length=NB))
```

The anchor is always the first cell, so that fixed the continuation to walk toward the **lower** spinodal — it could only ever produce the `"dn"` branch, whatever `BS_ANCHOR_STATE` said. The comment at the anchor site already described the other case (*":flower for the upsweep → hysteresis loop"*); the ordering to support it was never there.

## Why it matters right now

That is why the GS library has no `"up"` branch at any κ ≥ 1.0:

| κ | branches | B [µG] |
|---|---|---|
| 0.8 / 0.9 | up + dn | 12–28 |
| 1.0 / 1.4 / 1.8 | **dn only** | 25–110 |

`scripts/eu_adiabatic_ramp_protocol.jl` seeds its **rise** leg from branch `"up"`. So the adiabatic-passage protocol can be run at κ = 0.8 — the *crossover control* arm — but **not at the κ where the transition is supposed to be first-order**, which is the arm that carries the claim. A hysteresis loop is made of both branches; only one of them was reachable.

## The change

`BS_DIR=down|up`. `down` is the default and byte-for-byte the previous behaviour.

κ was already exposed as `BS_TRAP_Z` and the anchor state as `BS_ANCHOR_STATE` — **only the ordering was missing**. All three are now in the env list at the top of the file, which previously documented neither κ nor the anchor.

The banner also now prints κ, the true first→last B, the direction and the anchor state:

```
B-scan pinned continuation: grid=16^3 box=24.0 κ=1.8000  B=40.0→110.0 µG × 5 pts (up, anchor=flower) …
```

so a run's branch identity is visible in its own log. That matters because `eu_merge_library.jl` keys the library's `branch` column by **parsing the output directory name** — a mislabelled dir silently mislabels the library, and nothing downstream would notice.

## Verification

Smoke at κ = 1.8, grid 16, B ∈ [40, 110], 5 points:

| direction | anchor | B order | ⟨F⊥⟩ |
|---|---|---|---|
| `up` | flower | 40 → 110 | 4.13 → 1.35 |
| `down` (default) | m_plus_F | 110 → 40 | 1.30 → … |

The up branch really is the transverse/flower state at weak field, not a relabelled copy of the axial one. The default path is unchanged.

Next: generate the κ = 1.8 `"up"` branch on TSUBAME so the first-order arm of the ramp protocol becomes runnable. The κ = 0.8 control arm is already running there (job 8291428).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
