### PR TITLE
fix(barnett): the five archived edh_*.yaml reverse B sign at t=0

### DIFF
--- a/runs/eu_barnett_rotfield_clean/README.md
+++ b/runs/eu_barnett_rotfield_clean/README.md
@@ -20,6 +20,14 @@
 > What survives unconditionally is the **tooling** — the runners, the TSUBAME
 > NVMe-scratch guards, the analysis scripts, and the J_z-ledger diagnostics —
 > which is most of what this directory is for.
+>
+> **The five `edh_*.yaml` configs here were sign-corrected before landing**, so
+> they no longer reproduce the archived numbers. They had `Bz: "-0.01 Gauss"` in
+> the ground state against `from: 0.01` in the dynamics ramp — the field flipped
+> sign at t=0 — and the negative ground-state value selects m=+F under current
+> code anyway (measured; see the Zeeman-convention gate). Leaving them as-is
+> would have preserved the archive at the cost of shipping five configs that are
+> wrong to re-run, which is the worse trade.
 
 ¹⁵¹Eu (F=6) dipolar BEC, 32³, N=30000, a_s=110a₀ (ε_dd<1, no collapse),
 full DDI (non-secular), scalar LHY, GPU, unitary (no loss). All angular

--- a/runs/eu_barnett_rotfield_clean/edh_baseline.yaml
+++ b/runs/eu_barnett_rotfield_clean/edh_baseline.yaml
@@ -19,7 +19,7 @@ pipeline:
       interactions: {N_atoms: 30000, omega_ref: 628.3, c1_ratio: -0.005}
       ddi: {enabled: true, secular: false}
       lhy: {kind: scalar}
-      B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
       init_sigma: 1.5

--- a/runs/eu_barnett_rotfield_clean/edh_box18.yaml
+++ b/runs/eu_barnett_rotfield_clean/edh_box18.yaml
@@ -19,7 +19,7 @@ pipeline:
       interactions: {N_atoms: 30000, omega_ref: 628.3, c1_ratio: -0.005}
       ddi: {enabled: true, secular: false}
       lhy: {kind: scalar}
-      B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
       init_sigma: 1.5

--- a/runs/eu_barnett_rotfield_clean/edh_dt0.00125.yaml
+++ b/runs/eu_barnett_rotfield_clean/edh_dt0.00125.yaml
@@ -19,7 +19,7 @@ pipeline:
       interactions: {N_atoms: 30000, omega_ref: 628.3, c1_ratio: -0.005}
       ddi: {enabled: true, secular: false}
       lhy: {kind: scalar}
-      B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
       init_sigma: 1.5

--- a/runs/eu_barnett_rotfield_clean/edh_dt0.0025.yaml
+++ b/runs/eu_barnett_rotfield_clean/edh_dt0.0025.yaml
@@ -19,7 +19,7 @@ pipeline:
       interactions: {N_atoms: 30000, omega_ref: 628.3, c1_ratio: -0.005}
       ddi: {enabled: true, secular: false}
       lhy: {kind: scalar}
-      B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
       init_sigma: 1.5

--- a/runs/eu_barnett_rotfield_clean/edh_grid48.yaml
+++ b/runs/eu_barnett_rotfield_clean/edh_grid48.yaml
@@ -19,7 +19,7 @@ pipeline:
       interactions: {N_atoms: 30000, omega_ref: 628.3, c1_ratio: -0.005}
       ddi: {enabled: true, secular: false}
       lhy: {kind: scalar}
-      B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
       init_sigma: 1.5


### PR DESCRIPTION
Follow-up to #154, which merged before this commit landed on the branch.

## What is wrong on `main` right now

`runs/eu_barnett_rotfield_clean/edh_*.yaml` (5 files):

```yaml
  # ground state
  B: {Bz: "-0.01 Gauss", ...}
  # dynamics
  B: {Bz: {from: 0.01, to: 2.6e-5, ...}, ...}
```

The field **reverses sign at t = 0**. On top of that the negative ground-state value selects **m = +F** under current code, not the `m = -F` the config header says it prepares — measured, `Bz = -0.01 G → ⟨F_z⟩ = +6.0`.

Fixed to positive throughout, matching the ramp that was already positive.

## How it surfaced

Running `SPINORBEC_TEST_TIER=ci` on a branch with all of today's PRs merged. #154 was **adding** configs of exactly the class the Zeeman-convention gate in #163 removes, so the two land in conflict — the gate goes red on `main` the moment #163 merges. Neither PR is wrong on its own; only the combination shows it.

Worth stating plainly: `main`'s required checks are fast + oracles + formatter, so a green PR says nothing about the `ci` tier, and this would have landed red.

## Note on the archive

`README.md` now records that these five no longer reproduce the archived numbers. Preserving the archive byte-exact would have meant shipping five configs that are wrong to re-run — the worse trade, given the banner already says the results are not quotable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)