### PR TITLE
fix(edh): the GS field sign contradicted the seed AND the dynamics, in one file

### DIFF
--- a/runs/eu_barnett_rotfield_clean/edh_baseline.yaml
+++ b/runs/eu_barnett_rotfield_clean/edh_baseline.yaml
@@ -19,7 +19,7 @@ pipeline:
       interactions: {N_atoms: 30000, omega_ref: 628.3, c1_ratio: -0.005}
       ddi: {enabled: true, secular: false}
       lhy: {kind: scalar}
-      B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
       init_sigma: 1.5

--- a/runs/eu_barnett_rotfield_clean/edh_box18.yaml
+++ b/runs/eu_barnett_rotfield_clean/edh_box18.yaml
@@ -19,7 +19,7 @@ pipeline:
       interactions: {N_atoms: 30000, omega_ref: 628.3, c1_ratio: -0.005}
       ddi: {enabled: true, secular: false}
       lhy: {kind: scalar}
-      B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
       init_sigma: 1.5

--- a/runs/eu_barnett_rotfield_clean/edh_dt0.00125.yaml
+++ b/runs/eu_barnett_rotfield_clean/edh_dt0.00125.yaml
@@ -19,7 +19,7 @@ pipeline:
       interactions: {N_atoms: 30000, omega_ref: 628.3, c1_ratio: -0.005}
       ddi: {enabled: true, secular: false}
       lhy: {kind: scalar}
-      B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
       init_sigma: 1.5

--- a/runs/eu_barnett_rotfield_clean/edh_dt0.0025.yaml
+++ b/runs/eu_barnett_rotfield_clean/edh_dt0.0025.yaml
@@ -19,7 +19,7 @@ pipeline:
       interactions: {N_atoms: 30000, omega_ref: 628.3, c1_ratio: -0.005}
       ddi: {enabled: true, secular: false}
       lhy: {kind: scalar}
-      B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
       init_sigma: 1.5

--- a/runs/eu_barnett_rotfield_clean/edh_grid48.yaml
+++ b/runs/eu_barnett_rotfield_clean/edh_grid48.yaml
@@ -19,7 +19,7 @@ pipeline:
       interactions: {N_atoms: 30000, omega_ref: 628.3, c1_ratio: -0.005}
       ddi: {enabled: true, secular: false}
       lhy: {kind: scalar}
-      B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
       init_sigma: 1.5


### PR DESCRIPTION
`runs/eu_barnett_rotfield_clean/edh_*.yaml` (5 configs) solve the ground state at `Bz = -0.01 Gauss` while pinning `initial_state: m_minus_F`, then start the quench at `Bz = +0.01`:

```yaml
ground_state  B: {Bz: "-0.01 Gauss"}   initial_state: m_minus_F
dynamics      B: {Bz: {from: 0.01, to: 2.6e-5}}
```

Three things disagree and only one can be right. Under the convention (CLAUDE.md, `Units.bfield_to_p`: $H = -p F_z$ with $p \equiv -g_F \mu_B B$, so a **positive** $B_z$ makes $m=-F$ lowest for $g_F>0$) the seed wants $B_z>0$, and the dynamics block **already** uses $B_z>0$. The ground-state sign is the outlier, so it flips.

Nothing errored: ITP holds a stretched state it is handed, so the run completed and produced a plausible result for a state the field disfavoured — and then the field reversed sign under it at $t=0$.

## Why main went red

That is exactly what `test/workflow/test_config_zeeman_seed_agreement.jl` exists to stop. These five were re-introduced by #154 (archiving the campaign orphaned when #62 was closed) **after** the gate had already landed, so the gate fired on `main`'s ci tier. The required checks are `fast` + `oracles` only, so no PR showed it.

## Worth flagging

These headers claim to reproduce **Matsui et al., Science 2026** ("reproduced pop-growth here") — a type-C model-fidelity claim. **Any archived result under these five configs was produced with the inconsistent sign and should be re-run before it is quoted.**

Gate green: 3/3, 57 configs checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)