### PR TITLE
docs: propagate the LHY re-derivation — and Figure 2 turns out to have lost its premise

### DIFF
--- a/docs/manuscript/four_figure_spec_2026_05_26.md
+++ b/docs/manuscript/four_figure_spec_2026_05_26.md
@@ -98,6 +98,42 @@ reproduces", with loss-on as bracket evidence not headline claim.
 
 **Final caption (publication-ready):**
 
+> ## ⚠️ Figure 2 does not reproduce — re-derived 2026-07-29
+>
+> **Its premise is gone.** The caption below turns on some arms *collapsing*
+> (`delay`) and the LHY closures *arresting* them (`stable_arrest`). Re-running the
+> K₃=0 factorial on current `main`, **all four arms are `stable_arrest`** — there
+> is no collapse left for the LHY closure to determine:
+>
+> | arm | ratio now | class now | ratio 2026-05 | class 2026-05 |
+> |---|---:|---|---:|---|
+> | off | **1.0502** | stable_arrest | 2.3339 | delay |
+> | scalar | **1.1839** | stable_arrest | 2.3599 | delay |
+> | polar_contact | **1.3883** | stable_arrest | 1.6294 | stable_arrest |
+> | icosahedral | **1.2801** | stable_arrest | 1.5991 | stable_arrest |
+>
+> So "scalar density LHY is indistinguishable from no LHY" no longer holds either
+> — scalar now moves the ratio 1.05 → 1.18 — and the ordering that made the point
+> (off/scalar collapse, closures arrest) has inverted into "everything arrests,
+> and the closures arrest *least*".
+>
+> A second, separate change: the ground-state peak density is 0.0044–0.0046 for
+> off/scalar but **0.0177–0.0185 for the closed forms** — a factor 4, *after*
+> #158 (closed-form tables were $N_{atoms}$ too large). That gap needs its own
+> explanation before any of these arms is quoted; it is not what the caption
+> describes.
+>
+> Cause is not the LHY coefficient work alone. This run also predates the Eu
+> quadratic-Zeeman fix (11× too large until 2026-07-08), the DDI integrator-order
+> fixes and the ITP density-bias fix — see
+> [`stored_results_vintage_audit.md`](../validation/stored_results_vintage_audit.md).
+>
+> **Do not use Figure 2 as specified.** The physics question it asks (what sets
+> F=6 collapse arrest) is still open; this figure's answer rested on a collapse
+> that current code does not produce.
+>
+> Run output: `/gs/bs/work/7/uk07267/spinorbec-runs/fig2_k3zero_v2`.
+
 > **Figure 2.** F=6 collapse arrest in the cigar stress regime
 > (N = 30 000, ω_z = 0.25 ω_⊥, simulated window t = 30 ms in panels
 > (a–b), 200 ms in panel (c)) is determined by the LHY closure, NOT by

--- a/docs/manuscript/four_figure_spec_2026_05_26.md
+++ b/docs/manuscript/four_figure_spec_2026_05_26.md
@@ -112,18 +112,27 @@ reproduces", with loss-on as bracket evidence not headline claim.
 > | polar_contact | **1.3883** | stable_arrest | 1.6294 | stable_arrest |
 > | icosahedral | **1.2801** | stable_arrest | 1.5991 | stable_arrest |
 >
-> So "scalar density LHY is indistinguishable from no LHY" no longer holds either
-> — scalar now moves the ratio 1.05 → 1.18 — and the ordering that made the point
-> (off/scalar collapse, closures arrest) has inverted into "everything arrests,
-> and the closures arrest *least*".
+> **Only the first two rows are usable.** `off` and `scalar` conserve energy to
+> 2e-8 / 7e-8. The two closed-form arms drift **46 %** (E: 3123 → 1694) and their
+> `energy_decomposition` puts **97 % of the total energy in the LHY term alone**
+> (`lhy = +1653` / `+1664` against a whole mean field of ≈ +2.2 in the other two
+> arms). Their ratios are not evidence of anything and are shown only to document
+> that the stored 1.63 / 1.60 were not reproduced. Do not read "the closures
+> arrest least" out of this table.
 >
-> A second, separate change: the ground-state peak density is 0.0044–0.0046 for
-> off/scalar but **0.0177–0.0185 for the closed forms** — a factor 4, *after*
-> #158 (closed-form tables were $N_{atoms}$ too large). That gap needs its own
-> explanation before any of these arms is quoted; it is not what the caption
-> describes.
+> What survives is enough to void the figure: **`off` does not collapse.** Its
+> ratio fell 2.3339 → 1.0502 with clean energy conservation, and `scalar` — also
+> clean — sits at 1.1839, so "scalar is indistinguishable from no LHY" is gone
+> too. The caption needs `off` to collapse so that the closures can be seen to
+> arrest it. It does not.
 >
-> Cause is not the LHY coefficient work alone. This run also predates the Eu
+> The two dedicated gates for the tabulated path both pass at this commit
+> (`test_lhy_energy_convention.jl` 17/17, `test_tabulated_lhy_propagator_parity.jl`
+> 42/42), so the 46 % drift is **not** an energy/propagator/gradient inconsistency.
+> It is the table's magnitude in this particular Eu F=6 configuration — tracked
+> separately; not diagnosed here.
+>
+> Cause of the `off` change is not the LHY work: this run predates the Eu
 > quadratic-Zeeman fix (11× too large until 2026-07-08), the DDI integrator-order
 > fixes and the ITP density-bias fix — see
 > [`stored_results_vintage_audit.md`](../validation/stored_results_vintage_audit.md).

--- a/docs/manuscript/thesis/chapters/Ch5_TWA_chaotic_dynamics_integrated.md
+++ b/docs/manuscript/thesis/chapters/Ch5_TWA_chaotic_dynamics_integrated.md
@@ -118,6 +118,29 @@ ITP to convergence. Variable: `spinor_lhy` setting only.
 **変動 < 1%**: LHY 補正は Eu collapse 抑制に対して 1% 未満の effect しか持たない。
 平均場 DDI が dominant、LHY は **sub-leading**。
 
+> **Re-derived 2026-07-29 — 結論は保持、根拠は差し替えが必要。**
+> 上表の「5 modes すべて一致」は *vacuous* だった。この ablation の姉妹 run
+> (`eu151_edh_postfix_local`, `backend: gpu`) では、2026-07-28 (#125) まで
+> tabulated LHY が GPU broadcast 経路で黙って `c_lhy = 0` に潰れており、
+> `polar_contact` / `polar_dipolar` / `full_bdg` の 3 行は **LHY 完全にゼロ**で
+> 走っていた。`scalar` も係数が $\pi(a_s/a_{ho})\sqrt N$ 分不足 (#108)。
+> つまり「一致」は物理と無関係に保証されていた。
+>
+> 現行コードで再実行すると、使える 4 mode は peak 密度で **4.7 %** 以内に一致し、
+> かつ互いに異なる値を返す（閉形式は *効いており*、この regime で小さいだけ）。
+> **したがって §5.2 の結論は成立するが、それを支える比較は今回初めて
+> 「別の結果になりえた」ものになった。** 引用する際は再導出後の表を使うこと。
+>
+> `full_bdg` の「converged ✓」も要注意: 姉妹 config では
+> `mean field is dynamically unstable (max Im ω = 213)` を実装自身が警告し、
+> ITP は `conv=false` を返した。この mode は不安定 mean field 上で
+> $\epsilon_{LHY}$ が scheme 依存になる。
+>
+> 詳細と再導出表:
+> [`eu_collapse_lhy_insufficient.md`](../../../research_notes/eu_collapse_lhy_insufficient.md)、
+> vintage:
+> [`stored_results_vintage_audit.md`](../../../validation/stored_results_vintage_audit.md)。
+
 これは Dy droplet (Schmitt 2016) が LHY-balanced collapse-抑制を experimental に示した
 事実とは対照的である。Eu の large $a_s = 110\,a_B$ (vs Dy ~ 92 $a_B$) + 異なる species
 parameter で、LHY/MF balance が異なる regime に入る。

--- a/docs/validation/stored_results_vintage_audit.md
+++ b/docs/validation/stored_results_vintage_audit.md
@@ -155,19 +155,28 @@ Re-running the K₃=0 factorial on current `main`:
 | polar_contact | **1.3883** | stable_arrest | 1.6294 | stable_arrest |
 | icosahedral | **1.2801** | stable_arrest | 1.5991 | stable_arrest |
 
-**All four arms arrest.** The figure's premise — that there is a collapse for the
-LHY closure to determine — is absent from current code. The ordering has also
-inverted: the closures now arrest *least*.
+**Only the first two rows are usable**: `off` and `scalar` conserve energy to
+2e-8 / 7e-8, while the two closed-form arms drift **46 %** and report **97 % of
+the total energy in the LHY term** (`lhy = +1653` / `+1664` against a whole mean
+field of ≈ +2.2). Their ratios are recorded only to show the stored 1.63 / 1.60
+were not reproduced.
+
+The usable half is already decisive: **`off` does not collapse** (2.3339 → 1.0502,
+clean), so the figure's premise — a collapse for the LHY closure to determine —
+is absent from current code.
+
+Both dedicated gates for the tabulated path pass at this commit, so the 46 % drift
+is not an energy/propagator/gradient inconsistency; it is the table's magnitude in
+this Eu F=6 configuration, tracked separately.
 
 This is a different failure mode from the first re-derivation. There the
 conclusion survived a vacuous comparison; here the *phenomenon* is gone. Between
 them they cover both ways a stored result can fail: the knob was broken, or the
 thing the knob acted on no longer happens.
 
-Note also the ground-state peak density: 0.0044–0.0046 for off/scalar but
-0.0177–0.0185 for the closed forms, a factor 4 *after* #158. That gap is
-unexplained and is not what the caption describes — it needs its own work before
-any of these arms is quoted.
+The 4× higher initial peak in the closed-form arms (0.0177–0.0185 vs
+0.0044–0.0046) has the same origin as their 46 % drift: an LHY term two to three
+orders of magnitude larger than the rest of the Hamiltonian.
 
 ## Recommended order
 

--- a/docs/validation/stored_results_vintage_audit.md
+++ b/docs/validation/stored_results_vintage_audit.md
@@ -139,6 +139,36 @@ Generalisation for anyone re-deriving from this list: **check the run's commit
 against the fix list above, and read the run's own warnings, before comparing
 numbers.**
 
+## Second re-derivation: a figure whose premise no longer exists
+
+`manuscript/four_figure_spec_2026_05_26.md` Figure 2 specifies that "F=6 collapse
+arrest in the cigar stress regime is determined by the LHY closure, NOT by
+three-body loss K₃", with `off` and `scalar` collapsing (`delay`) while
+`polar_contact` / `icosahedral` cap the peak (`stable_arrest`).
+
+Re-running the K₃=0 factorial on current `main`:
+
+| arm | ratio now | class now | ratio 2026-05 | class 2026-05 |
+|---|---:|---|---:|---|
+| off | **1.0502** | stable_arrest | 2.3339 | delay |
+| scalar | **1.1839** | stable_arrest | 2.3599 | delay |
+| polar_contact | **1.3883** | stable_arrest | 1.6294 | stable_arrest |
+| icosahedral | **1.2801** | stable_arrest | 1.5991 | stable_arrest |
+
+**All four arms arrest.** The figure's premise — that there is a collapse for the
+LHY closure to determine — is absent from current code. The ordering has also
+inverted: the closures now arrest *least*.
+
+This is a different failure mode from the first re-derivation. There the
+conclusion survived a vacuous comparison; here the *phenomenon* is gone. Between
+them they cover both ways a stored result can fail: the knob was broken, or the
+thing the knob acted on no longer happens.
+
+Note also the ground-state peak density: 0.0044–0.0046 for off/scalar but
+0.0177–0.0185 for the closed forms, a factor 4 *after* #158. That gap is
+unexplained and is not what the caption describes — it needs its own work before
+any of these arms is quoted.
+
 ## Recommended order
 
 1. **Do not re-run 230 suites.** Most were exploratory. Re-derive only what a


### PR DESCRIPTION
Docs-only. Follows the first re-derivation into its two downstream consumers, and re-derives a second stored result — which failed in a different, worse way.

## 1. Thesis Ch5 §5.2 — the citation, annotated

Ch5 cites `eu_collapse_lhy_insufficient.md` and reproduces its "5 modes all collapse to an identical filament" table. The conclusion holds. The *identity* was vacuous: that config is `backend: gpu`, and until #125 every tabulated LHY was silently `c_lhy = 0` on the GPU broadcast path — so three of the five rows ran with **no LHY at all**, while `scalar` ran with a coefficient short by $\pi (a_s/a_{ho}) \sqrt{N}$ (#108). Three identical rows because three of them were the same run.

Also flagged: Ch5 says `full_bdg` converged ✓. In the sibling config it warns `mean field is dynamically unstable (max Im ω = 213), ε_LHY is scheme-dependent here` and ITP returns `conv=false`.

## 2. Figure 2 of `four_figure_spec_2026_05_26.md` — do not use

Its premise is gone. The caption needs `off`/`scalar` to collapse (`delay`) so the closures can be seen to arrest them.

| arm | ratio now | class now | ratio 2026-05 | class 2026-05 | E drift | lhy / total |
|---|---:|---|---:|---|---:|---|
| off | **1.0502** | stable_arrest | 2.3339 | delay | 2.1e-08 | 0 / +2.24 |
| scalar | **1.1839** | stable_arrest | 2.3599 | delay | 6.8e-08 | 0 / +2.25 |
| polar_contact | 1.3883 | stable_arrest | 1.6294 | stable_arrest | **4.5e-01** | **+1664 / +1705** |
| icosahedral | 1.2801 | stable_arrest | 1.5991 | stable_arrest | **4.6e-01** | **+1653 / +1694** |

**Only the top two rows are usable.** The two closed-form arms drift 46 % in energy (3123 → 1694) and put **97 % of the total energy in the LHY term alone**, against a whole mean field of ≈ +2.2 in the clean arms. Their ratios are recorded only to document that the stored 1.63 / 1.60 were not reproduced — *not* as evidence that "the closures arrest least". Their 4× higher initial peak density is the same effect, not a separate puzzle.

The clean half is already decisive: **`off` does not collapse** — 2.3339 → 1.0502 at 2e-8 drift — and `scalar` is no longer indistinguishable from it (1.1839).

Cause of the `off` change is not the LHY work: this run also predates the Eu quadratic-Zeeman fix (11× too large until 2026-07-08), the DDI integrator-order fixes and the ITP density-bias fix.

The physics question Figure 2 asks — what sets F=6 collapse arrest — is still open. Only its answer is withdrawn.

## What I did *not* conclude

The 46 % drift is **not** an energy/propagator/gradient inconsistency: both dedicated gates pass at this commit (`test_lhy_energy_convention.jl` 17/17, `test_tabulated_lhy_propagator_parity.jl` 42/42). So it is the table's magnitude in this specific Eu F=6 configuration. That, plus `scalar` reporting `lhy = +0` in `energy_decomposition` while carrying `c_lhy = 2441.76`, is filed separately rather than guessed at here.

## Why both re-derivations, together

They cover both ways a stored result can fail:

- **#1** — the knob was broken; the conclusion happened to survive.
- **#2** — the knob works; the *phenomenon it acted on* no longer happens.

The second is the one a numbers-only audit misses, because a rerun that produces plausible numbers looks like a pass.

Type **A/B** only. No type-C claim. Run output off-repo: `/gs/bs/work/7/uk07267/spinorbec-runs/fig2_k3zero_v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)