### PR TITLE
fix(lhy): the dynamics phase never resolved its own `lhy:` block

### DIFF
--- a/src/workflow/experiments/pipeline/run_step_dynamics.jl
+++ b/src/workflow/experiments/pipeline/run_step_dynamics.jl
@@ -30,6 +30,49 @@ end
     return TimeDependentInteractions(c0_wf, c1_wf)
 end
 
+"""
+    _resolve_dyn_lhy!(p, atom, c_dd_val) -> Bool
+
+Resolve a `dynamics:` step's own `lhy:` block, in place, exactly as the
+ground_state step does.
+
+`_resolve_lhy_block!` — which derives `interactions.c_lhy` for the scalar modes
+and writes the `lhy_opts` carrying `n_atoms` for the tabulated ones — runs inside
+`_resolve_derived_params!`, and the only caller of that is
+`run_step_ground_state.jl`. So a `dynamics: {lhy: …}` block reached
+`make_workspace` with **neither**:
+
+  * scalar / quasi_2d modes: `interactions.c_lhy` stayed 0, because the dynamics
+    `interactions` dict is re-parsed by `_parse_gs_interactions` and the GS
+    resolver only ever wrote `c_lhy` onto the *ground_state* block's dict. The
+    dynamics phase then ran with **no LHY at all** while `lhy: {kind: scalar}`
+    sat in the YAML — and, being absent rather than wrong, it conserved energy
+    perfectly and reported `lhy = +0`.
+  * tabulated modes: `lhy_opts` was missing, so the fallback
+    `LHYTableOpts()` supplied `n_atoms = 1`. That factor is the unit conversion,
+    not a table knob (see `_resolve_lhy_block!`): `n` is normalised to
+    `∫|ψ|²dV = 1` while `c₀` already carries `N`, so `n_atoms = 1` makes the
+    table **exactly `N_atoms` times too strong — in the propagator as well as
+    the energy.** At Eu F=6 / N=30000 that put 97 % of the total energy in the
+    LHY term and drifted the run by 46 %.
+
+Returns whether the block was resolved, so the caller can warn rather than
+silently keep the old behaviour when the interaction block is in the `c_total`
+form (no `N_atoms` to normalise by).
+"""
+@noinline function _resolve_dyn_lhy!(p::Dict{String, Any}, atom, c_dd_val::Float64)
+    get(p, "lhy", nothing) isa Dict || return true
+    inter_d = get(p, "interactions", nothing)
+    inter_d isa Dict || return false
+    n_atoms = Int(get(inter_d, "N_atoms", 0))
+    omega_ref = Float64(get(inter_d, "omega_ref", 0.0))
+    (n_atoms > 0 && omega_ref > 0) || return false
+    a_ho = sqrt(Units.HBAR / (atom.mass * omega_ref))
+    eps_dd = atom.a_s > 0 ? compute_a_dd(atom) / atom.a_s : 0.0
+    _resolve_lhy_block!(p, inter_d, atom, c_dd_val, eps_dd, n_atoms, a_ho)
+    return true
+end
+
 @noinline function _resolve_dyn_magnetic_gradient(
     p::Dict{String, Any}, ndim::Int, duration::Float64
 )
@@ -125,6 +168,16 @@ function _run_step(
     sp = SimParams(; dt, n_steps, save_every,
         rotating_frame_omega=rf_omega,
         spin_rotating_frame_omega=spin_rf_omega)
+
+    # Must run BEFORE `_parse_gs_interactions`, which is what reads the
+    # `c_lhy` this writes.
+    if !_resolve_dyn_lhy!(p, atom, c_dd_val)
+        @warn """dynamics `lhy:` block cannot be normalised: its `interactions:` \
+gives no (N_atoms, omega_ref), so the LHY tables have no atom number to divide \
+by and scalar `c_lhy` cannot be derived. The dynamics phase will run without \
+LHY. Give the dynamics step an `interactions: {N_atoms: …, omega_ref: …}` (the \
+`c_total` form is not enough).""" maxlog = 1
+    end
 
     inter = get(p, "interactions", nothing)
     interactions = inter !== nothing ? _parse_gs_interactions(inter, atom) : prev_interactions

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -35,6 +35,7 @@ const FAST_TESTS = [
     "workflow/test_calibration_edge_cases.jl",
     "workflow/test_loss_block_edge_cases.jl",
     "workflow/test_dynamics_lhy_plumbing.jl",
+    "workflow/test_dynamics_lhy_normalisation.jl",
     "workflow/test_lhy_texture_warning.jl",
     "workflow/test_lhy_block_wiring.jl",
     "workflow/test_interactions_roundtrip.jl",

--- a/test/workflow/test_dynamics_lhy_normalisation.jl
+++ b/test/workflow/test_dynamics_lhy_normalisation.jl
@@ -1,0 +1,118 @@
+using Test
+using SpinorBEC
+
+# The `dynamics:` step used to reach `make_workspace` with an unresolved `lhy:`
+# block, because `_resolve_lhy_block!` runs inside `_resolve_derived_params!`
+# and only `run_step_ground_state.jl` calls that. Two consequences, opposite in
+# direction, both silent:
+#
+#   * scalar / quasi_2d: `interactions.c_lhy` stayed 0 — the dynamics phase ran
+#     with NO LHY while `lhy: {kind: scalar}` sat in the YAML. Because the term
+#     was absent rather than wrong, energy conservation looked perfect.
+#   * tabulated closed forms: `lhy_opts` was missing, so `LHYTableOpts()` gave
+#     `n_atoms = 1`. That is the unit conversion (n is normalised to ∫|ψ|²dV = 1
+#     while c₀ already carries N), so the table came out exactly `N_atoms` times
+#     too strong — in the propagator as well as the energy. At Eu F=6 / N=30000
+#     that put 97 % of the total energy into the LHY term.
+#
+# Both halves are pinned here against the *ground_state* resolution of the same
+# block, which is the reference: the two phases must normalise identically.
+
+const _ATOM = SpinorBEC.ATOM_REGISTRY[:Eu151]
+const _N_ATOMS = 30_000
+const _OMEGA_REF = 628.3
+
+_inter() = Dict{String, Any}("N_atoms" => _N_ATOMS, "omega_ref" => _OMEGA_REF)
+
+# The scalar auto-derive is gated on DDI being active (`c_dd_val > 0`), so the
+# dynamics step passes the inherited `c_dd` and the test must too.
+const _C_DD = compute_c_dd_dimless(_ATOM; N_atoms=_N_ATOMS, omega_ref=_OMEGA_REF)
+
+function _dyn_block(kind::String)
+    Dict{String, Any}(
+        "duration" => 1.0, "dt" => 0.01,
+        "interactions" => _inter(),
+        "lhy" => Dict{String, Any}("kind" => kind),
+    )
+end
+
+# Ground-state resolution of the same `lhy:` block — the reference both phases
+# must agree with.
+function _gs_resolved(kind::String)
+    p = Dict{String, Any}(
+        "interactions" => _inter(),
+        "ddi" => Dict{String, Any}("enabled" => true),
+        "potential" => Dict{String, Any}("type" => "harmonic", "omega" => [1.0, 1.0, 1.0]),
+        "lhy" => Dict{String, Any}("kind" => kind),
+    )
+    SpinorBEC._resolve_derived_params!(p, _ATOM; verbose=false)
+    p
+end
+
+@testset "dynamics `lhy:` normalises the same way ground_state does" begin
+    @testset "tabulated: n_atoms is the atom number, not 1" begin
+        for kind in ("polar_contact", "icosahedral", "fm_contact")
+            p = _dyn_block(kind)
+            @test SpinorBEC._resolve_dyn_lhy!(p, _ATOM, _C_DD)
+            @test haskey(p, "lhy_opts")
+            opts = p["lhy_opts"]::SpinorBEC.LHYTableOpts
+
+            # The regression: the fallback `LHYTableOpts()` supplies 1 here, and
+            # `n_atoms` scales the table as 1/n_atoms, so 1 is exactly an
+            # N_atoms-fold over-strength.
+            @test opts.n_atoms == _N_ATOMS
+            @test opts.n_atoms != SpinorBEC.LHYTableOpts().n_atoms
+
+            # ... and it agrees with what the ground_state step would have built.
+            @test opts.n_atoms == (_gs_resolved(kind)["lhy_opts"]::SpinorBEC.LHYTableOpts).n_atoms
+        end
+    end
+
+    @testset "scalar: c_lhy reaches the dynamics interactions" begin
+        p = _dyn_block("scalar")
+        @test SpinorBEC._resolve_dyn_lhy!(p, _ATOM, _C_DD)
+        c_lhy = Float64(get(p["interactions"], "c_lhy", 0.0))
+
+        # The regression: this was 0, so the dynamics ran with no LHY while the
+        # YAML said `kind: scalar`.
+        @test c_lhy > 0.0
+
+        gs = _gs_resolved("scalar")
+        @test c_lhy ≈ Float64(gs["interactions"]["c_lhy"]) rtol = 1e-12
+
+        # And it survives the re-parse that actually feeds `make_workspace` —
+        # `_parse_gs_interactions` is what reads the key, which is why the
+        # resolution has to happen before it.
+        ip = SpinorBEC._parse_gs_interactions(p["interactions"], _ATOM)
+        @test ip.c_lhy ≈ c_lhy rtol = 1e-12
+    end
+
+    @testset "table strength actually changes by N_atoms" begin
+        # Guard the *consequence*, not just the field: a reviewer changing how
+        # `n_atoms` threads through should see this fail, not only the ==.
+        g = SpinorBEC.c_to_g(_ATOM.F,
+            SpinorBEC._parse_gs_interactions(_inter(), _ATOM))
+        tbl_right = SpinorBEC.compute_spinor_lhy_polar_contact(;
+            F=_ATOM.F, g_dict=g, n_max=0.02, n_points=200, n_atoms=_N_ATOMS)
+        tbl_wrong = SpinorBEC.compute_spinor_lhy_polar_contact(;
+            F=_ATOM.F, g_dict=g, n_max=0.02, n_points=200, n_atoms=1)
+        n = 0.005
+        @test SpinorBEC._lhy_V(n, tbl_wrong) ≈
+            _N_ATOMS * SpinorBEC._lhy_V(n, tbl_right) rtol = 1e-8
+    end
+
+    @testset "no `lhy:` block is a no-op, and c_total form is reported" begin
+        p = Dict{String, Any}("duration" => 1.0, "dt" => 0.01,
+            "interactions" => _inter())
+        @test SpinorBEC._resolve_dyn_lhy!(p, _ATOM, _C_DD)
+        @test !haskey(p, "lhy_opts")
+
+        # `c_total` carries no atom number, so the block cannot be normalised.
+        # It must report false (the caller warns) rather than fall back to 1.
+        p_ct = Dict{String, Any}("duration" => 1.0, "dt" => 0.01,
+            "interactions" => Dict{String, Any}("c_total" => 100.0),
+            "lhy" => Dict{String, Any}("kind" => "polar_contact"))
+        @test !SpinorBEC._resolve_dyn_lhy!(p_ct, _ATOM, _C_DD)
+        @test !haskey(p_ct, "lhy_opts")
+    end
+end


### PR DESCRIPTION
Root cause of the first half of #172, found while re-deriving Figure 2 (#171).

`_resolve_lhy_block!` derives `interactions.c_lhy` for the scalar modes and writes the `lhy_opts` that carries `n_atoms` for the tabulated ones. It runs inside `_resolve_derived_params!` — and the only caller of that is `run_step_ground_state.jl`. So a `dynamics: {lhy: …}` block reached `make_workspace` unresolved, failing in two opposite directions, both silent:

**Tabulated closed forms** got no `lhy_opts`, so the fallback `LHYTableOpts()` supplied `n_atoms = 1`. That factor is the unit conversion, not a table knob — `n` is normalised to $\int |\psi|^2 dV = 1$ while $c_0$ already carries $N$ — so the table came out **exactly `N_atoms` times too strong, in the propagator as well as the energy**. On the Eu F=6 K₃=0 factorial (N=30000):

```
E_LHY = +1664   against a whole mean field of +2.2   (97 % of the total energy)
E drift = 46 %  (3123 -> 1694)
```

Evaluating the *same* energy face on the *same* saved state with a correctly built table gives **+0.0915** — a ratio of exactly `N_atoms`.

**Scalar / quasi_2d** got `interactions.c_lhy = 0`: the dynamics `interactions` dict is re-parsed by `_parse_gs_interactions`, and the GS resolver only ever wrote `c_lhy` onto the *ground_state* block's dict. So the dynamics phase ran with **no LHY at all** while `lhy: {kind: scalar}` sat in the YAML. Being *absent* rather than wrong, it conserved energy to 7e-8 and reported `lhy = +0` — the failure mode that looks exactly like success.

## Fix

`_resolve_dyn_lhy!` runs the same resolver on the dynamics block, **before** `_parse_gs_interactions` (which is what reads the `c_lhy` it writes). One declaration, both phases.

The `c_total` interaction form carries no atom number and so cannot be normalised at all. That returns `false` and the caller `@warn`s, rather than silently keeping `n_atoms = 1`.

## Why every existing gate was green

- **`test_dynamics_lhy_plumbing.jl`** sets `c_lhy` **by hand** — `InteractionParams(Dict(...); c_lhy=2.5)` — then checks `make_workspace` picks it up. It bypassed the exact plumbing that was broken. It covers the schema and `make_workspace`'s silent-zero defence, not whether the pipeline threads a value.
- **`test_lhy_energy_convention.jl`** (17/17) and **`test_tabulated_lhy_propagator_parity.jl`** (42/42) are *internal*-consistency gates (ε vs ∫V dn; propagator paths against each other). A uniformly rescaled table satisfies both, which is why an `N_atoms`-fold error was invisible to them.

The new gate pins **both halves against the ground_state resolution of the same block** — the two phases must normalise identically — and asserts the *consequence* (table strength changes by exactly `N_atoms`) rather than only the field value.

## Scope

Affects every YAML run whose `dynamics:` step carries an `lhy:` block. Type **A** (code correctness).

Closes the first half of #172. The `off` arm's separate 2.3339 → 1.0502 change is **not** LHY — that arm has none — and stays open.

`tier=fast`: 163 files, all passed. `tier=ci` running locally (required checks do not cover it). A 4-arm end-to-end re-run is in flight to confirm the corrected Figure 2 numbers; I'll post them here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)