### PR TITLE
docs: Figure 2 settled — no arm collapses on fixed code, at either field sign

### DIFF
--- a/docs/manuscript/four_figure_spec_2026_05_26.md
+++ b/docs/manuscript/four_figure_spec_2026_05_26.md
@@ -112,6 +112,25 @@ reproduces", with loss-on as bracket evidence not headline claim.
 > | polar_contact | **1.3883** | stable_arrest | 1.6294 | stable_arrest |
 > | icosahedral | **1.2801** | stable_arrest | 1.5991 | stable_arrest |
 >
+> **Correction (same day): the comparison above is not like-for-like.** The stored
+> 2026-05 numbers were produced with `B: {Bz: "-0.01 Gauss"}`; the configs were
+> corrected to `+0.01 Gauss` in `bce2068f` ("211 Eu configs pinned m=-F under a
+> field that prefers m=+F"), so the re-run used a *different config*, not just
+> different code. That commit's own reasoning applies directly here: m=−F is a
+> Zeeman eigenstate, so ITP holds it either way and nothing errors, but under the
+> old negative field m=−F is the *highest* Zeeman state and "the dynamics then
+> proceed in a field whose sign is opposite to the intent".
+>
+> That is a plausible mechanism for `delay` → `stable_arrest` on its own — a
+> spin-mixing-unstable initial state depolarises and collapses differently from a
+> stable one — so the `off` arm's 2.3339 → 1.0502 must **not** be attributed to
+> the code changes listed below until the two are separated. An `off` arm at the
+> old field sign on current code is running to do exactly that.
+>
+> The verdict on the figure is unchanged and if anything firmer: its stored
+> numbers are **not reproducible from anything now in the repo**, because the
+> config that produced them was wrong in the field sign and has been fixed.
+>
 > **Only the first two rows are usable.** `off` and `scalar` conserve energy to
 > 2e-8 / 7e-8. The two closed-form arms drift **46 %** (E: 3123 → 1694) and their
 > `energy_decomposition` puts **97 % of the total energy in the LHY term alone**

--- a/docs/manuscript/four_figure_spec_2026_05_26.md
+++ b/docs/manuscript/four_figure_spec_2026_05_26.md
@@ -112,6 +112,43 @@ reproduces", with loss-on as bracket evidence not headline claim.
 > | polar_contact | **1.3883** | stable_arrest | 1.6294 | stable_arrest |
 > | icosahedral | **1.2801** | stable_arrest | 1.5991 | stable_arrest |
 >
+> ## Settled — re-measured on fixed code, both field signs
+>
+> After #174 (the dynamics phase never resolved its own `lhy:` block, so tabulated
+> tables ran exactly `N_atoms` too strong and scalar LHY was absent entirely), all
+> four arms re-run cleanly:
+>
+> | arm | ratio | E drift | `lhy` / `total` | class |
+> |---|---:|---:|---:|---|
+> | scalar | 1.0363 | 6.4e-09 | +0.157 / +2.406 | stable_arrest |
+> | off | 1.0502 | 6.4e-10 | 0 / +2.244 | stable_arrest |
+> | polar_contact | 1.0921 | 4.9e-09 | +0.1146 / +2.359 | stable_arrest |
+> | icosahedral | 1.0923 | 4.9e-09 | +0.1146 / +2.359 | stable_arrest |
+>
+> Energy now conserves to ~1e-9 in every arm (was 46 % for the closed forms), and
+> LHY is 5–7 % of the total rather than 97 %. The signs are physical: the LHY arms
+> have a *lower* initial peak than `off` (0.00432–0.00434 vs 0.00463) because a
+> repulsive correction broadens the ground state.
+>
+> **And the field sign is not the cause.** Re-running `off` at the old
+> `Bz: "-0.01 Gauss"` on fixed code gives **ratio 1.0479** — within 0.2 % of the
+> `+0.01 Gauss` value of 1.0502, both `stable_arrest`, drift 4e-10. So the
+> like-for-like objection below was real but numerically irrelevant here: the
+> `off` arm's 2.3339 → 1.05 **is** a code change, not the config flip. (Consistent
+> with the state staying 100 % in m=−6 either way — the linear Zeeman is a constant
+> offset for a single component, and 20 time units at `seed_amplitude: 1e-6` is not
+> enough for the instability to grow.)
+>
+> **Conclusion: Figure 2 as specified cannot be produced.** No arm collapses on
+> correct code at either field sign; the spread across all four LHY treatments is
+> 1.04–1.09. The stored `delay` at 2.33/2.36 and the "capped at 1.63/1.60" are both
+> unreproducible, so the figure's claim — that the F=6 collapse-arrest outcome is
+> *determined by the LHY closure* — has no phenomenon behind it in this regime. The
+> underlying physics question stays open; a new configuration that actually
+> collapses would be needed to ask it.
+>
+> Run output: `~/spinorbec-runs/fig2_k3zero_v3` and `…/fig2_oldsign`.
+>
 > **Correction (same day): the comparison above is not like-for-like.** The stored
 > 2026-05 numbers were produced with `B: {Bz: "-0.01 Gauss"}`; the configs were
 > corrected to `+0.01 Gauss` in `bce2068f` ("211 Eu configs pinned m=-F under a

--- a/docs/validation/stored_results_vintage_audit.md
+++ b/docs/validation/stored_results_vintage_audit.md
@@ -161,9 +161,20 @@ the total energy in the LHY term** (`lhy = +1653` / `+1664` against a whole mean
 field of ≈ +2.2). Their ratios are recorded only to show the stored 1.63 / 1.60
 were not reproduced.
 
-The usable half is already decisive: **`off` does not collapse** (2.3339 → 1.0502,
-clean), so the figure's premise — a collapse for the LHY closure to determine —
-is absent from current code.
+The usable half looked decisive — **`off` does not collapse** (2.3339 → 1.0502,
+clean) — but the two runs differ by more than code. `bce2068f` corrected these
+configs from `Bz: "-0.01 Gauss"` to `+0.01 Gauss`, so the stored numbers came
+from a config that no longer exists. Under the old negative field m=−F is the
+*highest* Zeeman state, hence spin-mixing unstable, which is a sufficient
+mechanism for `delay` → `stable_arrest` by itself. The figure's stored numbers
+are not reproducible from anything now in the repo; whether current code alone
+would also fail to collapse is a separate question, being measured by an `off`
+arm at the old field sign.
+
+**This is the third framing of the same result in one day.** First "the numbers
+moved", then "the premise is gone", now "the comparison was never like-for-like".
+Each correction came from checking one more thing that should have been checked
+first — and the config's own git history was a five-second check.
 
 Both dedicated gates for the tabulated path pass at this commit, so the 46 % drift
 is not an energy/propagator/gradient inconsistency; it is the table's magnitude in

--- a/docs/validation/stored_results_vintage_audit.md
+++ b/docs/validation/stored_results_vintage_audit.md
@@ -171,6 +171,13 @@ are not reproducible from anything now in the repo; whether current code alone
 would also fail to collapse is a separate question, being measured by an `off`
 arm at the old field sign.
 
+**Settled.** After #174 all four arms re-run clean (drift ~1e-9, LHY 5–7 % of the
+total instead of 97 %): scalar 1.0363, off 1.0502, polar_contact 1.0921,
+icosahedral 1.0923 — every one `stable_arrest`. And `off` at the OLD field sign on
+fixed code gives 1.0479, within 0.2 % of the new sign, so the like-for-like
+objection was real but numerically irrelevant: the change **is** code, not the
+config flip. Figure 2's claim has no phenomenon behind it in this regime.
+
 **This is the third framing of the same result in one day.** First "the numbers
 moved", then "the premise is gone", now "the comparison was never like-for-like".
 Each correction came from checking one more thing that should have been checked


### PR DESCRIPTION
Closes out the Figure 2 re-derivation. Two commits: the like-for-like correction to #171, then the settled measurement after #174.

## The correction

#171 attributed Figure 2's `off` arm going 2.3339 → 1.0502 to code changes. But the stored 2026-05 numbers used `B: {Bz: "-0.01 Gauss"}`, and `bce2068f` — *"211 Eu configs pinned m=-F under a field that prefers m=+F"* — had since corrected these configs to `+0.01 Gauss`. So the re-run exercised a **different config**, not merely different code. `git log` on the config file was a five-second check I should have run first.

## The measurement

Re-ran all four arms on fixed code (#174: the dynamics phase never resolved its own `lhy:` block, so tabulated tables were exactly `N_atoms` too strong and scalar LHY was absent entirely):

| arm | ratio | E drift | `lhy` / `total` | class |
|---|---:|---:|---:|---|
| scalar | 1.0363 | 6.4e-09 | +0.157 / +2.406 | stable_arrest |
| off | 1.0502 | 6.4e-10 | 0 / +2.244 | stable_arrest |
| polar_contact | 1.0921 | 4.9e-09 | +0.1146 / +2.359 | stable_arrest |
| icosahedral | 1.0923 | 4.9e-09 | +0.1146 / +2.359 | stable_arrest |

Energy conserves to ~1e-9 everywhere (was 46 % for the closed forms), and LHY is 5–7 % of the total rather than 97 %. The signs are physical: the LHY arms have a **lower** initial peak than `off` (0.00432–0.00434 vs 0.00463), because a repulsive correction broadens the ground state. The old 4× *higher* peak was the `N_atoms` over-strength acting through the propagator.

And **the field sign is not what moved it.** `off` re-run at the old `Bz: "-0.01 Gauss"` on fixed code gives **ratio 1.0479** — within 0.2 % of 1.0502, both `stable_arrest`, drift 4e-10. So the objection above was correct in principle but numerically irrelevant here: the `off` arm's change **is** code. Consistent with the state staying 100 % in m=−6 either way — the linear Zeeman is a constant offset for a single component, and 20 time units at `seed_amplitude: 1e-6` is not long enough for the instability to grow.

## Verdict

**Figure 2 as specified cannot be produced.** Nothing collapses on correct code at either field sign, and the spread across all four LHY treatments is 1.04–1.09. Its claim — that the F=6 collapse-arrest outcome is *determined by* the LHY closure rather than by K₃ — has no phenomenon behind it in this regime. The underlying physics question stays open; asking it needs a configuration that actually collapses.

Closes #172.

## Recorded as the lesson

Three framings of one result in a day — "the numbers moved" → "the premise is gone" → "the comparison was never like-for-like" → settled. Each correction came from checking one more thing that should have been checked first. `stored_results_vintage_audit.md` now carries the progression, because the transferable rule is: **when a stored result does not reproduce, diff the config's git history before the code's.**

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)