### PR TITLE
probe(barnett): the conversion efficiency is the converged quantity — 99% of lost L_z becomes spin

### DIFF
--- a/runs/eu_barnett_redo/fig4_convergence.py
+++ b/runs/eu_barnett_redo/fig4_convergence.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""fig4: what is converged and what is not.
+
+The honest companion to figs 1-3. Two quantities behave differently as the grid
+is refined at PRODUCTION stage lengths (stir = 30), and the difference is the
+whole argument:
+
+  * the conversion dF_z converges (+6.7%, then +0.6%)
+  * the J_z leak falls steeply and then stalls (-57%, then -15%)
+
+Those would be worrying together — a signal tracking its own error bar — and are
+reassuring apart. The per-term torque budget explains why they separate: the
+leak lives in the KINETIC term's failure to commute with L_z on a discrete
+k-grid, which the quench keeps re-feeding at the Nyquist edge, while the
+conversion is a bulk mean-field effect.
+
+Usage: python3 runs/eu_barnett_redo/fig4_convergence.py
+"""
+import pathlib
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+HERE = pathlib.Path(__file__).parent
+DATA = HERE / "data"
+FIGS = HERE / "figures"
+FIGS.mkdir(exist_ok=True)
+
+SERIES = [
+    (0.219, "ledger_plus.csv"),
+    (0.175, "ledger_plus_prod_dx175.csv"),
+    (0.146, "ledger_plus_prod_dx146.csv"),
+]
+T_STIR = 30.0
+
+plt.rcParams.update({
+    "font.size": 10, "axes.grid": True, "grid.alpha": 0.25,
+    "figure.dpi": 140, "savefig.bbox": "tight", "axes.axisbelow": True,
+})
+
+dx, conv, leak = [], [], []
+for d, fn in SERIES:
+    p = DATA / fn
+    if not p.exists():
+        continue
+    a = np.genfromtxt(p, delimiter=",", names=True)
+    i = int(np.argmax(a["t"] >= T_STIR))
+    dx.append(d)
+    conv.append(a["Fz"][-1] - a["Fz"][i])
+    leak.append(abs(a["Jz"][-1] - a["Jz"][i]))
+
+if len(dx) < 2:
+    raise SystemExit("need at least two resolutions")
+
+dx, conv, leak = np.array(dx), np.array(conv), np.array(leak)
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(9.4, 4.0))
+
+a1.plot(dx, conv, "o-", color="#1b6ca8", lw=1.9, ms=6)
+for x, y in zip(dx, conv):
+    a1.annotate(f"{y:.3f}", (x, y), textcoords="offset points", xytext=(0, 8),
+                ha="center", fontsize=8)
+a1.set_xlabel(r"$dx$  [$a_{\rm ho}$]")
+a1.set_ylabel(r"$\Delta\langle F_z\rangle$  [$\hbar$/atom]")
+a1.set_title("Conversion: converges")
+a1.invert_xaxis()
+a1.set_ylim(min(conv) - 0.12, max(conv) + 0.12)
+
+a2.plot(dx, leak, "o-", color="#c0392b", lw=1.9, ms=6)
+for x, y in zip(dx, leak):
+    a2.annotate(f"{y:.3f}", (x, y), textcoords="offset points", xytext=(0, 8),
+                ha="center", fontsize=8)
+a2.set_xlabel(r"$dx$  [$a_{\rm ho}$]")
+a2.set_ylabel(r"$|\Delta J_z|$  [$\hbar$/atom]")
+a2.set_title("Ledger leak: falls, then stalls")
+a2.invert_xaxis()
+a2.set_ylim(0, max(leak) * 1.15)
+
+fig.suptitle("Refining the grid separates the signal from its error\n"
+             r"(production protocol, stir $=30$)", y=1.04)
+fig.savefig(FIGS / "fig4_convergence.png")
+plt.close(fig)
+print("wrote", FIGS / "fig4_convergence.png")
+
+print(f"\n{'dx':>7} {'conversion':>11} {'leak':>9} {'leak/conv':>10}")
+for d, c, l in zip(dx, conv, leak):
+    print(f"{d:7.3f} {c:11.4f} {l:9.4f} {100*l/abs(c):9.1f}%")
+for i in range(1, len(dx)):
+    print(f"  {dx[i-1]:.3f} -> {dx[i]:.3f}: conversion {100*(conv[i]/conv[i-1]-1):+.1f}%, "
+          f"leak {100*(leak[i]/leak[i-1]-1):+.1f}%")

--- a/runs/eu_barnett_redo/run_core.jl
+++ b/runs/eu_barnett_redo/run_core.jl
@@ -161,6 +161,21 @@ let dxs = ntuple(d -> BOX[d] / NPTS[d], 3)
     get(ENV, "BR_CHECK", "0") == "1" && exit(0)
 end
 
+# Orszag 2/3 dealiasing. The per-term J_z torque budget on a real post-quench
+# state (torque_budget.jl) put the violation in the KINETIC term, ~5x the DDI:
+# L_z does not map the discrete k-grid onto itself, so whatever the state carries
+# near the Nyquist edge leaks angular momentum. The 2/3 filter removes exactly
+# that band, which is why it is the direct treatment rather than yet more dx.
+#
+# Deliberately NO explicit k_cut: `DEALIAS_K_CUT` hard-codes a box of 12 on every
+# axis, so on this 28x28x18 box it would cut the occupied band roughly in half.
+# The default (n_d / 3 per axis, index space) is box-independent and is what we
+# want.
+if get(ENV, "BR_DEALIAS", "0") == "1"
+    SpinorBEC.DEALIAS_2_3_ENABLED[] = true
+    println("  dealias: Orszag 2/3 ON (index-space n/3 per axis, no k_cut override)")
+end
+
 const GRID = make_grid(GridConfig(NPTS, BOX))
 const DV   = cell_volume(GRID)
 const C0   = compute_c_total(ATOM; N_atoms=N_ATOMS, omega_ref=OMEGA_REF)

--- a/runs/eu_barnett_redo/torque_budget.jl
+++ b/runs/eu_barnett_redo/torque_budget.jl
@@ -1,0 +1,138 @@
+# Where does the residual J_z leak come from? Measure the budget, do not argue.
+#
+# At B = 0 every term in the Hamiltonian commutes with J_z = L_z + F_z in the
+# continuum, so the EXACT d<J_z>/dt is zero. Discretised, each term contributes
+# its own violation, and they can be measured separately on a REAL state:
+#
+#     dJz/dt|_term = -2 Im <H_term psi | J_z psi>
+#
+# Summing over terms gives a predicted instantaneous leak rate, which is then
+# compared against the observed dJz/dt from the ledger at the same time. That
+# comparison is the point: if the terms account for the observed rate, the leak
+# is discretisation and we know which term; if they fall short, something else
+# (the boundary, the time stepping) carries it and the box/dt probes decide.
+#
+# Usage:
+#   julia --project=. runs/eu_barnett_redo/torque_budget.jl <frames.jld2> <ledger.csv>
+using SpinorBEC
+using JLD2, Printf, FFTW, LinearAlgebra
+
+const FRAMES = length(ARGS) >= 1 ? ARGS[1] : error("need frames.jld2")
+const LEDGER = length(ARGS) >= 2 ? ARGS[2] : ""
+
+const ATOM = SpinorBEC.resolve_atom(:Eu151)
+const N_ATOMS = 30000
+const OMEGA_REF = 628.3
+const OMEGA_TRAP = (1.0, 1.0, 2.0)
+
+# L_z psi = -i (x d_y - y d_x) psi, spectrally. Validated on an l=+1 state.
+function apply_Lz(psi, grid)
+    n = grid.config.n_points
+    D = size(psi, 4)
+    out = similar(psi)
+    kx, ky = grid.k[1], grid.k[2]
+    xg, yg = grid.x[1], grid.x[2]
+    buf = Array{ComplexF64}(undef, n...)
+    P = plan_fft(buf); Pi = plan_ifft(buf)
+    g = similar(buf); dxb = similar(buf); dyb = similar(buf)
+    for c in 1:D
+        @views buf .= psi[:, :, :, c]
+        f = P * buf
+        @inbounds for k in axes(f,3), j in axes(f,2), i in axes(f,1)
+            g[i,j,k] = im * kx[i] * f[i,j,k]
+        end
+        dxb .= Pi * g
+        @inbounds for k in axes(f,3), j in axes(f,2), i in axes(f,1)
+            g[i,j,k] = im * ky[j] * f[i,j,k]
+        end
+        dyb .= Pi * g
+        @inbounds for k in axes(buf,3), j in axes(buf,2), i in axes(buf,1)
+            out[i,j,k,c] = -im * (xg[i]*dyb[i,j,k] - yg[j]*dxb[i,j,k])
+        end
+    end
+    out
+end
+
+function jz_psi(psi, grid, F)
+    out = apply_Lz(psi, grid)
+    D = 2F + 1
+    @inbounds for c in 1:D
+        m = F - (c - 1)
+        @views out[:,:,:,c] .+= m .* psi[:,:,:,c]
+    end
+    out
+end
+
+f = jldopen(FRAMES, "r")
+nf = f["n_frames"]; box = Tuple(Float64.(f["box"])); npts = Tuple(Int.(f["n"]))
+println("frames=$nf  n=$npts  box=$box  dx=", round.(box ./ npts; digits=4))
+
+grid = make_grid(GridConfig(npts, box))
+F = ATOM.F; D = 2F + 1
+dV = cell_volume(grid)
+c0 = compute_c_total(ATOM; N_atoms=N_ATOMS, omega_ref=OMEGA_REF)
+c1 = -0.005 * c0
+c_dd = compute_c_dd_dimless(ATOM; N_atoms=N_ATOMS, omega_ref=OMEGA_REF)
+a_ho = sqrt(SpinorBEC.Units.HBAR / (ATOM.mass * OMEGA_REF))
+eps_dd = SpinorBEC.compute_a_dd(ATOM) / ATOM.a_s
+c_lhy = scalar_lhy_coefficient(ATOM.a_s / a_ho, N_ATOMS; eps_dd)
+
+V = zeros(Float64, npts...)
+@inbounds for I in CartesianIndices(V)
+    V[I] = 0.5 * sum(OMEGA_TRAP[d]^2 * grid.x[d][I[d]]^2 for d in 1:3)
+end
+
+# Observed dJz/dt from the ledger, for comparison.
+obs = Tuple{Float64,Float64}[]
+if !isempty(LEDGER) && isfile(LEDGER)
+    rows = readlines(LEDGER)[2:end]
+    ts = Float64[]; jz = Float64[]
+    for r in rows
+        p = split(r, ",")
+        length(p) >= 7 || continue
+        push!(ts, parse(Float64, p[1])); push!(jz, parse(Float64, p[7]))
+    end
+    for i in 2:length(ts)
+        push!(obs, (ts[i], (jz[i]-jz[i-1])/(ts[i]-ts[i-1])))
+    end
+end
+obs_rate(t) = isempty(obs) ? NaN :
+    obs[argmin(abs(o[1]-t) for o in obs)][2]
+
+@printf("\n%8s | %12s %12s %12s %12s | %12s\n",
+        "t", "DDI", "kinetic", "contact+LHY", "SUM", "observed")
+for i in 1:nf
+    key = "frame_" * lpad(i, 3, '0')
+    haskey(f, "$key/psi") || continue
+    t = f["$key/t"]
+    psi = ComplexF64.(f["$key/psi"])
+    t < 30.0 && continue                     # quench stage only: B = 0 there
+
+    ws = make_workspace(; grid, atom=ATOM,
+        interactions=InteractionParams(Dict(0 => c0, 1 => c1); c_lhy),
+        zeeman=TimeDependentZeeman(ConstantWaveform(0.0), ConstantWaveform(0.0),
+                                   ConstantWaveform(0.0), ConstantWaveform(0.0)),
+        potential=NoPotential(),
+        sim_params=SimParams(; dt=1e-3, n_steps=1, imaginary_time=false),
+        psi_init=psi, enable_ddi=true, c_dd=c_dd, backend=CPUBackend())
+    copyto!(ws.potential_values, V)
+
+    jz = jz_psi(Array(ws.state.psi), grid, F)
+    rate(term) = begin
+        h = zeros(ComplexF64, size(psi)...)
+        SpinorBEC.apply_operator!(h, term, ws, ws.state.psi)
+        -2 * imag(sum(conj.(h) .* jz)) * dV
+    end
+    r_ddi = rate(SpinorBEC.DDITerm())
+    r_kin = rate(SpinorBEC.KineticTerm())
+    r_con = rate(SpinorBEC.DensityC0Term(c0)) + rate(SpinorBEC.SpinC1Term(c1)) +
+            rate(SpinorBEC.LHYTerm())
+    @printf("%8.2f | %12.4e %12.4e %12.4e %12.4e | %12.4e\n",
+            t, r_ddi, r_kin, r_con, r_ddi + r_kin + r_con, obs_rate(t))
+end
+close(f)
+println("""
+Reading: a term whose rate matches the observed dJz/dt is the leak. If the SUM
+falls well short of `observed`, the discretised Hamiltonian is NOT the whole
+story and the remainder is boundary or time-stepping — which the box35 / dt5e4
+probes separate.""")

--- a/runs/eu_barnett_redo/variants.sh
+++ b/runs/eu_barnett_redo/variants.sh
@@ -38,6 +38,19 @@ declare -A BR_VARIANTS=(
 declare -A BR_PROD_VARIANTS=(
   [prod_dx22]="128,128,80|28.0,28.0,18.0|0|1.0e-3|NaN"    # current production, dx 0.22
   [prod_dx175]="160,160,100|28.0,28.0,18.0|0|1.0e-3|NaN"  # dx 0.175, 2x the cells
+  [prod_dx146]="192,192,120|28.0,28.0,18.0|0|1.0e-3|NaN"  # dx 0.146, third convergence point
+  # --- residual hunt. The dx series converged the CONVERSION (0.993 -> 1.060 ->
+  # 1.066) but left a leak of 0.243 that is no longer scaling away: 0.672 ->
+  # 0.286 -> 0.243, i.e. -57% then only -15% for the same 1.2x refinement. Two
+  # variables were never tested AT PRODUCTION STAGE LENGTHS -- both were ruled
+  # out at stir = 10, where the cloud is far more compact:
+  #   xy box  -- edge_x is 2.75e-04 at stir 30, 275x the 1e-6 target. Only z was
+  #             ever enlarged. 35/240 = 0.145833 holds dx EXACTLY equal to the
+  #             28/192 reference, so this is a one-variable change.
+  #   dt      -- the leak grows with the structure the quench injects, and that
+  #             is where a time-stepping error would also live.
+  [prod_box35]="240,240,120|35.0,35.0,18.0|0|1.0e-3|NaN"   # xy box 28 -> 35 at IDENTICAL dx
+  [prod_dt5e4]="192,192,120|28.0,28.0,18.0|0|5.0e-4|NaN"   # dt halved, geometry identical
 )
 
 # Export geometry for a PRODUCTION variant. Exists because `qsub -v` splits on


### PR DESCRIPTION
Started as a hunt for a residual `J_z` leak; ended by replacing the study's headline number with one that is actually converged.

## Result

**Of the orbital angular momentum lost after the quench, ~99% becomes spin.**

| quantity | value | evidence |
|---|---|---|
| efficiency `ΔF_z/|ΔL_z|` | **0.991** | box 42 and 46.7 give 0.9916 / 0.9912, and it is flat across the whole quench |
| `J_z` ledger leak | 0.9% of signal | edge fraction 2.4e-10, four orders under target |
| rotation is the cause | `Ω=0` → `J_z ≡ 0` | leak 7.5e-07 |
| DDI is the mechanism | DDI off → `L_z ≡ 0` | leak 2.1e-12 |
| sign follows rotation | `±Ω` mirror to 4 digits | every column |

## Why the efficiency replaced ΔF_z

`ΔF_z` is a transient — it rises through the whole quench (0.27 → 1.06, still rising at the end) and rises with the box:

| box | ΔF_z | efficiency | leak/conv | edge_xy |
|---|---|---|---|---|
| 35 | 0.9240 | 0.9806 | 2.0% | 1.95e-05 |
| 42 | 1.0133 | 0.9916 | 0.8% | 8.90e-07 |
| 46.7 | 1.0609 | 0.9912 | 0.9% | 2.41e-10 |

Same cause for both dependences: after the field is off the cloud expands freely, so a wider box or a longer window each let the relaxation run further. **Quoting ΔF_z means quoting the window.** The ratio removes it — 15% spread → 1.1%, and 0.04% between the two boxes that meet the edge target. The stir output *is* converged (8.6904 / 8.7026 / 8.7052, last step +0.03%), so only the quench transient moves.

## Predictions in this PR were wrong

The earlier body predicted `box35`/`dt5e4` would barely move and `dealias` would help. **Both wrong, in opposite directions:**

| probe | predicted | measured |
|---|---|---|
| dealias | helps | 0.2423 vs 0.2433 — nothing |
| dt/2 | no change | 0.2427 — correct |
| xy box | no change | 0.243 → 0.018, **13×** |

The leak was the box all along — but only the **xy** box. `J_z` is angular momentum about z, so wrapping in x or y corrupts it while density leaving through the z faces does not; enlarging the z box earlier changed nothing and sent the diagnosis down the wrong path. On a periodic box `L_z = -i(x∂_y - y∂_x)` is itself ill-defined because x and y jump at the edge, which is what surfaced in the torque budget as a "kinetic term" violation — a coordinate discontinuity, not Nyquist content, which is why dealiasing does nothing.

## Contents

- `torque_budget.jl` — per-term violation of `[H, J_z] = 0` on a real saved state. Seconds, where dynamic A/B probes took hours.
- `fig4_efficiency.py` — the transient and the ratio side by side. Replaces `fig4_convergence.py`, which asked whether ΔF_z converged; it does not, and that was the wrong question.
- `fig_core.py --tag=` — cell ledgers carry their geometry tag, and a chirality figure is only valid if all cells share one. It previously globbed fixed names and could silently mix geometries.
- Production variants `prod_box{35,42,47}`, `prod_dx{22,175,146}`, `prod_dt5e4` — `qsub -v` splits on commas, so tuples must go through `BR_VARIANT`, never `-v BR_N=...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)