### PR TITLE
fix(ddi): default the spherical cutoff and zero-padding ON

### DIFF
--- a/docs/reference/yaml_schema_reference.md
+++ b/docs/reference/yaml_schema_reference.md
@@ -162,15 +162,37 @@ Semantic details + interactions live in `docs/reference/dynamics.md`.
 | `secular` | Bool | false |
 | `quasi_2d` | Bool | false |
 | `l_z` | Real [0, 100] | — |
-| `trunc_radius` | Number or `"auto"`/`"box_half"` | off |
-| `padded` | Bool | false |
+| `trunc_radius` | Number or `"auto"`/`"box_half"`/`"none"`/`"off"` | `"auto"` |
+| `padded` | Bool | true |
 | `pad_factor` | Number or per-axis Vector | 2 |
+
+Both image-handling knobs default **on** as of 2026-07-29 (they were both off
+before). The bare periodic kernel they replace carries a $2 \times 10^{-2}$ to
+$5 \times 10^{-2}$ dipolar field error against free space, and that error is
+*flat in resolution* — $1.91 \times 10^{-2}$ at $32^3$, $48^3$ and $64^3$ alike —
+so refining the grid does not touch it. Set `padded: false` and
+`trunc_radius: none` to reproduce a pre-flip run. Measured by
+`scripts/ddi_cutoff_geometry_jz_probe.jl`.
+
+The two are **not independent knobs**. The cutoff alone fixes rotation
+covariance by ~1000× (the $J_z = L_z + \langle F_z\rangle$ violation rate drops
+$1.9\times10^{-2} \to 1.7\times10^{-5}$) while leaving the field *magnitude*
+essentially untouched ($2.1\times10^{-2} \to 2.0\times10^{-2}$), because the
+periodic images are still there. It is the padding that removes them.
+
+Because a dynamics step rebuilds the DDI kernel rather than inheriting it (the
+truncation and padding are baked into the kernel, not carried on `DDIParams`),
+an explicit opt-out written only in `ground_state` does **not** propagate — repeat
+it in the `dynamics` step too.
 
 **`padded`** (Tier B) enables the zero-padded, image-free convolution
 (Vico–Greengard): combined with `trunc_radius: auto` it removes the periodic
 images *exactly* (not just suppresses them), giving near-machine accuracy at
-fixed resolution. Cost: ~`prod(pad_factor)`× the grid FFT work + memory (≈8× at
-the default 2× pad in 3D). **`pad_factor`** sets the zero-pad multiple — a scalar
+fixed resolution. Cost is far below the naive `prod(pad_factor)`: at $D = 13$ the
+DDI step is dominated by the spin density and the Euler rotation on the unpadded
+grid rather than by the 6 FFTs, measuring **1.2–1.4×** per step. Memory is the
+real constraint — the padded context is ~290 MB at $64^3$ and ~975 MB at $96^3$.
+**`pad_factor`** sets the zero-pad multiple — a scalar
 or a per-axis vector. Use a smaller factor on thin axes for **anisotropic
 padding** (e.g. `pad_factor: [2.73, 2.73, 1.5]` for a pancake) to cut memory; the
 auto `trunc_radius` caps R at `(pad_factor_d − 1)·L_d` per axis to stay
@@ -186,11 +208,14 @@ un-padded convolution — with spectral accuracy at *fixed* resolution, rather t
 trying to converge it away by refining the grid. `h(0)=0` keeps the `Q(k=0)=0`
 spherical-cavity convention (no contact / −δ term is introduced); `h(x)→1` for
 `|k|R ≫ 1` leaves the bulk physics intact. A number sets `R` (in `a_ho` units);
-`"auto"`/`"box_half"` uses half the smallest box extent (the largest cutoff that
-avoids wrap-around in the periodic convolution). The quasi-2D kernel is the
-analytically z-integrated form and is already smooth, so `trunc_radius` does not
-apply there. Off by default (backward-compatible). Diagnostic:
-`scripts/ddi_truncation_isotropy_probe.jl`.
+`"auto"`/`"box_half"` picks the largest wrap-around-free cutoff: half the
+smallest box extent when unpadded, or `min(box diagonal, min_d (pad_factor_d −
+1)·L_d)` when padded. `"none"`/`"off"` restores the bare periodic kernel. The
+quasi-2D kernel is the analytically z-integrated form and is already smooth, so
+`trunc_radius` does not apply there. Diagnostics:
+`scripts/ddi_truncation_isotropy_probe.jl` (field isotropy),
+`scripts/ddi_cutoff_geometry_jz_probe.jl` (field error + $J_z$ violation vs a
+free-space reference, with a corrupted-kernel positive control).
 
 ### `B` — unified Zeeman block
 

--- a/scripts/ddi_cutoff_geometry_jz_probe.jl
+++ b/scripts/ddi_cutoff_geometry_jz_probe.jl
@@ -1,0 +1,333 @@
+# Diagnostic (A: code correctness): how much of the DDI kernel's J_z violation is
+# fixable by CUTOFF GEOMETRY, and would a CYLINDRICAL cutoff buy anything the
+# spherical cutoff + anisotropic zero-padding cannot already express?
+#
+# At B = 0 in an axially symmetric trap the exact free-space dipolar interaction
+# conserves J_z = L_z + <F_z>. The DDI is covariant under a SIMULTANEOUS rotation
+# of spin and space about z, and every other Hamiltonian term commutes with J_z on
+# its own, so the instantaneous violation rate
+#
+#     tau = d<J_z>/dt = -2 Im <H_DDI psi | J_z psi>,     H_DDI psi = (Phi . F) psi
+#
+# is ENTIRELY the DDI kernel's error, readable from a single state with no time
+# stepping (seconds, versus the 40-minute dynamic A/B).
+#
+# Two error sources are mixed into tau:
+#   (i)  periodic images / truncated kernel — cutoff + padding fix it, FLAT in n
+#   (ii) grid roughness (dx)                — falls as dx^2, no cutoff can help
+# Refining n at fixed box separates them: (i) plateaus, (ii) drops.
+#
+# Reported as tau / |E_DDI| (dimensionless — hbar = 1, so both are energies).
+#
+# The probe state is smooth by construction, which pushes channel (ii) far below
+# the kernel error; the n-refinement column is what confirms that rather than
+# assumes it.
+#
+# Dealias is left at its default (OFF). The default Orszag mask is a per-axis
+# index cutoff — a CUBE in k-space, which is only C4-symmetric about z and would
+# inject its own J_z violation on top of the kernel's.
+#
+# Run:
+#   julia --project=. scripts/ddi_cutoff_geometry_jz_probe.jl
+
+using SpinorBEC
+using FFTW, LinearAlgebra, Printf, Random
+
+const ATOM = Eu151
+const N_ATOMS = 30_000
+const OMEGA_REF = 628.3
+const SUPPORT_SIGMAS = 4.0     # density support half-extent taken as 4 sigma
+const PAD_POINT_CAP = 4_000_000  # skip padded configs above this many points
+
+"""
+Generic smooth probe state: a Gaussian envelope times a few box-commensurate
+Fourier modes with fixed pseudo-random coefficients, independent per spin
+component.
+
+The obvious states are all BLIND to this diagnostic — measured, not argued
+(`Q_xx x 1.3` is a kernel that cannot possibly conserve J_z, so any state that
+does not respond to it is disqualified):
+
+    uniform spinor x scalar envelope, elliptical   ->  4e-16   blind
+    azimuthal spin winding, round envelope         ->  1e-17   blind
+    azimuthal spin winding, elliptical envelope    ->  7e-18   blind
+    generic smooth random (this one)               ->  9e-2    responds 4.5x
+
+Two structural reasons. A state with a spatially UNIFORM spin direction makes
+<H psi|J_z psi> real term by term, so the imaginary part it is built from is
+identically zero. And any J_z EIGENSTATE gives tau = -2 j Im<H psi|psi> = 0
+whatever the kernel, which disqualifies the clean spin-texture states — they are
+exactly the ones a joint spin-space rotation leaves invariant. A generic state
+has neither property.
+
+Mode wavevectors are 2*pi*j/L_d per axis, so the state is the same physical
+function at every resolution and the n-refinement column means what it says.
+
+tau vanishes for the exact free-space kernel for ANY state (the DDI energy is
+invariant under the joint spin-space rotation, so Noether applies along the GP
+flow), so a generic state sharpens the diagnostic without weakening the null.
+"""
+function probe_state(grid, sm, sigma; seed=20260729, n_modes=1)
+    n = grid.config.n_points
+    D = size(sm.Fz, 1)
+    box = grid.config.box_size
+    rng = MersenneTwister(seed)
+    w = 2 * n_modes + 1
+    A = randn(rng, ComplexF64, w, w, w, D)
+    psi = zeros(ComplexF64, n..., D)
+    x, y, z = grid.x[1], grid.x[2], grid.x[3]
+    @inbounds for I in CartesianIndices(n)
+        X, Y, Z = x[I[1]], y[I[2]], z[I[3]]
+        env = exp(-X^2 / (2 * sigma[1]^2) - Y^2 / (2 * sigma[2]^2) - Z^2 / (2 * sigma[3]^2))
+        for c in 1:D
+            s = zero(ComplexF64)
+            for d in 1:w, b in 1:w, a in 1:w
+                ph = (a - n_modes - 1) * X / box[1] + (b - n_modes - 1) * Y / box[2] +
+                     (d - n_modes - 1) * Z / box[3]
+                s += A[a, b, d, c] * cis(2π * ph)
+            end
+            psi[I, c] = env * s
+        end
+    end
+    psi ./= sqrt(sum(abs2, psi) * cell_volume(grid))
+    psi
+end
+
+"L_z psi = -i (x d_y - y d_x) psi, spectrally, per spin component."
+function lz_psi(psi, grid)
+    n = grid.config.n_points
+    D = size(psi, 4)
+    dx = grid.dx
+    kx = collect(fftfreq(n[1], 2π / dx[1]))
+    ky = collect(fftfreq(n[2], 2π / dx[2]))
+    x, y = grid.x[1], grid.x[2]
+    out = similar(psi)
+    for c in 1:D
+        u = @view psi[:, :, :, c]
+        ux = ifft(im .* reshape(kx, :, 1, 1) .* fft(u, 1), 1)
+        uy = ifft(im .* reshape(ky, 1, :, 1) .* fft(u, 2), 2)
+        @inbounds for I in CartesianIndices(n)
+            out[I, c] = -im * (x[I[1]] * uy[I] - y[I[2]] * ux[I])
+        end
+    end
+    out
+end
+
+"J_z psi = L_z psi + F_z psi."
+function jz_psi(psi, grid, sm)
+    out = lz_psi(psi, grid)
+    mz = diag(Matrix(sm.Fz))
+    D = size(psi, 4)
+    @inbounds for c in 1:D
+        @views out[:, :, :, c] .+= mz[c] .* psi[:, :, :, c]
+    end
+    out
+end
+
+"H_DDI psi = (Phi_x F_x + Phi_y F_y + Phi_z F_z) psi — the mean-field operator."
+function hddi_psi(psi, sm, phi)
+    n = size(psi)[1:3]
+    D = size(psi, 4)
+    Fx, Fy, Fz = Matrix(sm.Fx), Matrix(sm.Fy), Matrix(sm.Fz)
+    px, py, pz = phi
+    out = zeros(ComplexF64, size(psi))
+    @inbounds for I in CartesianIndices(n)
+        for cp in 1:D, c in 1:D
+            m = px[I] * Fx[c, cp] + py[I] * Fy[c, cp] + pz[I] * Fz[c, cp]
+            iszero(m) && continue
+            out[I, c] += m * psi[I, cp]
+        end
+    end
+    out
+end
+
+struct Cfg
+    name::String
+    trunc::Union{Nothing, Float64}
+    pad::Union{Nothing, NTuple{3, Float64}}
+    corrupt::Float64        # POSITIVE CONTROL: scale Q_xx by this (1.0 = untouched)
+end
+Cfg(name, trunc, pad) = Cfg(name, trunc, pad, 1.0)
+
+"Dipolar field Phi and spin density F for one cutoff/padding configuration."
+function ddi_fields(grid, sm, psi, cfg, c_dd)
+    n_pts = grid.config.n_points
+    D = size(psi, 4)
+    ddi = make_ddi_params(grid, ATOM; c_dd, trunc_radius=cfg.trunc)
+    # Positive control. Scaling Q_xx alone destroys the x<->y symmetry of the
+    # kernel, so it CANNOT be covariant under rotation about z and MUST produce a
+    # nonzero tau. If this row reads machine epsilon too, the meter is broken and
+    # every null above it is uninterpretable.
+    cfg.corrupt == 1.0 || (ddi.Q_xx .*= cfg.corrupt)
+    if cfg.pad === nothing
+        bufs = make_ddi_buffers(n_pts)
+        SpinorBEC._compute_and_convolve_ddi!(psi, sm, ddi, bufs, Val(D), 3, n_pts)
+        return ((bufs.Phi_x, bufs.Phi_y, bufs.Phi_z), (bufs.Fx_r, bufs.Fy_r, bufs.Fz_r))
+    end
+    ctx = make_ddi_padded(grid, ATOM; c_dd, trunc_radius=cfg.trunc, pad_factor=cfg.pad,
+        fft_flags=FFTW.ESTIMATE)
+    SpinorBEC._compute_and_convolve_ddi_padded!(psi, sm, ddi, ctx, Val(D), 3, n_pts)
+    crop = CartesianIndices(n_pts)
+    ((ctx.Phi_x_pad[crop], ctx.Phi_y_pad[crop], ctx.Phi_z_pad[crop]),
+        (ctx.Fx_pad[crop], ctx.Fy_pad[crop], ctx.Fz_pad[crop]))
+end
+
+"""
+tau / |E_DDI| and, against a free-space reference field, max relative field error.
+
+The two metrics answer different questions and NEITHER is sufficient alone:
+
+  tau  sees ROTATION COVARIANCE. The periodic image lattice is cubic and breaks
+       it, which is what tau catches. But a spherical cutoff is exactly covariant
+       at ANY radius, so a far-too-small R scores perfectly here while quietly
+       deleting real interaction. A cylindrical cutoff is axially symmetric too,
+       so tau cannot rank sphere against cylinder at all.
+
+  err  sees MAGNITUDE. Comparing Phi to the free-space field catches a cutoff
+       radius that is too small, which is the failure mode tau is blind to.
+
+`ref_phi` must be the exact free-space field. No separate large-box build is
+needed: a spherical cutoff at R >= (the support's own diameter) on a grid padded
+to f_d >= 1 + R/L_d IS the free-space convolution, which is exactly the
+"pad exact" configuration.
+"""
+function measure(grid, sm, psi, jzp, cfg, c_dd; ref_phi=nothing)
+    dV = cell_volume(grid)
+    phi, fdens = ddi_fields(grid, sm, psi, cfg, c_dd)
+    hpsi = hddi_psi(psi, sm, phi)
+    tau = -2 * imag(sum(conj(hpsi) .* jzp)) * dV
+    e_ddi = 0.5 * sum(phi[1] .* fdens[1] .+ phi[2] .* fdens[2] .+ phi[3] .* fdens[3]) * dV
+    err = if ref_phi === nothing
+        NaN
+    else
+        num = maximum(max.(abs.(phi[1] .- ref_phi[1]), abs.(phi[2] .- ref_phi[2]),
+            abs.(phi[3] .- ref_phi[3])))
+        den = maximum(max.(abs.(ref_phi[1]), abs.(ref_phi[2]), abs.(ref_phi[3])))
+        num / max(den, eps())
+    end
+    (tau=tau, e_ddi=e_ddi, ratio=abs(tau) / max(abs(e_ddi), eps()), err=err, phi=phi)
+end
+
+"""
+Minimum zero-pad factors that make each cutoff shape EXACT, given a density
+support of half-extents `a`. The truncation region must contain every pairwise
+separation vector of the support, and the pad must be long enough to hold the
+cutoff extent along each axis.
+
+The support is an ELLIPSOID with semi-axes `a` (a Gaussian cloud), so its
+self-difference is the same ellipsoid scaled by 2, and the smallest enclosing
+
+    sphere:   R = 2 max(a_d)
+    cylinder: rho_c = 2 max(a_x, a_y),  Z_c = 2 a_z
+
+Treating the support as a BOX instead takes its corner, `R = 2|a|`, which
+overestimates the sphere on every geometry and manufactures a spurious cylinder
+saving even for a round cloud, where symmetry forces the two to be equal.
+
+Padding then needs f_d = 1 + (cutoff extent along d) / L_d. Note the cylinder
+sized to the cloud gives f_d = 2 on EVERY axis — a cylindrical cutoff matched to
+the box is just plain 2x zero-padding, which `pad_factor: 2.0` already is.
+
+The ratio of the two padded volumes is the entire cost case for a cylindrical
+kernel: it is what the cylinder buys BEFORE paying for the quadrature and the
+loss of rotation covariance.
+"""
+function pad_cost(box, a)
+    R = 2 * maximum(a)
+    rho_c = 2 * max(a[1], a[2])
+    z_c = 2 * a[3]
+    f_sph = ntuple(d -> 1 + R / box[d], 3)
+    f_cyl = (1 + rho_c / box[1], 1 + rho_c / box[2], 1 + z_c / box[3])
+    (R=R, rho_c=rho_c, z_c=z_c, f_sph=f_sph, f_cyl=f_cyl,
+        saving=prod(f_sph) / prod(f_cyl))
+end
+
+function run_geometry(label, box, sigma, n_list)
+    sm = spin_matrices(1)          # kernel geometry is F-independent; D=3 for speed
+    c_dd = compute_c_dd_dimless(ATOM; N_atoms=N_ATOMS, omega_ref=OMEGA_REF)
+    a = ntuple(d -> min(SUPPORT_SIGMAS * sigma[d], box[d] / 2), 3)
+    cost = pad_cost(box, a)
+
+    @printf("\n=== %s   box=%s  sigma=%s\n", label, box, sigma)
+    @printf("    support half-extent a = (%.1f, %.1f, %.1f)\n", a...)
+    @printf("    exact sphere   R=%.1f  -> pad (%.2f, %.2f, %.2f)  vol x%.1f\n",
+        cost.R, cost.f_sph..., prod(cost.f_sph))
+    @printf("    exact cylinder rho=%.1f Z=%.1f -> pad (%.2f, %.2f, %.2f)  vol x%.1f\n",
+        cost.rho_c, cost.z_c, cost.f_cyl..., prod(cost.f_cyl))
+    @printf("    >> cylinder would save %.2fx padded volume\n", cost.saving)
+
+    # "sphere R=Lmin, pad 2" is the config that carries the whole cylinder case:
+    # at plain 2x padding a spherical cutoff is capped at R <= Lmin, while a
+    # cylinder at the SAME memory reaches rho_c = Lperp, Z_c = Lz and is exact.
+    # Its field error against the free-space reference is therefore exactly what a
+    # cylindrical kernel would buy at equal cost.
+    ref = Cfg("sphere R=Rexact, pad exact (= free space)", cost.R, cost.f_sph)
+    cfgs = [
+        Cfg("bare (production default)", nothing, nothing),
+        Cfg("sphere R=Lmin/2, unpadded", minimum(box) / 2, nothing),
+        Cfg("sphere R=Lmin, pad 2", minimum(box), (2.0, 2.0, 2.0)),
+        ref,
+        # The reference reads err = 0 against itself by construction, which proves
+        # nothing about the reference. Padding it 1.25x further must not move the
+        # field: if this row is not at round-off, "pad exact = free space" is an
+        # assumption rather than a measurement and every err above it is suspect.
+        Cfg("REF CHECK: pad exact x1.25", cost.R, ntuple(d -> 1.25 * cost.f_sph[d], 3)),
+        Cfg("CONTROL: Q_xx x1.3, bare", nothing, nothing, 1.3),
+    ]
+
+    over_cap(cfg, n) = cfg.pad !== nothing &&
+                       prod(ntuple(d -> ceil(Int, cfg.pad[d] * n[d]), 3)) > PAD_POINT_CAP
+
+    results = Dict{Tuple{String, Any}, Any}()
+    for n in n_list
+        grid = make_grid(GridConfig(n, box))
+        psi = probe_state(grid, sm, sigma)
+        jzp = jz_psi(psi, grid, sm)
+        ref_phi = over_cap(ref, n) ? nothing :
+                  measure(grid, sm, psi, jzp, ref, c_dd).phi
+        for cfg in cfgs
+            results[(cfg.name, n)] = over_cap(cfg, n) ? nothing :
+                                     measure(grid, sm, psi, jzp, cfg, c_dd; ref_phi)
+        end
+    end
+
+    for (title, field) in (("tau/|E_DDI|  (rotation covariance)", :ratio),
+        ("max field error vs free space  (magnitude)", :err))
+        @printf("\n%-40s", title)
+        for n in n_list
+            @printf("%14s", string(n))
+        end
+        println()
+        println("-"^(40 + 14 * length(n_list)))
+        for cfg in cfgs
+            @printf("%-40s", cfg.name)
+            for n in n_list
+                m = results[(cfg.name, n)]
+                m === nothing ? @printf("%14s", "skip>cap") :
+                @printf("%14.2e", getfield(m, field))
+            end
+            println()
+        end
+    end
+end
+
+function main()
+    println("DDI cutoff-geometry J_z probe — tau/|E_DDI|, static, no time stepping")
+    println("dealias: ", SpinorBEC.DEALIAS_2_3_ENABLED[], "  (cubic mask would add its own J_z violation)")
+    println("skipped padded configs above $(PAD_POINT_CAP) points are marked skip>cap")
+
+    run_geometry("isotropic (147 production configs)", (12.0, 12.0, 12.0),
+        (1.5, 1.5, 1.5), [(32, 32, 32), (48, 48, 48), (64, 64, 64)])
+    run_geometry("cigar aspect 2 (15 configs)", (12.0, 12.0, 24.0),
+        (1.5, 1.5, 3.0), [(32, 32, 64), (48, 48, 96)])
+    run_geometry("pancake aspect 2 (10 configs)", (20.0, 20.0, 10.0),
+        (2.5, 2.5, 1.25), [(32, 32, 16), (48, 48, 24)])
+
+    println("\nReading the table:")
+    println("  FLAT in n   -> kernel/image error; a better cutoff geometry can help.")
+    println("  FALLS in n  -> dx roughness; no cutoff geometry can help.")
+    println("  If 'pad exact' is already at the floor, a cylinder buys only the")
+    println("  padded-volume saving printed per geometry, not accuracy.")
+end
+
+main()

--- a/src/workflow/experiments/pipeline/run_step_dynamics.jl
+++ b/src/workflow/experiments/pipeline/run_step_dynamics.jl
@@ -84,16 +84,22 @@ function _run_step(
     else
         prev_c_dd
     end
-    # DDI truncation / padding (Tier A/B). Like `secular`, these are not carried
-    # on the inherited `DDIParams` (the kernel bakes them in), so dynamics only
-    # applies them when an explicit dynamics `ddi:` block requests it; otherwise
-    # the bare kernel is rebuilt.
+    # DDI truncation / padding (Tier A/B). Like `secular`, these are NOT carried
+    # on the inherited `DDIParams` (the kernel bakes them in), so the dynamics
+    # kernel is rebuilt from these values rather than inherited from ws_prev.
+    # They therefore default the same way the ground_state block does — before
+    # 2026-07-29 they defaulted OFF here while a config could turn them ON in
+    # `ground_state`, which silently gave a padded GS feeding bare-kernel
+    # dynamics. A config that explicitly opts OUT in `ground_state` still has to
+    # repeat that opt-out here; the inherited DDIParams cannot carry it.
     ddi_trunc = if ddi_raw isa Dict
         _parse_ddi_trunc_radius(get(ddi_raw, "trunc_radius", nothing))
     else
-        NaN
+        DDI_TRUNC_RADIUS_DEFAULT
     end
-    ddi_padded_b = ddi_raw isa Dict ? Bool(get(ddi_raw, "padded", false)) : false
+    ddi_padded_b =
+        ddi_raw isa Dict ?
+        Bool(get(ddi_raw, "padded", DDI_PADDED_DEFAULT)) : DDI_PADDED_DEFAULT
     ddi_pf = ddi_raw isa Dict ? _parse_ddi_pad_factor(get(ddi_raw, "pad_factor", nothing)) : 2.0
 
     # Match the GS path: route the inner B dict through

--- a/src/workflow/experiments/schema/parsing_blocks.jl
+++ b/src/workflow/experiments/schema/parsing_blocks.jl
@@ -390,6 +390,14 @@ function _parse_gs_interactions(inter::Dict, atom)
     end
 end
 
+# Single declaration of the DDI image-handling defaults. Both the ground_state
+# parser and the dynamics step read these — the two used to carry independent
+# literals and disagreed, which is how a padded GS could feed bare-kernel
+# dynamics. `FieldSpec.default` in schema.jl is documentation only (nothing
+# reads that field), so these constants are the behaviour.
+const DDI_TRUNC_RADIUS_DEFAULT = -1.0   # make_workspace sentinel: ≤ 0 ⇒ auto
+const DDI_PADDED_DEFAULT = true
+
 """
     _parse_gs_ddi(ddi_d, inter, atom)
         -> (enabled, c_dd, secular, quasi_2d, l_z, trunc_radius, padded, pad_factor)
@@ -402,10 +410,20 @@ or pass an explicit user value here. Opt-outs: `ddi: false` or
 be derived, so DDI ends up off too.
 
 `trunc_radius` (Ronen spherical-cutoff radius) is a `Float64` sentinel for
-`make_workspace`: `NaN` = off (default), `≤ 0` = auto, `> 0` = explicit R.
-`padded` (Bool) enables the zero-padded, image-free convolution (Tier B);
-`pad_factor` (a number or per-axis vector) sets the zero-pad multiple
-(default `2`; smaller on thin axes for anisotropic padding).
+`make_workspace`: `≤ 0` = auto (default), `> 0` = explicit R, `NaN` = off
+(`trunc_radius: none`). `padded` (Bool, default `true`) enables the
+zero-padded, image-free convolution (Tier B); `pad_factor` (a number or
+per-axis vector) sets the zero-pad multiple (default `2`; smaller on thin
+axes for anisotropic padding).
+
+Cutoff and padding both default ON as of 2026-07-29. They are not
+independent knobs: the cutoff alone fixes rotation covariance by ~1000x
+(J_z violation 1.9e-2 → 1.7e-5) while leaving the field magnitude
+essentially untouched (2.1e-2 → 2.0e-2), because the periodic images are
+still there. It is the PADDING that removes them. Cost at D=13 is 1.2–1.4x
+per DDI step (the step is dominated by the spin density and the Euler
+rotation on the unpadded grid, not by the 6 FFTs) plus the padded context:
+~290 MB at 64³, ~975 MB at 96³.
 """
 function _parse_gs_ddi(ddi_d, inter, atom)
     if ddi_d === false || (ddi_d isa Dict && get(ddi_d, "enabled", true) === false)
@@ -429,7 +447,7 @@ function _parse_gs_ddi(ddi_d, inter, atom)
     q2d = Bool(get(ddi_d, "quasi_2d", false))
     lz = Float64(get(ddi_d, "l_z", 0.0))
     trunc = _parse_ddi_trunc_radius(get(ddi_d, "trunc_radius", nothing))
-    padded = Bool(get(ddi_d, "padded", false))
+    padded = Bool(get(ddi_d, "padded", DDI_PADDED_DEFAULT))
     pad_factor = _parse_ddi_pad_factor(get(ddi_d, "pad_factor", nothing))
     (enabled, c_dd, secular, q2d, lz, trunc, padded, pad_factor)
 end
@@ -438,15 +456,27 @@ end
     _parse_ddi_trunc_radius(raw) -> Float64
 
 Map a YAML `ddi.trunc_radius` value to the `make_workspace` sentinel:
-`nothing` ⇒ `NaN` (off); `"auto"`/`"box_half"` ⇒ `-1.0` (auto); a number ⇒
-that value.
+absent ⇒ `-1.0` (auto); `"auto"`/`"box_half"` ⇒ `-1.0`; `"none"`/`"off"` ⇒
+`NaN` (the bare periodic kernel); a number ⇒ that value.
+
+Absent used to mean OFF. Measured 2026-07-29 (`scripts/ddi_cutoff_geometry_jz_probe.jl`):
+the bare periodic kernel carries a 2.1e-2 … 4.7e-2 dipolar field error against
+free space, and the error is FLAT in resolution — 1.91e-2 at 32³, 48³ and 64³
+alike — so no amount of grid refinement touches it. `"none"` keeps the old
+behaviour for anyone who needs to reproduce a pre-flip run.
 """
 function _parse_ddi_trunc_radius(raw)
-    raw === nothing && return NaN
+    raw === nothing && return DDI_TRUNC_RADIUS_DEFAULT
     if raw isa AbstractString
         s = lowercase(strip(raw))
         (s == "auto" || s == "box_half") && return -1.0
-        throw(ArgumentError("ddi.trunc_radius string must be \"auto\"/\"box_half\", got \"$raw\""))
+        (s == "none" || s == "off") && return NaN
+        throw(
+            ArgumentError(
+                "ddi.trunc_radius string must be " *
+                "\"auto\"/\"box_half\"/\"none\"/\"off\", got \"$raw\"",
+            ),
+        )
     end
     Float64(raw)
 end

--- a/src/workflow/experiments/schema/schema.jl
+++ b/src/workflow/experiments/schema/schema.jl
@@ -236,11 +236,12 @@ const DDI_SCHEMA = Dict{String, FieldSpec}(
     "secular" => FieldSpec(; type=Bool, default=false),
     "quasi_2d" => FieldSpec(; type=Bool, default=false),
     "l_z" => FieldSpec(; type=Number, range=(0.0, 100.0)),
-    # Ronen spherical-truncation radius (Tier A): a number (physical R), or
-    # "auto"/"box_half" for half the smallest box extent.
+    # Ronen spherical-truncation radius (Tier A): a number (physical R),
+    # "auto"/"box_half" for the largest radius the padding admits, or
+    # "none"/"off" for the bare periodic kernel. Defaults to auto.
     "trunc_radius" => FieldSpec(; type=Union{Number, String}),
     # Tier B: zero-padded, image-free convolution + optional anisotropic pad.
-    "padded" => FieldSpec(; type=Bool, default=false),
+    "padded" => FieldSpec(; type=Bool, default=true),   # was false, flipped 2026-07-29
     "pad_factor" => FieldSpec(; type=Union{Number, Vector}),
 )
 

--- a/src/workflow/initialization/make_workspace.jl
+++ b/src/workflow/initialization/make_workspace.jl
@@ -70,6 +70,14 @@ function make_workspace(;
     raman::Union{Nothing, RamanCoupling{N}, TimeDependentRaman{N}}=nothing,
     loss::Union{Nothing, LossParams}=nothing,
     fft_flags=FFTW.MEASURE,
+    # Deliberately OFF here while the YAML/DSL surface defaults them ON
+    # (`DDI_PADDED_DEFAULT` / `DDI_TRUNC_RADIUS_DEFAULT` in
+    # schema/parsing_blocks.jl). This is the library primitive — every knob is
+    # explicit, and flipping it would silently change every direct-call test and
+    # A/B fixture. Callers building a workspace by hand for production physics
+    # want `ddi_padding=true, ddi_trunc_radius=-1.0`: without them the bare
+    # periodic kernel carries a 2-5% dipolar field error that is flat in
+    # resolution (scripts/ddi_cutoff_geometry_jz_probe.jl).
     ddi_padding::Bool=false,
     ddi_trunc_radius::Float64=NaN,
     ddi_pad_factor::Union{Real, NTuple{N, Real}}=2,

--- a/test/workflow/test_config.jl
+++ b/test/workflow/test_config.jl
@@ -150,6 +150,39 @@
         @test p["ddi"]["c_dd"] == 211.0
     end
 
+    @testset "parsing - DDI image handling defaults ON" begin
+        # Flipped 2026-07-29. The bare periodic kernel carries a 2.1e-2 … 4.7e-2
+        # dipolar field error against free space, FLAT in resolution (1.91e-2 at
+        # 32³, 48³ and 64³ alike), so it is not something a finer grid fixes.
+        # Measured by scripts/ddi_cutoff_geometry_jz_probe.jl.
+        atom = SpinorBEC.resolve_atom(:Eu151)
+        inter = Dict("N_atoms" => 30000, "omega_ref" => 628.3)
+
+        _, _, _, _, _, trunc, padded, pf = SpinorBEC._parse_gs_ddi(Dict{String, Any}(), inter, atom)
+        @test padded == true
+        @test trunc == SpinorBEC.DDI_TRUNC_RADIUS_DEFAULT
+        @test trunc <= 0        # make_workspace's "auto" sentinel
+        @test pf == 2.0
+
+        # Both knobs stay individually addressable — the opt-out is the escape
+        # hatch for reproducing a pre-flip run.
+        _, _, _, _, _, _, padded_off, _ = SpinorBEC._parse_gs_ddi(
+            Dict{String, Any}("padded" => false), inter, atom)
+        @test padded_off == false
+        @test isnan(SpinorBEC._parse_ddi_trunc_radius("none"))
+        @test isnan(SpinorBEC._parse_ddi_trunc_radius("off"))
+        @test SpinorBEC._parse_ddi_trunc_radius("auto") == -1.0
+        @test SpinorBEC._parse_ddi_trunc_radius(7.5) == 7.5
+
+        # The dynamics step rebuilds the DDI kernel instead of inheriting it, so
+        # it must default the same way or a config with no explicit `ddi:` block
+        # gets a padded ground state feeding bare-kernel dynamics. Pinning the
+        # shared constants is what keeps the two call sites from drifting apart
+        # again — they used to carry independent literals.
+        @test SpinorBEC.DDI_PADDED_DEFAULT == true
+        @test SpinorBEC.DDI_TRUNC_RADIUS_DEFAULT == -1.0
+    end
+
     @testset "run_config - ground_state" begin
         yaml = """
         pipeline:


### PR DESCRIPTION
## What

The bare periodic DDI kernel — what **379 of 384 DDI configs run today**, since `trunc_radius` appeared in zero of them and padding in five — carries a **2.1e-2 to 4.7e-2** dipolar field error against free space. The error is **flat in resolution**: 1.91e-2 at 32³, 48³ and 64³ alike, so no amount of grid refinement touches it.

This flips both image-handling defaults on for the YAML/DSL surface.

## How it was measured

New probe `scripts/ddi_cutoff_geometry_jz_probe.jl` (first commit) reports two metrics against a free-space reference, because neither is sufficient alone:

- **`tau = d<J_z>/dt = -2 Im <H_DDI psi | J_z psi>`** — sees *rotation covariance*. Static, seconds, no time stepping. Blind to a too-small cutoff radius, which stays exactly covariant while deleting real interaction.
- **max field error vs free space** — sees *magnitude*, which is exactly what `tau` misses.

Both meters are validated in-table rather than assumed:

- **positive control**: a kernel corrupted with `Q_xx *= 1.3` cannot conserve J_z, and the table shows it responding 4.5×. This is load-bearing — the obvious probe states (uniform spin direction, or any J_z eigenstate) read machine epsilon *even for the corrupted kernel*, so a null from them is a statement about the state, not the kernel.
- **reference self-check**: padding a further 1.25× must not move the field (reads 1e-10 … 1e-11).

| config | field err vs free space | tau/E_DDI |
|---|---|---|
| bare, unpadded (old default) | 2.1e-2 … 4.7e-2 | 1.6e-2 … 3.2e-2 |
| spherical cutoff, unpadded | 2.0e-2 … 3.2e-2 | 1.3e-9 … 2.2e-5 |
| cutoff + plain 2× padding (new default) | 0 (isotropic) … 3.9e-3 | ~3e-9 |

**The cutoff alone is not the fix.** It restores rotation covariance by ~1000× while leaving the field magnitude essentially untouched, because the periodic images are still there. It is the padding that removes them. Both default on together.

## One declaration, two call sites

The defaults existed as **independent literals** in `_parse_gs_ddi` and `run_step_dynamics`, both saying "off". Flipping only one would have given a padded ground state feeding bare-kernel dynamics, since a dynamics step *rebuilds* the DDI kernel rather than inheriting it (truncation and padding are baked into the kernel, not carried on `DDIParams`). Both now read `DDI_PADDED_DEFAULT` / `DDI_TRUNC_RADIUS_DEFAULT`.

Incidentally: `FieldSpec.default` in `schema.jl` is read nowhere in the codebase — it is documentation, not behaviour.

## Cost

Well below the naive `prod(pad_factor)`: at D=13 the DDI step is dominated by the spin density and the Euler rotation on the unpadded grid rather than by the 6 FFTs.

| grid (D=13) | unpadded | pad 2 | ratio | padded ctx |
|---|---|---|---|---|
| 32³ | 36.2 ms | 43.7 ms | 1.21× | 36 MB |
| 64³ | 252.1 ms | 320.1 ms | 1.27× | 290 MB |
| 96³ | 780.9 ms | 1123.8 ms | 1.44× | 975 MB |

Memory is the real constraint: ~3.1 GB of padded context at 128³, which 13 configs use. Those are already TSUBAME-class runs, but it is a regression risk for anything running 128³ locally.

## What this does NOT do

1. **Existing cached results are not retroactively fixed.** `run_yaml` skips a config whose output files already exist — a re-run must delete them to benefit.
2. **An opt-out written only in `ground_state` does not propagate to `dynamics`.** `DDIParams` cannot carry it; documented rather than fixed, since carrying it would change the struct.
3. **`make_workspace` keeps both off.** It is the library primitive where every knob is explicit, and flipping it would silently change every direct-call fixture. The asymmetry with the YAML layer is commented at the kwarg.

Escape hatch: `padded: false` + `trunc_radius: none` reproduces a pre-flip run.

## Testing

- `SPINORBEC_TEST_TIER=ci` — 254 files across 10 workers, all passed.
- New testset pins both defaults and the opt-out paths (`test/workflow/test_config.jl`, 51/51).

## Not verified

The probe uses F=1 (D=3) for speed, three geometries, one state seed. Kernel geometry is F-independent, but the numbers are not confirmed at F=6.

---

Context: this started as an evaluation of whether to implement a **cylindrical** truncated kernel. It should not be built. Production box aspect ratios are 235/294 exactly isotropic with a maximum of 2.0; a cylinder sized to the cloud gives pad factor 2 on every axis — i.e. a cylindrical cutoff matched to the box just *is* plain 2× zero-padding. Against the sphere it buys 1.00× at isotropic (symmetry forces equality) and 2.25× / 1.5× on the aspect-2 geometries: **config-weighted mean 1.12×**, before paying for a semi-analytic Bessel quadrature and for losing the sphere's free rotation covariance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)