### PR TITLE
fix(lbfgs): `method: lbfgs` ran every ground state with NO tabulated LHY

### DIFF
--- a/src/solvers/lbfgs/driver.jl
+++ b/src/solvers/lbfgs/driver.jl
@@ -56,6 +56,14 @@ function find_ground_state_lbfgs(;
     # VRAM-constrained at large grids.
     verbose::Bool=_default_solver_verbose(),
     light_shift::Union{Nothing, LightShift}=nothing,
+    # Spinor (tabulated) LHY. Until 2026-07-29 these kwargs did not exist, so
+    # `find_ground_state_lbfgs` could not build a workspace carrying a
+    # `TabulatedLHY` at all — every LBFGS ground state ran with NO spinor LHY,
+    # silently. `scalar` was unaffected because it rides in
+    # `interactions.c_lhy`, which was already threaded; only the modes that
+    # need a table (full_bdg / polar_contact / icosahedral / …) were dropped.
+    spinor_lhy::Union{Nothing, Symbol, AbstractLHY}=nothing,
+    lhy_opts::LHYTableOpts=LHYTableOpts(),
     dtype::Union{Nothing, Type{<:AbstractFloat}}=nothing,
     sobolev_alpha::Union{Float64, Symbol}=:auto,
     precond_alpha_v::Float64=-1.0,        # ≥0 ⇒ combined P_C = P_V^½ P_K P_V^½
@@ -140,7 +148,7 @@ function find_ground_state_lbfgs(;
             sim_params=sp, psi_init,
             enable_ddi, c_dd, secular_ddi, ddi_trunc_radius, ddi_padding, ddi_pad_factor,
             quasi_2d_ddi, l_z_ddi, backend,
-            light_shift, dtype,
+            light_shift, spinor_lhy, lhy_opts, dtype,
         )
     end
 

--- a/src/workflow/experiments/pipeline/run_step_ground_state.jl
+++ b/src/workflow/experiments/pipeline/run_step_ground_state.jl
@@ -539,6 +539,8 @@ function _run_step(
                 target_magnetization=target_mz, backend,
                 verbose,
                 light_shift=gs_light_shift,
+                spinor_lhy=spinor_lhy_mode,
+                lhy_opts=gs_lhy_opts,
                 pin=pin_closure, epsilon_ramp=pin_eps,
                 residual_polish,
             )

--- a/test/workflow/test_lhy_block_wiring.jl
+++ b/test/workflow/test_lhy_block_wiring.jl
@@ -11,6 +11,7 @@
 # out to be uniform, which must NOT trip the silent-zero throw.
 
 using Test
+using JLD2: jldopen
 using SpinorBEC
 using SpinorBEC: _build_spinor_lhy, _resolve_lhy_block!, LHYTableOpts, LHY_SCHEMA
 
@@ -131,6 +132,63 @@ _uniform(n=6) = (p=zeros(ComplexF64, n, n, n, _D1); p[:, :, :, 1].=0.4; p)
         @test "spatial" in LHY_SCHEMA["kind"].enum
         @test LHY_SCHEMA["n_bins"].default == 12
         @test LHY_SCHEMA["n_bins"].range == (2, 64)
+    end
+
+    @testset "method: lbfgs reaches the tabulated LHY (not just scalar)" begin
+        # `find_ground_state_lbfgs` had no `spinor_lhy` kwarg at all until
+        # 2026-07-29, and the pipeline's LBFGS branch passed none — so every
+        # `method: lbfgs` ground state ran with NO spinor LHY. It failed
+        # silently and in the worst possible direction: the texture B-scan's
+        # whole point was the A/B "does the phase assignment survive LHY?", and
+        # it came back bit-identical to its `kind: none` twin on all 34 shared
+        # points, which reads as the physics answer "LHY changes nothing".
+        #
+        # `scalar` was NOT affected — it rides in `interactions.c_lhy`, which
+        # was already threaded — so testing scalar alone would have stayed
+        # green throughout. The gate has to use a mode that needs a TABLE.
+        mktempdir() do dir
+            function run_kind(kind)
+                yaml = joinpath(dir, "gs_$kind.yaml")
+                write(
+                    yaml,
+                    """
+        units: {B: Gauss}
+        defaults: {kind: spinor, backend: cpu}
+        pipeline:
+          - ground_state:
+              atom: Eu151
+              interactions: {N_atoms: 50000, omega_ref: 691.1504, c1_ratio: 0.0}
+              grid: {n: [12, 12, 12], box: [12.0, 12.0, 12.0]}
+              potential: {type: harmonic, omega: [1.0, 1.0, 1.0]}
+              method: lbfgs
+              m_lbfgs: 6
+              ddi: {enabled: true, secular: false}
+              lhy: {kind: $kind}
+              B: {Bz: "6.0e-5 Gauss", theta: 0.0, phi: 0.0}
+              initial_state: flower
+              n_steps: 12
+              tol: 1.0e-8
+        """,
+                )
+                out = joinpath(dir, "out_$kind")
+                run_yaml(yaml; base_dir=out, verbose=false)
+                d = first(filter(isdir, joinpath.(out, readdir(out))))
+                f = first(filter(x -> endswith(x, ".jld2"), readdir(d)))
+                jldopen(joinpath(d, f), "r") do j
+                    (String(string(get(j, "lhy_kind", "?"))), Float64(get(j, "energy", NaN)))
+                end
+            end
+
+            kind_none, e_none = run_kind("none")
+            kind_pc, e_pc = run_kind("polar_contact")
+
+            @test kind_none == "none"
+            # The mode actually installed, not silently dropped to nothing.
+            @test occursin("PolarContact", kind_pc)
+            # And it CHANGED the answer. Bit-identity here is the bug.
+            @test e_pc != e_none
+            @test isfinite(e_pc)
+        end
     end
 
     @testset "LHYTableOpts is concrete" begin


### PR DESCRIPTION
`find_ground_state_lbfgs` had no `spinor_lhy` / `lhy_opts` kwargs at all, so it
could not build a workspace carrying a `TabulatedLHY` even in principle, and
the pipeline's LBFGS branch passed neither — while the ITP branch two screens
above passes both. Every `method: lbfgs` YAML ground state therefore ran with
no spinor LHY.

Reproduced minimally on CPU, no scan, no comparison_runs:

    method   kind             recorded lhy_kind   LHY active
    lbfgs    scalar           ScalarLHY           yes
    itp      scalar           ScalarLHY           yes
    itp      full_bdg         FullBdGLHY          yes
    lbfgs    full_bdg         none                NO
    lbfgs    polar_contact    none                NO

`scalar` is unaffected because it rides in `interactions.c_lhy`, which was
already threaded; only the modes that need a TABLE were dropped. A gate written
against scalar would have stayed green through all of this.

How it surfaced. `runs/eu_gs_phase_c1_B_kappa/config_texture_bscan_lhy_full_bdg.yaml`
exists to run one A/B — its header says "ONLY difference is `lhy.kind`. Its job
is the A/B: does 'PCV wins at 50 uG' survive LHY?" — and it uses
`method: lbfgs`. Against its own `kind: none` twin it came back bit-identical
on all 34 shared points, |D| = 0.0. That does not read as a broken run; it
reads as the physics answer "LHY changes nothing", which is the worst way for
this to fail.

After the fix, on the same 12^3 fixture:

    lhy: none            E = 6.756617
    lhy: polar_contact   E = 7.205216
    lhy: full_bdg        E = 2421.98      (ITP agrees to order: 2570.17)

Gate: `test/workflow/test_lhy_block_wiring.jl` -> "method: lbfgs reaches the
tabulated LHY (not just scalar)". It runs `none` and `polar_contact` through
`run_yaml` and asserts the mode is installed AND that the energy moved —
bit-identity is the bug, so equality is the failure condition.

Blast radius: 7 committed configs pair `method: lbfgs` with a tabulated kind,
all `full_bdg`, all under `runs/eu_gs_phase_c1_B_kappa/`. Every result from
them is mean-field regardless of what their `lhy:` block says, including the
texture B-scan whose phase assignments the Eu handoff calls "provisional
pending the LHY recompute" — that recompute has not actually happened yet.

Assisted-by: Claude Code (model: claude-opus-5[1m])

🤖 Generated with [Claude Code](https://claude.com/claude-code)
