### PR TITLE
docs: name the drift metric, and report the closure agreement I had omitted

### DIFF
--- a/docs/manuscript/four_figure_spec_2026_05_26.md
+++ b/docs/manuscript/four_figure_spec_2026_05_26.md
@@ -125,7 +125,20 @@ reproduces", with loss-on as bracket evidence not headline claim.
 > | polar_contact | 1.0921 | 4.9e-09 | +0.1146 / +2.359 | stable_arrest |
 > | icosahedral | 1.0923 | 4.9e-09 | +0.1146 / +2.359 | stable_arrest |
 >
-> Energy now conserves to ~1e-9 in every arm (was 46 % for the closed forms), and
+> **The two closed forms land 0.16 % apart, and that is real, not a bug.**
+> `polar_contact` and `icosahedral` give `lhy` = +0.11457 vs +0.11458 and ratios
+> 1.0921 vs 1.0923. Comparing the tables directly, `V_polar/V_icosa = 0.9983870`
+> at *every* density — a constant, because both closed forms are `ε = C·n^(5/2)`
+> and only `C` differs. Eu's g_S ladder is flat enough (2681…3957, a 32 % spread)
+> that the polar and icosahedral channel structures give nearly the same zero-point
+> sum. The code does discriminate: `fm_contact`, which uses only `g_{2F}`, sits
+> 46 % below both.
+>
+> This is an independent reason the figure's claim cannot hold here — two of the
+> three closures it contrasts are 0.16 % apart, so "the outcome is determined by
+> the LHY closure" has nothing to vary.
+>
+> Energy now conserves to ~1e-9 in every arm (was 135 % peak excursion for the closed forms), and
 > LHY is 5–7 % of the total rather than 97 %. The signs are physical: the LHY arms
 > have a *lower* initial peak than `off` (0.00432–0.00434 vs 0.00463) because a
 > repulsive correction broadens the ground state.
@@ -169,7 +182,7 @@ reproduces", with loss-on as bracket evidence not headline claim.
 > config that produced them was wrong in the field sign and has been fixed.
 >
 > **Only the first two rows are usable.** `off` and `scalar` conserve energy to
-> 2e-8 / 7e-8. The two closed-form arms drift **46 %** (E: 3123 → 1694) and their
+> 2e-8 / 7e-8. The two closed-form arms drift **135 %** peak excursion / 45 % endpoint (E: 3123 → 1694; `energy_rel_drift` is `max|E(t)−E(0)|/|E(0)|`, not the endpoint difference) and their
 > `energy_decomposition` puts **97 % of the total energy in the LHY term alone**
 > (`lhy = +1653` / `+1664` against a whole mean field of ≈ +2.2 in the other two
 > arms). Their ratios are not evidence of anything and are shown only to document
@@ -184,7 +197,7 @@ reproduces", with loss-on as bracket evidence not headline claim.
 >
 > The two dedicated gates for the tabulated path both pass at this commit
 > (`test_lhy_energy_convention.jl` 17/17, `test_tabulated_lhy_propagator_parity.jl`
-> 42/42), so the 46 % drift is **not** an energy/propagator/gradient inconsistency.
+> 42/42), so the drift is **not** an energy/propagator/gradient inconsistency.
 > It is the table's magnitude in this particular Eu F=6 configuration — tracked
 > separately; not diagnosed here.
 >

--- a/docs/validation/stored_results_vintage_audit.md
+++ b/docs/validation/stored_results_vintage_audit.md
@@ -156,7 +156,7 @@ Re-running the K₃=0 factorial on current `main`:
 | icosahedral | **1.2801** | stable_arrest | 1.5991 | stable_arrest |
 
 **Only the first two rows are usable**: `off` and `scalar` conserve energy to
-2e-8 / 7e-8, while the two closed-form arms drift **46 %** and report **97 % of
+2e-8 / 7e-8, while the two closed-form arms drift **135 %** (`energy_rel_drift`, i.e. peak excursion; 45 % at the endpoint) and report **97 % of
 the total energy in the LHY term** (`lhy = +1653` / `+1664` against a whole mean
 field of ≈ +2.2). Their ratios are recorded only to show the stored 1.63 / 1.60
 were not reproduced.
@@ -183,7 +183,7 @@ moved", then "the premise is gone", now "the comparison was never like-for-like"
 Each correction came from checking one more thing that should have been checked
 first — and the config's own git history was a five-second check.
 
-Both dedicated gates for the tabulated path pass at this commit, so the 46 % drift
+Both dedicated gates for the tabulated path pass at this commit, so the drift
 is not an energy/propagator/gradient inconsistency; it is the table's magnitude in
 this Eu F=6 configuration, tracked separately.
 
@@ -193,7 +193,7 @@ them they cover both ways a stored result can fail: the knob was broken, or the
 thing the knob acted on no longer happens.
 
 The 4× higher initial peak in the closed-form arms (0.0177–0.0185 vs
-0.0044–0.0046) has the same origin as their 46 % drift: an LHY term two to three
+0.0044–0.0046) has the same origin as their energy drift: an LHY term two to three
 orders of magnitude larger than the rest of the Hamiltonian.
 
 ## Recommended order


### PR DESCRIPTION
Follow-up to #175, which merged before this commit reached the branch. Two fixes to my own text in that PR.

## 1. "46 % drift" conflated two metrics

`energy_rel_drift` in `summary.json` is `max|E(t) − E(0)| / |E(0)|` — the **peak excursion**, which is **135 %** for these runs. The **45 %** I also quoted is the **endpoint** difference `|E(end) − E(0)| / |E(0)|`, computed separately. Both are true of the same run and I used them interchangeably without saying which was which. Now stated with the definition attached.

## 2. An observation I left out of the results table

`polar_contact` and `icosahedral` came out agreeing to 5 significant figures — `lhy` = +0.11457 vs +0.11458, ratio 1.0921 vs 1.0923. I published the table and said nothing about it.

Checked rather than left hanging: `V_polar / V_icosa = 0.9983870` at **every** density — a constant, because both closed forms are $\varepsilon = C n^{5/2}$ and only $C$ differs. Eu's $g_S$ ladder spans just 32 % (2681…3957), flat enough that the polar and icosahedral channel structures give nearly the same zero-point sum. `fm_contact`, which uses only $g_{2F}$, sits 46 % below both — so the code *is* discriminating between the closures.

Benign, but it is an **independent** reason Figure 2's claim cannot hold in this regime: two of the three closures it contrasts are 0.16 % apart, so "the outcome is determined by the LHY closure" has nothing to vary. That belonged in the first table, not a follow-up.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)