### PR TITLE
docs(validation): the LHY factorial ran under three defects — flag what it can and cannot support

### DIFF
--- a/docs/manuscript/four_figure_spec_2026_05_26.md
+++ b/docs/manuscript/four_figure_spec_2026_05_26.md
@@ -389,7 +389,13 @@ Fig 1 (d)    :  runs/matsui_baseline/matsui_5ms_n64_density_slice.json
 Fig 1 inset  :  runs/matsui_baseline/{matsui_40ms_lossy_medium,strong}.yaml
                   → analysis to extract N(t)/N(0) ratio for inset
 Fig 2 (a, b) :  runs/eu_k3_lhy_control/factorial_2x4.json
+                  !! 2026-07-29: every LHY-enabled cell ran under #125 / #158 /
+                  !! #174. The scalar rows had no dynamics LHY at all; the
+                  !! polar/icosa rows had it 30000x too strong, which is where
+                  !! the `stable_arrest` classification comes from. Being
+                  !! re-measured -- do not draw this panel from the current json.
 Fig 2 (c)    :  runs/eu_lhy_longtime/{polar,icosa}_{50,100,200}ms .jld2
+                  !! same three defects; re-running on TSUBAME.
                   → extract peak(t), N(t), Fz(t) trajectories
 Fig 3 (a, b) :  runs/eu_k3_sweep/summary.json + runs/eu_k3_sweep_96/summary.json
 Fig 4        :  runs/barnett_eu_window/summary.json

--- a/docs/validation/day_inventory_2026_05_26.md
+++ b/docs/validation/day_inventory_2026_05_26.md
@@ -60,8 +60,43 @@ docs/validation/figures/
 |---|---|
 | 1. L4 isotropic no-collapse | `runs/l4_k3_ladder/summary.json` + 12 cell dirs `L4_K3_n{64,96,128}_*_<hash>` |
 | 2. Matsui Fig 2C reproduction | `runs/matsui_baseline/summary.json` + `matsui_5ms_n64_density_slice.json` + 3 cell dirs |
-| 3. scalar LHY ≡ off at F=6 | `runs/eu_k3_lhy_control/factorial_2x4.json` (cells K3∈{0,200} × LHY=scalar vs off) |
-| 4. spinor LHY closure stabilizes alone | same factorial_2x4.json (K3=0 + polar/icosa rows) |
+| 3. scalar LHY ≡ off at F=6 — **evidence VACUOUS, see below** | `runs/eu_k3_lhy_control/factorial_2x4.json` (cells K3∈{0,200} × LHY=scalar vs off) |
+| 4. spinor LHY closure stabilizes alone — **UNDER REVIEW, see below** | same factorial_2x4.json (K3=0 + polar/icosa rows) |
+
+### 2026-07-29: the factorial ran under three LHY defects
+
+Every LHY-enabled cell of `factorial_2x4.json` predates fixes that change what it
+measured. Three defects, each silent:
+
+- **#174** — the dynamics phase never resolved its own `lhy:` block. For a
+  SCALAR kind that meant `interactions.c_lhy = 0`: **the dynamics ran with no
+  LHY at all** while `lhy: {kind: scalar}` sat in the YAML. Being absent rather
+  than wrong, it conserved energy and reported `lhy = +0` — the failure mode
+  that looks exactly like success.
+- **#158** — the closed-form tables were exactly `N_atoms` too large (here
+  30000×), in the **propagator** as well as the energy.
+- **#125** — the broadcast propagator, which the GPU always takes, dropped every
+  tabulated LHY entirely.
+
+**Claim 3 is circular.** "scalar LHY ≡ off" was read off two rows whose dynamics
+both ran with scalar LHY off:
+
+    K3=0, LHY=off      Fz_per_N = -4.2489457
+    K3=0, LHY=scalar   Fz_per_N = -4.2487269
+
+Agreement to 7 significant figures is the signature of the same physics run
+twice, not of a physical equivalence. The **conclusion may well survive** — at
+this gas parameter (`n_SI·a_s³ ≈ 4e-5`) a correctly-built scalar LHY is ~0.05%
+of the energy, so the difference would be small anyway — but this evidence does
+not establish it.
+
+**Claim 4 is the one that may not survive.** The `stable_arrest` classification
+appears only in the `polar_contact` / `icosa` rows, and those are exactly the
+rows whose LHY was **30000× too strong**. The arrest may be an artefact of the
+defect rather than of the closure.
+
+Both claims are being re-measured with all three fixes in; `fig4_lhy_model_
+interference.png` rests on the same factorial and inherits the same status.
 | 5. K3 not primary arrest mechanism | factorial_2x4.json + `runs/eu_k3_sweep/summary.json` (10-pt K3 sweep) + `runs/eu_k3_sweep_96/summary.json` (96³ anchor) |
 | LHY long-time stability | `runs/eu_lhy_longtime/` (5 cells: polar 50/100/200, icosa 50/100) |
 | Barnett window | `runs/barnett_eu_window/summary.json` (14 cells) |

--- a/docs/validation/self_contained_validation_report.md
+++ b/docs/validation/self_contained_validation_report.md
@@ -319,6 +319,18 @@ K1_gdr1_LHY0     on  on  off  -2.6911     0.9971           5.132e-3
 K1_gdr1_LHY1     on  on  on   -2.6926     0.9971           5.106e-3
 ```
 
+> **2026-07-29 — the four `LHY1` cells did not have LHY on during dynamics.**
+> `_resolve_lhy_block!` ran only for the ground_state step (#174), so a
+> `dynamics: {lhy: {kind: scalar}}` block reached `make_workspace` unresolved
+> and `interactions.c_lhy` stayed 0. The GS-phase LHY was applied; the dynamics
+> phase was not. So `LHY0` vs `LHY1` here compares *ground states*, not
+> trajectories, and the ⟨F_z⟩/N spread of 0.05% between them is the residual of
+> that, not a demonstration that the dynamics is insensitive to LHY.
+>
+> The **EdH transfer conclusion itself is unaffected** — it is invariant across
+> K3 and gdr as well, and those knobs were live. What cannot be claimed from
+> this table is robustness *to LHY* during the dynamics. Being re-measured.
+
 **Robust conclusions (invariant across all 8 cells):**
 
 - **EdH transfer signature**: ⟨F_z⟩/N falls from −F=−6 (initial m=−F)


### PR DESCRIPTION
## Inventory

98 configs under `runs/` enable an LHY, 41 have output, **22 are affected**:

| class | count | what happened |
|---|---|---|
| tabulated + GPU | 6 | LHY dropped entirely (#125) **and** N_atoms too strong (#158/#174) |
| tabulated + CPU | 4 | propagator ran, but N_atoms = 30000× too strong |
| scalar/quasi_2d dynamics | 12 | **dynamics ran with no LHY at all** (#174) |

They funnel into one artifact: `runs/eu_k3_lhy_control/factorial_2x4.json`,
which is the sole source for two documented claims.

## Claim 3 — "scalar LHY ≡ off at F=6" is circular

```
K3=0, LHY=off      Fz_per_N = -4.2489457
K3=0, LHY=scalar   Fz_per_N = -4.2487269
```

Seven significant figures is the signature of the same physics run twice, not of
a physical equivalence — #174 meant both dynamics arms had scalar LHY off.

**The conclusion may well survive.** At this gas parameter (`n_SI·a_s³ ≈ 4e-5`)
a correctly-built scalar LHY is ~0.05% of the energy, so the difference would be
small anyway. But this evidence does not establish it. Same verdict shape as
`b29e2a8d`: *the conclusion holds; its evidence was vacuous*.

## Claim 4 — "spinor LHY closure stabilizes alone" may not survive

`stable_arrest` appears **only** in the `polar_contact` / `icosa` rows — exactly
the rows whose LHY was 30000× too strong. The arrest may be an artefact of the
defect rather than of the closure. This is the one where the conclusion itself
is at risk.

## Also flagged

- **`self_contained_validation_report.md`**, 8-cell robust factorial: its four
  `LHY1` cells are four of the affected runs. `LHY0` vs `LHY1` there compares
  *ground states*, not trajectories. The **EdH transfer conclusion is
  unaffected** — invariant across K3 and gdr, and those knobs were live — but
  robustness *to LHY during dynamics* cannot be claimed from that table.
- **`four_figure_spec_2026_05_26.md`** Fig 2 (a,b) draws from this factorial and
  (c) from `eu_lhy_longtime`; both inherit the status. Consistent with #171
  already finding Fig 2 had lost its premise.

## Status

All 12 re-runs are queued on TSUBAME with the three fixes in
(`8293310`–`8293321`). This PR records what the **current** artifacts can and
cannot support rather than waiting for them — the docs presently assert things
the data does not show.

Docs only; no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)