### PR TITLE
test(seed_from): main went red on a 2.2 %-per-run flake, not on the change that merged

### DIFF
--- a/test/workflow/test_seed_from.jl
+++ b/test/workflow/test_seed_from.jl
@@ -6,11 +6,26 @@
 using Test
 using SpinorBEC
 using JLD2
+using Random
 
 @testset "seed_from warm-start" begin
     dir = mktempdir()
-    psi_a = randn(ComplexF64, 8, 8, 8, 3)     # F=1 → D=3, cubic even
-    psi_b = randn(ComplexF64, 8, 8, 8, 3)
+    # The "paired with point_001, not point_002" checks below discriminate by
+    # NORM, so the two decoys must be distinguishable by construction rather
+    # than by luck. Unscaled, `sum(abs2, randn(ComplexF64, 8,8,8,3))` is
+    # 3072 ± 78 (1536 entries, 2.55 % relative sd), so two independent draws
+    # land within the rtol=1e-3 of the negative assertions about 2.2 % of the
+    # time — which is exactly how this file went red on main at 2f81f4f7, both
+    # negative assertions failing together off one unlucky pair.
+    #
+    # Scaling psi_b puts the norms 9× apart, and the seed makes any future
+    # failure reproducible instead of a 1-in-45 mystery.
+    rng = MersenneTwister(20260729)
+    psi_a = randn(rng, ComplexF64, 8, 8, 8, 3)     # F=1 → D=3, cubic even
+    psi_b = 3.0 .* randn(rng, ComplexF64, 8, 8, 8, 3)
+    # Pin the precondition: if someone drops the scaling, this fails loudly
+    # rather than the file quietly becoming flaky again.
+    @test !isapprox(sum(abs2, psi_a), sum(abs2, psi_b); rtol=0.5)
     jldopen(joinpath(dir, "point_001_stretched.jld2"), "w") do f
         f["psi"] = psi_a
         f["override"] = Dict{String, Any}(


### PR DESCRIPTION
**main is currently red.** `test/workflow/test_seed_from.jl` failed at `2f81f4f7` (PR #178's merge), lines 47 and 76 failing **together**. Not caused by #178 — a latent flake that has been in the file since it was written, and #178 simply drew the unlucky pair.

## The flake

The test writes two decoy runs from unseeded `randn(ComplexF64, 8,8,8,3)`, then checks that the warm-start paired with `point_001` by **norm**: matches `psi_a` at `rtol=1e-6` (exact — spectral upsample preserves ∫|ψ|²) and *differs* from `psi_b` at `rtol=1e-3`.

But `sum(abs2, ·)` over 1536 complex standard normals is **3072 ± 78** — a 2.55 % relative sd. Two independent draws land within `1e-3` of each other about **2.2 % of runs**, and when they do, *both* negative assertions fail at once because they share the pair. Exactly the observed signature.

## The fix — structural, not statistical

- `psi_b` scaled ×3, putting the norms **9× apart by construction**
- RNG seeded, so any future failure reproduces instead of being a 1-in-45 mystery
- an explicit precondition asserts the two norms are far apart, so dropping the scaling fails **loudly** rather than quietly restoring the flake

## Class swept

The only two other files in `test/` pairing unseeded `randn` with a negative tolerance are both safe by construction: `test_itp_tol_drho.jl` compares `psi_phase` against the `psi` it was derived from, and `test_magnetic_gradient_analytic.jl` compares against `zero(psi)`.

**No static gate added, deliberately.** Distinguishing "two independent draws" from "a transformed copy of one draw" is not a grep, and those two files would be its false positives. The inline precondition is the local gate instead.

## Worth noting for the next red main

The docs-only merge that landed *after* `2f81f4f7` reports `success` — with the test steps skipped by the paths filter. **It does not clear a red main.** This was only visible by checking main's own CI rather than the PRs'.

`tier=fast`: 165 files, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)