### PR TITLE
fix(lbfgs): report a real dE, and leave the iterate the line search measured

### DIFF
--- a/src/solvers/lbfgs/driver.jl
+++ b/src/solvers/lbfgs/driver.jl
@@ -303,10 +303,15 @@ function find_ground_state_lbfgs(;
 
         # Carry the new gradient/energy to the next iteration (swap buffers so the
         # old `grad` is reused as scratch for the next `grad_new`).
+        # `E_prev` is the energy BEFORE this step, so `dE` is the step's energy
+        # decrease. It used to be assigned `E_trial` — the energy AT the accepted
+        # point, i.e. the same iterate `E_new` is measured at, and bit-identical
+        # to it — so the reported `dE` was exactly 0.0 from step 2 onward, for
+        # every run, including the value returned in `result.dE`.
         grad, grad_new = grad_new, grad
         grad_norm = grad_norm_new
+        E_prev = E
         E = E_new
-        E_prev = E_trial
         last_step = step
     end
 

--- a/src/solvers/lbfgs/helpers.jl
+++ b/src/solvers/lbfgs/helpers.jl
@@ -135,13 +135,21 @@ function _line_search_energy_decrease(
         # the local minimiser along the ray (steepest-descent scale finding).
         if expand
             best_α, best_E = α, E_trial
+            last_α = α
             for _ in 1:max_expand
                 α2 = best_α * grow
                 E2 = eval_energy(α2)
+                last_α = α2
                 (E2 < best_E && accept(α2, E2)) || break
                 best_α, best_E = α2, E2
             end
-            best_α == α || eval_energy(best_α)  # leave ws.state.psi at best
+            # Re-place the iterate whenever the LAST evaluation was somewhere
+            # other than `best_α`. The earlier guard was `best_α == α`, which is
+            # TRUE in the common case that the very first trial doubling is
+            # rejected — and then `ws.state.psi` was left at that rejected step
+            # while `best_E` described `α_init`. The returned energy and the
+            # workspace state disagreed.
+            last_α == best_α || eval_energy(best_α)  # leave ws.state.psi at best
             return best_α, best_E
         end
         return α, E_trial

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -195,6 +195,10 @@ const CI_EXTRA = [
     "solvers/test_checkpoint.jl",
     "solvers/test_itp_checkpoint_hook.jl",
     "solvers/test_itp_tol_drho.jl",
+    # In CI, not FULL, on purpose: every other L-BFGS test lives in FULL_EXTRA,
+    # so a green `ci` run executes none of them. This one is a 12x12x8 F=1
+    # problem — cheap enough to belong where it will actually run.
+    "solvers/test_lbfgs_line_search_and_de.jl",
     "analysis/test_energy.jl",
     # Evaporation OPTIMIZATION/SCAN tools run the scalar model in loops
     # (optimizer, parameter scans, K3 fit) — aggregate-heavy, kept out of the
@@ -620,6 +624,7 @@ const _COST = Dict{String, Float64}(
     "solvers/test_3d.jl" => 5.0,
     "dynamics/test_twa.jl" => 5.0,
     "solvers/test_lbfgs.jl" => 5.0,
+    "solvers/test_lbfgs_line_search_and_de.jl" => 15.0,
 )
 
 _cost(f) = get(_COST, f, _DEFAULT_COST)

--- a/test/solvers/test_lbfgs_line_search_and_de.jl
+++ b/test/solvers/test_lbfgs_line_search_and_de.jl
@@ -1,0 +1,73 @@
+# Two L-BFGS bookkeeping gates (2026-07-29).
+#
+# 1. The line search must leave `ws.state.psi` at the step whose energy it
+#    returns. Its own comment says "leave ws.state.psi at best", but the guard
+#    was `best_α == α_init`, which is TRUE in the common case that the first
+#    trial doubling is rejected — and then the workspace was left holding the
+#    rejected step while the returned energy described `α_init`. Latent today
+#    (the driver recomputes the retraction and `energy_gradient!` overwrites
+#    `ws.state.psi`), so only a direct call can see it; any caller that starts
+#    trusting the returned state would inherit a silent mismatch.
+#
+# 2. `result.dE` must be the energy change across the last step. `E_prev` was
+#    assigned the energy AT the accepted point — the same iterate `E_new` is
+#    measured at, and bit-identical to it — so `dE` was exactly 0.0 from step 2
+#    onward in every run.
+
+using SpinorBEC
+using LinearAlgebra
+using Test
+
+@testset "L-BFGS line-search state and dE bookkeeping" begin
+    grid = make_grid(GridConfig((12, 12, 8), (8.0, 8.0, 6.0)))
+    atom = AtomSpecies("test", 2.5e-25, 1, 50e-10, 60e-10, 6.977e-23)
+    base = (;
+        grid, atom,
+        interactions=InteractionParams(Dict(0 => 20.0, 1 => -0.5)),
+        potential=HarmonicTrap((1.0, 1.0, 1.5)),
+        initial_state=:polar,
+        verbose=false,
+    )
+
+    @testset "line search leaves the iterate its energy belongs to" begin
+        seed = find_ground_state_lbfgs(; base..., n_steps=5, tol=0.0)
+        ws = seed.workspace
+        psi = copy(ws.state.psi)
+        dV = cell_volume(grid)
+        F = atom.F
+
+        g = similar(psi)
+        E0 = SpinorBEC.energy_gradient!(g, psi, ws)
+        SpinorBEC._project_constraints!(g, psi, grid, nothing, F)
+
+        # Sweep the direction scale so the accept-then-expand branch, the
+        # backtracking branch, and the "first doubling rejected" corner are all
+        # exercised. Every accepted return must describe the state it leaves.
+        checked = 0
+        for s in (1.0e-6, 1.0e-4, 1.0e-2, 1.0e-1, 1.0, 10.0), expand in (false, true)
+            dirn = (-s) .* g
+            slope = real(dot(g, dirn)) * dV
+            α, E = SpinorBEC._line_search_energy_decrease(
+                psi, dirn, E0, ws, grid, dV, nothing, F;
+                slope=slope, expand=expand,
+            )
+            α == 0.0 && continue
+            checked += 1
+            @test total_energy(ws) == E
+        end
+        @test checked > 0
+    end
+
+    @testset "dE is the last step's energy change, not zero" begin
+        # The trajectory is deterministic, so a 6-step run's last step is
+        # exactly the 5-step run's endpoint: the 6-step run's reported dE must
+        # be the gap between the two runs' energies. `dE > 0` alone would be a
+        # weak (and, on a step whose line search fails, flaky) statement; this
+        # one is an identity. Before the fix it was exactly 0.0.
+        r5 = find_ground_state_lbfgs(; base..., n_steps=5, tol=0.0)
+        r6 = find_ground_state_lbfgs(; base..., n_steps=6, tol=0.0)
+        gap = abs(r6.energy - r5.energy)
+        @test gap > 0            # still descending, so the gate has teeth
+        @test r6.dE ≈ gap rtol = 1.0e-8
+    end
+end


### PR DESCRIPTION
Two bookkeeping defects in `find_ground_state_lbfgs`, found while reading the solver's hot path for a separate performance change. Split out so they can land on their own.

## `result.dE` was identically zero

`E_prev` was assigned `E_trial` — the energy **at** the accepted point. That is the same iterate `E_new` is measured at, and bit-identical to it, so `dE = abs(E - E_prev)` differenced a value against itself. From step 2 onward, every run reported `dE == 0.0`, including the value returned in the result NamedTuple and the one printed by `verbose`.

`E_prev` is now the energy before the step, so `dE` is the step's energy decrease.

## The line search could return an energy for a state it did not leave

The expansion phase guards its re-placement with `best_α == α_init`. That is true precisely in the common case where the **first** trial doubling is rejected — and in that case `ws.state.psi` was left holding the rejected step while the returned `best_E` described `α_init`. The function's own comment says it leaves the workspace at best.

Latent at HEAD: the driver recomputes the retraction and `energy_gradient!` overwrites `ws.state.psi`, so nothing observes it today. It is fixed here because it is a mismatch between a returned value and reachable state, and any caller that starts trusting the returned state would inherit it silently.

The guard is now on the last evaluated α.

## Gate

`test/solvers/test_lbfgs_line_search_and_de.jl`:

- the `dE` assertion is an identity, not a sign check: the trajectory is deterministic, so a 6-step run's last step is exactly the 5-step run's endpoint, and the 6-step run's `dE` must equal the gap between the two runs' energies. `dE > 0` alone would flake on a step whose line search fails.
- the line-search assertion sweeps the direction scale so the accept-then-expand branch, the backtracking branch, and the "first doubling rejected" corner are all exercised, and asserts `total_energy(ws) == E` exactly for every accepted return.

It is registered in `CI_EXTRA`, not `FULL_EXTRA`. Every other L-BFGS test lives in `FULL_EXTRA`, so a green `ci` run currently executes none of them — a `tier=ci` run on this repo passed 257 files without touching the solver.

## Verification

`tier=ci` on TSUBAME (job 8297433) — will report below before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)