### PR TITLE
fix(lhy): three more paths dropped the tabulated table, and restore the gate that would have caught them

### DIFF
--- a/src/solvers/ground_state.jl
+++ b/src/solvers/ground_state.jl
@@ -100,6 +100,7 @@ const _LBFGS_FORWARD_KWARGS = (
     :ddi_padding, :ddi_pad_factor,
     :target_magnetization, :backend, :m_lbfgs, :verbose, :light_shift,
     :dtype, :sobolev_alpha, :rotating_frame_omega,
+    :spinor_lhy, :lhy_opts,
 )
 
 function find_ground_state(;
@@ -159,11 +160,13 @@ function find_ground_state(;
 )
     # KEEP IN SYNC: `_LBFGS_FORWARD_KWARGS` below lists every kwarg this
     # dispatcher forwards to `find_ground_state_lbfgs`. The pinning test
-    # `test_lbfgs_forward_coverage` (test/solvers/) walks both kwarg sets
-    # and fails if a kwarg present on `find_ground_state_lbfgs` is missing
-    # from this forward — the same class of bug that hid
-    # `rotating_frame_omega` from LBFGS pre-2026-06-02. See
-    # `feedback_never_patch_when_root_fix_is_available`.
+    # `test/solvers/test_lbfgs_forward_coverage.jl` walks both kwarg sets and
+    # fails if a kwarg present on `find_ground_state_lbfgs` is missing from this
+    # forward, AND if a name in the list is absent from the call below — the
+    # class of bug that hid `rotating_frame_omega` from LBFGS pre-2026-06-02,
+    # and then hid `spinor_lhy` / `lhy_opts` from it after #179, because that
+    # gate had been deleted in an orphan sweep as "plumbing, not physics". A
+    # dropped kwarg IS physics when it is a Hamiltonian term.
     if method === :lbfgs
         return find_ground_state_lbfgs(;
             grid, atom, interactions, zeeman, potential,
@@ -172,6 +175,7 @@ function find_ground_state(;
             ddi_padding, ddi_pad_factor,
             target_magnetization, backend, m_lbfgs, verbose, light_shift,
             dtype, sobolev_alpha, rotating_frame_omega,
+            spinor_lhy, lhy_opts,
         )
     end
     method === :strang || throw(
@@ -248,6 +252,8 @@ function find_ground_state(;
             grid,
             atom,
             interactions,
+            spinor_lhy,
+            lhy_opts,
             zeeman,
             potential,
             dt,

--- a/src/solvers/ground_state/adaptive.jl
+++ b/src/solvers/ground_state/adaptive.jl
@@ -30,6 +30,12 @@ function _find_ground_state_adaptive(;
     l_z_ddi::Float64=0.0,
     quasi_2d::Bool=false,
     l_z::Float64=0.0,
+    # Spinor (tabulated) LHY. `find_ground_state` / `find_ground_state_lbfgs`
+    # accept these and forward them to their own `make_workspace`, so a branch
+    # that does not thread them silently drops the TABLE while `scalar` (which
+    # rides in `interactions.c_lhy`) keeps working — the shape of #174 and #179.
+    spinor_lhy::Union{Nothing, Symbol, AbstractLHY}=nothing,
+    lhy_opts::LHYTableOpts=LHYTableOpts(),
     backend::AbstractBackend=CPUBackend(),
     light_shift=nothing,
     verbose::Bool=true,
@@ -60,6 +66,8 @@ function _find_ground_state_adaptive(;
         ddi_trunc_radius,
         ddi_padding,
         ddi_pad_factor,
+        spinor_lhy,
+        lhy_opts,
         fft_flags,
         quasi_2d_ddi,
         l_z_ddi,

--- a/src/solvers/ground_state/pinned.jl
+++ b/src/solvers/ground_state/pinned.jl
@@ -63,6 +63,12 @@ function _lbfgs_pin_continuation(;
     init_state_params::Dict{Symbol, Float64},
     psi_init::Union{Nothing, AbstractArray},
     ws_init::Union{Nothing, Workspace},
+    # Spinor (tabulated) LHY. `find_ground_state` / `find_ground_state_lbfgs`
+    # accept these and forward them to their own `make_workspace`, so a branch
+    # that does not thread them silently drops the TABLE while `scalar` (which
+    # rides in `interactions.c_lhy`) keeps working — the shape of #174 and #179.
+    spinor_lhy::Union{Nothing, Symbol, AbstractLHY}=nothing,
+    lhy_opts::LHYTableOpts=LHYTableOpts(),
     enable_ddi::Bool,
     c_dd::Float64,
     secular_ddi::Bool,
@@ -122,6 +128,7 @@ function _lbfgs_pin_continuation(;
         psi_init=seed,
         enable_ddi, c_dd, secular_ddi, ddi_trunc_radius, ddi_padding, ddi_pad_factor,
         quasi_2d_ddi, l_z_ddi, backend, light_shift, dtype,
+        spinor_lhy, lhy_opts,
     )
 
     rows = NamedTuple[]
@@ -139,6 +146,7 @@ function _lbfgs_pin_continuation(;
             enable_ddi, c_dd, secular_ddi, ddi_trunc_radius, ddi_padding, ddi_pad_factor,
             quasi_2d_ddi, l_z_ddi, target_magnetization, backend, m_lbfgs, verbose,
             light_shift, dtype, sobolev_alpha, precond_alpha_v, precond_alpha_k,
+            spinor_lhy, lhy_opts,
             rotating_frame_omega, newton_polish, newton_max_outer, newton_max_cg, newton_eps,
             lbfgs_history=hist,
         )

--- a/src/solvers/lbfgs/driver.jl
+++ b/src/solvers/lbfgs/driver.jl
@@ -97,6 +97,7 @@ function find_ground_state_lbfgs(;
             quasi_2d_ddi, l_z_ddi, target_magnetization, backend, m_lbfgs, verbose,
             light_shift, dtype, sobolev_alpha, precond_alpha_v, precond_alpha_k,
             rotating_frame_omega, newton_polish, newton_max_outer, newton_max_cg, newton_eps,
+            spinor_lhy, lhy_opts,
         )
     end
 

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -36,6 +36,8 @@ const FAST_TESTS = [
     "workflow/test_loss_block_edge_cases.jl",
     "workflow/test_dynamics_lhy_plumbing.jl",
     "workflow/test_dynamics_lhy_normalisation.jl",
+    "solvers/test_lbfgs_forward_coverage.jl",
+    "oracles/test_lhy_table_path_coverage.jl",
     "workflow/test_lhy_texture_warning.jl",
     "workflow/test_lhy_block_wiring.jl",
     "workflow/test_interactions_roundtrip.jl",
@@ -536,7 +538,10 @@ const _COST = Dict{String, Float64}(
     "hamiltonian/test_tabulated_lhy_propagator_parity.jl" => 22.0,
     "oracles/test_imag_time_propagator_generator.jl" => 22.8,
     "validation/test_L5_operator_rhs_compare.jl" => 22.6,
-    "hamiltonian/test_ddi_padded.jl" => 22.1,
+    "hamiltonian/test_ddi_padded.jl" => 97.8,
+    "workflow/test_dynamics_lhy_normalisation.jl" => 3.0,
+    "solvers/test_lbfgs_forward_coverage.jl" => 2.0,
+    "oracles/test_lhy_table_path_coverage.jl" => 2.0,
     "analysis/test_diagnostics.jl" => 21.3,
     "oracles/test_zeeman_diagonal_analytic.jl" => 19.9,
     "hamiltonian/test_ddi_convention_factorial.jl" => 18.2,
@@ -601,7 +606,10 @@ const _COST = Dict{String, Float64}(
     "solvers/test_continuation.jl" => 58.0,
     "workflow/test_pipeline.jl" => 17.0,
     "workflow/test_infrastructure.jl" => 15.0,
-    "workflow/test_lhy_block_wiring.jl" => 13.0,   # 7 modes x table builds
+    # Was 13.0 when it only built tables; #179 added a run_yaml A/B
+    # (`method: lbfgs` reaches the tabulated LHY), which dominates. Now the
+    # heaviest single file in the fast tier — measured 255.9 s.
+    "workflow/test_lhy_block_wiring.jl" => 255.9,
     "hamiltonian/test_lhy_gradient_all_modes.jl" => 7.0,  # 4 F=6 table builds + FD
     "test_level4_general_F_phase_emergence.jl" => 13.0,
     "analysis/test_tof_multiframe.jl" => 9.5,

--- a/test/oracles/test_lhy_table_path_coverage.jl
+++ b/test/oracles/test_lhy_table_path_coverage.jl
@@ -1,0 +1,106 @@
+# Every solver path that builds a workspace must carry the tabulated LHY.
+#
+# The HamTerm registry made LHY's SIGN single-declaration, but it says nothing
+# about which *table* a given code path installs as `ws.lhy` — and that
+# resolution is written once per path. All four known paths have silently
+# dropped it:
+#
+#   #125  GPU broadcast path collapsed every table to c_lhy = 0
+#   #174  dynamics pipeline step never resolved its own `lhy:` block
+#   #179  find_ground_state_lbfgs had no spinor_lhy kwarg at all
+#   here  the adaptive-ITP branch and the L-BFGS pin ε-continuation
+#
+# The failure is always silent and always looks like a physics answer, because
+# `scalar` keeps working (it rides in `interactions.c_lhy`, threaded separately)
+# while only the modes that need a TABLE vanish. #179 is the cautionary case: an
+# LHY-on/LHY-off A/B came back bit-identical on all 34 points, which reads as
+# "LHY changes nothing" rather than as a broken run.
+#
+# So this gate is deliberately structural, not behavioural. A behavioural test
+# has to pick a path to exercise, and the bug is precisely in the path nobody
+# picked. Two invariants:
+#
+#   1. PAIRING — `spinor_lhy` and `lhy_opts` always appear together. #174 was
+#      exactly the split: `spinor_lhy` threaded, `lhy_opts` defaulted, so the
+#      table got built with n_atoms = 1 and came out N_atoms too strong.
+#   2. FORWARDING — a file that declares `spinor_lhy` forwards it to every
+#      `make_workspace` and every ground-state solver call it makes. A branch
+#      that accepts the kwarg and drops it is the #179/adaptive/pin shape.
+
+using Test
+using SpinorBEC
+
+@testset "LHY table reaches every workspace-building path" begin
+    srcdir = abspath(joinpath(@__DIR__, "..", "..", "src"))
+    isdir(srcdir) || (srcdir = abspath(joinpath(@__DIR__, "..", "src")))
+
+    jl_files = String[]
+    for (root, _, files) in walkdir(srcdir), f in files
+        endswith(f, ".jl") && push!(jl_files, joinpath(root, f))
+    end
+    @test !isempty(jl_files)
+
+    # Strip `#` comments AND `"""` docstrings before matching. Comments close
+    # the token-comment loophole a naive grep guard has; docstrings matter too —
+    # `pinned.jl`'s docstring writes `find_ground_state_lbfgs(; pin=…)` as prose,
+    # which read as an unforwarded call site until this stripped it.
+    function code_of(path)
+        body = replace(read(path, String), r"\"\"\"(?s).*?\"\"\"" => "")
+        join((replace(l, r"#.*$" => "") for l in split(body, '\n')), "\n")
+    end
+
+    codes = Dict(relpath(p, srcdir) => code_of(p) for p in jl_files)
+
+    # ---- invariant 1: spinor_lhy and lhy_opts travel together ----------------
+    declares(code, name) = occursin(Regex("\\b$name\\s*::"), code)
+    split_decl = [f for (f, c) in codes
+                        if declares(c, "spinor_lhy") != declares(c, "lhy_opts")]
+    if !isempty(split_decl)
+        @info """A file declares one of (spinor_lhy, lhy_opts) without the other. \
+`lhy_opts` carries n_atoms, which is the unit conversion — defaulting it makes \
+every table N_atoms too strong (#174).""" split_decl
+    end
+    @test isempty(split_decl)
+
+    # ---- invariant 2: whoever declares it, forwards it -----------------------
+    # `make_workspace` itself is the consumer, not a forwarder.
+    consumers = Set(["workflow/initialization/make_workspace.jl"])
+    decl_files = sort([f for (f, c) in codes if declares(c, "spinor_lhy")])
+    @test !isempty(decl_files)          # the pattern still exists at all
+    @test "solvers/ground_state.jl" in decl_files          # ITP
+    @test "solvers/lbfgs/driver.jl" in decl_files          # L-BFGS
+    @test "solvers/ground_state/adaptive.jl" in decl_files # adaptive ITP
+    @test "solvers/ground_state/pinned.jl" in decl_files   # pin ε-continuation
+
+    # A call is "covered" when `spinor_lhy` appears in the same call parens.
+    function unforwarded_calls(code, callee)
+        bad = 0
+        for m in eachmatch(Regex("\\b$callee\\s*\\(", "s"), code)
+            i = m.offset + length(m.match) - 1     # at the '('
+            depth, j, n = 1, i + 1, lastindex(code)
+            while j <= n && depth > 0
+                c = code[j]
+                depth += (c == '(') - (c == ')')
+                j = nextind(code, j)
+            end
+            occursin("spinor_lhy", code[i:min(j, n)]) || (bad += 1)
+        end
+        bad
+    end
+
+    gaps = Tuple{String, String, Int}[]
+    for f in decl_files
+        f in consumers && continue
+        for callee in ("make_workspace", "find_ground_state", "find_ground_state_lbfgs",
+            "_find_ground_state_adaptive", "_lbfgs_pin_continuation")
+            n = unforwarded_calls(codes[f], callee)
+            n > 0 && push!(gaps, (f, callee, n))
+        end
+    end
+    if !isempty(gaps)
+        @info """A file that accepts `spinor_lhy` calls a workspace-building \
+routine without passing it on. That branch runs with NO tabulated LHY, silently, \
+and `scalar` keeps working so the gap looks like a physics result (#179).""" gaps
+    end
+    @test isempty(gaps)
+end

--- a/test/solvers/test_lbfgs_forward_coverage.jl
+++ b/test/solvers/test_lbfgs_forward_coverage.jl
@@ -1,0 +1,80 @@
+using Test
+using SpinorBEC
+using SpinorBEC: _LBFGS_FORWARD_KWARGS, find_ground_state_lbfgs
+
+# `find_ground_state(method=:lbfgs)` is a hand-written forward into
+# `find_ground_state_lbfgs`. A kwarg added to the callee and forgotten here is
+# silently dropped — the caller sees no error, the solver just runs without it.
+#
+# This gate existed before, caught `rotating_frame_omega` (pre-2026-06-02), and
+# was then DELETED in an orphan sweep as "pure-introspection dispatch-coverage
+# micro guards — plumbing, not physics". With it gone, #179 added `spinor_lhy`
+# and `lhy_opts` to `find_ground_state_lbfgs` and nothing noticed that this
+# dispatcher still dropped both, so `find_ground_state(method=:lbfgs,
+# spinor_lhy=:polar_contact)` ran with no tabulated LHY at all.
+#
+# So: a dropped kwarg IS physics when it is a Hamiltonian term. Restored, and
+# strengthened — the old version compared the signature against the
+# hand-maintained `_LBFGS_FORWARD_KWARGS` tuple only, which cannot tell whether
+# the tuple matches the CALL. Updating the list and forgetting the call would
+# have passed. Now both directions are checked against the source.
+
+@testset "find_ground_state(method=:lbfgs) forwards every LBFGS kwarg" begin
+    kw_names = Base.kwarg_decl(first(methods(find_ground_state_lbfgs)))
+    lbfgs_kwargs = Set(k for k in kw_names if !endswith(string(k), "..."))
+    forwarded = Set(_LBFGS_FORWARD_KWARGS)
+    @test !isempty(lbfgs_kwargs)
+    @test !isempty(forwarded)
+
+    # Kwargs that exist only on the L-BFGS path, with no Strang counterpart for
+    # the dispatcher to supply. Each is listed by name so adding a new one is a
+    # deliberate act, not an accident.
+    lbfgs_exclusive = Set([
+        :ws_init,                     # warm-start workspace; Strang builds its own
+        :lbfgs_history,               # L-BFGS curvature memory
+        :m_lbfgs,                     # history depth
+        :pin, :epsilon_ramp,          # ε-continuation, L-BFGS-only entry
+        :precond_alpha_v, :precond_alpha_k,   # Sobolev preconditioner knobs
+        :newton_polish, :newton_max_outer, :newton_max_cg, :newton_eps,
+        # eigenvector-residual final polish inside the driver (see the
+        # `if residual_polish` block); a convergence stage, no Strang counterpart
+        :residual_polish, :residual_hvp_order,
+    ])
+
+    not_forwarded = setdiff(lbfgs_kwargs, forwarded, lbfgs_exclusive)
+    if !isempty(not_forwarded)
+        @info """`find_ground_state(method=:lbfgs)` does NOT forward these. If the \
+kwarg affects the Hamiltonian, the solver silently runs without it — add it to \
+both `_LBFGS_FORWARD_KWARGS` and the forward block, or declare it \
+L-BFGS-exclusive here.""" not_forwarded
+    end
+    @test isempty(not_forwarded)
+
+    # Reverse: the list must not advertise a kwarg L-BFGS no longer accepts
+    # (catches renames and removals).
+    stale = setdiff(forwarded, lbfgs_kwargs)
+    if !isempty(stale)
+        @info "`_LBFGS_FORWARD_KWARGS` names kwargs `find_ground_state_lbfgs` does not accept" stale
+    end
+    @test isempty(stale)
+
+    # The list is documentation; the call is what runs. Assert they agree, by
+    # reading the actual forward block out of the source. Without this, keeping
+    # the tuple in sync while forgetting the call still passes.
+    src = abspath(joinpath(@__DIR__, "..", "..", "src", "solvers", "ground_state.jl"))
+    isfile(src) || (src = abspath(joinpath(@__DIR__, "..", "src", "solvers", "ground_state.jl")))
+    @test isfile(src)
+    code = read(src, String)
+    i = findfirst("return find_ground_state_lbfgs(;", code)
+    @test i !== nothing
+    j = findnext(")", code, last(i))
+    call = code[first(i):(j === nothing ? lastindex(code) : last(j))]
+
+    absent_from_call = [k for k in _LBFGS_FORWARD_KWARGS
+                              if !occursin(Regex("\\b$(k)\\b"), call)]
+    if !isempty(absent_from_call)
+        @info """`_LBFGS_FORWARD_KWARGS` lists kwargs the actual forward block does \
+not pass. The list is not the contract — the call is.""" absent_from_call
+    end
+    @test isempty(absent_from_call)
+end


### PR DESCRIPTION
Sweeps the class behind #174 and #179. The HamTerm registry single-declares each term's **sign**, but says nothing about **which table a code path installs as `ws.lhy`** — and that resolution is written once per path. Three more paths were dropping it.

| path | what was wrong |
|---|---|
| `_find_ground_state_adaptive` | `find_ground_state` accepts `spinor_lhy`/`lhy_opts` and forwards them to its own `make_workspace`, but the `adaptive_dt` branch passed neither and the callee didn't accept them |
| `_lbfgs_pin_continuation` | neither the bare (ε=0) reference workspace nor **any rung's** `find_ground_state_lbfgs` call carried them |
| `find_ground_state(method=:lbfgs)` | the dispatcher forward, and `_LBFGS_FORWARD_KWARGS` alongside it |

**Blast radius on stored results is zero** — checked, not assumed. GS `adaptive_dt` lives in `DYNAMICS_SCHEMA` and `run_step_ground_state` never reads it, so the adaptive GS path isn't YAML-reachable; and all 12 committed configs using `pin:` are `kind: none`. Latent traps, not damage.

Silent for the same reason as #179: `scalar` keeps working because it rides in `interactions.c_lhy`, threaded separately, so only the modes needing a **table** vanish. #179 is the cautionary case — an LHY-on/off A/B came back bit-identical on all 34 points, which reads as *"LHY changes nothing"* rather than as a broken run.

## The gate for this existed, and had been deleted

`test/solvers/test_lbfgs_forward_coverage.jl` caught `rotating_frame_omega` pre-2026-06-02, then was removed in the orphan sweep `e3151c9a` as *"pure-introspection dispatch-coverage micro guards — plumbing, not physics"*, while `src/solvers/ground_state.jl` went on claiming it audited this. That's why #179 could add `spinor_lhy` to the callee with nothing checking the forward.

**A dropped kwarg IS physics when it is a Hamiltonian term.**

Restored and strengthened. The old version compared the signature against the hand-maintained `_LBFGS_FORWARD_KWARGS` tuple only, which cannot tell whether the tuple matches the **call** — updating the list and forgetting the call passed. Now both directions are read out of the source. It also flagged `residual_polish` / `residual_hvp_order`; those are a convergence stage inside the driver with no Strang counterpart, so they join the by-name exclusion list with that reason stated.

## New structural gate

`test/oracles/test_lhy_table_path_coverage.jl`, deliberately **structural rather than behavioural**: a behavioural test has to pick a path to exercise, and the bug is precisely in the path nobody picked. Two invariants:

1. **Pairing** — `spinor_lhy` and `lhy_opts` are always declared together. Their split *was* #174: `spinor_lhy` threaded, `lhy_opts` defaulted, so the table was built with `n_atoms = 1` and came out `N_atoms` too strong.
2. **Forwarding** — any file declaring `spinor_lhy` passes it to every `make_workspace` / ground-state call it makes.

It strips docstrings as well as `#` comments — `pinned.jl`'s docstring writes `find_ground_state_lbfgs(; pin=…)` as prose, which first read as an unforwarded call site.

## Also

Two `_COST` entries the runner explicitly asked for, including `test_lhy_block_wiring.jl` **13.0 → 255.9 s**: #179 added a `run_yaml` A/B to it, making it the heaviest single file in the fast tier. Worth a look at whether it belongs in `ci` rather than `fast`.

`tier=fast`: 167 files, all passed locally. Branch is based on `fbae9bd3`; main has since moved to `634e0234` (#183), so CI's merge-commit run is what validates the structural gates against current main — a local rebase wasn't available here.

Type **A** (code correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)