### PR TITLE
fix(bscan): opt the B-scan into production DDI image handling

### DIFF
--- a/scripts/eu_bscan_pinned_continuation.jl
+++ b/scripts/eu_bscan_pinned_continuation.jl
@@ -111,9 +111,21 @@ const B_UG = DIR == "down" ? collect(range(BMAX, BMIN; length=NB)) :
         isempty(RP_RAMP) ? "none" : join(RP_RAMP, ",")) : "")
 flush(stdout)
 
+# `make_workspace` deliberately defaults both image knobs OFF — it is the
+# library primitive, and flipping it there would move every direct-call fixture
+# (see its own comment). The YAML/DSL surface defaults them ON, and this script
+# is production physics reached by direct call, so it opts in explicitly.
+#
+# It matters more here than almost anywhere else. The bare periodic kernel
+# carries a 2-5 % dipolar field error that is FLAT in resolution, and its origin
+# is the square lattice of periodic images breaking rotational symmetry — an
+# ANISOTROPIC error. This scan's whole subject is how the trap aspect ratio κ
+# controls the order of the transition, so an anisotropy-dependent DDI error is
+# a direct confound on the axis being measured, not a uniform offset.
 base_kw(p) = (; grid=PRESET.grid, atom=ATOM, interactions=PRESET.interactions,
     potential=PRESET.potential, zeeman=static_zeeman(; Bz=p, Bx=EPS, q=0.0),
-    enable_ddi=true, c_dd=PRESET.c_dd, secular_ddi=false, backend=BACKEND)
+    enable_ddi=true, c_dd=PRESET.c_dd, secular_ddi=false, backend=BACKEND,
+    ddi_padding=true, ddi_trunc_radius=-1.0)
 
 # density-weighted axial + transverse magnetisation (manifest scalars).
 function frame_scalars(psi)


### PR DESCRIPTION
`make_workspace` deliberately defaults `ddi_padding` and `ddi_trunc_radius` OFF
— it is the library primitive, and #178's own comment says flipping it there
would silently move every direct-call fixture. #178 turned them on for the
YAML/DSL surface only. `eu_bscan_pinned_continuation.jl` reaches
`find_ground_state*` by DIRECT call, so it kept the bare periodic kernel.

That matters more here than almost anywhere else. The bare kernel's 2-5 %
dipolar field error is flat in resolution, and its origin is the square lattice
of periodic images breaking rotational symmetry — an ANISOTROPIC error. This
scan's entire subject is how the trap aspect ratio kappa controls the ORDER of
the weak-field texture transition, so an anisotropy-dependent DDI error sits
directly on the axis being measured. It is not a uniform offset that cancels
between branches.

Measured (smoke, kappa=1.8, up branch, grid 16, B in [40,110]):

    B [uG]        bare   padded+cutoff    delta<F_perp>
      40.0      4.1292          4.1237          -0.0055
      57.5      3.3951          3.3943          -0.0008
      75.0      2.5580          2.5365          -0.0215
     110.0      1.3461          1.3806          +0.0345

Small against the kappa=1.8 branch separation (3.83 at 40 uG), but 3x the
threshold at which the kappa=0.9 branches were called coincident (<= 0.01
for B >= 14). Near the tricritical kappa the window is narrow and the gap is
small, which is exactly where a 1e-2 anisotropic shift changes the verdict.

Every kappa in the bracketing scan therefore needs re-running with this on,
including the kappa=1.8 branch already generated.

Assisted-by: Claude Code (model: claude-opus-5[1m])

🤖 Generated with [Claude Code](https://claude.com/claude-code)
