### PR TITLE
fix(ddi): give the dipolar field a cutoff, and the cutoff a way past the short axis

### DIFF
--- a/docs/reference/yaml_schema_reference.md
+++ b/docs/reference/yaml_schema_reference.md
@@ -164,7 +164,7 @@ Semantic details + interactions live in `docs/reference/dynamics.md`.
 | `l_z` | Real [0, 100] | — |
 | `trunc_radius` | Number or `"auto"`/`"box_half"`/`"none"`/`"off"` | `"auto"` |
 | `padded` | Bool | true |
-| `pad_factor` | Number or per-axis Vector | 2 |
+| `pad_factor` | Number, per-axis Vector, or `"auto"` | 2 |
 
 Both image-handling knobs default **on** as of 2026-07-29 (they were both off
 before). The bare periodic kernel they replace carries a $2 \times 10^{-2}$ to
@@ -192,11 +192,20 @@ fixed resolution. Cost is far below the naive `prod(pad_factor)`: at $D = 13$ th
 DDI step is dominated by the spin density and the Euler rotation on the unpadded
 grid rather than by the 6 FFTs, measuring **1.2–1.4×** per step. Memory is the
 real constraint — the padded context is ~290 MB at $64^3$ and ~975 MB at $96^3$.
-**`pad_factor`** sets the zero-pad multiple — a scalar
-or a per-axis vector. Use a smaller factor on thin axes for **anisotropic
-padding** (e.g. `pad_factor: [2.73, 2.73, 1.5]` for a pancake) to cut memory; the
-auto `trunc_radius` caps R at `(pad_factor_d − 1)·L_d` per axis to stay
-wrap-around-free. Only meaningful with `padded: true`.
+**`pad_factor`** sets the zero-pad multiple — a scalar,
+a per-axis vector, or `"auto"`. Use a smaller factor on thin axes for
+**anisotropic padding** (e.g. `pad_factor: [2.73, 2.73, 1.5]` for a pancake) to
+cut memory; the auto `trunc_radius` caps R at `(pad_factor_d − 1)·L_d` per axis
+to stay wrap-around-free. Only meaningful with `padded: true`.
+
+`pad_factor: auto` matters only on an **anisotropic** box. A single sphere has
+one radius, so at a flat $2\times$ pad the cutoff is capped at $\min(L_d)$ while
+covering every separation in the box needs $\max(L_d)$ — the SHORT axis binds.
+Auto solves $(f_d - 1)L_d \ge \max(L_d)$ per axis, giving
+$f_d = 1 + \max(L_d)/L_d$. On the aspect-2 cigar that is $(3, 3, 2)$ and takes
+the field error from $1.8\times10^{-3}$ to $0$, for $2.25\times$ the padded
+volume. Isotropic boxes resolve to exactly 2 on every axis, so nothing changes
+for them — which is why the default stays `2` rather than `auto`.
 
 **`trunc_radius`** applies the spherically-truncated DDI kernel
 (Ronen–Bortolotti–Bohn cutoff; Vico–Greengard–Ferrando spectral form). Every

--- a/scripts/ddi_cutoff_geometry_jz_probe.jl
+++ b/scripts/ddi_cutoff_geometry_jz_probe.jl
@@ -263,8 +263,12 @@ function run_geometry(label, box, sigma, n_list)
     # cylindrical kernel would buy at equal cost.
     ref = Cfg("sphere R=Rexact, pad exact (= free space)", cost.R, cost.f_sph)
     cfgs = [
-        Cfg("bare (production default)", nothing, nothing),
+        Cfg("bare, unpadded", nothing, nothing),
         Cfg("sphere R=Lmin/2, unpadded", minimum(box) / 2, nothing),
+        # Padding with NO cutoff. Pushes the density images out but leaves the
+        # kernel itself periodic on the doubled box, so a residual survives —
+        # this is what `analysis/dipole_field.jl` currently does.
+        Cfg("pad 2, no cutoff", nothing, (2.0, 2.0, 2.0)),
         Cfg("sphere R=Lmin, pad 2", minimum(box), (2.0, 2.0, 2.0)),
         ref,
         # The reference reads err = 0 against itself by construction, which proves
@@ -328,6 +332,12 @@ function main()
     println("  FALLS in n  -> dx roughness; no cutoff geometry can help.")
     println("  If 'pad exact' is already at the floor, a cylinder buys only the")
     println("  padded-volume saving printed per geometry, not accuracy.")
+    println("\n  Cutoff and padding are not interchangeable. Padding alone leaves a")
+    println("  ~4e-4 (isotropic) to ~9e-4 (aspect 2) residual; the cutoff alone")
+    println("  fixes covariance but not magnitude. On an ANISOTROPIC box at pad 2")
+    println("  the auto cutoff is capped at R <= Lmin while exactness wants Lmax, so")
+    println("  it trades a slightly larger field error for essentially exact J_z —")
+    println("  raise pad_factor on the short axes to get both.")
 end
 
 main()

--- a/src/analysis/dipole_field.jl
+++ b/src/analysis/dipole_field.jl
@@ -17,7 +17,8 @@
 
 export dipole_magnetic_field, magnetic_field_from_density, magnetic_field_from_spinor
 
-function _dipole_q_tensor(grid::Grid{3}, work_shape::NTuple{3, Int})
+function _dipole_q_tensor(grid::Grid{3}, work_shape::NTuple{3, Int},
+    trunc_radius::Union{Nothing, Float64})
     dx = grid.dx
     rk_shape = rfft_output_shape(work_shape)
     # n·dk = 2π/dx is the sampling frequency fed to {r,}fftfreq — identical for
@@ -41,12 +42,13 @@ function _dipole_q_tensor(grid::Grid{3}, work_shape::NTuple{3, Int})
     _build_q_tensor!(
         Q_xx, Q_xy, Q_xz, Q_yy, Q_yz, Q_zz,
         kx, ky, kz, k_sq, rk_shape; secular=false, full_n=work_shape,
+        trunc_radius,
     )
     (Q_xx, Q_xy, Q_xz, Q_yy, Q_yz, Q_zz)
 end
 
 """
-    dipole_magnetic_field(grid, Mx, My, Mz; mu0=Units.MU_0, padded=true)
+    dipole_magnetic_field(grid, Mx, My, Mz; mu0=Units.MU_0, padded=true, truncate=true)
 
 Magnetic field `B(r)` [tesla] produced by a magnetisation density
 `M(r) = (Mx, My, Mz)` [A/m] sampled on `grid`, via the magnetic dipole–dipole
@@ -60,6 +62,19 @@ Returns `(Bx, By, Bz)` as real arrays the size of `grid`.
 matching `convn(..., 'same')`; `padded=false` is the cheaper periodic form,
 acceptable when the cloud sits well inside the box. The long-range 1/r³ tail
 makes the padded form the safer default for a radiated field.
+
+`truncate=true` additionally applies the real-space spherical cutoff at the
+largest wrap-around-free radius (`auto_ddi_trunc_radius`). Padding alone is NOT
+enough: it pushes the *source* images out but leaves the *kernel* periodic on
+the doubled box, and the 1/r³ tail wraps. Measured on the DDI mean field, which
+is the same convolution, padding alone leaves a 3.9e-4 (isotropic) to 9.1e-4
+(aspect-2) relative field error against free space, versus 0 with the cutoff —
+see `scripts/ddi_cutoff_geometry_jz_probe.jl`. Pass an explicit `Float64` to set
+the radius yourself, or `false`/`nothing` for the bare kernel.
+
+On an anisotropic box at the doubled grid the cutoff is capped at `min(box)`
+while exactness wants `max(box)`, so a residual survives there; it trades that
+for a kernel that is exactly rotation-covariant.
 """
 function dipole_magnetic_field(
     grid::Grid{3},
@@ -68,6 +83,7 @@ function dipole_magnetic_field(
     Mz::AbstractArray;
     mu0::Float64=Units.MU_0,
     padded::Bool=true,
+    truncate::Union{Bool, Float64}=true,
 )
     n_pts = grid.config.n_points
     for (name, M) in (("Mx", Mx), ("My", My), ("Mz", Mz))
@@ -76,7 +92,15 @@ function dipole_magnetic_field(
     end
 
     work_shape = padded ? ntuple(d -> 2 * n_pts[d], 3) : n_pts
-    Q_xx, Q_xy, Q_xz, Q_yy, Q_yz, Q_zz = _dipole_q_tensor(grid, work_shape)
+    box = ntuple(d -> n_pts[d] * grid.dx[d], 3)
+    R = if truncate isa Float64
+        truncate
+    elseif truncate
+        auto_ddi_trunc_radius(box, padded ? 2.0 : nothing)
+    else
+        nothing
+    end
+    Q_xx, Q_xy, Q_xz, Q_yy, Q_yz, Q_zz = _dipole_q_tensor(grid, work_shape, R)
     plans = make_rfft_plans(work_shape, CPUBackend(); flags=FFTW.MEASURE, dtype=Float64)
     rk_shape = plans.rk_shape
     corner = CartesianIndices(n_pts)
@@ -117,7 +141,7 @@ end
 
 """
     magnetic_field_from_density(grid, density; atom, a_ho, n_atoms=1.0,
-                                polarization=(0,0,1), padded=true)
+                                polarization=(0,0,1), padded=true, truncate=true)
 
 Field of a fully spin-polarised cloud. `density` is the dimensionless density
 on the internal grid (∫ density dV = 1, i.e. `total_density(psi, 3)` of a
@@ -137,15 +161,16 @@ function magnetic_field_from_density(
     n_atoms::Real=1.0,
     polarization::NTuple{3, <:Real}=(0.0, 0.0, 1.0),
     padded::Bool=true,
+    truncate::Union{Bool, Float64}=true,
 )
     pn = sqrt(sum(abs2, polarization))
     p̂ = pn == 0 ? (0.0, 0.0, 1.0) : polarization ./ pn
     Mabs = (atom.mu_mag * n_atoms / a_ho^3) .* density   # |M| if fully polarised [A/m]
-    dipole_magnetic_field(grid, Mabs .* p̂[1], Mabs .* p̂[2], Mabs .* p̂[3]; padded)
+    dipole_magnetic_field(grid, Mabs .* p̂[1], Mabs .* p̂[2], Mabs .* p̂[3]; padded, truncate)
 end
 
 """
-    magnetic_field_from_spinor(psi, grid, sm, atom; a_ho, n_atoms=1.0, padded=true)
+    magnetic_field_from_spinor(psi, grid, sm, atom; a_ho, n_atoms=1.0, padded=true, truncate=true)
 
 General (not necessarily polarised) version: the magnetisation follows the
 local spin-density vector `⟨F_α⟩(r)` of `psi`, so a textured spinor radiates
@@ -162,8 +187,9 @@ function magnetic_field_from_spinor(
     a_ho::Float64,
     n_atoms::Real=1.0,
     padded::Bool=true,
+    truncate::Union{Bool, Float64}=true,
 ) where {D}
     fx, fy, fz = spin_density_vector(psi, sm, 3)
     scale = atom.mu_mag / atom.F * n_atoms / a_ho^3   # (g_F μ_B) · n_atoms / a_ho³
-    dipole_magnetic_field(grid, fx .* scale, fy .* scale, fz .* scale; padded)
+    dipole_magnetic_field(grid, fx .* scale, fy .* scale, fz .* scale; padded, truncate)
 end

--- a/src/hamiltonian/terms/ddi/qtensor.jl
+++ b/src/hamiltonian/terms/ddi/qtensor.jl
@@ -29,6 +29,51 @@ function _zero_odd_offdiag_at_nyquist!(Q_xy, Q_xz, Q_yz, full_n::NTuple{N, Int})
 end
 
 """
+    auto_ddi_trunc_radius(box, pad_factor=nothing) → Float64
+
+Largest wrap-around-free spherical cutoff radius for `box`, which is what
+`trunc_radius: auto` resolves to.
+
+Unpadded, the truncated kernel is exact only while `R` stays inside half the
+smallest box extent — beyond that the real-space sphere overlaps its own
+periodic image. Zero-padding to `pad_factor_d · L_d` buys the extra room, so `R`
+may grow to `(pad_factor_d − 1)·L_d` on every axis, capped by the box diagonal
+(no separation in the box exceeds it, so a larger `R` truncates nothing).
+
+The single declaration of this rule: `make_workspace` and
+`analysis/dipole_field.jl` both call it rather than restating it.
+"""
+function auto_ddi_trunc_radius(box::NTuple{N, <:Real}, pad_factor=nothing) where {N}
+    pad_factor === nothing && return Float64(minimum(box)) / 2
+    pf = if pad_factor isa Real
+        ntuple(_ -> Float64(pad_factor), N)
+    else
+        ntuple(d -> Float64(pad_factor[d]), N)
+    end
+    diag = sqrt(sum(b -> Float64(b)^2, box))
+    min(diag, minimum(ntuple(d -> (pf[d] - 1) * Float64(box[d]), N)))
+end
+
+"""
+    auto_ddi_pad_factor(box) → NTuple{N, Float64}
+
+Per-axis zero-pad factors that let the spherical cutoff reach `max(box)`, which
+is what `pad_factor: auto` resolves to.
+
+A single sphere has one radius, so on an anisotropic box the binding axis is the
+SHORT one: `auto_ddi_trunc_radius` caps `R` at `min_d (f_d − 1)·L_d`, while
+covering every separation in the box needs `R ≥ max(box)`. Solving
+`(f_d − 1)·L_d ≥ max(box)` per axis gives `f_d = 1 + max(box)/L_d`.
+
+Isotropic boxes come out at exactly 2 on every axis — unchanged from the plain
+default, which is already exact there. An aspect-2 cigar comes out at (3, 3, 2),
+2.25x the padded volume of a flat 2x: that memory is the price of removing the
+last ~2e-3 of field error, and is why this is opt-in rather than the default.
+"""
+auto_ddi_pad_factor(box::NTuple{N, <:Real}) where {N} =
+    ntuple(d -> 1 + Float64(maximum(box)) / Float64(box[d]), N)
+
+"""
     ddi_trunc_factor(x) → T
 
 Radial modifier `h(x)` of the spherically-truncated DDI kernel

--- a/src/workflow/experiments/schema/parsing_blocks.jl
+++ b/src/workflow/experiments/schema/parsing_blocks.jl
@@ -486,10 +486,22 @@ end
 
 Map a YAML `ddi.pad_factor` value to `make_workspace`'s `ddi_pad_factor`:
 `nothing` ⇒ `2.0` (default); a number ⇒ scalar factor; a vector ⇒ per-axis
-factors (anisotropic padding).
+factors (anisotropic padding); `"auto"` ⇒ `-1.0`, the sentinel `make_workspace`
+resolves via `auto_ddi_pad_factor(box)` once the box is known.
+
+`"auto"` matters only on an ANISOTROPIC box. A single sphere has one radius, so
+at a flat 2x pad the cutoff is capped at `min(box)` while covering every
+separation needs `max(box)`; the auto factors lift that cap. On the aspect-2
+cigar that takes the field error from 1.8e-3 to 0, for 2.25x the padded volume.
+Isotropic boxes resolve to exactly 2 on every axis, so nothing changes for them —
+which is why the default stays 2.0 rather than auto.
 """
 function _parse_ddi_pad_factor(raw)
     raw === nothing && return 2.0
+    if raw isa AbstractString
+        lowercase(strip(raw)) == "auto" && return -1.0
+        throw(ArgumentError("ddi.pad_factor string must be \"auto\", got \"$raw\""))
+    end
     # Return an NTuple (not a Vector) so it satisfies the `Union{Real, NTuple}`
     # kwarg type on make_workspace / the solver entry points.
     raw isa AbstractVector && return Tuple(Float64.(raw))

--- a/src/workflow/experiments/schema/schema.jl
+++ b/src/workflow/experiments/schema/schema.jl
@@ -242,7 +242,9 @@ const DDI_SCHEMA = Dict{String, FieldSpec}(
     "trunc_radius" => FieldSpec(; type=Union{Number, String}),
     # Tier B: zero-padded, image-free convolution + optional anisotropic pad.
     "padded" => FieldSpec(; type=Bool, default=true),   # was false, flipped 2026-07-29
-    "pad_factor" => FieldSpec(; type=Union{Number, Vector}),
+    # A number, a per-axis vector, or "auto" (size the padding so the cutoff can
+    # reach max(box) instead of being capped by the short axis).
+    "pad_factor" => FieldSpec(; type=Union{Number, Vector, String}),
 )
 
 # `kind` selects the solver path:

--- a/src/workflow/initialization/make_workspace.jl
+++ b/src/workflow/initialization/make_workspace.jl
@@ -216,7 +216,11 @@ function make_workspace(;
     #       (pad_factor_d − 1)·L_d — the largest R the zero-pad can hold
     #       without wrap-around (validated: exceeding it re-introduces images).
     box = ntuple(d -> grid.config.n_points[d] * grid.dx[d], N)
-    pf_t = if ddi_pad_factor isa Real
+    # A negative scalar is the `pad_factor: auto` sentinel — size the padding so
+    # the cutoff can reach `max(box)` instead of being capped by the short axis.
+    pf_t = if ddi_pad_factor isa Real && ddi_pad_factor < 0
+        auto_ddi_pad_factor(box)
+    elseif ddi_pad_factor isa Real
         ntuple(_ -> Float64(ddi_pad_factor), N)
     else
         ntuple(d -> Float64(ddi_pad_factor[d]), N)
@@ -224,14 +228,14 @@ function make_workspace(;
     ddi_trunc = if isnan(ddi_trunc_radius)
         nothing
     elseif ddi_trunc_radius <= 0.0
-        minimum(box) / 2
+        auto_ddi_trunc_radius(box)
     else
         ddi_trunc_radius
     end
     ddi_trunc_pad = if isnan(ddi_trunc_radius)
         nothing
     elseif ddi_trunc_radius <= 0.0
-        min(sqrt(sum(b -> b^2, box)), minimum(ntuple(d -> (pf_t[d] - 1) * box[d], N)))
+        auto_ddi_trunc_radius(box, pf_t)
     else
         ddi_trunc_radius
     end
@@ -319,7 +323,9 @@ function make_workspace(;
             quasi_2d=quasi_2d_ddi,
             l_z=l_z_ddi,
             trunc_radius=ddi_trunc_pad,
-            pad_factor=ddi_pad_factor,
+            # `pf_t`, not the raw kwarg: the `auto` sentinel is negative and
+            # `_padded_grid_size` rejects anything below 1.
+            pad_factor=pf_t,
             backend,
             dtype=U,
         )

--- a/test/analysis/test_dipole_field.jl
+++ b/test/analysis/test_dipole_field.jl
@@ -100,4 +100,78 @@ using SpinorBEC: Units
         # Near the dense centre the two convolutions agree to a few %.
         @test isapprox(Bzp[ic, ic, kfar], Bz_axis; rtol=0.1)
     end
+
+    @testset "uniformly magnetised sphere — interior is EXACTLY zero" begin
+        # Independent analytic oracle, no reference implementation involved.
+        # Inside a uniformly magnetised sphere H = -M/3 exactly, and this
+        # convention returns B = μ₀H + μ₀M/3 (the +δ/3 of Q_αβ), so the two
+        # cancel and the interior field vanishes identically. Every nonzero
+        # value inside is error.
+        Ls, ns, Rs, Ms = 12.0, 48, 3.0, 1.0e5
+        gs = make_grid(GridConfig((ns, ns, ns), (Ls, Ls, Ls)))
+        xs, ys, zs = gs.x
+        Ms_z = zeros(Float64, ns, ns, ns)
+        for I in CartesianIndices(Ms_z)
+            (xs[I[1]]^2 + ys[I[2]]^2 + zs[I[3]]^2 <= Rs^2) && (Ms_z[I] = Ms)
+        end
+        Zs = zeros(Float64, ns, ns, ns)
+        scale = μ0 * Ms / 3           # the natural field scale of the problem
+        # Sample well inside, away from the staircase surface.
+        inner = [
+            I for I in CartesianIndices(Ms_z)
+                  if xs[I[1]]^2 + ys[I[2]]^2 + zs[I[3]]^2 <= (Rs / 2)^2
+        ]
+        resid(kw) =
+            let (_, _, B) = dipole_magnetic_field(gs, Zs, Zs, Ms_z; kw...)
+                maximum(I -> abs(B[I]), inner) / scale
+            end
+
+        r_pad_trunc = resid((padded=true, truncate=true))
+        r_pad_only = resid((padded=true, truncate=false))
+        r_bare = resid((padded=false, truncate=false))
+
+        @test r_pad_trunc < 1e-2                 # the oracle holds at all
+        @test r_pad_only < 0.5 * r_bare          # padding is the big win here
+        @test r_pad_trunc <= r_pad_only          # and the cutoff does not hurt
+        # This residual is dominated by the sphere's staircase surface (it falls
+        # with resolution), so it gates the padding but cannot resolve the
+        # cutoff's contribution. The smooth-source test below does that.
+    end
+
+    @testset "cutoff removes the residual a padded kernel still has" begin
+        # Padding pushes the SOURCE images out but leaves the KERNEL periodic on
+        # the doubled box, and the 1/r³ tail wraps. Reference: same dx, doubled
+        # box, so the images are twice as far and the interior is converged.
+        σr, nr, Lr = 1.2, 32, 12.0
+        gauss(g) =
+            let (gx, gy, gz) = g.x
+                [
+                    M0 * exp(-(gx[i]^2 + gy[j]^2 + gz[k]^2) / (2σr^2))
+                    for i in eachindex(gx), j in eachindex(gy), k in eachindex(gz)
+                ]
+            end
+        gref = make_grid(GridConfig((2nr, 2nr, 2nr), (2Lr, 2Lr, 2Lr)))
+        Mref = gauss(gref)
+        _, _, Bref = dipole_magnetic_field(gref, zero(Mref), zero(Mref), Mref;
+            padded=true, truncate=true)
+
+        gsm = make_grid(GridConfig((nr, nr, nr), (Lr, Lr, Lr)))
+        Msm = gauss(gsm)
+        off = nr ÷ 2                  # same dx ⇒ small box is the centre block
+        err(kw) =
+            let (_, _, B) = dipole_magnetic_field(gsm, zero(Msm), zero(Msm), Msm; kw...)
+                num, den = 0.0, 0.0
+                for k in 1:nr, j in 1:nr, i in 1:nr
+                    r = Bref[i + off, j + off, k + off]
+                    num = max(num, abs(B[i, j, k] - r))
+                    den = max(den, abs(r))
+                end
+                num / den
+            end
+
+        e_trunc = err((padded=true, truncate=true))
+        e_pad_only = err((padded=true, truncate=false))
+        @test e_trunc < 0.1 * e_pad_only    # measured 5.5e-5 vs 2.6e-3, a 46x gap
+        @test e_trunc < 1e-3
+    end
 end

--- a/test/hamiltonian/test_ddi_padded.jl
+++ b/test/hamiltonian/test_ddi_padded.jl
@@ -206,4 +206,42 @@
         @test ws.ddi === nothing
         @test ws.ddi_padded === nothing
     end
+
+    @testset "pad_factor auto lifts the short-axis cap on the cutoff" begin
+        # A single sphere has ONE radius, so on an anisotropic box the binding
+        # axis is the SHORT one: at a flat 2x pad the cutoff is capped at
+        # min(box) while covering every separation in the box needs max(box).
+        # `pad_factor: auto` sizes the padding per axis so the cap lifts.
+        iso = (12.0, 12.0, 12.0)
+        cigar = (12.0, 12.0, 24.0)
+
+        # Isotropic boxes are already exact at a flat 2x — auto must not change
+        # them, or it would cost memory for nothing on 235 of 294 DDI configs.
+        @test SpinorBEC.auto_ddi_pad_factor(iso) == (2.0, 2.0, 2.0)
+        @test SpinorBEC.auto_ddi_trunc_radius(iso, 2.0) == 12.0
+
+        # Aspect 2: the short axis needs 3x so the cutoff can reach max(box).
+        @test SpinorBEC.auto_ddi_pad_factor(cigar) == (3.0, 3.0, 2.0)
+        @test SpinorBEC.auto_ddi_trunc_radius(cigar, SpinorBEC.auto_ddi_pad_factor(cigar)) == 24.0
+        # …which is exactly the cap a flat 2x would have imposed instead.
+        @test SpinorBEC.auto_ddi_trunc_radius(cigar, 2.0) == 12.0
+
+        # Unpadded stays at half the smallest extent (the sphere would otherwise
+        # overlap its own periodic image).
+        @test SpinorBEC.auto_ddi_trunc_radius(cigar) == 6.0
+
+        # The sentinel survives the YAML parser and resolves inside make_workspace.
+        @test SpinorBEC._parse_ddi_pad_factor("auto") == -1.0
+        @test SpinorBEC._parse_ddi_pad_factor(nothing) == 2.0
+        @test_throws ArgumentError SpinorBEC._parse_ddi_pad_factor("box_half")
+
+        grid = make_grid(GridConfig((16, 16, 32), cigar))
+        ws = make_workspace(; grid, atom=Eu151,
+            interactions=InteractionParams(Dict(0 => 1.0)),
+            sim_params=SimParams(; dt=0.001, n_steps=1),
+            enable_ddi=true, c_dd=1.0,
+            ddi_padding=true, ddi_pad_factor=-1.0, ddi_trunc_radius=-1.0)
+        # 1 + max/L per axis on (16,16,32) at box (12,12,24) -> (3,3,2)x the grid.
+        @test ws.ddi_padded.padded_shape == (48, 48, 64)
+    end
 end

--- a/test/workflow/test_config.jl
+++ b/test/workflow/test_config.jl
@@ -181,6 +181,26 @@
         # again — they used to carry independent literals.
         @test SpinorBEC.DDI_PADDED_DEFAULT == true
         @test SpinorBEC.DDI_TRUNC_RADIUS_DEFAULT == -1.0
+
+        # `pad_factor: auto` has to survive schema validation as a String, not
+        # just parse — the FieldSpec type is what rejects it otherwise.
+        yaml_auto = """
+        pipeline:
+          - ground_state:
+              atom: Eu151
+              grid: {n: [8, 8, 16], box: [6.0, 6.0, 12.0]}
+              interactions: {N_atoms: 1000, omega_ref: 628.3}
+              ddi: {enabled: true, pad_factor: auto}
+              dt: 0.005
+              n_steps: 10
+              tol: 1.0e-6
+              potential: {type: harmonic, omega: [1.0, 1.0, 1.0]}
+        """
+        cfg_auto = load_config_from_string(yaml_auto)
+        _, _, _, _, _, _, _, pf_auto = SpinorBEC._parse_gs_ddi(
+            cfg_auto.steps[1].params["ddi"], inter, atom
+        )
+        @test pf_auto == -1.0
     end
 
     @testset "run_config - ground_state" begin


### PR DESCRIPTION
Follow-up to #178, which defaulted the DDI spherical cutoff and zero-padding on. Two gaps that survived it, both measured against a free-space reference.

## 1. `analysis/dipole_field.jl` padded but never truncated

Padding pushes the **source** images out. It leaves the **kernel** periodic on the doubled box, and the 1/r³ tail wraps. Against a same-dx doubled-box reference, on a smooth Gaussian source:

| config | max rel. field error |
|---|---|
| unpadded, no cutoff | 1.14e-1 |
| padded, no cutoff (previous behaviour) | 2.55e-3 |
| **padded + cutoff (new default)** | **5.50e-5** |

A 46× improvement. `truncate` is a kwarg (`true` / `false` / an explicit `Float64` radius), so the old behaviour stays reachable.

## 2. The cutoff was capped by the short axis

A sphere has **one** radius, so at a flat 2× pad `auto_ddi_trunc_radius` stops at `min(box)`, while covering every separation in the box needs `max(box)`. On the aspect-2 cigar that left 1.8e-3 of field error — *worse* than the 9.4e-4 of padding alone — bought in exchange for exact rotation covariance (J_z violation 5.1e-9 vs 1.1e-3). It was a trade, not a win.

`pad_factor: auto` solves `(f_d − 1)·L_d >= max(box)` per axis, giving `f_d = 1 + max(box)/L_d`. On that cigar: `(3, 3, 2)` — which is exactly the configuration the probe already measures at **0** error.

**Auto is opt-in, not the default.** Isotropic boxes resolve to exactly 2 on every axis (235 of 294 DDI configs, already exact there), so defaulting it would buy nothing for the majority while charging 2.25× the padded volume on the rest.

## Single declaration

Both auto rules now live once in `terms/ddi/qtensor.jl` (`auto_ddi_trunc_radius`, `auto_ddi_pad_factor`); `make_workspace` and `dipole_field.jl` call them instead of restating the formula. Found on the way: `make_workspace` passed the **raw** `ddi_pad_factor` kwarg to `make_ddi_padded` rather than the resolved factors, so the `auto` sentinel reached `_padded_grid_size` and threw.

## Tests

The sphere oracle is analytic and independent of any reference implementation: inside a uniformly magnetised sphere `H = -M/3` exactly, and this convention returns `B = μ₀H + μ₀M/3` (the `+δ/3` of `Q_αβ`), so the two cancel and **the interior field vanishes identically**. Every nonzero value there is error.

It gates the padding (1.2e-2 → 4.6e-3) but *not* the cutoff — that residual is dominated by the sphere's staircase surface and falls with resolution, so it cannot resolve the cutoff's contribution. The smooth-source test does that. Both assertions are in the diff, with that limitation written down rather than left implicit.

Also included (first commit): the probe row for padding-without-a-cutoff, which is what exposed gap 1.

- Tier ci: 258 files across 10 workers, all passed.
- `test/analysis/test_dipole_field.jl` 20/20, `test/hamiltonian/test_ddi_padded.jl` 36/36, `test/workflow/test_config.jl` 52/52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)