### PR TITLE
fix(lhy): full_bdg ignored n_atoms on the degenerate-Zeeman branch — E_LHY was 99.8% of E_tot

### DIFF
--- a/src/hamiltonian/terms/lhy/full_bdg.jl
+++ b/src/hamiltonian/terms/lhy/full_bdg.jl
@@ -153,10 +153,18 @@ function compute_spinor_lhy_table(;
         #     n = 2.0:  1.2e-5           vs  2.4e-5
         n_points >= 3 || throw(ArgumentError("n_points must be >= 3"))
         n_max > 0 || throw(ArgumentError("n_max must be positive"))
+        n_atoms >= 1 || throw(ArgumentError("n_atoms must be >= 1"))
         eps_1 = _lhy_bdg_energy_density(spinor, 1.0, F, interactions, zeeman,
             c_dd, k_max, n_k, n_dir; rtol)
         densities = collect(range(0.0, n_max; length=n_points))
-        return FullBdGLHY(densities, (2.5 * eps_1) .* densities .^ 1.5)
+        # `/ n_atoms` for the same reason `_tabulate_lhy` divides: `g` comes from
+        # the dimensionless c₀ = 4π(a_s/a_ho)N, which already carries N, while
+        # `n = |ψ|²` is normalised to ∫|ψ|²dV = 1. This branch bypasses
+        # `_tabulate_lhy` for accuracy and used to bypass its division with it,
+        # so `full_bdg` was exactly N too large for every DEGENERATE Zeeman
+        # config — i.e. the whole weak-field regime. Dividing V is equivalent to
+        # dividing ε, since V = dε/dn and the scaling is exactly n^(5/2) here.
+        return FullBdGLHY(densities, (2.5 * eps_1 / n_atoms) .* densities .^ 1.5)
     end
 
     _tabulate_lhy(FullBdGLHY; n_max, n_points, n_atoms) do n0

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -129,6 +129,7 @@ const FAST_TESTS = [
     "hamiltonian/test_lhy_2d.jl",
     "analysis/test_bogoliubov_enhanced.jl",
     "hamiltonian/test_spinor_lhy.jl",
+    "hamiltonian/test_full_bdg_n_atoms_branches.jl",
     "hamiltonian/test_tabulated_lhy_propagator_parity.jl",
     "hamiltonian/test_lhy_energy_convention.jl",
     "hamiltonian/test_spatial_lhy.jl",

--- a/test/hamiltonian/test_full_bdg_n_atoms_branches.jl
+++ b/test/hamiltonian/test_full_bdg_n_atoms_branches.jl
@@ -1,0 +1,71 @@
+# `compute_spinor_lhy_table` must honour `n_atoms` on BOTH of its branches.
+#
+# It has two: a fast path for degenerate Zeeman levels, where ε ∝ n^(5/2) exactly
+# and one integral fills the table, and the general path through
+# `_tabulate_lhy`. Only the general one divided by `n_atoms`. The fast path
+# accepted the kwarg and ignored it, so `full_bdg` was exactly N too large
+# whenever the Zeeman levels were degenerate — which is the entire weak-field
+# regime the Eu campaign works in.
+#
+# Measured before the fix, F=1 polar, c₀=1, c₁=0.05, n_atoms 1 vs 50000:
+#
+#     degenerate  (p=q=0)    ratio 1.0       <- ignored
+#     non-degen.  (p=0.5)    ratio 50000.0   <- honoured
+#
+# Downstream it showed up as E_LHY = 99.8 % of E_tot through `run_yaml` while
+# `polar_contact` on the same cell and state gave 1.34 %. The direct-call parity
+# oracle stayed green at 97/97 throughout, because it compares the two modes at
+# `n_atoms = 1` where the branches agree — which is why this needs its own gate
+# rather than a tighter tolerance on that one.
+
+using Test
+using SpinorBEC
+
+@testset "full_bdg honours n_atoms on both branches" begin
+    F = 1
+    spinor = ComplexF64[0, 1, 0]                       # polar
+    ip = InteractionParams(Dict(0 => 1.0, 1 => 0.05))
+    N = 50_000
+    probe = 6                                          # any interior density point
+
+    tbl(zee, n_atoms) = compute_spinor_lhy_table(;
+        spinor, F, interactions=ip, zeeman=zee,
+        n_max=2.0, n_points=9, n_atoms)
+
+    @testset "degenerate Zeeman (the fast path)" begin
+        zee = ZeemanParams(0.0, 0.0)
+        v1 = tbl(zee, 1).potential_values[probe]
+        vN = tbl(zee, N).potential_values[probe]
+        @test v1 > 0                                   # not vacuously equal at 0
+        @test isapprox(v1 / vN, N; rtol=1e-9)
+    end
+
+    @testset "non-degenerate Zeeman (through _tabulate_lhy)" begin
+        zee = ZeemanParams(0.5, 0.0)
+        v1 = tbl(zee, 1).potential_values[probe]
+        vN = tbl(zee, N).potential_values[probe]
+        @test v1 > 0
+        @test isapprox(v1 / vN, N; rtol=1e-9)
+    end
+
+    @testset "the two branches agree where they overlap" begin
+        # A vanishing but non-degenerate splitting must land on the degenerate
+        # answer; otherwise the branch boundary is itself a discontinuity, which
+        # is how a per-branch normalisation error hides.
+        #
+        # The bound is set by the general path's central-difference V, not by
+        # physics, so it is resolution-dependent. Measured gap at the midpoint
+        # density, n_atoms = 50000:
+        #
+        #     n_points     9      41      201      801
+        #     rel gap   1.4e-2  3.5e-4  1.26e-5  2.5e-6
+        #
+        # — clean ~1/n_points² convergence. 201 points with rtol 1e-4 leaves
+        # ~8× margin over the measured 1.26e-5 rather than sitting on it.
+        fine(zee) = compute_spinor_lhy_table(;
+            spinor, F, interactions=ip, zeeman=zee,
+            n_max=2.0, n_points=201, n_atoms=N).potential_values[100]
+        @test isapprox(fine(ZeemanParams(0.0, 0.0)),
+            fine(ZeemanParams(1e-12, 0.0)); rtol=1e-4)
+    end
+end


### PR DESCRIPTION
Found while trying to run the Eu texture B-scan LHY recompute. It blocks that recompute independently of #179.

## The defect

`compute_spinor_lhy_table` has two paths. Degenerate Zeeman levels take a fast one — ε ∝ n^(5/2) exactly, so one integral fills the table and `V = dε/dn` is analytic — otherwise it goes through `_tabulate_lhy`. **Only the second divided by `n_atoms`.** The fast path accepted the kwarg and ignored it.

That division is the #158 fix: `g` comes from the dimensionless `c₀ = 4π(a_s/a_ho)N`, which already carries N, while `n = |ψ|²` is normalised to 1. Carried twice at the 5/2 power the table comes out a factor N too large.

So `full_bdg` was **exactly N too large for every degenerate-Zeeman config** — which is the entire weak-field regime the Eu campaign works in.

## Evidence

Proven with no physics comparison at all, F=1 polar, `n_atoms` 1 vs 50000:

| branch | ratio | |
|---|---|---|
| degenerate (p=q=0) | **1.0** | ignored |
| non-degenerate (p=0.5) | 50000.0 | honoured |

End to end through `run_yaml` — one cell, polar state, DDI off, i.e. the state whose closed form is exact:

| mode | before | after |
|---|---|---|
| `polar_contact` | 1.337 % of E_tot | 1.337 % |
| **`full_bdg`** | **99.805 %** | **1.259 %** |

An LHY that is 99.8 % of the total energy is a correction that is not a correction.

## Why the existing oracle did not catch it

**`test/oracles/test_lhy_full_bdg_closed_form_parity.jl` was green at 97/97 throughout, and still is.** It compares the modes at `n_atoms = 1`, where the two branches agree, so the defect is invisible to it by construction. A tighter tolerance there would not have helped — this needed a gate on the parameter the oracle holds fixed.

## The new gate

`test/hamiltonian/test_full_bdg_n_atoms_branches.jl` (ci tier):

- `n_atoms` is honoured on **both** branches (and `v > 0` first, so it cannot pass vacuously at zero);
- a vanishing splitting lands on the degenerate answer, so the branch boundary is not itself a discontinuity — that is the shape a per-branch normalisation error hides in.

Its tolerance is **measured, not fitted**. The cross-branch gap is central-difference error in the general path and converges cleanly:

| n_points | 9 | 41 | 201 | 801 |
|---|---|---|---|---|
| rel gap | 1.4e-2 | 3.5e-4 | 1.26e-5 | 2.5e-6 |

so the test runs at 201 with `rtol = 1e-4`, ~8× margin rather than sitting on the measured value.

## Blast radius

Every `lhy: {kind: full_bdg}` result at weak field. Third wiring-layer LHY defect today after #158 and #179, and like both of those it is invisible to a gate written against the kernel or against `scalar` — `scalar` rides in `interactions.c_lhy` and never touches the table path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)