### PR TITLE
perf(itp): 2.2× on CPU — Taylor-Horner spin rotation, and drop the per-step host sync

### DIFF
--- a/bench/profile_1step_gpu.jl
+++ b/bench/profile_1step_gpu.jl
@@ -104,13 +104,13 @@ t_diag = gtime(() -> SpinorBEC._dispatch_diagonal_step!(ws, Val(3), zd, 0.00125,
 let Ext = Base.get_extension(SpinorBEC, :SpinorBECCUDAExt)
     pm = sqrt(maximum(bufs.Phi_x.^2 .+ bufs.Phi_y.^2 .+ bufs.Phi_z.^2))
     R = 0.0025 * pm * Float64(sm.system.F)
-    use0 = Ext._SPIN_TAYLOR_ENABLED[]
+    use0 = SpinorBEC.SPIN_TAYLOR_ENABLED[]
     @printf("\nDDI rotation: peak R = dt·max|Φ|·F = %.4f (the kernel sizes each voxel from its own R)\n", R)
-    Ext._SPIN_TAYLOR_ENABLED[] = true
+    SpinorBEC.SPIN_TAYLOR_ENABLED[] = true
     t_rot_tay = gtime(() -> SpinorBEC._apply_ddi_rotation!(psi, bufs.Phi_x, bufs.Phi_y, bufs.Phi_z, sm, 0.0025, 3))
-    Ext._SPIN_TAYLOR_ENABLED[] = false
+    SpinorBEC.SPIN_TAYLOR_ENABLED[] = false
     t_rot_eul = gtime(() -> SpinorBEC._apply_ddi_rotation!(psi, bufs.Phi_x, bufs.Phi_y, bufs.Phi_z, sm, 0.0025, 3))
-    Ext._SPIN_TAYLOR_ENABLED[] = use0          # restore the real default
+    SpinorBEC.SPIN_TAYLOR_ENABLED[] = use0          # restore the real default
     @printf("  ddi_rotation  Taylor %8.1f μs   Euler %8.1f μs   (Euler/Taylor=%.2fx)\n",
         t_rot_tay, t_rot_eul, t_rot_eul / t_rot_tay)
 end

--- a/bench/rtp_gpu_ab.jl
+++ b/bench/rtp_gpu_ab.jl
@@ -42,7 +42,7 @@ function build(n; c1_ratio=0.05, dt=1e-4)
 end
 
 function arm!(ws, psi0, mode::Symbol, k)
-    Ext._SPIN_TAYLOR_ENABLED[] = mode !== :euler
+    SpinorBEC.SPIN_TAYLOR_ENABLED[] = mode !== :euler
     step! = mode === :combined ? SpinorBEC.split_step_combined! : SpinorBEC.split_step!
     copyto!(ws.state.psi, psi0)
     ws.state.t = 0.0
@@ -97,7 +97,7 @@ for n in SIZES
 end
 
 # Kernel breakdown of both surviving paths at the largest size.
-Ext._SPIN_TAYLOR_ENABLED[] = true
+SpinorBEC.SPIN_TAYLOR_ENABLED[] = true
 let n = SIZES[end]
     for (label, step!) in (("sequential", SpinorBEC.split_step!),
         ("combined", SpinorBEC.split_step_combined!))

--- a/bench/taylor_tolerance_sweep.jl
+++ b/bench/taylor_tolerance_sweep.jl
@@ -94,7 +94,15 @@ println("="^78)
 
 # Reference 1: the EXACT rotation. Any Taylor arm's deviation from this is
 # truncation error and nothing else.
-println("\n[1/3] exact Euler reference…")
+# Warm up BOTH realizations before anything is timed. The first version of this
+# script timed the exact-Euler reference first and cold, which made its wall
+# time absorb the whole JIT cascade and reported a "4×" whole-run speedup that
+# was an artefact. Kernel-level A/B (bench/bench_itp_step.jl) said 2.19×.
+println("\n[0/3] warm-up (both realizations)…")
+run_itp(; dt=DT, n_steps=2, taylor=false)
+run_itp(; dt=DT, n_steps=2, taylor=true)
+
+println("[1/3] exact Euler reference…")
 ref = run_itp(; dt=DT, n_steps=N_STEPS, taylor=false)
 @printf("  E_exact   = %.15g   (%.1f s)\n", ref.E, ref.wall)
 

--- a/bench/taylor_tolerance_sweep.jl
+++ b/bench/taylor_tolerance_sweep.jl
@@ -1,0 +1,131 @@
+# What accuracy does the Taylor spin rotation actually need, and what does it
+# cost?
+#
+# `SPIN_TAYLOR_TOL` was inherited from the CUDA kernel, where it was justified by
+# a measurement on that device (1e-9 → 1e-13 cost 1.088× at 64³ and 1.024× at
+# 128³ — the degree is nearly free when the kernel is memory-bound). The CPU
+# Horner is a different realization on different hardware and that justification
+# does NOT carry over. This script is the missing measurement.
+#
+# Two questions, deliberately separated:
+#
+#   COST    step time and mean Horner degree vs tol. If cost is flat, there is
+#           no decision to make: pin at machine precision and delete the knob.
+#
+#   ANSWER  |E(tol) − E(exact Euler)| vs tol, put NEXT TO the splitting error
+#           |E(dt) − E(dt/2)| for the same config. That second number is the
+#           error the user already accepted when they chose dt. A truncation
+#           error far below it changes nothing anyone can observe; one above it
+#           is the tolerance doing damage.
+#
+# The point of the ratio is that it turns `tol` from a judgement into a derived
+# quantity. Nobody has to know what 1e-13 means — they have to know that the
+# rotation must not be the dominant error, which is a statement about the
+# integrator they already chose.
+
+using Printf
+using SpinorBEC
+using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_TOL, SPIN_TAYLOR_RK_MAX,
+    _taylor_rot_schedule, _cpu_spin_rk, _compute_spin_density!
+
+include(joinpath(@__DIR__, "eu151_params.jl"))
+
+const N_GRID = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 32
+const N_STEPS = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 200
+
+function run_itp(; dt, n_steps, taylor::Bool, tol_taylor=nothing)
+    old_en = SPIN_TAYLOR_ENABLED[]
+    old_tol = SPIN_TAYLOR_TOL[]
+    SPIN_TAYLOR_ENABLED[] = taylor
+    tol_taylor === nothing || (SPIN_TAYLOR_TOL[] = tol_taylor)
+    try
+        grid = make_grid(GridConfig(ntuple(_ -> N_GRID, 3), ntuple(_ -> 12.0, 3)))
+        psi0 = init_psi(grid, SpinSystem(6); state=:spin_coherent,
+            init_theta=π / 4, init_phi=0.3)
+        t0 = time()
+        gs = find_ground_state(;
+            grid, atom=Eu151,
+            interactions=eu_interaction_params(0.05),
+            zeeman=ZeemanParams(EU_p_weak, 0.0),
+            potential=HarmonicTrap((1.0, 1.0, EU_λ_z)),
+            psi_init=psi0,
+            dt, n_steps, tol=0.0,          # tol=0 ⇒ always runs all n_steps
+            save_every=max(1, n_steps ÷ 2),
+            enable_ddi=true, c_dd=EU_c_dd,
+            ddi_padding=true, ddi_trunc_radius=-1.0,
+            verbose=false,
+        )
+        (E=gs.energy, wall=time() - t0, psi=copy(gs.workspace.state.psi))
+    finally
+        SPIN_TAYLOR_ENABLED[] = old_en
+        SPIN_TAYLOR_TOL[] = old_tol
+    end
+end
+
+# Mean/max Horner degree actually taken at a given tol, over the DDI field of a
+# converged-ish state. This is what the cost is a function of.
+function degree_stats(psi, sm, dt, tol)
+    n_pts = size(psi)[1:3]
+    N = prod(n_pts)
+    fx, fy, fz = (zeros(Float64, n_pts), zeros(Float64, n_pts), zeros(Float64, n_pts))
+    _compute_spin_density!(fx, fy, fz, psi, sm, Val(13), 3, n_pts)
+    rk = _cpu_spin_rk(Float64, dt)
+    F2 = Float64(sm.system.F)^2
+    tol2 = tol^2
+    rsafe2 = 1.0
+    tot = 0
+    mx = 0
+    @inbounds for i in 1:N
+        g = (fx[i]^2 + fy[i]^2 + fz[i]^2) * F2
+        _, _, kv = _taylor_rot_schedule(g, rk, SPIN_TAYLOR_RK_MAX, tol2, rsafe2)
+        tot += kv
+        mx = max(mx, kv)
+    end
+    (mean=tot / N, max=mx)
+end
+
+const DT = 0.002
+const TOLS = [1e-5, 1e-7, 1e-9, 1e-11, 1e-13, 1e-15]
+
+println("="^78)
+println("Taylor tolerance sweep — Eu F=6 D=13, $(N_GRID)³, $(N_STEPS) ITP steps, dt=$DT")
+println("threads=$(Threads.nthreads())")
+println("="^78)
+
+# Reference 1: the EXACT rotation. Any Taylor arm's deviation from this is
+# truncation error and nothing else.
+println("\n[1/3] exact Euler reference…")
+ref = run_itp(; dt=DT, n_steps=N_STEPS, taylor=false)
+@printf("  E_exact   = %.15g   (%.1f s)\n", ref.E, ref.wall)
+
+# Reference 2: the SPLITTING error the user already accepted by choosing dt.
+# Same integrator, half the step, twice the steps — same physical time.
+println("[2/3] splitting-error reference (dt/2, 2×steps, exact rotation)…")
+ref_half = run_itp(; dt=DT / 2, n_steps=2N_STEPS, taylor=false)
+split_err = abs(ref_half.E - ref.E)
+@printf("  E(dt/2)   = %.15g\n", ref_half.E)
+@printf("  |E(dt) − E(dt/2)| = %.3e   ← the error already present at dt=%g\n",
+    split_err, DT)
+
+println("[3/3] Taylor arms…")
+@printf("\n  %-9s %12s %10s %10s %9s %8s %8s\n",
+    "tol", "|ΔE| vs exact", "/split err", "wall (s)", "vs Euler", "deg avg", "deg max")
+for tol in TOLS
+    r = run_itp(; dt=DT, n_steps=N_STEPS, taylor=true, tol_taylor=tol)
+    d = degree_stats(ref.psi, spin_matrices(6), DT, tol)
+    dE = abs(r.E - ref.E)
+    @printf("  %-9.0e %12.3e %10.2e %10.1f %9.3f %8.2f %8d\n",
+        tol, dE, dE / max(split_err, eps()), r.wall, r.wall / ref.wall, d.mean, d.max)
+end
+
+println("""
+
+Reading this table:
+  * `/split err` < 1 means the rotation is NOT the dominant error at this dt —
+    the answer is the same one the user would have got from the exact rotation,
+    to within what they already accepted.
+  * `vs Euler` is the whole-run cost. If it is flat across tol, the tolerance is
+    free and should be pinned at machine precision rather than exposed.
+  * `deg avg` explains the cost: the Horner degree grows like log(1/tol)/log(1/R),
+    so tightening a decade adds well under one term at production R.
+""")

--- a/bench/verify_spin_rotation_taylor.jl
+++ b/bench/verify_spin_rotation_taylor.jl
@@ -18,7 +18,7 @@ function inputs(N, D, ::Type{T}, scale) where {T}
 end
 
 function run(use_taylor, sm, psi, px, py, pz, dt, it)
-    Ext._SPIN_TAYLOR_ENABLED[] = use_taylor
+    SpinorBEC.SPIN_TAYLOR_ENABLED[] = use_taylor
     p = copy(psi)
     SpinorBEC._apply_ddi_rotation!(p, px, py, pz, sm, dt, 3; imaginary_time=it)
     CUDA.synchronize()
@@ -38,12 +38,12 @@ for T in (Float64, Float32)
             tay = run(true, sm, psi, px, py, pz, dt, it)
             relerr = norm(Array(tay) .- Array(eul)) / norm(Array(eul))
             tol = T == Float64 ? 1e-11 : 5e-5
-            tag = R > Ext._SPIN_TAYLOR_RSAFE[] ? "halved" : "direct"
+            tag = R > SpinorBEC.SPIN_TAYLOR_RSAFE[] ? "halved" : "direct"
             ok = relerr < tol
             println("  T=$T R=$(round(R,digits=4)) it=$it  $tag  relerr=$relerr  ",
                 ok ? "OK" : "*** FAIL ***")
         end
     end
 end
-Ext._SPIN_TAYLOR_ENABLED[] = true
+SpinorBEC.SPIN_TAYLOR_ENABLED[] = true
 println("DONE")

--- a/ext/SpinorBECCUDAExt/SpinorBECCUDAExt.jl
+++ b/ext/SpinorBECCUDAExt/SpinorBECCUDAExt.jl
@@ -25,7 +25,7 @@ using SpinorBEC: _voxel_index
 # Horner, so the two devices cannot drift to different tolerances or a different
 # spin algebra.
 using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_TOL, SPIN_TAYLOR_RSAFE,
-    SPIN_TAYLOR_RK_MAX
+    SPIN_TAYLOR_RK_MAX, SPIN_TAYLOR_MIN_DEGREE
 
 include("backend.jl")
 include("gpu_rng.jl")

--- a/ext/SpinorBECCUDAExt/SpinorBECCUDAExt.jl
+++ b/ext/SpinorBECCUDAExt/SpinorBECCUDAExt.jl
@@ -20,6 +20,12 @@ using LinearAlgebra: dot
 # Shared with the CPU kernels — see src/foundation/voxel_index.jl. Declared once
 # so the padded-corner field access cannot drift between the two devices.
 using SpinorBEC: _voxel_index
+# The Taylor accuracy contract and the tridiagonal generator are declared in
+# src/foundation/spinor_utils/spin_rotation_taylor.jl and shared with the CPU
+# Horner, so the two devices cannot drift to different tolerances or a different
+# spin algebra.
+using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_TOL, SPIN_TAYLOR_RSAFE,
+    SPIN_TAYLOR_RK_MAX
 
 include("backend.jl")
 include("gpu_rng.jl")

--- a/ext/SpinorBECCUDAExt/SpinorBECCUDAExt.jl
+++ b/ext/SpinorBECCUDAExt/SpinorBECCUDAExt.jl
@@ -25,7 +25,7 @@ using SpinorBEC: _voxel_index
 # Horner, so the two devices cannot drift to different tolerances or a different
 # spin algebra.
 using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_TOL, SPIN_TAYLOR_RSAFE,
-    SPIN_TAYLOR_RK_MAX, SPIN_TAYLOR_MIN_DEGREE
+    SPIN_TAYLOR_RK_MAX, SPIN_TAYLOR_DEGREE_CAP
 
 include("backend.jl")
 include("gpu_rng.jl")

--- a/ext/SpinorBECCUDAExt/gpu_normalize.jl
+++ b/ext/SpinorBECCUDAExt/gpu_normalize.jl
@@ -5,12 +5,28 @@
 # a GPU→CPU sync point.
 
 """
-GPU-native normalize: compute total norm in one GPU reduction.
+GPU-native normalize: one GPU reduction, and the norm never leaves the device.
+
+`sum(abs2, psi)` returns a HOST scalar, so it ends in a device-to-host copy —
+i.e. a full stream drain. ITP normalises on EVERY step (`normalize_every = 1`
+whenever the magnetisation is unconstrained), so that was one host round-trip
+per step: measured 61 µs at 32³ and 152 µs at 64³ on an H100, which is 12 % of
+a 32³ ITP step and, at 8× the data for 2.5× the time, plainly latency and not
+bandwidth. Reducing with `dims` leaves the result in a `(1,1,…,1)` device array
+that broadcasts against ψ, so nothing is transferred and nothing waits.
+
+Same failure mode the Taylor rotation's per-voxel degree was introduced to
+avoid (gpu_spin_rotation_taylor.jl, "Accuracy contract"): a scalar read back to
+the host is a stream drain wearing a reduction's clothes.
+
+Not bit-identical to the scalar form — a `dims` reduction need not sum in the
+same order — but it is the same quantity to within reduction round-off, and it
+is a normalisation constant.
 """
 function SpinorBEC._normalize_psi!(psi::CuArray{<:Complex}, grid, n_components, ndim)
     dV = SpinorBEC.cell_volume(grid)
-    norm_sq = sum(abs2, psi) * dV  # single GPU reduction + scalar transfer
-    psi ./= sqrt(norm_sq)
+    norm_sq = sum(abs2, psi; dims=ntuple(identity, ndims(psi)))  # stays on device
+    psi ./= sqrt.(norm_sq .* dV)
     nothing
 end
 

--- a/ext/SpinorBECCUDAExt/gpu_spin_chain.jl
+++ b/ext/SpinorBECCUDAExt/gpu_spin_chain.jl
@@ -106,8 +106,8 @@ function SpinorBEC._apply_spin_chain!(
 
     CUDA.@cuda threads = 256 blocks = cld(N, 16) _spin_chain_warp_kernel!(
         P, fv..., pv..., vph, zf, zb, coef.mz, coef.sxu, coef.syu, rk_sm, rk_dd,
-        Int32(_SPIN_RK_MAX), T(_SPIN_TAYLOR_TOL[])^2, F * F,
-        T(_SPIN_TAYLOR_RSAFE[])^2, Val(D), Val(!it))
+        Int32(SPIN_TAYLOR_RK_MAX), T(SPIN_TAYLOR_TOL[])^2, F * F,
+        T(SPIN_TAYLOR_RSAFE[])^2, Val(D), Val(!it))
     nothing
 end
 

--- a/ext/SpinorBECCUDAExt/gpu_spin_chain.jl
+++ b/ext/SpinorBECCUDAExt/gpu_spin_chain.jl
@@ -23,7 +23,7 @@
 
 @inline function _spin_chain_warp_kernel!(
     P, fx, fy, fz, px, py, pz, vph, zph_fwd, zph_bwd, mz, sxu, syu, rk_sm, rk_dd,
-    K::Int32, tol2, F2, rsafe2, ::Val{D}, ::Val{RT},
+    K::Int32, tol2, F2, rsafe2, kmin::Int32, ::Val{D}, ::Val{RT},
 ) where {D, RT}
     T = real(eltype(P))
     CT = Complex{T}
@@ -40,8 +40,8 @@
 
     ds, bs, bms, gs = _rot_generator(Fx, Fy, Fz, mz, sxu, syu, c, cdn, F2, Val(16))
     dd, bd, bmd, gd = _rot_generator(Px, Py, Pz, mz, sxu, syu, c, cdn, F2, Val(16))
-    hs, shs, kvs = _rot_schedule(gs, rk_sm, K, tol2, rsafe2)
-    hd, shd, kvd = _rot_schedule(gd, rk_dd, K, tol2, rsafe2)
+    hs, shs, kvs = _rot_schedule(gs, rk_sm, K, tol2, rsafe2, kmin)
+    hd, shd, kvd = _rot_schedule(gd, rk_dd, K, tol2, rsafe2, kmin)
 
     # Associate as `ψ · (vph · zph)`, exactly as `_diag_step_kernel!` does
     # (`P[i, c] *= vph * zph[c]`). Floating-point multiplication is not
@@ -107,7 +107,7 @@ function SpinorBEC._apply_spin_chain!(
     CUDA.@cuda threads = 256 blocks = cld(N, 16) _spin_chain_warp_kernel!(
         P, fv..., pv..., vph, zf, zb, coef.mz, coef.sxu, coef.syu, rk_sm, rk_dd,
         Int32(SPIN_TAYLOR_RK_MAX), T(SPIN_TAYLOR_TOL[])^2, F * F,
-        T(SPIN_TAYLOR_RSAFE[])^2, Val(D), Val(!it))
+        T(SPIN_TAYLOR_RSAFE[])^2, Int32(SPIN_TAYLOR_MIN_DEGREE[]), Val(D), Val(!it))
     nothing
 end
 

--- a/ext/SpinorBECCUDAExt/gpu_spin_chain.jl
+++ b/ext/SpinorBECCUDAExt/gpu_spin_chain.jl
@@ -23,7 +23,7 @@
 
 @inline function _spin_chain_warp_kernel!(
     P, fx, fy, fz, px, py, pz, vph, zph_fwd, zph_bwd, mz, sxu, syu, rk_sm, rk_dd,
-    K::Int32, tol2, F2, rsafe2, kmin::Int32, ::Val{D}, ::Val{RT},
+    K::Int32, tol2, F2, rsafe2, cap::Int32, ::Val{D}, ::Val{RT},
 ) where {D, RT}
     T = real(eltype(P))
     CT = Complex{T}
@@ -40,8 +40,8 @@
 
     ds, bs, bms, gs = _rot_generator(Fx, Fy, Fz, mz, sxu, syu, c, cdn, F2, Val(16))
     dd, bd, bmd, gd = _rot_generator(Px, Py, Pz, mz, sxu, syu, c, cdn, F2, Val(16))
-    hs, shs, kvs = _rot_schedule(gs, rk_sm, K, tol2, rsafe2, kmin)
-    hd, shd, kvd = _rot_schedule(gd, rk_dd, K, tol2, rsafe2, kmin)
+    hs, shs, kvs = _rot_schedule(gs, rk_sm, K, tol2, rsafe2, cap)
+    hd, shd, kvd = _rot_schedule(gd, rk_dd, K, tol2, rsafe2, cap)
 
     # Associate as `ψ · (vph · zph)`, exactly as `_diag_step_kernel!` does
     # (`P[i, c] *= vph * zph[c]`). Floating-point multiplication is not
@@ -107,7 +107,7 @@ function SpinorBEC._apply_spin_chain!(
     CUDA.@cuda threads = 256 blocks = cld(N, 16) _spin_chain_warp_kernel!(
         P, fv..., pv..., vph, zf, zb, coef.mz, coef.sxu, coef.syu, rk_sm, rk_dd,
         Int32(SPIN_TAYLOR_RK_MAX), T(SPIN_TAYLOR_TOL[])^2, F * F,
-        T(SPIN_TAYLOR_RSAFE[])^2, Int32(SPIN_TAYLOR_MIN_DEGREE[]), Val(D), Val(!it))
+        T(SPIN_TAYLOR_RSAFE[])^2, Int32(SPIN_TAYLOR_DEGREE_CAP[]), Val(D), Val(!it))
     nothing
 end
 

--- a/ext/SpinorBECCUDAExt/gpu_spin_rotation_taylor.jl
+++ b/ext/SpinorBECCUDAExt/gpu_spin_rotation_taylor.jl
@@ -186,7 +186,7 @@ end
 # full-warp mask, so the two voxels sharing a warp must execute the same trip
 # count or the `shfl_sync` deadlocks; neighbouring voxels pick near-identical
 # values, so rounding up costs almost nothing.
-@inline function _rot_schedule(g::T, rk, K::Int32, tol2, rsafe2) where {T}
+@inline function _rot_schedule(g::T, rk, K::Int32, tol2, rsafe2, kmin::Int32) where {T}
     scale1 = @inbounds rk[1]        # rk[1] = scale ⇒ r2 starts as R²
     r2 = scale1 * scale1 * g
     sh = zero(Int32)
@@ -207,7 +207,7 @@ end
     while kk < K
         a = @inbounds rk[kk]
         u *= a * a * gh
-        if kk >= Int32(2) && u <= tol2
+        if kk >= kmin && u <= tol2
             kv = kk
             break
         end
@@ -263,8 +263,8 @@ end
 end
 
 @inline function _spin_taylor_warp_kernel!(
-    P, vx, vy, vz, mz, sxu, syu, rk, K::Int32, tol2, F2, rsafe2, ::Val{D}, ::Val{RT},
-    src,
+    P, vx, vy, vz, mz, sxu, syu, rk, K::Int32, tol2, F2, rsafe2, kmin::Int32,
+    ::Val{D}, ::Val{RT}, src,
 ) where {D, RT}
     T = real(eltype(P))
     CT = Complex{T}
@@ -282,7 +282,7 @@ end
     Vz = in_range ? (@inbounds vz[j]) : zero(T)
 
     diag_c, b_c, bmc, g = _rot_generator(Vx, Vy, Vz, mz, sxu, syu, c, cdn, F2, Val(16))
-    h, sh, kv = _rot_schedule(g, rk, K, tol2, rsafe2)
+    h, sh, kv = _rot_schedule(g, rk, K, tol2, rsafe2, kmin)
 
     psi0 = live ? (@inbounds P[vox, c]) : zero(CT)
     w = _horner_rot(psi0, diag_c, b_c, bmc, c, cdn, rk, kv, h, sh, Val(16), Val(RT))
@@ -314,7 +314,8 @@ function _apply_spin_rotation_taylor!(
     rsafe2 = T(SPIN_TAYLOR_RSAFE[])^2
     CUDA.@cuda threads = threads blocks = blocks _spin_taylor_warp_kernel!(
         P, vx, vy, vz, coef.mz, coef.sxu, coef.syu, rk, Int32(SPIN_TAYLOR_RK_MAX),
-        tol2, F * F, rsafe2, Val(D), Val(!imaginary_time), src_idx)
+        tol2, F * F, rsafe2, Int32(SPIN_TAYLOR_MIN_DEGREE[]),
+        Val(D), Val(!imaginary_time), src_idx)
     nothing
 end
 

--- a/ext/SpinorBECCUDAExt/gpu_spin_rotation_taylor.jl
+++ b/ext/SpinorBECCUDAExt/gpu_spin_rotation_taylor.jl
@@ -186,7 +186,7 @@ end
 # full-warp mask, so the two voxels sharing a warp must execute the same trip
 # count or the `shfl_sync` deadlocks; neighbouring voxels pick near-identical
 # values, so rounding up costs almost nothing.
-@inline function _rot_schedule(g::T, rk, K::Int32, tol2, rsafe2, kmin::Int32) where {T}
+@inline function _rot_schedule(g::T, rk, K::Int32, tol2, rsafe2, cap::Int32) where {T}
     scale1 = @inbounds rk[1]        # rk[1] = scale ⇒ r2 starts as R²
     r2 = scale1 * scale1 * g
     sh = zero(Int32)
@@ -207,13 +207,13 @@ end
     while kk < K
         a = @inbounds rk[kk]
         u *= a * a * gh
-        if kk >= kmin && u <= tol2
+        if kk >= Int32(2) && u <= tol2
             kv = kk
             break
         end
         kk += one(Int32)
     end
-    (h, sh, max(kv, CUDA.shfl_xor_sync(0xffffffff, kv, 16)))
+    (h, sh, min(max(kv, CUDA.shfl_xor_sync(0xffffffff, kv, 16)), cap))
 end
 
 # `w ← exp(z·A) w`. The halving `h` is folded ONCE into the generator rather
@@ -263,7 +263,7 @@ end
 end
 
 @inline function _spin_taylor_warp_kernel!(
-    P, vx, vy, vz, mz, sxu, syu, rk, K::Int32, tol2, F2, rsafe2, kmin::Int32,
+    P, vx, vy, vz, mz, sxu, syu, rk, K::Int32, tol2, F2, rsafe2, cap::Int32,
     ::Val{D}, ::Val{RT}, src,
 ) where {D, RT}
     T = real(eltype(P))
@@ -282,7 +282,7 @@ end
     Vz = in_range ? (@inbounds vz[j]) : zero(T)
 
     diag_c, b_c, bmc, g = _rot_generator(Vx, Vy, Vz, mz, sxu, syu, c, cdn, F2, Val(16))
-    h, sh, kv = _rot_schedule(g, rk, K, tol2, rsafe2, kmin)
+    h, sh, kv = _rot_schedule(g, rk, K, tol2, rsafe2, cap)
 
     psi0 = live ? (@inbounds P[vox, c]) : zero(CT)
     w = _horner_rot(psi0, diag_c, b_c, bmc, c, cdn, rk, kv, h, sh, Val(16), Val(RT))
@@ -314,7 +314,7 @@ function _apply_spin_rotation_taylor!(
     rsafe2 = T(SPIN_TAYLOR_RSAFE[])^2
     CUDA.@cuda threads = threads blocks = blocks _spin_taylor_warp_kernel!(
         P, vx, vy, vz, coef.mz, coef.sxu, coef.syu, rk, Int32(SPIN_TAYLOR_RK_MAX),
-        tol2, F * F, rsafe2, Int32(SPIN_TAYLOR_MIN_DEGREE[]),
+        tol2, F * F, rsafe2, Int32(SPIN_TAYLOR_DEGREE_CAP[]),
         Val(D), Val(!imaginary_time), src_idx)
     nothing
 end

--- a/ext/SpinorBECCUDAExt/gpu_spin_rotation_taylor.jl
+++ b/ext/SpinorBECCUDAExt/gpu_spin_rotation_taylor.jl
@@ -47,12 +47,10 @@ function _get_spin_tridiag_coef(
     key = hash((objectid(sm), D, T))
     c = get(_SPIN_TRIDIAG_CACHE, key, nothing)
     c !== nothing && return c::SpinTridiagCoef{T}
-    Fx = sm.Fx
-    Fy = sm.Fy
-    Fz = sm.Fz
-    mz = T[T(real(Fz[i, i])) for i in 1:D]
-    sxu = Complex{T}[i < D ? Complex{T}(Fx[i, i + 1]) : zero(Complex{T}) for i in 1:D]
-    syu = Complex{T}[i < D ? Complex{T}(Fy[i, i + 1]) : zero(Complex{T}) for i in 1:D]
+    # The bands are stated ONCE, in src/foundation/spinor_utils/spin_rotation_taylor.jl,
+    # and the CPU Horner reads the same three vectors — the spin algebra cannot
+    # be written down differently on the two devices.
+    mz, sxu, syu = SpinorBEC.spin_tridiag_bands(sm, T)
     coef = SpinTridiagCoef{T}(CuArray(mz), CuArray(sxu), CuArray(syu))
     _SPIN_TRIDIAG_CACHE[key] = coef
     coef
@@ -60,7 +58,7 @@ end
 
 # --- Accuracy contract ---
 #
-# The degree and, above `_SPIN_TAYLOR_RSAFE[]`, the angle halving are decided
+# The degree and, above `SPIN_TAYLOR_RSAFE[]`, the angle halving are decided
 # PER VOXEL inside the kernel from that voxel's own `R = |scale|·|v(r)|·F`.
 # Nothing about the field is needed on the host.
 #
@@ -72,8 +70,6 @@ end
 # host. It was also pessimistic in the other direction — a trapped cloud is
 # mostly dilute tail, and paying the peak's degree everywhere is most of the
 # arithmetic (bench/micro_spin_taylor.jl).
-const _SPIN_TAYLOR_ENABLED = Ref(true)
-const _SPIN_TAYLOR_TOL = Ref(1.0e-13)  # backward-error target
 # 1e-13 because the per-voxel degree made this number BINDING. It used to be
 # slack: one degree was chosen from max|v| and then applied everywhere, so
 # every voxel below the peak got far more accuracy than 1e-9 asked for, and the
@@ -97,7 +93,6 @@ const _SPIN_TAYLOR_TOL = Ref(1.0e-13)  # backward-error target
 # squaring). Production R is 0.01–0.2 so no voxel ever halves; the branch exists
 # so that the Taylor path is exact at ANY R and the caller never has to ask.
 # 1.0 keeps the degree at ≤ 12 for tol = 1e-9, comfortably inside the table.
-const _SPIN_TAYLOR_RSAFE = Ref(1.0)
 
 # --- Horner coefficient table ---
 # `w ← ψ + (z/k)(A·w)` needs z/k for k = K…1. Computed per call as a device
@@ -113,9 +108,8 @@ const _SPIN_TAYLOR_RSAFE = Ref(1.0)
 # `Complex(0,-scale/k)·(a+bi) = (scale/k)·(b - ai)` exactly, and likewise for
 # imaginary time. Filled by a device kernel (no host allocation, no HtoD).
 #
-# `_SPIN_RK_MAX = 40` is the degree ceiling. With the halving above it is never
+# `SPIN_TAYLOR_RK_MAX = 40` is the degree ceiling. With the halving above it is never
 # approached: R ≤ 1 needs 12 terms at tol = 1e-9 and 24 at tol = 1e-24.
-const _SPIN_RK_MAX = 40
 # Keyed by the SCALE, not just the eltype: a fixed-dt run uses a handful of
 # distinct scales (c₁·τ/2 and τ for each of the predictor's and corrector's
 # half-steps) and then never refills. That matters out of proportion to the
@@ -137,8 +131,8 @@ function _get_spin_rk(::CuArray{Complex{T}}, scale::T) where {T}
     hit = get(_SPIN_RK_CACHE, key, nothing)
     hit !== nothing && return hit::CuArray{T, 1}
     length(_SPIN_RK_CACHE) >= _SPIN_RK_CACHE_MAX && empty!(_SPIN_RK_CACHE)
-    rk = CUDA.zeros(T, _SPIN_RK_MAX)
-    CUDA.@cuda threads = _SPIN_RK_MAX blocks = 1 _fill_rk_kernel!(rk, scale)
+    rk = CUDA.zeros(T, SPIN_TAYLOR_RK_MAX)
+    CUDA.@cuda threads = SPIN_TAYLOR_RK_MAX blocks = 1 _fill_rk_kernel!(rk, scale)
     _SPIN_RK_CACHE[key] = rk
     rk
 end
@@ -316,10 +310,10 @@ function _apply_spin_rotation_taylor!(
     threads = 256
     blocks = cld(N, voxels_per_block)
     rk = _get_spin_rk(P, scale)
-    tol2 = T(_SPIN_TAYLOR_TOL[])^2
-    rsafe2 = T(_SPIN_TAYLOR_RSAFE[])^2
+    tol2 = T(SPIN_TAYLOR_TOL[])^2
+    rsafe2 = T(SPIN_TAYLOR_RSAFE[])^2
     CUDA.@cuda threads = threads blocks = blocks _spin_taylor_warp_kernel!(
-        P, vx, vy, vz, coef.mz, coef.sxu, coef.syu, rk, Int32(_SPIN_RK_MAX),
+        P, vx, vy, vz, coef.mz, coef.sxu, coef.syu, rk, Int32(SPIN_TAYLOR_RK_MAX),
         tol2, F * F, rsafe2, Val(D), Val(!imaginary_time), src_idx)
     nothing
 end
@@ -340,7 +334,7 @@ imaginary time `exp(-scale·(v·F))`; the kernel's `Val{RT}` picks which.
 function _spin_taylor_plan(
     psi::CuArray{Complex{T}}, sm::SpinorBEC.SpinMatrices{D},
 ) where {T <: AbstractFloat, D}
-    _SPIN_TAYLOR_ENABLED[] || return nothing
+    SPIN_TAYLOR_ENABLED[] || return nothing
     # The warp layout puts one spin component per lane of a width-16 subgroup,
     # so D > 16 (F ≥ 8) has no lane to hold the upper components. Fall back.
     D <= 16 || return nothing

--- a/scripts/tsubame/submit_bench_itp_gpu_ab.sh
+++ b/scripts/tsubame/submit_bench_itp_gpu_ab.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#$ -cwd
+#$ -l gpu_1=1
+#$ -l h_rt=0:25:00
+#$ -N bench_itp_ab
+#$ -o /gs/bs/work/7/uk07267/logs/
+#$ -e /gs/bs/work/7/uk07267/logs/
+#
+# Both arms of a GPU ITP A/B in ONE job, so the comparison is on one card in one
+# allocation and cannot be confounded by the queue putting the arms on different
+# nodes (or the same node in different thermal states).
+#   qsub -g tga-kozuma-kouhi \
+#        -v SPINORBEC_AB_A=<baseline-worktree>,SPINORBEC_AB_B=<changed-worktree> \
+#        scripts/tsubame/submit_bench_itp_gpu_ab.sh
+set -u
+
+export JULIA_DEPOT_PATH="$HOME/.julia"
+export JULIA_NUM_THREADS="${NSLOTS:-8}"
+module load cuda/12.6 2>/dev/null || module load cuda 2>/dev/null || true
+
+JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia
+A="${SPINORBEC_AB_A:-/gs/bs/work/7/uk07267/bec-perf-itp}"
+B="${SPINORBEC_AB_B:-/gs/bs/work/7/uk07267/bec-itp-norm}"
+CFGS="${SPINORBEC_AB_CFGS:-32 64}"
+
+echo "host=$(hostname) date=$(date)"
+nvidia-smi --query-gpu=name --format=csv,noheader || true
+
+# One script file against both `--project`s, so the bench itself is not a
+# variable between the arms.
+SCRIPT="$B/bench/bench_itp_step.jl"
+
+for n in $CFGS; do
+    for root in "$A" "$B"; do
+        echo; echo "###### n=$n ROOT=$root commit=$(cd "$root" && git rev-parse --short HEAD)"
+        (cd "$root" && $JULIA --project=. "$SCRIPT" gpu "$n" none 2>&1 |
+            grep -vE "^│|^└|^┌" | tail -22)
+    done
+done
+echo "ALL DONE $(date)"

--- a/scripts/tsubame/submit_itp_cpu_ab.sh
+++ b/scripts/tsubame/submit_itp_cpu_ab.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#$ -cwd
+#$ -l cpu_4=1
+#$ -l h_rt=0:45:00
+#$ -N itp_cpu_ab
+#$ -o /gs/bs/work/7/uk07267/logs/
+#$ -e /gs/bs/work/7/uk07267/logs/
+#
+# Gates on the changed worktree, then the CPU ITP breakdown for BOTH arms in one
+# allocation.
+#   qsub -g tga-kozuma-kouhi \
+#        -v SPINORBEC_AB_A=<baseline>,SPINORBEC_AB_B=<changed> \
+#        scripts/tsubame/submit_itp_cpu_ab.sh
+set -u
+
+export JULIA_DEPOT_PATH="$HOME/.julia"
+export JULIA_NUM_THREADS="${NSLOTS:-4}"
+
+JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia
+A="${SPINORBEC_AB_A:-/gs/bs/work/7/uk07267/bec-perf-itp}"
+B="${SPINORBEC_AB_B:-/gs/bs/work/7/uk07267/bec-itp-taylor}"
+GATES="${SPINORBEC_AB_GATES:-hamiltonian/test_cpu_spin_rotation_taylor_parity.jl hamiltonian/test_spin_mixing.jl hamiltonian/test_ddi.jl hamiltonian/test_ddi_padded.jl solvers/test_itp_ddi_strang_save_every.jl oracles/test_spin_density_consistency.jl oracles/test_ddi_translation_covariance.jl analysis/test_spin_rotation.jl}"
+
+echo "host=$(hostname) date=$(date) threads=$JULIA_NUM_THREADS"
+echo "A=$A  B=$B"
+
+echo; echo "###### GATES on B commit=$(cd "$B" && git rev-parse --short HEAD)"
+for t in $GATES; do
+    echo "--- $t"
+    (cd "$B" && $JULIA --project=. \
+        -e "using Test; using SpinorBEC; include(\"test/$t\")" 2>&1 | tail -12)
+done
+
+echo; echo "###### BREAKDOWN"
+SCRIPT="$B/bench/bench_itp_step.jl"
+for n in 32 48; do
+    for root in "$A" "$B"; do
+        echo; echo "--- n=$n ROOT=$root commit=$(cd "$root" && git rev-parse --short HEAD)"
+        (cd "$root" && $JULIA --project=. "$SCRIPT" cpu "$n" none 2>&1 | tail -22)
+    done
+done
+echo "ALL DONE $(date)"

--- a/scripts/tsubame/submit_taylor_tol_sweep.sh
+++ b/scripts/tsubame/submit_taylor_tol_sweep.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#$ -cwd
+#$ -l cpu_4=1
+#$ -l h_rt=0:25:00
+#$ -N tol_sweep
+#$ -o /gs/bs/work/7/uk07267/logs/
+#$ -e /gs/bs/work/7/uk07267/logs/
+#
+# Is SPIN_TAYLOR_TOL a decision or a derived quantity? Measures the cost of the
+# tolerance and, next to it, the splitting error the caller already accepted by
+# choosing dt.
+#   qsub -g tga-kozuma-kouhi -v SPINORBEC_BENCH_ROOT=<worktree> \
+#        scripts/tsubame/submit_taylor_tol_sweep.sh
+set -u
+export JULIA_DEPOT_PATH="$HOME/.julia"
+export JULIA_NUM_THREADS="${NSLOTS:-4}"
+JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia
+cd "${SPINORBEC_BENCH_ROOT:-/gs/bs/work/7/uk07267/bec-itp-norm}"
+echo "host=$(hostname) date=$(date) commit=$(git rev-parse --short HEAD) threads=$JULIA_NUM_THREADS"
+$JULIA --project=. bench/taylor_tolerance_sweep.jl "${SPINORBEC_SWEEP_N:-32}" "${SPINORBEC_SWEEP_STEPS:-200}" 2>&1
+echo "ALL DONE $(date)"

--- a/src/foundation/spinor_utils.jl
+++ b/src/foundation/spinor_utils.jl
@@ -8,6 +8,12 @@
 #   spinor_utils/euler_batched.jl    — _apply_euler_5stage_batched_real! +
 #                                       _apply_euler_5stage_batched_imag!
 #                                       (CPU-batched gemm form)
+#   spinor_utils/spin_rotation_taylor.jl — apply_spin_rotation_taylor!
+#                                       (CPU Taylor-Horner form of the SAME
+#                                       rotation; shares its accuracy contract
+#                                       and tridiagonal bands with the CUDA
+#                                       kernel, which is a warp-cooperative
+#                                       realization of the same math)
 #   spinor_utils/euler_fused.jl      — apply_euler_5stage_fused!
 #                                       (GPU-friendly fused-broadcast form
 #                                       with optional cis_PD scratch)
@@ -26,6 +32,7 @@
 include("spinor_utils/slice_helpers.jl")
 include("spinor_utils/euler_per_voxel.jl")
 include("spinor_utils/euler_batched.jl")
+include("spinor_utils/spin_rotation_taylor.jl")
 include("spinor_utils/euler_fused.jl")
 include("spinor_utils/uniform_rotation.jl")
 include("spinor_utils/frame_rotation.jl")

--- a/src/foundation/spinor_utils/spin_rotation_taylor.jl
+++ b/src/foundation/spinor_utils/spin_rotation_taylor.jl
@@ -72,18 +72,21 @@ const SPIN_TAYLOR_RSAFE = Ref(1.0)
 """Degree ceiling. With the halving above it is never approached."""
 const SPIN_TAYLOR_RK_MAX = 40
 
-"""Smallest Horner degree the schedule may return.
+"""Upper clamp on the Horner degree. Defaults to no clamp.
 
-This is the constant that actually holds the accuracy criterion, which is why it
-has a name instead of being a literal in the loop. At production
-`R = |scale|·|v|·F ≈ 0.01–0.2` a degree of 2 already puts the truncation ~1e-5
-of the splitting error, so the schedule returns 2 for EVERY tolerance from
-1e-15 up to 1 and `SPIN_TAYLOR_TOL` never binds
-(bench/taylor_tolerance_sweep.jl). Lowering this is the only way to make the
-rotation the dominant error, which is exactly what
-`test_taylor_tolerance_criterion.jl` needs its positive control to do —
-otherwise that gate would assert something unreachable."""
-const SPIN_TAYLOR_MIN_DEGREE = Ref(2)
+Exists because the accuracy criterion needs a positive control and nothing else
+could provide one. `SPIN_TAYLOR_TOL` cannot degrade the rotation — the degree is
+floored at 2 and at production `R = |scale|·|v|·F ≈ 1e-5` the schedule returns 2
+for every tolerance over ten decades. Neither can the floor: measured, an
+order-1 rotation is still ~1e-8 relative, four orders inside the splitting
+error. The rotation is simply nowhere near binding, and the only way to make the
+observable notice it is to REMOVE it — `cap = 0` skips the Horner loop entirely,
+leaving ψ untouched.
+
+That is the honest control for "this approximation is negligible": show that the
+observable moves when the operator is absent. If it does not, the claim was
+vacuous. See `test/hamiltonian/test_taylor_tolerance_criterion.jl`."""
+const SPIN_TAYLOR_DEGREE_CAP = Ref(SPIN_TAYLOR_RK_MAX)
 
 """
     spin_tridiag_bands(sm, ::Type{T}) -> (mz, sxu, syu)
@@ -138,11 +141,12 @@ end
 
 This voxel's angle halving `h = 2^-sh` and Horner degree `kv`, from
 `g = |v|²F²`. Both tests run on SQUARES so no `sqrt` is needed:
-`(R/2^sh/k)² = (rk[k]·h)²·g`. `kmin` is the degree floor — see
-[`SPIN_TAYLOR_MIN_DEGREE`](@ref).
+`(R/2^sh/k)² = (rk[k]·h)²·g`. `cap` clamps the result from above — see
+[`SPIN_TAYLOR_DEGREE_CAP`](@ref); it exists for the accuracy gate's positive
+control and is unclamped in production.
 """
 @inline function _taylor_rot_schedule(
-    g::T, rk, K::Int, tol2::T, rsafe2::T, kmin::Int=SPIN_TAYLOR_MIN_DEGREE[]
+    g::T, rk, K::Int, tol2::T, rsafe2::T, cap::Int=SPIN_TAYLOR_DEGREE_CAP[]
 ) where {T}
     scale1 = @inbounds rk[1]          # rk[1] = scale ⇒ r2 starts as R²
     r2 = scale1 * scale1 * g
@@ -163,13 +167,13 @@ This voxel's angle halving `h = 2^-sh` and Horner degree `kv`, from
     while kk < K
         a = @inbounds rk[kk]
         u *= a * a * gh
-        if kk >= kmin && u <= tol2
+        if kk >= 2 && u <= tol2
             kv = kk
             break
         end
         kk += 1
     end
-    (h, sh, kv)
+    (h, sh, min(kv, cap))
 end
 
 # `scale / k` for k = 1…K, cached per (eltype, scale). Two FP64 divisions per

--- a/src/foundation/spinor_utils/spin_rotation_taylor.jl
+++ b/src/foundation/spinor_utils/spin_rotation_taylor.jl
@@ -31,8 +31,36 @@ compare against. Honoured by BOTH the CPU kernel here and the CUDA one."""
 const SPIN_TAYLOR_ENABLED = Ref(true)
 
 """Backward-error target for the per-voxel Taylor degree: the smallest `k ≥ 2`
-with `R^k / k! ≤ tol` is used. See the CUDA kernel's "Accuracy contract" block
-for the measurement that fixed this at 1e-13 rather than 1e-9."""
+with `R^k / k! ≤ tol` is used.
+
+This is NOT a knob to expose. `bench/taylor_tolerance_sweep.jl` measured it
+against the thing that actually binds the answer — the splitting error the
+caller already accepted when they chose `dt`. At Eu F=6, 32³, dt = 0.002, that
+splitting error (`|E(dt) − E(dt/2)|`, exact rotation both arms) is 7.6e-3, and
+the Taylor truncation sits at:
+
+    tol     |ΔE| vs exact   as a fraction of the splitting error   mean degree
+    1e-5      2.5e-7                     3.3e-5                       2.00
+    1e-9      2.9e-12                    3.9e-10                      2.26
+    1e-13     2.4e-13                    3.1e-11                      2.65
+    1e-15     2.4e-13                    3.2e-11                      2.82
+
+Three things follow. The answer SATURATES at 1e-11 — below that ΔE stops
+falling, so a tighter tolerance buys nothing. The cost is flat: the degree grows
+like log(1/tol)/log(1/R), which over ten decades is 2.00 → 2.82 terms, and the
+whole-run times (5.2–6.0 s) show no trend above the scatter of single runs. And
+even at the LOOSEST tolerance tested the rotation contributes 4.5 orders of
+magnitude less error than `dt` does.
+
+So the tolerance is not a decision the caller should be asked to make; `dt` is
+the decision, and this follows from it. 1e-13 is kept because it is free and
+leaves a decade of margin past saturation, and because one number for both
+devices is one declaration. The CUDA kernel's "Accuracy contract" block records
+the same conclusion measured on that device.
+
+The relationship, not this number, is what is gated:
+`test_cpu_spin_rotation_taylor_parity.jl` fails if the truncation error stops
+being negligible against the splitting error."""
 const SPIN_TAYLOR_TOL = Ref(1.0e-13)
 
 """Angle above which a voxel halves its rotation and applies it twice (repeated

--- a/src/foundation/spinor_utils/spin_rotation_taylor.jl
+++ b/src/foundation/spinor_utils/spin_rotation_taylor.jl
@@ -72,6 +72,19 @@ const SPIN_TAYLOR_RSAFE = Ref(1.0)
 """Degree ceiling. With the halving above it is never approached."""
 const SPIN_TAYLOR_RK_MAX = 40
 
+"""Smallest Horner degree the schedule may return.
+
+This is the constant that actually holds the accuracy criterion, which is why it
+has a name instead of being a literal in the loop. At production
+`R = |scale|·|v|·F ≈ 0.01–0.2` a degree of 2 already puts the truncation ~1e-5
+of the splitting error, so the schedule returns 2 for EVERY tolerance from
+1e-15 up to 1 and `SPIN_TAYLOR_TOL` never binds
+(bench/taylor_tolerance_sweep.jl). Lowering this is the only way to make the
+rotation the dominant error, which is exactly what
+`test_taylor_tolerance_criterion.jl` needs its positive control to do —
+otherwise that gate would assert something unreachable."""
+const SPIN_TAYLOR_MIN_DEGREE = Ref(2)
+
 """
     spin_tridiag_bands(sm, ::Type{T}) -> (mz, sxu, syu)
 
@@ -125,9 +138,12 @@ end
 
 This voxel's angle halving `h = 2^-sh` and Horner degree `kv`, from
 `g = |v|²F²`. Both tests run on SQUARES so no `sqrt` is needed:
-`(R/2^sh/k)² = (rk[k]·h)²·g`.
+`(R/2^sh/k)² = (rk[k]·h)²·g`. `kmin` is the degree floor — see
+[`SPIN_TAYLOR_MIN_DEGREE`](@ref).
 """
-@inline function _taylor_rot_schedule(g::T, rk, K::Int, tol2::T, rsafe2::T) where {T}
+@inline function _taylor_rot_schedule(
+    g::T, rk, K::Int, tol2::T, rsafe2::T, kmin::Int=SPIN_TAYLOR_MIN_DEGREE[]
+) where {T}
     scale1 = @inbounds rk[1]          # rk[1] = scale ⇒ r2 starts as R²
     r2 = scale1 * scale1 * g
     sh = 0
@@ -147,7 +163,7 @@ This voxel's angle halving `h = 2^-sh` and Horner degree `kv`, from
     while kk < K
         a = @inbounds rk[kk]
         u *= a * a * gh
-        if kk >= 2 && u <= tol2
+        if kk >= kmin && u <= tol2
             kv = kk
             break
         end

--- a/src/foundation/spinor_utils/spin_rotation_taylor.jl
+++ b/src/foundation/spinor_utils/spin_rotation_taylor.jl
@@ -1,0 +1,243 @@
+# CPU spin rotation `exp(z · (v·F)) ψ` per voxel, by Taylor–Horner.
+#
+# Same operator, same accuracy contract and same tridiagonal generator as the
+# GPU kernel in `ext/SpinorBECCUDAExt/gpu_spin_rotation_taylor.jl`; a DIFFERENT
+# realization, because the GPU form is warp-cooperative (one spin component per
+# lane, neighbours by `shfl`) and a CPU core has no such thing. Here the whole
+# spinor sits in stack buffers and the tridiagonal matvec is written out.
+#
+# What it replaces: `_apply_euler_5stage_batched_{real,imag}!`, which moves ψ
+# through cache ~18 times per rotation (5 phase passes + 4 gemms) and needs an
+# `atan`/`acos`/`sqrt` pre-pass to turn v into Euler angles. Horner moves ψ
+# twice and needs no trigonometry at all. Measured on TSUBAME (cpu_4, Eu F=6
+# D=13, 32³) the Euler core plus its pre-pass was ~67 % of an ITP step.
+#
+# The accuracy contract is NOT restated here — `SPIN_TAYLOR_TOL` / `_RSAFE` /
+# `_RK_MAX` below are the ones the GPU kernel reads, so the two devices cannot
+# drift to different tolerances. Likewise the generator bands come from
+# `spin_tridiag_bands`, which both devices call; the spin algebra is stated once
+# in `sm.Fx/Fy/Fz`.
+#
+# Degree and angle halving are decided PER VOXEL from that voxel's own
+# `R = |scale|·|v(r)|·F`, exactly as on the GPU. The CPU has no warp to round up
+# to, so its degrees are if anything slightly lower; both satisfy the same
+# backward-error bound, which is why CPU↔GPU parity is a tolerance and not `==`.
+
+using StaticArrays: MVector
+
+"""Master switch for the Taylor realization of a spin rotation. `false` routes
+every caller back to the exact Euler form, which is what the parity gates
+compare against. Honoured by BOTH the CPU kernel here and the CUDA one."""
+const SPIN_TAYLOR_ENABLED = Ref(true)
+
+"""Backward-error target for the per-voxel Taylor degree: the smallest `k ≥ 2`
+with `R^k / k! ≤ tol` is used. See the CUDA kernel's "Accuracy contract" block
+for the measurement that fixed this at 1e-13 rather than 1e-9."""
+const SPIN_TAYLOR_TOL = Ref(1.0e-13)
+
+"""Angle above which a voxel halves its rotation and applies it twice (repeated
+squaring — exact). Production `R` is 0.01–0.2 so no voxel ever halves; the
+branch exists so the Taylor path is exact at ANY `R` and the caller never has
+to ask."""
+const SPIN_TAYLOR_RSAFE = Ref(1.0)
+
+"""Degree ceiling. With the halving above it is never approached."""
+const SPIN_TAYLOR_RK_MAX = 40
+
+"""
+    spin_tridiag_bands(sm, ::Type{T}) -> (mz, sxu, syu)
+
+The three bands of `A = v·F`, which is Hermitian TRIDIAGONAL in the `F_z`
+basis: `mz[c] = F_z[c,c]` (real), `sxu[c] = F_x[c,c+1]`, `syu[c] = F_y[c,c+1]`,
+both zero at `c = D`. The sub-diagonal is `conj` of the super-diagonal and is
+not stored.
+
+Read straight off `sm.Fx/Fy/Fz` — the single declaration of the spin algebra.
+The CUDA extension uploads exactly these vectors, so the two devices cannot
+state the generator differently.
+"""
+function spin_tridiag_bands(sm::SpinMatrices{D}, ::Type{T}) where {D, T}
+    Fx, Fy, Fz = sm.Fx, sm.Fy, sm.Fz
+    mz = T[T(real(Fz[i, i])) for i in 1:D]
+    sxu = Complex{T}[i < D ? Complex{T}(Fx[i, i + 1]) : zero(Complex{T}) for i in 1:D]
+    syu = Complex{T}[i < D ? Complex{T}(Fy[i, i + 1]) : zero(Complex{T}) for i in 1:D]
+    (mz, sxu, syu)
+end
+
+"""
+    _spin_field_scratch(T, n_pts) -> (fx, fy, fz)
+
+Three `n_pts`-shaped real buffers for a spin-density field, cached per
+`(eltype, shape)`. The spin-mixing rotation needs ⟨F⟩ as a field and would
+otherwise allocate it on every substep — four per ITP step.
+"""
+function _spin_field_scratch(::Type{T}, n_pts::NTuple{N, Int}) where {T, N}
+    scratch_get!(:spin_field, (T, n_pts)) do
+        (
+            zeros(T, n_pts), zeros(T, n_pts), zeros(T, n_pts)
+        )
+    end::Tuple{Array{T, N}, Array{T, N}, Array{T, N}}
+end
+
+# Bands are a property of (spin algebra, eltype) only, so they are built once.
+const _SPIN_BANDS_CACHE = Dict{Tuple{UInt64, DataType}, Any}()
+
+function spin_tridiag_bands_cached(sm::SpinMatrices{D}, ::Type{T}) where {D, T}
+    key = (objectid(sm), T)
+    hit = get(_SPIN_BANDS_CACHE, key, nothing)
+    hit !== nothing &&
+        return hit::Tuple{Vector{T}, Vector{Complex{T}}, Vector{Complex{T}}}
+    b = spin_tridiag_bands(sm, T)
+    _SPIN_BANDS_CACHE[key] = b
+    b
+end
+
+"""
+    _taylor_rot_schedule(g, rk, K, tol2, rsafe2) -> (h, sh, kv)
+
+This voxel's angle halving `h = 2^-sh` and Horner degree `kv`, from
+`g = |v|²F²`. Both tests run on SQUARES so no `sqrt` is needed:
+`(R/2^sh/k)² = (rk[k]·h)²·g`.
+"""
+@inline function _taylor_rot_schedule(g::T, rk, K::Int, tol2::T, rsafe2::T) where {T}
+    scale1 = @inbounds rk[1]          # rk[1] = scale ⇒ r2 starts as R²
+    r2 = scale1 * scale1 * g
+    sh = 0
+    while r2 > rsafe2 && sh < 30
+        r2 *= T(0.25)
+        sh += 1
+    end
+    h = one(T)
+    for _ in 1:sh
+        h *= T(0.5)
+    end
+    gh = g * h * h
+
+    kv = K
+    u = one(T)
+    kk = 1
+    while kk < K
+        a = @inbounds rk[kk]
+        u *= a * a * gh
+        if kk >= 2 && u <= tol2
+            kv = kk
+            break
+        end
+        kk += 1
+    end
+    (h, sh, kv)
+end
+
+# `scale / k` for k = 1…K, cached per (eltype, scale). Two FP64 divisions per
+# degree per voxel is not free, and a fixed-dt run asks for a handful of
+# distinct scales and then never refills — the same reasoning (and the same
+# bound) as the CUDA table.
+const _CPU_SPIN_RK_CACHE = Dict{Tuple{DataType, Float64}, Any}()
+const _CPU_SPIN_RK_CACHE_MAX = 64
+
+function _cpu_spin_rk(::Type{T}, scale::T) where {T}
+    key = (T, Float64(scale))
+    hit = get(_CPU_SPIN_RK_CACHE, key, nothing)
+    hit !== nothing && return hit::Vector{T}
+    length(_CPU_SPIN_RK_CACHE) >= _CPU_SPIN_RK_CACHE_MAX && empty!(_CPU_SPIN_RK_CACHE)
+    rk = T[scale / T(k) for k in 1:SPIN_TAYLOR_RK_MAX]
+    _CPU_SPIN_RK_CACHE[key] = rk
+    rk
+end
+
+"""
+    apply_spin_rotation_taylor!(P, vx, vy, vz, bands, scale, Val(D);
+                                imaginary_time, F, src)
+
+`P[vox, :] ← exp(z · (v(vox)·F)) · P[vox, :]` for every voxel, with
+`z = -i·scale` (real time) or `-scale` (imaginary time). `P` is the
+`(N_spatial, D)` reshape of ψ; `bands` is `spin_tridiag_bands`'s tuple.
+
+`src` maps voxel → index in `vx/vy/vz` (`nothing` = contiguous; a
+`CartesianIndices` when the field is the corner of a zero-padded DDI buffer).
+"""
+function apply_spin_rotation_taylor!(
+    P::AbstractMatrix{Complex{T}}, vx, vy, vz,
+    bands::Tuple{Vector{T}, Vector{Complex{T}}, Vector{Complex{T}}},
+    scale::T, ::Val{D};
+    imaginary_time::Bool=false, F::T=one(T), src=nothing,
+) where {T, D}
+    if imaginary_time
+        _spin_taylor_cpu_kernel!(P, vx, vy, vz, bands, scale, Val(D), Val(false), F, src)
+    else
+        _spin_taylor_cpu_kernel!(P, vx, vy, vz, bands, scale, Val(D), Val(true), F, src)
+    end
+    nothing
+end
+
+# `Val{RT}` (real time) is a type parameter, not a Bool argument: it selects the
+# Horner coefficient's form, and the branch has to vanish from a loop body that
+# runs K·D times per voxel.
+function _spin_taylor_cpu_kernel!(
+    P::AbstractMatrix{Complex{T}}, vx, vy, vz,
+    bands::Tuple{Vector{T}, Vector{Complex{T}}, Vector{Complex{T}}},
+    scale::T, ::Val{D}, ::Val{RT}, F::T, src,
+) where {T, D, RT}
+    mz, sxu, syu = bands
+    N = size(P, 1)
+    rk = _cpu_spin_rk(T, scale)
+    tol2 = T(SPIN_TAYLOR_TOL[])^2
+    rsafe2 = T(SPIN_TAYLOR_RSAFE[])^2
+    F2 = F * F
+    K = SPIN_TAYLOR_RK_MAX
+    CT = Complex{T}
+    z0 = zero(CT)
+
+    _voxel_loop!(N) do i
+        @inbounds begin
+            j = _voxel_index(src, i)
+            Vx = T(vx[j])
+            Vy = T(vy[j])
+            Vz = T(vz[j])
+            g = (Vx * Vx + Vy * Vy + Vz * Vz) * F2
+            h, sh, kv = _taylor_rot_schedule(g, rk, K, tol2, rsafe2)
+
+            # Per-voxel stack buffers (MVector, the same idiom
+            # `_apply_euler_spin_rotation` uses to keep D=13 off the heap).
+            base = MVector{D, CT}(undef)
+            w = MVector{D, CT}(undef)
+            bu = MVector{D, CT}(undef)     # h·A[c,c+1], reused across degrees
+
+            for c in 1:D
+                base[c] = P[i, c]
+                bu[c] = (Vx * sxu[c] + Vy * syu[c]) * h
+            end
+            for c in 1:D
+                w[c] = base[c]
+            end
+
+            for _rep in 1:(1 << sh)
+                for k in kv:-1:1
+                    a = rk[k]
+                    prev_old = z0            # w_{c-1} BEFORE this degree's update
+                    for c in 1:D
+                        cur_old = w[c]
+                        up_old = c < D ? w[c + 1] : z0
+                        # A[c,c-1] = conj(A[c-1,c]) = conj(bu[c-1])
+                        low = c > 1 ? conj(bu[c - 1]) : z0
+                        Aw = (Vz * mz[c] * h) * cur_old + bu[c] * up_old + low * prev_old
+                        # RT: (-i·a)·Aw = a·(imag Aw − i·real Aw);  IT: −a·Aw
+                        w[c] = RT ? base[c] + a * CT(imag(Aw), -real(Aw)) :
+                               base[c] - a * Aw
+                        prev_old = cur_old
+                    end
+                end
+                if sh > 0
+                    for c in 1:D
+                        base[c] = w[c]
+                    end
+                end
+            end
+
+            for c in 1:D
+                P[i, c] = w[c]
+            end
+        end
+    end
+    nothing
+end

--- a/src/hamiltonian/terms/contact/spin_mixing.jl
+++ b/src/hamiltonian/terms/contact/spin_mixing.jl
@@ -59,62 +59,57 @@ function _spin_mixing_loop!(
     if D == 3
         return _spin_mixing_rodrigues!(psi, psi_mf, sm, c1, dt_frac, n_pts, imaginary_time)
     end
-    # Same algorithm as the per-voxel scalar Euler decomposition, but the
-    # two D×D matvecs (Stages 2 and 4) become single BLAS gemms over the
-    # (N_spatial, D) reshape. Pre-pass computes per-voxel (α, β, θ) into
-    # the shared rotation cache; the 5-stage core then runs gemm-batched.
-    # Saves 30–35% on the per-step rotation cost (matched the DDI win).
+    # Two realizations of exp(-i·c₁·dt·(⟨F⟩·F)) per voxel, selected by
+    # `SPIN_TAYLOR_ENABLED[]`:
+    #
+    #   Taylor–Horner  the spinor stays in stack buffers for the whole
+    #                  rotation, so ψ moves through cache twice and no
+    #                  trigonometry is needed at all.
+    #   Euler 5-stage  the exact reference the Taylor path is gated against:
+    #                  per-voxel (α, β, θ) into the shared rotation cache, then
+    #                  3 phase passes + 4 BLAS gemms over the (N_spatial, D)
+    #                  reshape — ψ through cache ~18 times.
     N_spatial = prod(n_pts)
     F = T(sm.system.F)
-    fp_coeffs = fp_ladder_coeffs(T, sm.system.F, Val(D))
+    P = reshape(psi, N_spatial, D)
+    c1_t = T(c1)
+    dt_t = T(dt_frac)
+
+    # The rotation axis and angle come from ⟨F⟩ of the mean-field source (Track
+    # A1: `psi_mf` may be a midpoint estimate while `psi` is the state being
+    # propagated). `_compute_spin_density!` already states that reduction — this
+    # used to be a second, hand-written copy of it fused into an angle pre-pass.
+    fx, fy, fz = _spin_field_scratch(T, n_pts)
+    _compute_spin_density!(fx, fy, fz, psi_mf, sm, Val(D), ndim_from_n_pts(n_pts), n_pts)
+
+    # `_apply_euler_spin_rotation` skips per-voxel when phi·dt < 1e-14; mirror
+    # that at the call level so a polar / vacuum state (⟨F⟩ ≡ 0) pays only the
+    # spin-density pass. Taylor would return ψ unchanged there, just not for
+    # free.
+    fmax = max(maximum(abs, fx), maximum(abs, fy), maximum(abs, fz))
+    theta_max = abs(c1_t * dt_t) * fmax * F
+    theta_max < T(1e-14) && return nothing
+
+    if SPIN_TAYLOR_ENABLED[]
+        # v = ⟨F⟩ raw, scale = c₁·dt — the same split the GPU spin-mixing
+        # substep passes to the same operator.
+        apply_spin_rotation_taylor!(
+            P, fx, fy, fz, spin_tridiag_bands_cached(sm, T),
+            c1_t * dt_t, Val(D); imaginary_time, F, src=nothing)
+        return nothing
+    end
 
     rc = _get_ddi_rotation_cache_cpu(psi, sm, ndim_from_n_pts(n_pts))
     alpha = rc.alpha
     beta = rc.beta
     theta = rc.theta
-
-    P = reshape(psi, N_spatial, D)
-    Pmf = reshape(psi_mf, N_spatial, D)
-    c1_t = T(c1)
-    dt_t = T(dt_frac)
-
-    # Pre-pass: for each voxel compute (α, β, θ) from local spinor.
-    # Track max|θ| so we can skip the rotation entirely when the spin
-    # density vanishes everywhere (polar GS, vacuum regions in scan
-    # warm-ups, etc.) — that case used to early-return per voxel in the
-    # scalar path. Without this guard the four BLAS gemms run on an
-    # all-zero phase array, doing 5 ms of useless work on the bench's
-    # polar workspace.
-    # Track A1: read ⟨F⟩ from `Pmf` so the rotation operator is built
-    # from the user-supplied mean-field source psi (typically a midpoint
-    # estimate). Rotation is still applied to `P` (= state psi).
-    # Threaded, like the identically-shaped DDI angle pre-pass
-    # (`_ddi_compute_angles!`). It was serial only because it also carried the
-    # `max θ` reduction in the loop variable; θ is written to the cache anyway,
-    # so the guard below reads it back instead. At 32³ × D = 13 this pre-pass —
-    # D abs2, D−1 complex products, an atan, an acos and a sqrt per voxel — was
-    # the single largest serial region left in a CPU ITP step.
+    one_t = one(T)
     _voxel_loop!(N_spatial) do k
         @inbounds begin
-            fz_val = T(0)
-            @simd for c in 1:D
-                fz_val += T(F - (c - 1)) * abs2(Pmf[k, c])
-            end
-            fxy_re = T(0)
-            fxy_im = T(0)
-            @simd for c in 2:D
-                pc_m1 = Pmf[k, c - 1]
-                pc = Pmf[k, c]
-                prod = conj(pc_m1) * pc
-                coef = fp_coeffs[c]
-                fxy_re += coef * real(prod)
-                fxy_im += coef * imag(prod)
-            end
-            px = c1_t * fxy_re
-            py = c1_t * fxy_im
-            pz = c1_t * fz_val
-            pm_sq = px * px + py * py + pz * pz
-            pm = sqrt(pm_sq)
+            px = c1_t * fx[k]
+            py = c1_t * fy[k]
+            pz = c1_t * fz[k]
+            pm = sqrt(px * px + py * py + pz * pz)
             if pm < T(1e-100)
                 alpha[k] = T(0)
                 beta[k] = T(0)
@@ -122,20 +117,12 @@ function _spin_mixing_loop!(
             else
                 alpha[k] = atan(py, px)
                 cb = pz / pm
-                cb = cb > one(T) ? one(T) : (cb < -one(T) ? -one(T) : cb)
+                cb = cb > one_t ? one_t : (cb < -one_t ? -one_t : cb)
                 beta[k] = acos(cb)
                 theta[k] = pm * dt_t
             end
         end
     end
-
-    # `_apply_euler_spin_rotation` skips per-voxel when phi·dt < 1e-14;
-    # mirror that here at the call level so polar / vacuum states pay
-    # only the pre-pass cost (~150 μs at 16³) instead of running four
-    # gemms over a zero phase field. θ = |c₁⟨F⟩|·dt ≥ 0 everywhere, so
-    # max θ² is (max θ)² — the same number the in-loop accumulator held.
-    max_theta = maximum(theta)
-    max_theta * max_theta < T(1e-28) && return nothing
 
     if imaginary_time
         _apply_euler_5stage_batched_imag!(P, rc.W, rc.conj_V, rc.V_T,

--- a/src/hamiltonian/terms/ddi/rotation.jl
+++ b/src/hamiltonian/terms/ddi/rotation.jl
@@ -85,12 +85,21 @@ function _apply_ddi_rotation_batched_real!(
     n_pts = ntuple(d -> size(psi, d), ndim)
     N_spatial = prod(n_pts)
     F = T(sm.system.F)
-    rc = _get_ddi_rotation_cache_cpu(psi, sm, ndim)
-
-    _ddi_compute_angles!(rc.alpha, rc.beta, rc.theta,
-        phi_x, phi_y, phi_z, dt_frac, N_spatial,
-        _ddi_phi_index_map(phi_x, n_pts))
     P = reshape(psi, N_spatial, D)
+    src = _ddi_phi_index_map(phi_x, n_pts)
+
+    # Taylor needs the raw field, so the whole atan/acos/sqrt angle pre-pass
+    # disappears with the 5-stage core rather than feeding it.
+    if SPIN_TAYLOR_ENABLED[]
+        apply_spin_rotation_taylor!(
+            P, phi_x, phi_y, phi_z, spin_tridiag_bands_cached(sm, T),
+            T(dt_frac), Val(D); imaginary_time=false, F, src)
+        return nothing
+    end
+
+    rc = _get_ddi_rotation_cache_cpu(psi, sm, ndim)
+    _ddi_compute_angles!(rc.alpha, rc.beta, rc.theta,
+        phi_x, phi_y, phi_z, dt_frac, N_spatial, src)
     _apply_euler_5stage_batched_real!(P, rc.W, rc.conj_V, rc.V_T,
         rc.alpha, rc.beta, rc.theta, F, Val(D))
     nothing
@@ -104,12 +113,19 @@ function _apply_ddi_rotation_batched_imag!(
     n_pts = ntuple(d -> size(psi, d), ndim)
     N_spatial = prod(n_pts)
     F = T(sm.system.F)
-    rc = _get_ddi_rotation_cache_cpu(psi, sm, ndim)
-
-    _ddi_compute_angles!(rc.alpha, rc.beta, rc.theta,
-        phi_x, phi_y, phi_z, dt_frac, N_spatial,
-        _ddi_phi_index_map(phi_x, n_pts))
     P = reshape(psi, N_spatial, D)
+    src = _ddi_phi_index_map(phi_x, n_pts)
+
+    if SPIN_TAYLOR_ENABLED[]
+        apply_spin_rotation_taylor!(
+            P, phi_x, phi_y, phi_z, spin_tridiag_bands_cached(sm, T),
+            T(dt_frac), Val(D); imaginary_time=true, F, src)
+        return nothing
+    end
+
+    rc = _get_ddi_rotation_cache_cpu(psi, sm, ndim)
+    _ddi_compute_angles!(rc.alpha, rc.beta, rc.theta,
+        phi_x, phi_y, phi_z, dt_frac, N_spatial, src)
     _apply_euler_5stage_batched_imag!(P, rc.W, rc.conj_V, rc.V_T,
         rc.alpha, rc.beta, rc.theta, F, Val(D))
     nothing

--- a/src/workflow/validation.jl
+++ b/src/workflow/validation.jl
@@ -26,6 +26,7 @@ include("validation/open_result.jl")            # JLD2 → RunResult loader
 include("validation/operations.jl")             # sweep_runs / compare_runs
 include("validation/specs.jl")                  # Specs + check() dispatch
 include("validation/stability_spec.jl")         # 3-valued energetic-stability gate
+include("validation/error_budget.jl")           # is a numerical knob justified? (mandatory positive control)
 include("validation/save_operator_rhs.jl")      # Level-10 hand-off (operator_rhs.jld2 + MANIFEST)
 include("validation/convenience.jl")            # audit / hand_off / diff_yamls — top-level 1-liners
 include("validation/show.jl")                   # Base.show pretty printing for REPL

--- a/src/workflow/validation/error_budget.jl
+++ b/src/workflow/validation/error_budget.jl
@@ -1,0 +1,187 @@
+# --- Error budget: is a numerical knob justified, or just chosen? ---
+#
+# Every approximation in this codebase carries a knob — a Taylor tolerance, a
+# table resolution, a truncation radius, a Newton tolerance. Setting one
+# correctly means comparing the error it introduces against the error the caller
+# has ALREADY accepted by choosing something else (`dt`, the grid, `n_points`).
+# Asking each call site to do that comparison is a design failure: the knowledge
+# never fits in the caller's head, so in practice the number gets copied from
+# wherever it was last seen and nobody can check it again.
+#
+# This is the mechanism for not doing that. An `ErrorBudget` records three
+# numbers measured on the SAME observable and config:
+#
+#   baseline        the error already present — typically |obs(dt) − obs(dt/2)|
+#                   with the approximation OFF, i.e. what the caller's own
+#                   choice costs before this knob does anything
+#   approximation   |obs(approx) − obs(exact)|, the knob's actual contribution
+#   control         |obs(deliberately-bad) − obs(exact)|, an arm that MUST
+#                   breach the criterion
+#
+# `check(NegligibleErrorSpec(frac), budget)` then answers whether the
+# approximation is negligible — and refuses to answer when it cannot mean
+# anything:
+#
+#   :indeterminate  the baseline is degenerate (nothing to be negligible
+#                   against), or THE CONTROL DOES NOT BREACH. In the second case
+#                   a `:pass` would say "this comparison cannot fail", not "the
+#                   approximation is good".
+#   :fail           the approximation is not negligible.
+#   :pass           it is, and the criterion was reachable.
+#
+# The control being MANDATORY is the whole point, and it is not hypothetical.
+# The first gate written for `SPIN_TAYLOR_TOL` used a loosened tolerance as its
+# control and could not breach: the Taylor degree is floored at 2, so at
+# production rotation angles the schedule returns degree 2 for every tolerance
+# over ten decades, and the floor alone already passed. The criterion was held
+# by the degree floor, not by the tolerance. Without a control that gate would
+# have sat green forever while asserting nothing. Here that outcome is
+# `:indeterminate` by construction rather than a silent pass.
+#
+# WHAT THIS DOES NOT DO. Three preconditions, none of which it can check for you:
+#
+#   1. an EXACT reference must exist, or `approximation` is not separable from
+#      everything else that differs;
+#   2. the baseline must be the error that actually dominates, and must be one
+#      the caller already chose — otherwise the ratio compares nothing;
+#   3. `observable` must be the quantity you care about. Negligible in energy is
+#      not negligible in a winding number. This is the precondition that gets
+#      missed.
+#
+# And the ratio is generally NOT scale-free: if the baseline is a splitting
+# error ~dt² while the approximation accumulates over ~1/dt substeps, the ratio
+# grows as dt⁻³. A budget belongs to the configuration it was measured at.
+
+export ErrorBudget, NegligibleErrorSpec, measure_error_budget
+
+"""
+    ErrorBudget(; label, baseline, approximation, control, kwargs...)
+
+Three errors on one observable and one config: what the caller already accepted
+(`baseline`), what the approximation adds (`approximation`), and what a
+deliberately-degraded arm adds (`control`). `rows` optionally carries a knob
+sweep — `(knob, error, cost)` NamedTuples — for reporting.
+"""
+struct ErrorBudget
+    label::String
+    baseline::Float64
+    baseline_label::String
+    approximation::Float64
+    approximation_label::String
+    control::Float64
+    control_label::String
+    rows::Vector{NamedTuple}
+end
+
+function ErrorBudget(;
+    label::String,
+    baseline::Real,
+    approximation::Real,
+    control::Real,
+    baseline_label::String="already accepted",
+    approximation_label::String="approximation",
+    control_label::String="control",
+    rows::Vector{<:NamedTuple}=NamedTuple[],
+)
+    ErrorBudget(label, Float64(baseline), baseline_label,
+        Float64(approximation), approximation_label,
+        Float64(control), control_label, Vector{NamedTuple}(rows))
+end
+
+"""
+    NegligibleErrorSpec(frac = 1e-3)
+
+The approximation must contribute less than `frac` of the baseline error.
+
+`frac` is the only judgement left, and it is a cheap one: it says how much of
+the error budget the approximation is allowed to occupy, not what any physical
+tolerance should be. 1e-3 means "at most a tenth of a percent of an error the
+caller already lives with".
+"""
+struct NegligibleErrorSpec
+    frac::Float64
+    NegligibleErrorSpec(frac::Real=1.0e-3) =
+        frac > 0 ? new(Float64(frac)) :
+        throw(ArgumentError("frac must be > 0, got $frac"))
+end
+
+function check(spec::NegligibleErrorSpec, b::ErrorBudget)
+    bound = spec.frac * b.baseline
+    details = Pair{Symbol, Any}[
+        :baseline => (got=b.baseline, label=b.baseline_label),
+        :approximation => (got=b.approximation, bound=bound,
+            pass=b.approximation < bound, label=b.approximation_label),
+        :control => (got=b.control, bound=bound,
+            breaches=b.control >= bound, label=b.control_label),
+        :ratio => (got=b.baseline > 0 ? b.approximation / b.baseline : NaN,),
+    ]
+
+    if !(b.baseline > 0) || !isfinite(b.baseline)
+        return CheckResult(:indeterminate, details,
+            "$(b.label): baseline error is $(b.baseline) — there is nothing for the " *
+            "approximation to be negligible against, so no verdict is possible.")
+    end
+    if !(b.control >= bound)
+        return CheckResult(:indeterminate, details,
+            "$(b.label): the control ($(b.control_label), error $(b.control)) does NOT " *
+            "breach $(spec.frac)×baseline = $bound. A pass would mean the comparison " *
+            "cannot fail, not that the approximation is good — pick a control that " *
+            "attacks whatever actually holds the criterion.")
+    end
+
+    pass = b.approximation < bound
+    CheckResult(pass, details,
+        "$(b.label): approximation error $(b.approximation) " *
+        (pass ? "<" : "≥") * " $(spec.frac)×baseline = $bound " *
+        "(ratio $(b.baseline > 0 ? b.approximation / b.baseline : NaN)); " *
+        "control breaches at $(b.control).")
+end
+
+"""
+    measure_error_budget(; label, exact, refined, approx, control, kwargs...)
+
+Run the four arms and assemble an [`ErrorBudget`](@ref). Each argument is a
+zero-argument closure returning the observable as a real number:
+
+* `exact`    — the approximation switched OFF, at the caller's configuration
+* `refined`  — the same, at a refined configuration (finer `dt`, finer grid, …).
+  `|exact − refined|` is the baseline: the error the caller's own choice carries.
+* `approx`   — the approximation ON, at the caller's configuration
+* `control`  — a deliberately degraded arm that must breach the criterion
+
+`sweep` optionally maps knob values to closures for a reported (non-judged)
+table of `(knob, error, cost)`.
+"""
+function measure_error_budget(;
+    label::String,
+    exact::Function,
+    refined::Function,
+    approx::Function,
+    control::Function,
+    baseline_label::String="refinement",
+    approximation_label::String="approximation",
+    control_label::String="control",
+    sweep=nothing,
+)
+    o_exact = Float64(exact())
+    o_refined = Float64(refined())
+    o_approx = Float64(approx())
+    o_control = Float64(control())
+
+    rows = NamedTuple[]
+    if sweep !== nothing
+        for (knob, f) in sweep
+            t0 = time()
+            o = Float64(f())
+            push!(rows, (knob=knob, error=abs(o - o_exact), cost=time() - t0))
+        end
+    end
+
+    ErrorBudget(;
+        label,
+        baseline=abs(o_refined - o_exact), baseline_label,
+        approximation=abs(o_approx - o_exact), approximation_label,
+        control=abs(o_control - o_exact), control_label,
+        rows,
+    )
+end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -188,6 +188,11 @@ const FAST_TESTS = [
 
 # ── CI tier: fast + core integration tests that run ITP/RTP ──
 const CI_EXTRA = [
+    # `SPIN_TAYLOR_TOL` is not a knob a caller should reason about — this pins
+    # the RELATIONSHIP it exists to satisfy (truncation ≪ splitting error), so
+    # the number can change and the criterion still holds. Runs
+    # find_ground_state, hence ci and not fast.
+    "hamiltonian/test_taylor_tolerance_criterion.jl",
     # Noether ledger for the EdH / Barnett program: at B=0 the DDI conserves
     # J_z = L_z + F_z exactly, and the drift is set by the box, not by dt.
     "oracles/test_jz_conservation_ddi.jl",

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -104,6 +104,10 @@ const FAST_TESTS = [
     "hamiltonian/test_batched_kinetic.jl",
     "hamiltonian/test_ddi_padded.jl",
     "hamiltonian/test_ddi_padded_zero_pad_invariant.jl",
+    # Taylor-Horner spin rotation on the CPU, against the exact Euler 5-stage it
+    # replaces. Reads the same SPIN_TAYLOR_TOL[] as the CUDA gate, so relaxing
+    # the accuracy contract turns both red.
+    "hamiltonian/test_cpu_spin_rotation_taylor_parity.jl",
     "foundation/test_clebsch_gordan.jl",
     "foundation/test_general_f.jl",
     "foundation/test_optical_pumping_rate_eq.jl",

--- a/test/gpu/test_gpu_spin_rotation_taylor_parity.jl
+++ b/test/gpu/test_gpu_spin_rotation_taylor_parity.jl
@@ -26,15 +26,15 @@ else
 
     # exp(z·v·F) via each realization, same input.
     function _rotate(taylor::Bool, sm, psi0, vx, vy, vz, dt, it)
-        old = Ext._SPIN_TAYLOR_ENABLED[]
-        Ext._SPIN_TAYLOR_ENABLED[] = taylor
+        old = SpinorBEC.SPIN_TAYLOR_ENABLED[]
+        SpinorBEC.SPIN_TAYLOR_ENABLED[] = taylor
         try
             p = copy(psi0)
             SpinorBEC._apply_ddi_rotation!(p, vx, vy, vz, sm, dt, 3; imaginary_time=it)
             CUDA.synchronize()
             return p
         finally
-            Ext._SPIN_TAYLOR_ENABLED[] = old
+            SpinorBEC.SPIN_TAYLOR_ENABLED[] = old
         end
     end
 
@@ -72,15 +72,15 @@ else
         psi0 = CUDA.CuArray(randn(ComplexF64, n, n, n, D) ./ 10)
         for it in (false, true), c1 in (0.5, -0.5)
             outs = map((false, true)) do taylor
-                old = Ext._SPIN_TAYLOR_ENABLED[]
-                Ext._SPIN_TAYLOR_ENABLED[] = taylor
+                old = SpinorBEC.SPIN_TAYLOR_ENABLED[]
+                SpinorBEC.SPIN_TAYLOR_ENABLED[] = taylor
                 try
                     p = copy(psi0)
                     apply_spin_mixing_step!(p, sm, c1, 0.01, 3; imaginary_time=it)
                     CUDA.synchronize()
                     Array(p)
                 finally
-                    Ext._SPIN_TAYLOR_ENABLED[] = old
+                    SpinorBEC.SPIN_TAYLOR_ENABLED[] = old
                 end
             end
             @test norm(outs[2] .- outs[1]) / norm(outs[1]) < 1e-10
@@ -114,7 +114,7 @@ else
         end
     end
 
-    # Above `_SPIN_TAYLOR_RSAFE[]` a voxel halves its angle and applies the
+    # Above `SPIN_TAYLOR_RSAFE[]` a voxel halves its angle and applies the
     # rotation 2^s times. Production R is 0.01-0.2 so that branch never fires
     # there; it is what makes the Taylor path valid at ANY R, which is in turn
     # what lets the degree be chosen on the device with no max|v| read-back.
@@ -138,7 +138,7 @@ else
     # A rotation is unitary; the Taylor truncation must not leak norm at the
     # production angle. (The imaginary-time arm is deliberately not unitary.)
     #
-    # This is also the gate on `_SPIN_TAYLOR_TOL[]`. Since the degree is chosen
+    # This is also the gate on `SPIN_TAYLOR_TOL[]`. Since the degree is chosen
     # PER VOXEL, that tolerance is binding rather than slack — at 1e-9 the drift
     # here is 9.6e-13, at 1e-13 it is 2.2e-16 — so the bound below is set at
     # machine precision on purpose: loosening the tolerance turns it red instead

--- a/test/hamiltonian/test_cpu_spin_rotation_taylor_parity.jl
+++ b/test/hamiltonian/test_cpu_spin_rotation_taylor_parity.jl
@@ -1,0 +1,132 @@
+# Gate for the CPU Taylor–Horner spin rotation.
+#
+# Two substeps apply `exp(z·(v·F))` per voxel — DDI with v = Φ and spin-mixing
+# with v = c₁⟨F⟩ — and both now take the Taylor kernel, with the exact Euler
+# 5-stage as the reference. This file pins Taylor ≡ Euler for BOTH, across F,
+# real/imaginary time and rotation angle R.
+#
+# The reference is the EXACT realization running on the same device against the
+# same input, which is what makes this an oracle rather than a self-check: a
+# Taylor degree chosen too aggressively shows up here and nowhere else. A
+# CPU↔GPU comparison could not see it, because the two would agree to the same
+# wrong tolerance.
+#
+# `test/gpu/test_gpu_spin_rotation_taylor_parity.jl` is the same gate for the
+# CUDA realization. Both read the SAME `SPIN_TAYLOR_TOL[]`, so relaxing the
+# contract turns both red.
+
+using Test
+using Random
+using LinearAlgebra: norm
+using SpinorBEC
+using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_TOL, SPIN_TAYLOR_RSAFE,
+    _apply_ddi_rotation!, apply_spin_mixing_step!, spin_matrices
+
+# Run `f` with the Taylor path forced on/off, restoring the flag afterwards.
+function _with_taylor(f, on::Bool)
+    old = SPIN_TAYLOR_ENABLED[]
+    SPIN_TAYLOR_ENABLED[] = on
+    try
+        f()
+    finally
+        SPIN_TAYLOR_ENABLED[] = old
+    end
+end
+
+_relerr(a, b) = norm(vec(a) .- vec(b)) / max(norm(vec(b)), eps())
+
+@testset "CPU spin rotation: Taylor ≡ exact Euler" begin
+    n = (6, 6, 6)
+    Ns = prod(n)
+
+    @testset "DDI rotation (F=$F, IT=$it, amp=$amp)" for F in (1, 2, 6),
+        it in (false, true), amp in (0.01, 1.0, 30.0)
+
+        sm = spin_matrices(F)
+        D = 2F + 1
+        rng = MersenneTwister(11 + F + (it ? 3 : 0) + round(Int, 100amp))
+        psi0 = randn(rng, ComplexF64, n..., D)
+        # `amp` sweeps R = dt·|Φ|·F from deep inside the production range
+        # (0.01–0.2) to far past `SPIN_TAYLOR_RSAFE[]`, where every voxel halves
+        # its angle and applies it repeatedly.
+        px = amp .* randn(rng, Float64, n...)
+        py = amp .* randn(rng, Float64, n...)
+        pz = amp .* randn(rng, Float64, n...)
+        dt = 0.01
+
+        a = _with_taylor(true) do
+            p = copy(psi0)
+            _apply_ddi_rotation!(p, px, py, pz, sm, dt, 3; imaginary_time=it)
+            p
+        end
+        b = _with_taylor(false) do
+            p = copy(psi0)
+            _apply_ddi_rotation!(p, px, py, pz, sm, dt, 3; imaginary_time=it)
+            p
+        end
+        # The Taylor degree targets a BACKWARD error of SPIN_TAYLOR_TOL on the
+        # rotation; allow a modest multiple for the accumulated forward error.
+        @test _relerr(a, b) < 1e-10
+    end
+
+    @testset "spin-mixing (F=$F, IT=$it)" for F in (2, 6), it in (false, true)
+        sm = spin_matrices(F)
+        D = 2F + 1
+        rng = MersenneTwister(77 + F + (it ? 5 : 0))
+        psi0 = randn(rng, ComplexF64, n..., D)
+        c1, dt = 0.7, 0.02
+
+        a = _with_taylor(true) do
+            p = copy(psi0)
+            apply_spin_mixing_step!(p, sm, c1, dt, 3; imaginary_time=it)
+            p
+        end
+        b = _with_taylor(false) do
+            p = copy(psi0)
+            apply_spin_mixing_step!(p, sm, c1, dt, 3; imaginary_time=it)
+            p
+        end
+        @test _relerr(a, b) < 1e-10
+    end
+
+    # Real time is UNITARY: the rotation must preserve the norm to machine
+    # precision. This is the property a wrong Horner coefficient or a
+    # mis-signed band breaks first, and it needs no reference to check.
+    @testset "real-time rotation preserves norm (F=$F)" for F in (1, 6)
+        sm = spin_matrices(F)
+        D = 2F + 1
+        rng = MersenneTwister(303 + F)
+        psi = randn(rng, ComplexF64, n..., D)
+        n0 = norm(vec(psi))
+        px = randn(rng, Float64, n...)
+        py = randn(rng, Float64, n...)
+        pz = randn(rng, Float64, n...)
+        _with_taylor(true) do
+            for _ in 1:20
+                _apply_ddi_rotation!(psi, px, py, pz, sm, 0.01, 3; imaginary_time=false)
+            end
+        end
+        @test norm(vec(psi)) ≈ n0 rtol = 1e-13
+    end
+
+    # The per-voxel stack buffers must not reach the heap: at D = 13 an
+    # `MVector` that escapes is 208 B × N_spatial × 6 rotations per step, which
+    # would hand back the traffic this kernel exists to save.
+    @testset "kernel does not allocate per voxel" begin
+        sm = spin_matrices(6)
+        D = 13
+        rng = MersenneTwister(5)
+        psi = randn(rng, ComplexF64, n..., D)
+        px = randn(rng, Float64, n...)
+        py = randn(rng, Float64, n...)
+        pz = randn(rng, Float64, n...)
+        _with_taylor(true) do
+            _apply_ddi_rotation!(psi, px, py, pz, sm, 0.01, 3; imaginary_time=true)  # warm
+            bytes = @allocated _apply_ddi_rotation!(
+                psi, px, py, pz, sm, 0.01, 3; imaginary_time=true)
+            # A per-voxel heap MVector would be ≥ 3·208·216 B ≈ 130 KB here;
+            # the threading itself costs a small fixed amount.
+            @test bytes < 20_000
+        end
+    end
+end

--- a/test/hamiltonian/test_taylor_tolerance_criterion.jl
+++ b/test/hamiltonian/test_taylor_tolerance_criterion.jl
@@ -11,16 +11,25 @@
 # dt = 0.002): baseline |E(dt) − E(dt/2)| = 7.6e-3, truncation 2.4e-13 — a ratio
 # of 3e-11.
 #
-# WHY THE CONTROL IS NOT A LOOSENED `tol`. That was the first attempt, and it
-# cannot breach. The degree is floored at 2, so at production
-# `R = dt·|v|·F ≈ 0.01–0.2` the schedule returns degree 2 for every tolerance
-# from 1e-15 up to 1 — the sweep measures the same mean degree 2.00 at tol 1e-5
-# and 1e-7 — and that floor alone leaves the truncation at 3.3e-5 of the
-# baseline, which passes. The criterion is held by the DEGREE FLOOR, not by the
-# tolerance, which is why that floor is now a named constant
-# (`SPIN_TAYLOR_MIN_DEGREE`) rather than a literal in the schedule. The control
-# lowers it to 1 — same pipeline, same observable, same code path, one order
-# less.
+# FINDING THE CONTROL TOOK TWO WRONG GUESSES, AND THAT IS THE POINT.
+#
+#   1. Loosen `SPIN_TAYLOR_TOL`. Cannot breach: the degree is floored at 2, and
+#      at production `R = |scale|·|v|·F ≈ 1e-5` the schedule returns 2 for every
+#      tolerance over ten decades — the sweep measures the same mean degree 2.00
+#      at tol 1e-5 and 1e-7.
+#   2. Lower the degree floor to 1. Also cannot breach: an order-1 rotation is
+#      still ~1e-8 relative, four orders inside the splitting error. So the
+#      criterion is NOT held by the floor either, which is what I had claimed.
+#
+# What actually holds it is that `R` is tiny — the rotation is nowhere near the
+# binding error at any order ≥ 1. The only control left is to REMOVE the
+# operator: `SPIN_TAYLOR_DEGREE_CAP[] = 0` skips the Horner loop, leaving ψ
+# untouched. That is also the honest general form of the question — show the
+# observable moves when the operator is absent, or "negligible" meant nothing.
+#
+# Both wrong guesses would have shipped as green gates asserting nothing. They
+# were caught because `NegligibleErrorSpec` returns `:indeterminate`, not
+# `:pass`, when the control fails to breach.
 #
 # HOW FAR THE MARGIN REACHES. The ratio is not scale-free: the baseline falls as
 # dt² while the truncation accumulates over ~1/dt rotations, so the ratio grows
@@ -33,7 +42,7 @@
 using Test
 
 using SpinorBEC
-using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_RK_MAX, SPIN_TAYLOR_MIN_DEGREE,
+using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_RK_MAX, SPIN_TAYLOR_DEGREE_CAP,
     NegligibleErrorSpec, measure_error_budget, check, passed,
     _taylor_rot_schedule, _cpu_spin_rk
 
@@ -47,14 +56,15 @@ function _with_taylor(f, on::Bool)
     end
 end
 
-# Run `f` with the Horner degree floor forced to `k`.
-function _with_min_degree(f, k::Int)
-    old = SPIN_TAYLOR_MIN_DEGREE[]
-    SPIN_TAYLOR_MIN_DEGREE[] = k
+# Run `f` with the Horner degree clamped from above. `k = 0` removes the
+# rotation entirely.
+function _with_degree_cap(f, k::Int)
+    old = SPIN_TAYLOR_DEGREE_CAP[]
+    SPIN_TAYLOR_DEGREE_CAP[] = k
     try
         f()
     finally
-        SPIN_TAYLOR_MIN_DEGREE[] = old
+        SPIN_TAYLOR_DEGREE_CAP[] = old
     end
 end
 
@@ -85,16 +95,16 @@ end
         approx=() -> _with_taylor(true) do
             _energy(DT, NST)
         end,
-        # Same pipeline and same observable, one order less: the floor that
-        # actually holds the criterion, lowered.
+        # Same pipeline, same observable, operator removed. Two weaker
+        # controls were tried first and neither could breach — see the header.
         control=() -> _with_taylor(true) do
-            _with_min_degree(1) do
+            _with_degree_cap(0) do
                 _energy(DT, NST)
             end
         end,
         baseline_label="splitting error, dt vs dt/2",
         approximation_label="Taylor truncation",
-        control_label="degree floor lowered to 1",
+        control_label="rotation removed (degree cap 0)",
     )
 
     result = check(NegligibleErrorSpec(1e-3), budget)
@@ -103,12 +113,14 @@ end
     # cannot breach is not a green result here, it is a refusal to judge.
     @test passed(result)
 
-    # The degree floor is what holds the criterion, so pin it directly.
-    @testset "the schedule never returns a degree below 2" begin
+    # The floor is not what holds the criterion, but it IS what makes `tol`
+    # unable to degrade the rotation — the reason guess (1) failed. Pin it so
+    # that fact stays true and the header stays honest.
+    @testset "tol cannot drive the degree below 2" begin
         rk = _cpu_spin_rk(Float64, DT)
         for g in (0.0, 1e-8, 1.0, 1e4), tol in (1e-15, 1e-5, 1.0)
             _, _, kv = _taylor_rot_schedule(g, rk, SPIN_TAYLOR_RK_MAX, tol^2, 1.0)
-            @test kv >= SPIN_TAYLOR_MIN_DEGREE[]
+            @test kv >= 2
         end
     end
 end

--- a/test/hamiltonian/test_taylor_tolerance_criterion.jl
+++ b/test/hamiltonian/test_taylor_tolerance_criterion.jl
@@ -1,47 +1,41 @@
-# Gate: the Taylor truncation error stays negligible against the SPLITTING error
-# — the tolerance is a consequence of the caller's `dt`, not a decision the
-# caller is asked to make.
+# Gate: the Taylor spin rotation's truncation error stays negligible against the
+# error the caller already accepted by choosing `dt`.
 #
-# `SPIN_TAYLOR_TOL` should not be a user-facing knob: setting it correctly needs
-# a comparison against the integrator's own error, and demanding that knowledge
-# per call site is a design failure. So the relationship is what is pinned here.
+# Expressed through `ErrorBudget` / `NegligibleErrorSpec`
+# (src/workflow/validation/error_budget.jl) rather than as hand-rolled
+# assertions, so the thing being pinned is the RELATIONSHIP and the positive
+# control is structurally mandatory: a control that fails to breach makes the
+# verdict `:indeterminate`, never a green pass.
 #
 # Measured at production scale (bench/taylor_tolerance_sweep.jl, Eu F=6, 32³,
-# dt = 0.002): splitting error |E(dt) − E(dt/2)| = 7.6e-3 against a truncation
-# error of 2.4e-13 — a ratio of 3e-11.
+# dt = 0.002): baseline |E(dt) − E(dt/2)| = 7.6e-3, truncation 2.4e-13 — a ratio
+# of 3e-11.
 #
-# WHY `tol` IS NOT THE POSITIVE CONTROL. The obvious control — loosen `tol` and
-# watch the criterion break — does NOT work here, and finding that out is the
-# point of insisting on one. The degree is floored at 2, so at production
+# WHY THE CONTROL IS NOT A LOOSENED `tol`. That was the first attempt, and it
+# cannot breach. The degree is floored at 2, so at production
 # `R = dt·|v|·F ≈ 0.01–0.2` the schedule returns degree 2 for every tolerance
-# from 1e-15 up to 1, and the sweep duly measures the same mean degree 2.00 at
-# tol = 1e-5 and 1e-7. Even that floor puts the truncation at 3.3e-5 of the
-# splitting error, which passes. So the criterion is held by the DEGREE FLOOR,
-# not by the tolerance, and a control built on `tol` would be asserting
-# something that cannot fail.
+# from 1e-15 up to 1 — the sweep measures the same mean degree 2.00 at tol 1e-5
+# and 1e-7 — and that floor alone leaves the truncation at 3.3e-5 of the
+# baseline, which passes. The criterion is held by the DEGREE FLOOR, not by the
+# tolerance, which is why that floor is now a named constant
+# (`SPIN_TAYLOR_MIN_DEGREE`) rather than a literal in the schedule. The control
+# lowers it to 1 — same pipeline, same observable, same code path, one order
+# less.
 #
-# The control below attacks the floor instead: an order-1 truncation of the same
-# rotation must be materially worse. That makes the assertion above a statement
-# about a property something could break, rather than a tautology.
-#
-# HOW FAR THE MARGIN REACHES. The ratio is not scale-free: the splitting error
-# falls as dt² while the truncation accumulates over ~1/dt rotations, so
-# truncation/splitting grows roughly as dt⁻³. The 3e-11 measured at dt = 0.002
-# therefore buys about three decades of margin per factor of ~10 in dt — a run
-# at dt ≈ 1e-4 would still sit ~1e-2 of the splitting error, and only far below
-# that would the rotation start to matter. Production dt is 1e-3–5e-3, so this
-# is comfortable; but the number belongs to the dt it was established at, and a
-# convergence study that pushes dt much further should re-measure rather than
-# cite it.
+# HOW FAR THE MARGIN REACHES. The ratio is not scale-free: the baseline falls as
+# dt² while the truncation accumulates over ~1/dt rotations, so the ratio grows
+# roughly as dt⁻³ — about three decades of margin per factor of ten in dt.
+# Production dt is 1e-3–5e-3, so 3e-11 is comfortable; but the number belongs to
+# the dt it was established at.
 #
 # Lives in the ci tier, not fast: it runs `find_ground_state`.
 
 using Test
-using LinearAlgebra: norm
+
 using SpinorBEC
-using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_RK_MAX,
-    _taylor_rot_schedule, _cpu_spin_rk, spin_tridiag_bands, spin_matrices,
-    _apply_ddi_rotation!
+using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_RK_MAX, SPIN_TAYLOR_MIN_DEGREE,
+    NegligibleErrorSpec, measure_error_budget, check, passed,
+    _taylor_rot_schedule, _cpu_spin_rk
 
 function _with_taylor(f, on::Bool)
     old = SPIN_TAYLOR_ENABLED[]
@@ -50,6 +44,17 @@ function _with_taylor(f, on::Bool)
         f()
     finally
         SPIN_TAYLOR_ENABLED[] = old
+    end
+end
+
+# Run `f` with the Horner degree floor forced to `k`.
+function _with_min_degree(f, k::Int)
+    old = SPIN_TAYLOR_MIN_DEGREE[]
+    SPIN_TAYLOR_MIN_DEGREE[] = k
+    try
+        f()
+    finally
+        SPIN_TAYLOR_MIN_DEGREE[] = old
     end
 end
 
@@ -67,69 +72,43 @@ end
         enable_ddi=true, c_dd=0.6, ddi_padding=true,
         verbose=false).energy
 
-    # Both references use the EXACT rotation, so their difference is the
-    # splitting error alone: what `dt` already costs, before any truncation.
-    e_exact, e_half = _with_taylor(false) do
-        (_energy(DT, NST), _energy(DT / 2, 2NST))
-    end
-    split_err = abs(e_half - e_exact)
-    @test split_err > 0        # a degenerate reference would make this vacuous
+    budget = measure_error_budget(;
+        label="Taylor spin rotation",
+        # Both references use the EXACT rotation, so their difference is the
+        # splitting error alone: what `dt` already costs.
+        exact=() -> _with_taylor(false) do
+            _energy(DT, NST)
+        end,
+        refined=() -> _with_taylor(false) do
+            _energy(DT / 2, 2NST)
+        end,
+        approx=() -> _with_taylor(true) do
+            _energy(DT, NST)
+        end,
+        # Same pipeline and same observable, one order less: the floor that
+        # actually holds the criterion, lowered.
+        control=() -> _with_taylor(true) do
+            _with_min_degree(1) do
+                _energy(DT, NST)
+            end
+        end,
+        baseline_label="splitting error, dt vs dt/2",
+        approximation_label="Taylor truncation",
+        control_label="degree floor lowered to 1",
+    )
 
-    e_taylor = _with_taylor(true) do
-        _energy(DT, NST)
-    end
-    @test abs(e_taylor - e_exact) < 1e-3 * split_err
+    result = check(NegligibleErrorSpec(1e-3), budget)
+    @info "error budget" summary = result.summary
+    # `passed` is false for BOTH :fail and :indeterminate — a control that
+    # cannot breach is not a green result here, it is a refusal to judge.
+    @test passed(result)
 
     # The degree floor is what holds the criterion, so pin it directly.
     @testset "the schedule never returns a degree below 2" begin
         rk = _cpu_spin_rk(Float64, DT)
         for g in (0.0, 1e-8, 1.0, 1e4), tol in (1e-15, 1e-5, 1.0)
             _, _, kv = _taylor_rot_schedule(g, rk, SPIN_TAYLOR_RK_MAX, tol^2, 1.0)
-            @test kv >= 2
+            @test kv >= SPIN_TAYLOR_MIN_DEGREE[]
         end
-    end
-
-    # Positive control, aimed at the floor rather than at `tol`.
-    @testset "an order-1 truncation IS materially worse" begin
-        F, D = 6, 13
-        sm = spin_matrices(F)
-        n = (4, 4, 4)
-        Ns = prod(n)
-        psi = reshape([ComplexF64(sin(3i), cos(2i)) for i in 1:(Ns * D)], n..., D)
-        px = reshape([0.4sin(i) for i in 1:Ns], n)
-        py = reshape([0.4cos(i) for i in 1:Ns], n)
-        pz = reshape([0.4sin(2i) for i in 1:Ns], n)
-        dt = 0.05
-
-        exact = _with_taylor(false) do
-            p = copy(psi)
-            _apply_ddi_rotation!(p, px, py, pz, sm, dt, 3; imaginary_time=false)
-            p
-        end
-        taylor = _with_taylor(true) do
-            p = copy(psi)
-            _apply_ddi_rotation!(p, px, py, pz, sm, dt, 3; imaginary_time=false)
-            p
-        end
-
-        # Order-1: ψ + (−i·dt)·(v·F)ψ, built from the SAME bands the kernel uses,
-        # so the comparison isolates the order and nothing else.
-        mz, sxu, syu = spin_tridiag_bands(sm, Float64)
-        P = reshape(copy(psi), Ns, D)
-        out = similar(P)
-        for i in 1:Ns
-            vx, vy, vz = px[i], py[i], pz[i]
-            for c in 1:D
-                Aw = vz * mz[c] * P[i, c]
-                c < D && (Aw += (vx * sxu[c] + vy * syu[c]) * P[i, c + 1])
-                c > 1 && (Aw += conj(vx * sxu[c - 1] + vy * syu[c - 1]) * P[i, c - 1])
-                out[i, c] = P[i, c] + (-im * dt) * Aw
-            end
-        end
-        order1 = reshape(out, n..., D)
-
-        err_taylor = norm(vec(taylor) .- vec(exact)) / norm(vec(exact))
-        err_order1 = norm(vec(order1) .- vec(exact)) / norm(vec(exact))
-        @test err_order1 > 1e4 * max(err_taylor, eps())
     end
 end

--- a/test/hamiltonian/test_taylor_tolerance_criterion.jl
+++ b/test/hamiltonian/test_taylor_tolerance_criterion.jl
@@ -1,25 +1,37 @@
-# Gate: the Taylor truncation error must stay negligible against the SPLITTING
-# error — i.e. the tolerance is a consequence of the caller's `dt`, not a
-# decision the caller is asked to make.
+# Gate: the Taylor truncation error stays negligible against the SPLITTING error
+# — the tolerance is a consequence of the caller's `dt`, not a decision the
+# caller is asked to make.
 #
 # `SPIN_TAYLOR_TOL` should not be a user-facing knob: setting it correctly needs
 # a comparison against the integrator's own error, and demanding that knowledge
-# per call site is a design failure. So the relationship is what is pinned here,
-# not the number — someone who has never heard of 1e-13 still finds out when it
-# stops holding.
+# per call site is a design failure. So the relationship is what is pinned here.
 #
 # Measured at production scale (bench/taylor_tolerance_sweep.jl, Eu F=6, 32³,
 # dt = 0.002): splitting error |E(dt) − E(dt/2)| = 7.6e-3 against a truncation
-# error of 2.4e-13, a ratio of 3e-11 — and even at the loosest tolerance tested,
-# 1e-5, the ratio is 3.3e-5. The config below is small and short so the gate is
-# cheap; the RATIO is what travels between scales, not the absolute numbers.
+# error of 2.4e-13 — a ratio of 3e-11.
 #
-# Lives in the ci tier, not fast: it runs `find_ground_state`, which the fast
-# tier excludes by construction.
+# WHY `tol` IS NOT THE POSITIVE CONTROL. The obvious control — loosen `tol` and
+# watch the criterion break — does NOT work here, and finding that out is the
+# point of insisting on one. The degree is floored at 2, so at production
+# `R = dt·|v|·F ≈ 0.01–0.2` the schedule returns degree 2 for every tolerance
+# from 1e-15 up to 1, and the sweep duly measures the same mean degree 2.00 at
+# tol = 1e-5 and 1e-7. Even that floor puts the truncation at 3.3e-5 of the
+# splitting error, which passes. So the criterion is held by the DEGREE FLOOR,
+# not by the tolerance, and a control built on `tol` would be asserting
+# something that cannot fail.
+#
+# The control below attacks the floor instead: an order-1 truncation of the same
+# rotation must be materially worse. That makes the assertion above a statement
+# about a property something could break, rather than a tautology.
+#
+# Lives in the ci tier, not fast: it runs `find_ground_state`.
 
 using Test
+using LinearAlgebra: norm
 using SpinorBEC
-using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_TOL
+using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_RK_MAX,
+    _taylor_rot_schedule, _cpu_spin_rk, spin_tridiag_bands, spin_matrices,
+    _apply_ddi_rotation!
 
 function _with_taylor(f, on::Bool)
     old = SPIN_TAYLOR_ENABLED[]
@@ -33,12 +45,12 @@ end
 
 @testset "Taylor truncation ≪ splitting error" begin
     grid = make_grid(GridConfig((10, 10, 10), (9.0, 9.0, 9.0)))
-    psi0 = init_psi(grid, SpinSystem(2); state=:spin_coherent,
+    psi0 = init_psi(grid, SpinSystem(6); state=:spin_coherent,
         init_theta=π / 4, init_phi=0.3)
     DT, NST = 0.004, 30
 
     _energy(dt, n_steps) = find_ground_state(;
-        grid, atom=Na23,
+        grid, atom=Eu151,
         interactions=InteractionParams(Dict(0 => 8.0, 1 => -0.4)),
         potential=HarmonicTrap((1.0, 1.0, 1.0)), psi_init=psi0,
         dt, n_steps, tol=0.0, save_every=n_steps,
@@ -58,19 +70,56 @@ end
     end
     @test abs(e_taylor - e_exact) < 1e-3 * split_err
 
-    # Positive control. Without it "truncation is negligible" could hold because
-    # the comparison cannot fail, rather than because the tolerance is right: an
-    # absurd tolerance must make the rotation the dominant error.
-    @testset "an absurd tolerance DOES breach the criterion" begin
-        old = SPIN_TAYLOR_TOL[]
-        SPIN_TAYLOR_TOL[] = 0.3
-        try
-            e_bad = _with_taylor(true) do
-                _energy(DT, NST)
-            end
-            @test abs(e_bad - e_exact) > 1e-3 * split_err
-        finally
-            SPIN_TAYLOR_TOL[] = old
+    # The degree floor is what holds the criterion, so pin it directly.
+    @testset "the schedule never returns a degree below 2" begin
+        rk = _cpu_spin_rk(Float64, DT)
+        for g in (0.0, 1e-8, 1.0, 1e4), tol in (1e-15, 1e-5, 1.0)
+            _, _, kv = _taylor_rot_schedule(g, rk, SPIN_TAYLOR_RK_MAX, tol^2, 1.0)
+            @test kv >= 2
         end
+    end
+
+    # Positive control, aimed at the floor rather than at `tol`.
+    @testset "an order-1 truncation IS materially worse" begin
+        F, D = 6, 13
+        sm = spin_matrices(F)
+        n = (4, 4, 4)
+        Ns = prod(n)
+        psi = reshape([ComplexF64(sin(3i), cos(2i)) for i in 1:(Ns * D)], n..., D)
+        px = reshape([0.4sin(i) for i in 1:Ns], n)
+        py = reshape([0.4cos(i) for i in 1:Ns], n)
+        pz = reshape([0.4sin(2i) for i in 1:Ns], n)
+        dt = 0.05
+
+        exact = _with_taylor(false) do
+            p = copy(psi)
+            _apply_ddi_rotation!(p, px, py, pz, sm, dt, 3; imaginary_time=false)
+            p
+        end
+        taylor = _with_taylor(true) do
+            p = copy(psi)
+            _apply_ddi_rotation!(p, px, py, pz, sm, dt, 3; imaginary_time=false)
+            p
+        end
+
+        # Order-1: ψ + (−i·dt)·(v·F)ψ, built from the SAME bands the kernel uses,
+        # so the comparison isolates the order and nothing else.
+        mz, sxu, syu = spin_tridiag_bands(sm, Float64)
+        P = reshape(copy(psi), Ns, D)
+        out = similar(P)
+        for i in 1:Ns
+            vx, vy, vz = px[i], py[i], pz[i]
+            for c in 1:D
+                Aw = vz * mz[c] * P[i, c]
+                c < D && (Aw += (vx * sxu[c] + vy * syu[c]) * P[i, c + 1])
+                c > 1 && (Aw += conj(vx * sxu[c - 1] + vy * syu[c - 1]) * P[i, c - 1])
+                out[i, c] = P[i, c] + (-im * dt) * Aw
+            end
+        end
+        order1 = reshape(out, n..., D)
+
+        err_taylor = norm(vec(taylor) .- vec(exact)) / norm(vec(exact))
+        err_order1 = norm(vec(order1) .- vec(exact)) / norm(vec(exact))
+        @test err_order1 > 1e4 * max(err_taylor, eps())
     end
 end

--- a/test/hamiltonian/test_taylor_tolerance_criterion.jl
+++ b/test/hamiltonian/test_taylor_tolerance_criterion.jl
@@ -24,6 +24,16 @@
 # rotation must be materially worse. That makes the assertion above a statement
 # about a property something could break, rather than a tautology.
 #
+# HOW FAR THE MARGIN REACHES. The ratio is not scale-free: the splitting error
+# falls as dt² while the truncation accumulates over ~1/dt rotations, so
+# truncation/splitting grows roughly as dt⁻³. The 3e-11 measured at dt = 0.002
+# therefore buys about three decades of margin per factor of ~10 in dt — a run
+# at dt ≈ 1e-4 would still sit ~1e-2 of the splitting error, and only far below
+# that would the rotation start to matter. Production dt is 1e-3–5e-3, so this
+# is comfortable; but the number belongs to the dt it was established at, and a
+# convergence study that pushes dt much further should re-measure rather than
+# cite it.
+#
 # Lives in the ci tier, not fast: it runs `find_ground_state`.
 
 using Test

--- a/test/hamiltonian/test_taylor_tolerance_criterion.jl
+++ b/test/hamiltonian/test_taylor_tolerance_criterion.jl
@@ -1,0 +1,76 @@
+# Gate: the Taylor truncation error must stay negligible against the SPLITTING
+# error — i.e. the tolerance is a consequence of the caller's `dt`, not a
+# decision the caller is asked to make.
+#
+# `SPIN_TAYLOR_TOL` should not be a user-facing knob: setting it correctly needs
+# a comparison against the integrator's own error, and demanding that knowledge
+# per call site is a design failure. So the relationship is what is pinned here,
+# not the number — someone who has never heard of 1e-13 still finds out when it
+# stops holding.
+#
+# Measured at production scale (bench/taylor_tolerance_sweep.jl, Eu F=6, 32³,
+# dt = 0.002): splitting error |E(dt) − E(dt/2)| = 7.6e-3 against a truncation
+# error of 2.4e-13, a ratio of 3e-11 — and even at the loosest tolerance tested,
+# 1e-5, the ratio is 3.3e-5. The config below is small and short so the gate is
+# cheap; the RATIO is what travels between scales, not the absolute numbers.
+#
+# Lives in the ci tier, not fast: it runs `find_ground_state`, which the fast
+# tier excludes by construction.
+
+using Test
+using SpinorBEC
+using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_TOL
+
+function _with_taylor(f, on::Bool)
+    old = SPIN_TAYLOR_ENABLED[]
+    SPIN_TAYLOR_ENABLED[] = on
+    try
+        f()
+    finally
+        SPIN_TAYLOR_ENABLED[] = old
+    end
+end
+
+@testset "Taylor truncation ≪ splitting error" begin
+    grid = make_grid(GridConfig((10, 10, 10), (9.0, 9.0, 9.0)))
+    psi0 = init_psi(grid, SpinSystem(2); state=:spin_coherent,
+        init_theta=π / 4, init_phi=0.3)
+    DT, NST = 0.004, 30
+
+    _energy(dt, n_steps) = find_ground_state(;
+        grid, atom=Na23,
+        interactions=InteractionParams(Dict(0 => 8.0, 1 => -0.4)),
+        potential=HarmonicTrap((1.0, 1.0, 1.0)), psi_init=psi0,
+        dt, n_steps, tol=0.0, save_every=n_steps,
+        enable_ddi=true, c_dd=0.6, ddi_padding=true,
+        verbose=false).energy
+
+    # Both references use the EXACT rotation, so their difference is the
+    # splitting error alone: what `dt` already costs, before any truncation.
+    e_exact, e_half = _with_taylor(false) do
+        (_energy(DT, NST), _energy(DT / 2, 2NST))
+    end
+    split_err = abs(e_half - e_exact)
+    @test split_err > 0        # a degenerate reference would make this vacuous
+
+    e_taylor = _with_taylor(true) do
+        _energy(DT, NST)
+    end
+    @test abs(e_taylor - e_exact) < 1e-3 * split_err
+
+    # Positive control. Without it "truncation is negligible" could hold because
+    # the comparison cannot fail, rather than because the tolerance is right: an
+    # absurd tolerance must make the rotation the dominant error.
+    @testset "an absurd tolerance DOES breach the criterion" begin
+        old = SPIN_TAYLOR_TOL[]
+        SPIN_TAYLOR_TOL[] = 0.3
+        try
+            e_bad = _with_taylor(true) do
+                _energy(DT, NST)
+            end
+            @test abs(e_bad - e_exact) > 1e-3 * split_err
+        finally
+            SPIN_TAYLOR_TOL[] = old
+        end
+    end
+end


### PR DESCRIPTION
Two independent ITP wins, measured on TSUBAME with both arms in ONE job on one
node/card. Baseline is `main` (634e0234), i.e. after #183.

| config | before | after | Δ |
|---|---|---|---|
| cpu_4 32³ | 60.43 ms | **27.56 ms** | **2.19×** |
| cpu_4 48³ | 244.2 ms | **108.4 ms** | **2.25×** |
| H100 32³ | 0.506 ms | **0.472 ms** | −34 µs (−6.7 %) |
| H100 64³ | 2.645 ms | **2.624 ms** | −21 µs (−0.8 %) |

Against the pre-#183 baseline the CPU step is now **2.39×** at 32³ and **2.48×**
at 48³.

## 1. CPU spin rotation by Taylor–Horner (the large one)

The spin rotation was ~67 % of a CPU ITP step — `spin_mixing` 4 × 6.97 ms and
`ddi_rotation` 2 × 6.33 ms of a 60.4 ms step at 32³. The Euler 5-stage moves ψ
through cache ~18 times per rotation (5 phase passes + 4 gemms) and needs an
`atan`/`acos`/`sqrt` pre-pass to turn the field into Euler angles.
Taylor–Horner moves it twice and needs no trigonometry at all: the spinor sits
in stack buffers for the whole rotation and the tridiagonal matvec is written
out. Per substep:

| | before | after |
|---|---|---|
| `spin_mixing` (32³) | 6.97 ms | **1.48 ms** (4.7×) |
| `ddi_rotation` (32³) | 6.33 ms | **1.34 ms** (4.7×) |
| `spin_mixing` (48³) | 26.8 ms | **4.60 ms** (5.8×) |
| `ddi_rotation` (48³) | 24.6 ms | **4.23 ms** (5.8×) |

`ddi_convolve` and `diagonal` are unchanged, as they should be.

This is the realization the GPU has had since its per-voxel-degree rewrite
(3.6× against Euler at D=13 there); the CPU had no counterpart. It is a
**different realization, not a port** — the GPU form is warp-cooperative, one
spin component per lane with neighbours by `shfl`, which a CPU core has nothing
to match.

Three things stop being stated twice:

* **the accuracy contract** — `SPIN_TAYLOR_{ENABLED,TOL,RSAFE,RK_MAX}` move to
  `src/foundation/spinor_utils/spin_rotation_taylor.jl` and the CUDA ext reads
  them, so the two devices cannot drift to different tolerances;
* **the generator** — `spin_tridiag_bands` reads the bands off `sm.Fx/Fy/Fz`
  and both devices call it;
* **the spin-mixing field** — the rotation axis now comes from
  `_compute_spin_density!` rather than a second hand-written copy of that
  reduction fused into the angle pre-pass.

### This one is NOT bit-identical

It is a truncated series with a per-voxel degree, targeting a backward error of
`SPIN_TAYLOR_TOL = 1e-13` per rotation. That is a deliberate accuracy decision
and it changes every CPU ITP/RTP result at that level, so it is gated
accordingly:

`test/hamiltonian/test_cpu_spin_rotation_taylor_parity.jl` compares against the
**exact Euler form running on the same input** — deliberately not against the
GPU, because CPU and GPU would otherwise agree to the same wrong tolerance. It
sweeps F ∈ {1,2,6}, real/imaginary time, and R from 0.01 (well inside the
0.01–0.2 production range) to 30 (far past `SPIN_TAYLOR_RSAFE`, where every
voxel halves its angle). It also pins real-time unitarity over 20 rotations and
asserts the per-voxel stack buffers do not reach the heap — an escaping
`MVector` at D=13 would hand back exactly the traffic this kernel saves.

`SPIN_TAYLOR_ENABLED[] = false` restores the exact Euler path.

## 2. The ITP normalisation no longer syncs to the host

`sum(abs2, psi)` returns a **host** scalar, so it ends in a device-to-host copy
— a full stream drain. ITP normalises on every step (`normalize_every = 1`
whenever the magnetisation is unconstrained). Reducing with `dims` leaves the
result in a `(1,1,…,1)` device array that broadcasts against ψ.

Worth stating plainly: I predicted this from the isolated kernel timing (61 µs,
"12 % of a 32³ step") and it delivered **34 µs, 6.7 %**. The isolated
measurement overstated it because the benchmark syncs around each part anyway;
the honest number is the whole-step one in the table.

## Verification

* `ci` tier and GPU gates: see the comment below.
* Targeted CPU gates, all green on TSUBAME:
  `test_cpu_spin_rotation_taylor_parity`, `test_spin_mixing`, `test_ddi`,
  `test_ddi_padded`, `test_itp_ddi_strang_save_every`,
  `test_spin_density_consistency`, `test_ddi_translation_covariance`,
  `analysis/test_spin_rotation`.

## Still not done

`#184` — the padding default-flip also disabled the fused RTP spin-chain
half-step. Untouched here; that is the RTP path and needs the fused kernel
taught the padded convolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
