### PR TITLE
fix(rtp): a padded DDI declined the fused V half-step, so no production run took it

### DIFF
--- a/bench/rtp_padding_ab.jl
+++ b/bench/rtp_padding_ab.jl
@@ -1,0 +1,73 @@
+# What the production RTP step actually costs, padded vs bare.
+#
+#   LD_LIBRARY_PATH=... julia --project=. bench/rtp_padding_ab.jl [N] [steps]
+#
+# `bench/profile_rtp.jl` builds its workspace by calling `make_workspace`
+# directly, where `ddi_padding` defaults to FALSE. Since 9c117c05 the YAML
+# parsers default it TRUE (`DDI_PADDED_DEFAULT`, parsing_blocks.jl), and
+# `_spin_chain_reason` declines the fused `diag · SM · DDI · SM · diag`
+# half-step whenever `ws.ddi_padded !== nothing`. So the benchmark measures the
+# fused path and production does not.
+#
+# This prints, for each arm, BOTH the step time and the reason string, so the
+# mechanism is read off the run rather than inferred from the source.
+
+import CUDA
+using SpinorBEC
+using Printf
+include(joinpath(@__DIR__, "eu151_params.jl"))
+include(joinpath(@__DIR__, "reconcile.jl"))
+
+const N_GRID = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 64
+const N_STEPS = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 10
+
+function build_ws(; n=N_GRID, padded::Bool)
+    grid = make_grid(GridConfig(ntuple(_ -> n, 3), ntuple(_ -> 12.0, 3)))
+    sp = SimParams(; dt=1e-4, n_steps=N_STEPS, imaginary_time=false, save_every=10^9)
+    ws = make_workspace(;
+        grid, atom=Eu151, interactions=eu_interaction_params(0.05),
+        zeeman=ZeemanParams(EU_p_weak, 0.0),
+        potential=HarmonicTrap(1.0, 1.0, EU_λ_z),
+        sim_params=sp, enable_ddi=true, c_dd=EU_c_dd,
+        ddi_padding=padded, backend=CUDABackend(),
+    )
+    psi = init_psi(grid, ws.spin_matrices.system;
+        state=:spin_coherent, init_theta=0.6, init_phi=0.4)
+    psi ./= sqrt(sum(abs2, psi) * cell_volume(grid))
+    copyto!(ws.state.psi, psi)
+    ws
+end
+
+step_n!(ws, k) = (for _ in 1:k
+    SpinorBEC.split_step!(ws)
+end; CUDA.synchronize())
+
+function arm(padded::Bool)
+    ws = build_ws(; padded)
+    # The eligibility answer, straight from the predicate the propagator calls.
+    reason = SpinorBEC._spin_chain_reason(ws, ws.interactions, ws.state.psi)
+    fused_ok = reason === nothing && SpinorBEC._spin_chain_available(ws.state.psi, ws)
+    step_n!(ws, 3)
+    t = 1e3 * timed(() -> step_n!(ws, N_STEPS); warmup=1, samples=5).t / N_STEPS
+    ws = nothing
+    GC.gc(true)
+    CUDA.reclaim()
+    (t, fused_ok, reason)
+end
+
+function main()
+    @printf("RTP padded-vs-bare — %s, Eu151 F=6 (D=13) F64, %d^3\n",
+        CUDA.name(CUDA.device()), N_GRID)
+    println("  DDI_PADDED_DEFAULT (what every YAML run gets) = ",
+        SpinorBEC.DDI_PADDED_DEFAULT)
+    println()
+    for (label, padded) in (("bare (ddi_padding=false, what bench/profile_rtp.jl builds)", false),
+                            ("padded (ddi_padding=true, what run_yaml builds)", true))
+        t, ok, reason = arm(padded)
+        @printf("  %-58s %8.3f ms/step\n", label, t)
+        @printf("      fused half-step taken: %-5s  %s\n", ok,
+            reason === nothing ? "(eligible)" : reason)
+    end
+end
+
+main()

--- a/ext/SpinorBECCUDAExt/gpu_spin_chain.jl
+++ b/ext/SpinorBECCUDAExt/gpu_spin_chain.jl
@@ -20,10 +20,15 @@
 #     DDI through the convolution, and the midpoint freezes ψ_mf, so all three
 #     substeps were computing the same ⟨F⟩)
 #   * 5 kernel launches → 2
+#
+# A zero-padded (open-boundary) DDI changes none of that. Both ⟨F⟩ and Φ then
+# live in the `[1:n_pts...]` corner of the padded buffers, which is one index map
+# in the rotation — the same `_voxel_index` the standalone DDI rotation reads
+# through — not a reason to unfuse.
 
 @inline function _spin_chain_warp_kernel!(
     P, fx, fy, fz, px, py, pz, vph, zph_fwd, zph_bwd, mz, sxu, syu, rk_sm, rk_dd,
-    K::Int32, tol2, F2, rsafe2, ::Val{D}, ::Val{RT},
+    K::Int32, tol2, F2, rsafe2, ::Val{D}, ::Val{RT}, src,
 ) where {D, RT}
     T = real(eltype(P))
     CT = Complex{T}
@@ -31,12 +36,17 @@
     in_range = vox <= size(P, 1)
     live = active && in_range
 
-    Fx = in_range ? (@inbounds fx[vox]) : zero(T)
-    Fy = in_range ? (@inbounds fy[vox]) : zero(T)
-    Fz = in_range ? (@inbounds fz[vox]) : zero(T)
-    Px = in_range ? (@inbounds px[vox]) : zero(T)
-    Py = in_range ? (@inbounds py[vox]) : zero(T)
-    Pz = in_range ? (@inbounds pz[vox]) : zero(T)
+    # `src` maps voxel → index in the field buffers, exactly as in
+    # `_spin_taylor_warp_kernel!`: `nothing` when ⟨F⟩ and Φ are contiguous, a
+    # `CartesianIndices(n_pts)` when they are the corner of a zero-padded DDI
+    # buffer. `vph` is this kernel's own scratch and is always contiguous.
+    j = in_range ? _voxel_index(src, vox) : _voxel_index(src, 1)
+    Fx = in_range ? (@inbounds fx[j]) : zero(T)
+    Fy = in_range ? (@inbounds fy[j]) : zero(T)
+    Fz = in_range ? (@inbounds fz[j]) : zero(T)
+    Px = in_range ? (@inbounds px[j]) : zero(T)
+    Py = in_range ? (@inbounds py[j]) : zero(T)
+    Pz = in_range ? (@inbounds pz[j]) : zero(T)
 
     ds, bs, bms, gs = _rot_generator(Fx, Fy, Fz, mz, sxu, syu, c, cdn, F2, Val(16))
     dd, bd, bmd, gd = _rot_generator(Px, Py, Pz, mz, sxu, syu, c, cdn, F2, Val(16))
@@ -71,13 +81,29 @@ function SpinorBEC._apply_spin_chain!(
     it = imaginary_time === true
     dt_outer = T(dt_half) / 2                # the outer chain's substep dt
 
-    # ⟨F⟩(ψ_mf) into bufs.F*_r and Φ_DDI into bufs.Phi_* — ONE spin-density
-    # pass feeding both, which is the point of fusing. The convolution leaves
-    # F*_r intact, and it is bit-identical to what the separate spin-mixing
-    # substep would have computed (same kernel, same coefficients, same frozen
-    # ψ_mf).
-    SpinorBEC._compute_and_convolve_ddi!(
-        psi_mf, sm, ws.ddi, bufs, Val(D), ndim, n_pts)
+    # ⟨F⟩(ψ_mf) and Φ_DDI, from ONE spin-density pass feeding both — the point of
+    # fusing. The convolution leaves ⟨F⟩ intact, and it is bit-identical to what
+    # the separate spin-mixing substep would have computed (same kernel, same
+    # coefficients, same frozen ψ_mf).
+    #
+    # With `ddi_padding` on — which is `DDI_PADDED_DEFAULT`, i.e. every
+    # `run_yaml` run — both fields live in the `[1:n_pts...]` corner of the
+    # padded buffers rather than in contiguous arrays of their own. That changes
+    # where the rotation reads them, which is an index map, not a reason to fall
+    # back to five separate operators. The corner ⟨F⟩ is the same kernel over the
+    # same values as the contiguous one (`_compute_spin_density!` dispatches on
+    # buffer shape and differs only in the destination index), so the
+    # bit-identity claim carries over — pinned by
+    # `test/gpu/test_gpu_padded_corner_parity.jl` on that side and by the padded
+    # arm of the fusion oracle on this one.
+    pad = ws.ddi_padded
+    if pad === nothing
+        SpinorBEC._compute_and_convolve_ddi!(
+            psi_mf, sm, ws.ddi, bufs, Val(D), ndim, n_pts)
+    else
+        SpinorBEC._compute_and_convolve_ddi_padded!(
+            psi_mf, sm, ws.ddi, pad, Val(D), ndim, n_pts)
+    end
 
     P = reshape(psi, N, D)
     Pmf = reshape(psi_mf::CuArray{Complex{T}}, N, D)
@@ -99,15 +125,32 @@ function SpinorBEC._apply_spin_chain!(
     rk_sm = _get_spin_rk(psi, T(ip[1]) * dt_outer)
     rk_dd = _get_spin_rk(psi, T(dt_half))
 
-    fv = reshape(bufs.Fx_r, N), reshape(bufs.Fy_r, N), reshape(bufs.Fz_r, N)
-    pv = _gpu_phi_vec(bufs.Phi_x, n_pts, N),
-    _gpu_phi_vec(bufs.Phi_y, n_pts, N),
-    _gpu_phi_vec(bufs.Phi_z, n_pts, N)
+    # Two call sites rather than one with a Union-typed field/map tuple, so each
+    # launches a concretely-typed kernel — the shape `_ddi_rotate_taylor!` uses
+    # for the standalone DDI rotation.
+    if pad === nothing
+        _launch_spin_chain!(
+            P, reshape(bufs.Fx_r, N), reshape(bufs.Fy_r, N), reshape(bufs.Fz_r, N),
+            reshape(bufs.Phi_x, N), reshape(bufs.Phi_y, N), reshape(bufs.Phi_z, N),
+            vph, zf, zb, coef, rk_sm, rk_dd, F, N, Val(D), it, nothing)
+    else
+        _launch_spin_chain!(
+            P, pad.Fx_pad, pad.Fy_pad, pad.Fz_pad,
+            pad.Phi_x_pad, pad.Phi_y_pad, pad.Phi_z_pad,
+            vph, zf, zb, coef, rk_sm, rk_dd, F, N, Val(D), it,
+            CartesianIndices(n_pts))
+    end
+    nothing
+end
 
+@inline function _launch_spin_chain!(
+    P, fx, fy, fz, px, py, pz, vph, zf, zb, coef, rk_sm, rk_dd, F::T, N,
+    ::Val{D}, it::Bool, src,
+) where {T, D}
     CUDA.@cuda threads = 256 blocks = cld(N, 16) _spin_chain_warp_kernel!(
-        P, fv..., pv..., vph, zf, zb, coef.mz, coef.sxu, coef.syu, rk_sm, rk_dd,
-        Int32(_SPIN_RK_MAX), T(_SPIN_TAYLOR_TOL[])^2, F * F,
-        T(_SPIN_TAYLOR_RSAFE[])^2, Val(D), Val(!it))
+        P, fx, fy, fz, px, py, pz, vph, zf, zb, coef.mz, coef.sxu, coef.syu,
+        rk_sm, rk_dd, Int32(_SPIN_RK_MAX), T(_SPIN_TAYLOR_TOL[])^2, F * F,
+        T(_SPIN_TAYLOR_RSAFE[])^2, Val(D), Val(!it), src)
     nothing
 end
 

--- a/src/hamiltonian/integrator/spin_chain.jl
+++ b/src/hamiltonian/integrator/spin_chain.jl
@@ -54,6 +54,14 @@ a uniform axial Zeeman. **If you add an operator to the outer chain, or a term
 to the diagonal step, add it here** — otherwise the fused path would silently
 drop it. `test/oracles/test_spin_chain_fusion_parity.jl` pins one arm per entry
 and demands bit-identity for the eligible shape.
+
+An entry belongs here only for something that sits BETWEEN the operators, or
+that changes the diagonal phase's form. How Φ itself is computed is neither: the
+zero-padded, open-boundary convolution gets a branch in the realization instead.
+That distinction is load-bearing rather than stylistic — `DDI_PADDED_DEFAULT` is
+`true` (9c117c05), so listing it here declined the fusion for every `run_yaml`
+RTP run, while `bench/profile_rtp.jl` went on measuring the fused path because
+it calls `make_workspace` directly, where `ddi_padding` defaults `false`.
 """
 function _spin_chain_reason(ws::Workspace, ip::InteractionParams, psi_mf)
     SPIN_CHAIN_FUSION_ENABLED[] || return "SPIN_CHAIN_FUSION_ENABLED[] is off"
@@ -61,7 +69,6 @@ function _spin_chain_reason(ws::Workspace, ip::InteractionParams, psi_mf)
         return "the mean field is not frozen (no midpoint predictor-corrector)"
     ws.ddi === nothing && return "no DDI substep to fuse with"
     ws.ddi_bufs === nothing && return "no DDI buffers"
-    ws.ddi_padded === nothing || return "zero-padded DDI uses a different convolution"
     is_active(ip[1]) || return "c₁ = 0, so there is no spin-mixing rotation to fuse"
     is_active(get_cn(ip, 2)) && return "c₂ ≠ 0 (singlet-pair substep sits between them)"
     ws.tensor_cache === nothing || return "tensor channels sit between them"

--- a/test/oracles/test_spin_chain_fusion_parity.jl
+++ b/test/oracles/test_spin_chain_fusion_parity.jl
@@ -76,6 +76,25 @@ else
         @test norm(a) > 0 && a != Array(_ws().state.psi)
     end
 
+    # `DDI_PADDED_DEFAULT` is `true`, so this — not the bare kernel above — is the
+    # shape every `run_yaml` RTP run builds. It was unpinned while
+    # `_spin_chain_reason` declined a padded DDI outright, which meant the arm
+    # above was gating a path production had stopped taking.
+    @testset "the fusion holds with a zero-padded DDI too" begin
+        SpinorBEC.MEANFIELD_MIDPOINT_ENABLED[] = true
+        a = _run(true, 5; ddi_padding=true)
+        b = _run(false, 5; ddi_padding=true)
+        @test a == b
+        wsp = _ws(; ddi_padding=true)
+        @test wsp.ddi_padded !== nothing
+        @test SpinorBEC._spin_chain_reason(
+            wsp, wsp.interactions, CUDA.zeros(ComplexF64, 2)) === nothing
+        # Padding changes Φ, so the padded arm must NOT agree with the bare one.
+        # Without this, a padded workspace that silently ran the bare convolution
+        # — the failure the index map exists to prevent — would still pass.
+        @test a != _run(true, 5)
+    end
+
     @testset "no frozen mean field ⇒ the fusion declines" begin
         ws = _ws()
         # `psi_mf === nothing` is the plain (non-midpoint) half-step: the two


### PR DESCRIPTION
## What broke

`9c117c05` set `DDI_PADDED_DEFAULT = true`. `_spin_chain_reason` carried

```julia
ws.ddi_padded === nothing || return "zero-padded DDI uses a different convolution"
```

so from that commit **no `run_yaml` RTP run took the fused `diag · SM · DDI · SM · diag` half-step**. Round 9's fusion stopped reaching users the day padding became the default.

`bench/profile_rtp.jl` could not see it: it calls `make_workspace` directly, and there `ddi_padding` defaults to `false`. The benchmark went on measuring a path production had left. **A bench that bypasses the config parser cannot see a parser default flip.**

## Why the entry did not belong there

The list is for operators that sit *between* `diag`, `SM`, `DDI`, `SM`, `diag`, or that change the diagonal phase's form — things the fused kernel would silently drop. Padding is neither. It changes how Φ is computed, and leaves Φ and ⟨F⟩ in the `[1:n_pts...]` corner of the padded buffers instead of in contiguous arrays. That is one index map in the rotation — `_voxel_index`, which #183 already built and which the standalone DDI rotation already reads through.

## Bit-identity carries over

`_compute_spin_density!` dispatches on buffer shape and differs only in the destination index, so the corner ⟨F⟩ the fused kernel reads is the same kernel over the same values as the contiguous ⟨F⟩ the unfused spin-mixing substep computes. `test/gpu/test_gpu_padded_corner_parity.jl` asserts exactly that with `==`.

The fusion oracle claims one arm per eligibility entry; `ddi_padded` had **none**, which is how a gate stayed green on a path production no longer took. It has one now, and that arm also checks the padded result *differs* from the bare one, so a workspace that silently ran the bare convolution cannot pass it.

## Measured

One H100, Eu151 F=6 (D=13) F64, `bench/rtp_padding_ab.jl` (new — it prints `_spin_chain_reason`'s verdict beside each timing, so which path ran is read off the run rather than inferred):

| grid | padded, before | padded, after | |
|---|---|---|---|
| 64³ | 4.824 ms/step | 3.309 | **1.46×** |
| 96³ | 17.057 | 12.152 | **1.40×** |
| 128³ | 40.270 | 28.688 | **1.41×** |

The bare shape is unchanged (2.066 → 2.060, 6.454 → 6.478, 14.573 → 14.536), as it must be.

## Gates

- `test/oracles/test_spin_chain_fusion_parity.jl` — green, including the new padded arm (5 RTP steps fused vs unfused, `==`).
- `test/gpu/test_gpu_padded_corner_parity.jl`, `test/hamiltonian/test_ddi_padded_zero_pad_invariant.jl` — green.
- `ci` tier on a TSUBAME GPU node — see the companion perf PR, which stacks on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)