### PR TITLE
perf(rtp): two traffic cuts in the fused V half-step

### DIFF
--- a/bench/ddi_pad_factor_accuracy.jl
+++ b/bench/ddi_pad_factor_accuracy.jl
@@ -1,0 +1,118 @@
+# How much zero-padding the open-boundary DDI actually needs.
+#
+#   LD_LIBRARY_PATH=... julia --project=. bench/ddi_pad_factor_accuracy.jl [N]
+#
+# `ddi_pad_factor` defaults to 2 in every axis, so the convolution runs on 8× the
+# voxels. Since `DDI_PADDED_DEFAULT` flipped to `true` (9c117c05) that is every
+# production run, and at 128³ those six rFFTs on a 256³ grid are more than half
+# the RTP step — the largest single item left after the fused half-step.
+#
+# 9c117c05 measured what the padding BUYS: the bare periodic kernel carries a
+# 2.1e-2 to 4.7e-2 dipolar field error against free space, flat in resolution.
+# Nobody measured what it COSTS to buy less of it. The padding removes periodic
+# images, and image strength falls like 1/r³ with the image distance, so the
+# error should fall steeply in `pad_factor` and a factor of 2 may be far more
+# than needed.
+#
+# Reference is pad_factor 3 rather than an analytic form: the question is not
+# "what is Φ" but "how much does Φ still move as the box grows", which is the
+# same convergence question the padding exists to answer, and it needs no second
+# implementation to be trusted. The bare (unpadded) arm is the positive control —
+# it must show the ~2e-2 that commit reported, or the meter is not measuring the
+# thing it claims to.
+
+import CUDA
+using SpinorBEC
+using Printf
+using LinearAlgebra: norm
+
+include(joinpath(@__DIR__, "eu151_params.jl"))
+
+const N_GRID = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 48
+const PAD_REF = 3.0
+
+function build(; pad::Union{Nothing, Float64}, n=N_GRID)
+    grid = make_grid(GridConfig(ntuple(_ -> n, 3), ntuple(_ -> 12.0, 3)))
+    sp = SimParams(; dt=1e-4, n_steps=1, imaginary_time=false, save_every=10^9)
+    kw = pad === nothing ? (; ddi_padding=false) :
+         (; ddi_padding=true, ddi_pad_factor=pad)
+    ws = make_workspace(;
+        grid, atom=Eu151, interactions=eu_interaction_params(0.05),
+        zeeman=ZeemanParams(EU_p_weak, 0.0),
+        potential=HarmonicTrap(1.0, 1.0, EU_λ_z),
+        sim_params=sp, enable_ddi=true, c_dd=EU_c_dd,
+        backend=CUDABackend(), kw...,
+    )
+    psi = init_psi(grid, ws.spin_matrices.system;
+        state=:spin_coherent, init_theta=0.6, init_phi=0.4)
+    psi ./= sqrt(sum(abs2, psi) * cell_volume(grid))
+    copyto!(ws.state.psi, psi)
+    ws
+end
+
+"Φ on the physical grid, as three host arrays."
+function phi_of(ws)
+    sm = ws.spin_matrices
+    D = sm.system.n_components
+    n_pts = ntuple(d -> size(ws.state.psi, d), 3)
+    if ws.ddi_padded === nothing
+        SpinorBEC._compute_and_convolve_ddi!(
+            ws.state.psi, sm, ws.ddi, ws.ddi_bufs, Val(D), 3, n_pts)
+        CUDA.synchronize()
+        b = ws.ddi_bufs
+        return (Array(b.Phi_x), Array(b.Phi_y), Array(b.Phi_z))
+    end
+    p = ws.ddi_padded
+    SpinorBEC._compute_and_convolve_ddi_padded!(
+        ws.state.psi, sm, ws.ddi, p, Val(D), 3, n_pts)
+    CUDA.synchronize()
+    c = CartesianIndices(n_pts)
+    (Array(p.Phi_x_pad)[c], Array(p.Phi_y_pad)[c], Array(p.Phi_z_pad)[c])
+end
+
+rel_err(a, b) = sqrt(sum(norm(a[i] - b[i])^2 for i in 1:3)) /
+                sqrt(sum(norm(b[i])^2 for i in 1:3))
+
+"ms per RTP step at this padding."
+function ms_per_step(ws; k=10, samples=3)
+    step!(m) = (for _ in 1:m
+        SpinorBEC.split_step!(ws)
+    end; CUDA.synchronize())
+    step!(3)
+    best = Inf
+    for _ in 1:samples
+        t0 = time_ns()
+        step!(k)
+        best = min(best, (time_ns() - t0) * 1e-6 / k)
+    end
+    best
+end
+
+function main()
+    @printf("DDI pad_factor — %s, Eu151 F=6 (D=13) F64, %d³ box 12\n",
+        CUDA.name(CUDA.device()), N_GRID)
+    @printf("  reference: pad_factor = %.1f\n\n", PAD_REF)
+
+    ref = phi_of(build(; pad=PAD_REF))
+    GC.gc(true);
+    CUDA.reclaim()
+
+    @printf("  %-14s %14s %14s %10s\n",
+        "pad_factor", "rel. Φ error", "ms/RTP step", "FFT voxels")
+    for pad in (nothing, 1.25, 1.5, 1.75, 2.0, 2.5)
+        ws = build(; pad)
+        e = rel_err(phi_of(ws), ref)
+        t = ms_per_step(ws)
+        vox = pad === nothing ? 1.0 : Float64(pad)^3
+        lbl = pad === nothing ? "none (bare)" : @sprintf("%.2f", pad)
+        @printf("  %-14s %14.3e %14.3f %9.2f×\n", lbl, e, t, vox)
+        ws = nothing
+        GC.gc(true)
+        CUDA.reclaim()
+    end
+    println("\n  The `none` row is the positive control: 9c117c05 measured the bare")
+    println("  periodic kernel at 2.1e-2 to 4.7e-2 against free space, so a value")
+    println("  far below that would mean this meter is not seeing the images.")
+end
+
+main()

--- a/bench/perf_targets.txt
+++ b/bench/perf_targets.txt
@@ -296,12 +296,41 @@ apply_ddi_step_rotating!  kernel/apply_ddi_step_rotating_eu151_16cubed  Eu151 16
 #   the MPS/Yoshida composers, where the docstring ties it to Richardson order
 #   recovery. There is no free 1.5× hiding there.
 #
-# NEXT: at 128³ the padded step is 26.95 ms against 12.79 bare, i.e. the
-#   open-boundary convolution — six rFFTs on a 256³ grid — is now more than half
-#   the step and the largest single item left. #183 already removed its pad
-#   re-zeroing and its Φ crop. What remains to try is the transform itself:
-#   whether cuFFT does better on one batched 3-field plan than on three, and
-#   whether the pad factor has to be 2 in every axis for the field error the
-#   padding is there to remove (9c117c05 measured 2.1e-2 to 4.7e-2 against free
-#   space; nobody has measured it against pad_factor). Measure the error before
-#   trading it, and on an H100 — the ratio moves with the FP64 rate.
+# rejected(measured — it is an accuracy trade, not a free win) 2026-07-29:
+#   lowering `ddi_pad_factor` below 2. At 128³ the padded step is 26.95 ms
+#   against 12.79 bare, so the open-boundary convolution — six rFFTs on a 256³
+#   grid — is the largest single item left, and the pad factor sets that volume
+#   as pad³. Nobody had measured what the error buys, only what NOT padding
+#   costs (9c117c05: 2.1e-2 to 4.7e-2 against free space). `bench/
+#   ddi_pad_factor_accuracy.jl` (new) sweeps it, referencing pad_factor 3 —
+#   the question is how much Φ still moves as the box grows, which needs no
+#   second implementation to be trusted. H100, Eu151 D=13, box 12, IDENTICAL at
+#   48³ and 64³ (so this is geometry, not resolution — as that commit also found):
+#
+#     pad_factor   rel. Φ error   ms/step (64³)   FFT voxels
+#       none         1.27e-1         1.815          1.00×
+#       1.25         4.58e-2         2.079          1.95×
+#       1.50         1.92e-2         2.385          3.38×
+#       1.75         8.82e-3         2.703          5.36×
+#       2.00         4.29e-3         3.054          8.00×
+#       2.50         9.87e-4         4.535         15.62×
+#
+#   pad 1.5 would be 1.28× faster than the default and still removes 85 % of the
+#   image error — but the 1.9e-2 it leaves is the same size as the error
+#   9c117c05 introduced the padding to remove. So the knob is real and the curve
+#   is steep, and the answer is still no without a physics decision.
+#
+#   Read the `none` row with care: 1.27e-1 here against that commit's 2.1e-2 to
+#   4.7e-2. Same phenomenon, different meters — theirs is a free-space reference
+#   on a field-magnitude measure, this is an L2 ratio over the whole grid against
+#   pad 3. It confirms the meter SEES the images and that they fall steeply, but
+#   it does not reproduce their number and should not be quoted as if it did.
+#   The pad 2.5 row is also near this meter's own floor (its residual against a
+#   true free-space limit is of the same order), so only rows ≤ 2.0 are solid.
+#
+# NEXT: the convolution, without touching its physics. Whether cuFFT does better
+#   on one batched 3-field plan than on three separate ones is unmeasured, and
+#   for the PADDED context it needs only a DDIPaddedContext field-type change,
+#   not a Workspace one — the objection that killed the same idea for the
+#   unpadded buffers in Round 9. Measure on an H100: the FFT-vs-rest balance
+#   moves with the FP64 rate, and the local card will rank it wrong.

--- a/bench/perf_targets.txt
+++ b/bench/perf_targets.txt
@@ -204,3 +204,104 @@ apply_ddi_step_rotating!  kernel/apply_ddi_step_rotating_eu151_16cubed  Eu151 16
 #   transactions cost 2.4× (Round 8 measured that for the single-rotation
 #   kernel); (b) whether 105 launches/step matters at ~5 µs each. Get a TSUBAME
 #   profile before optimizing either.
+
+# === Round 10 (2026-07-29, RTP on TSUBAME H100) ===
+#
+# Round 9's two open questions, answered on the card it said to ask:
+#
+#   (a) IS the rotation kernel memory-bound on an H100? YES, flatly.
+#       bench/micro_spin_taylor.jl 128 13 cloud, full H100:
+#         K       1     2     4     8    16    24
+#         ms  0.864 0.865 0.865 0.864 0.864 0.864
+#       t(16)/t(4) = 1.00 against 4.0 for pure compute, ceiling 938.6 GB/s.
+#       So the lever on this machine is ψ TRAFFIC, not the Horner op count —
+#       the opposite of the consumer card, where Round 9 measured ~74 % of FP64
+#       peak in the same body. Both of the cuts below are traffic cuts.
+#   (b) launches: at 128³ the GPU is busy 97.9 % of wall, so the ~105 launches
+#       per step are already hidden. Not a target.
+#
+# BUT FIRST, a defect that mattered more than either. `9c117c05` set
+# `DDI_PADDED_DEFAULT = true`, and `_spin_chain_reason` carried
+# `ws.ddi_padded === nothing || return "..."` — so from that commit no
+# `run_yaml` RTP run took the fused V half-step at all. `bench/profile_rtp.jl`
+# cannot see this: it calls `make_workspace` directly, where `ddi_padding`
+# defaults FALSE. The benchmark went on measuring a path production had left.
+# A bench that bypasses the config parser cannot see a parser default flip.
+#
+# `bench/rtp_padding_ab.jl` (new) prints `_spin_chain_reason`'s verdict beside
+# each timing, so which path ran is read off the run rather than inferred, and
+# it reports BOTH shapes per invocation. Baseline is 634e0234 (post-#183, which
+# had already fixed the ITP-side padded fast paths).
+#
+#   one H100, alternating arms, repeats agreed to < 0.5 %:
+#
+#                  bare (what the bench builds)   padded (what run_yaml builds)
+#                    BASE    FIX    PERF            BASE     FIX    PERF
+#    64³            2.066  2.060   1.79            4.824   3.309   3.05
+#    96³            6.454  6.478   5.69           17.057  12.126  11.37
+#   128³           14.573 14.536  12.79           40.270  28.688  26.95
+#
+#   production shape, BASE → PERF:  1.58× / 1.50× / 1.49×
+#     of which the FIX (re-fusing the padded path) is 1.46× / 1.40× / 1.41×
+#     and the two traffic cuts add                     1.09× / 1.07× / 1.06×
+#
+# The traffic cuts are worth 1.14-1.15× on the bare shape but only 1.06-1.09×
+# on the padded one, because padding runs the convolution on a 2× grid per axis
+# and those FFTs dilute a ψ-traffic saving. Quote the padded column: it is the
+# one production pays.
+#
+# ACCURACY (bench/rtp_order_padded.jl, new). Order had never been measured on
+# the combination production actually runs — GPU + zero-padded + `split_step!`
+# + the fused kernel. `bench/conv_order.jl` is CPU, N=12, unpadded, and calls
+# the half-potential helpers directly. Self-convergence at 24³, Eu151 D=13 F64:
+#
+#   padded, fused ON    dt 2e-4 → 1e-4 → 5e-5 : order 2.000, 2.000
+#   padded, fused OFF                          : order 2.000, 2.000
+#   bare,   fused ON                           : order 2.000, 2.000
+#   and fused ≡ unfused at EVERY dt, bit for bit.
+#
+# Strang is 2 and stays 2. The mean field is what puts that at risk — evaluated
+# at each substep's entry it collapses to ~1 with DDI on — so this is the
+# measurement that would catch a fused half-step that had quietly become a
+# different splitting. An order table alone cannot distinguish "same splitting"
+# from "different splitting of the same order", which is why the bit-identity
+# line is printed next to it.
+#
+# done 2026-07-29 (1): the Picard midpoint opened every iterate with a full-ψ
+#   `copyto!(psi_mid_curr, psi_orig)` — two per step for a plain `split_step!`
+#   (n_picard = 1), four for the composers (n_picard = 2), 436 MB each way at
+#   128³ D=13 F64. The fused kernel reads each (voxel, component) once before
+#   writing it, so it takes a separate source array for free: `psi_in` hands it
+#   ψ_orig and the copy disappears rather than moving. The generic chain, which
+#   is in-place throughout, materialises the request as the copy it would have
+#   paid anyway, so nothing off the fused path changes.
+#
+#   Sanity-check the mechanism against the measurement before believing it: the
+#   saving at 128³ bare is 0.84 ms for 2 × 872 MB = 2.07 TB/s, which an H100 can
+#   do. The same arithmetic is how the first draft of this note — which claimed
+#   SIX copies per step — was caught: six would have needed 6.2 TB/s, above
+#   HBM3 peak. `_half_potential!` passes `n_picard=1`; only the composers use 2.
+#
+# done 2026-07-29 (2): `_spin_density_kernel!` and `_diag_phase_kernel!` are
+#   both per-voxel reductions over the same D components of the same ψ_mf,
+#   launched back to back with the same geometry — the second re-read 436 MB for
+#   a sum the first had in registers (Σ_c|ψ_c|² is a term of both). Fused; each
+#   accumulator keeps its own kernel's terms and order, so bit-identical. Needed
+#   `_convolve_ddi!` / `_convolve_ddi_padded!` (the k-space halves) split out of
+#   the two `_compute_and_convolve_*` wrappers, which now share them.
+#
+# NOT a lever, contrary to the first draft of this note: `n_picard`. The RTP
+#   dispatcher already passes 1 (`_half_potential!`), so a plain step is four
+#   fused half-steps, not six. 2 is reached only by `split_step_midpoint!` and
+#   the MPS/Yoshida composers, where the docstring ties it to Richardson order
+#   recovery. There is no free 1.5× hiding there.
+#
+# NEXT: at 128³ the padded step is 26.95 ms against 12.79 bare, i.e. the
+#   open-boundary convolution — six rFFTs on a 256³ grid — is now more than half
+#   the step and the largest single item left. #183 already removed its pad
+#   re-zeroing and its Φ crop. What remains to try is the transform itself:
+#   whether cuFFT does better on one batched 3-field plan than on three, and
+#   whether the pad factor has to be 2 in every axis for the field error the
+#   padding is there to remove (9c117c05 measured 2.1e-2 to 4.7e-2 against free
+#   space; nobody has measured it against pad_factor). Measure the error before
+#   trading it, and on an H100 — the ratio moves with the FP64 rate.

--- a/bench/rtp_order_padded.jl
+++ b/bench/rtp_order_padded.jl
@@ -1,0 +1,103 @@
+# dt-convergence order of `split_step!` on the shape production actually runs.
+#
+#   LD_LIBRARY_PATH=... julia --project=. bench/rtp_order_padded.jl [N] [steps]
+#
+# `bench/conv_order.jl` measures the same property on the CPU, at N=12, with an
+# UNPADDED DDI, and by calling the half-potential helpers directly. None of that
+# is what `run_yaml` runs: since `DDI_PADDED_DEFAULT` flipped to `true`
+# (9c117c05) production is GPU + zero-padded + `split_step!`, and once the fused
+# V half-step stopped declining a padded DDI it is also the fused kernel. Order
+# had never been measured on that combination.
+#
+# Self-convergence, so no reference solution is needed and no other integrator is
+# trusted: with e(h) = ‖ψ_h − ψ_{h/2}‖ at a common final time,
+#
+#     order ≈ log2( e(h) / e(h/2) )
+#
+# Strang ⇒ 2. The mean field is what puts that at risk — evaluated at each
+# substep's entry it collapses to ~1 with DDI on, which is why the midpoint
+# predictor-corrector exists — so this is the measurement that would catch a
+# fused half-step that had quietly become a different splitting.
+
+import CUDA
+using SpinorBEC
+using Printf
+using LinearAlgebra: norm
+include(joinpath(@__DIR__, "eu151_params.jl"))
+
+const N_GRID = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 24
+const N_COARSE = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 64
+const DT0 = 2.0e-4
+const T_FINAL = DT0 * N_COARSE
+
+function run_to_T(dt::Float64; n::Int=N_GRID, padded::Bool, fused::Bool)
+    old = SpinorBEC.SPIN_CHAIN_FUSION_ENABLED[]
+    SpinorBEC.SPIN_CHAIN_FUSION_ENABLED[] = fused
+    try
+        grid = make_grid(GridConfig(ntuple(_ -> n, 3), ntuple(_ -> 10.0, 3)))
+        nsteps = round(Int, T_FINAL / dt)
+        sp = SimParams(; dt, n_steps=nsteps, imaginary_time=false, save_every=10^9)
+        ws = make_workspace(;
+            grid, atom=Eu151, interactions=eu_interaction_params(0.05),
+            zeeman=ZeemanParams(EU_p_weak, 0.0),
+            potential=HarmonicTrap(1.0, 1.0, EU_λ_z),
+            sim_params=sp, enable_ddi=true, c_dd=EU_c_dd,
+            ddi_padding=padded, backend=CUDABackend(),
+        )
+        # Tilted spin-coherent: ⟨F⟩ has all three components non-zero, so the
+        # spin-mixing and DDI rotations are both genuinely exercised.
+        psi = init_psi(grid, ws.spin_matrices.system;
+            state=:spin_coherent, init_theta=0.6, init_phi=0.4)
+        psi ./= sqrt(sum(abs2, psi) * cell_volume(grid))
+        copyto!(ws.state.psi, psi)
+        for _ in 1:nsteps
+            SpinorBEC.split_step!(ws)
+        end
+        CUDA.synchronize()
+        out = Array(ws.state.psi)
+        ws = nothing
+        GC.gc(true)
+        CUDA.reclaim()
+        return out
+    finally
+        SpinorBEC.SPIN_CHAIN_FUSION_ENABLED[] = old
+    end
+end
+
+function order_table(; padded::Bool, fused::Bool)
+    @printf("\n  DDI %s, fused half-step %s   (T = %.4g, %d³)\n",
+        padded ? "zero-padded (production)" : "bare", fused ? "ON" : "OFF",
+        T_FINAL, N_GRID)
+    dts = [DT0 / 2^k for k in 0:3]
+    psis = [run_to_T(dt; padded, fused) for dt in dts]
+    errs = [norm(psis[i] - psis[i + 1]) for i in 1:(length(psis) - 1)]
+    @printf("  %10s %14s %8s\n", "dt", "‖ψ_h−ψ_h/2‖", "order")
+    for i in eachindex(errs)
+        o = i < length(errs) ? log2(errs[i] / errs[i + 1]) : NaN
+        if isnan(o)
+            @printf("  %10.3e %14.6e %8s\n", dts[i], errs[i], "—")
+        else
+            @printf("  %10.3e %14.6e %8.3f\n", dts[i], errs[i], o)
+        end
+    end
+    psis
+end
+
+function main()
+    @printf("RTP dt-order — %s, Eu151 F=6 (D=13) F64\n", CUDA.name(CUDA.device()))
+    println("  DDI_PADDED_DEFAULT = ", SpinorBEC.DDI_PADDED_DEFAULT,
+        "   (what every run_yaml run gets)")
+
+    a = order_table(; padded=true, fused=true)
+    b = order_table(; padded=true, fused=false)
+
+    # The fused and unfused arms claim to be the same splitting, so they must
+    # agree bit for bit at every dt — not merely converge to the same order.
+    # An order table alone cannot tell those apart.
+    same = all(a[i] == b[i] for i in eachindex(a))
+    @printf("\n  fused ≡ unfused at every dt, bit for bit: %s\n", same)
+
+    order_table(; padded=false, fused=true)
+end
+
+main()

--- a/ext/SpinorBECCUDAExt/gpu_spin_chain.jl
+++ b/ext/SpinorBECCUDAExt/gpu_spin_chain.jl
@@ -14,21 +14,30 @@
 # on the way into the kernel and out of it — only the per-component Zeeman
 # factor differs between the two sides.
 #
-# What it removes, per V half-step at D = 13 (i.e. ×4 per RTP step):
-#   * 8 ψ passes → 3 (one prepass read of ψ_mf, one read+write here)
+# What it removes, per V half-step at D = 13. A plain `split_step!` takes two of
+# them per V half (predictor + corrector, n_picard = 1) and two V halves, so ×4
+# per RTP step:
+#   * 8 ψ passes → 2 (one prepass read of ψ_mf, one read+write here)
 #   * 3 spin-density passes over ψ_mf → 1 (⟨F⟩ feeds spin-mixing directly and
 #     DDI through the convolution, and the midpoint freezes ψ_mf, so all three
 #     substeps were computing the same ⟨F⟩)
 #   * 5 kernel launches → 2
+#
+# Every lane reads its own (voxel, component) once, before it writes it, so the
+# kernel takes a separate SOURCE array at no cost. That is what lets the Picard
+# midpoint hand its ψ_orig in as `Pin` instead of memcpy-ing it into the scratch
+# buffer first — see `_half_potential_step_midpoint!`.
 #
 # A zero-padded (open-boundary) DDI changes none of that. Both ⟨F⟩ and Φ then
 # live in the `[1:n_pts...]` corner of the padded buffers, which is one index map
 # in the rotation — the same `_voxel_index` the standalone DDI rotation reads
 # through — not a reason to unfuse.
 
+using StaticArrays: SVector
+
 @inline function _spin_chain_warp_kernel!(
     P, fx, fy, fz, px, py, pz, vph, zph_fwd, zph_bwd, mz, sxu, syu, rk_sm, rk_dd,
-    K::Int32, tol2, F2, rsafe2, ::Val{D}, ::Val{RT}, src,
+    K::Int32, tol2, F2, rsafe2, ::Val{D}, ::Val{RT}, src, Pin,
 ) where {D, RT}
     T = real(eltype(P))
     CT = Complex{T}
@@ -57,12 +66,71 @@
     # (`P[i, c] *= vph * zph[c]`). Floating-point multiplication is not
     # associative, and this gate demands bit-identity.
     vp = in_range ? (@inbounds vph[vox]) : one(CT)
-    w = live ? (@inbounds P[vox, c]) * (vp * (@inbounds zph_fwd[c])) : zero(CT)
+    w = live ? (@inbounds Pin[vox, c]) * (vp * (@inbounds zph_fwd[c])) : zero(CT)
     w = _horner_rot(w, ds, bs, bms, c, cdn, rk_sm, kvs, hs, shs, Val(16), Val(RT))
     w = _horner_rot(w, dd, bd, bmd, c, cdn, rk_dd, kvd, hd, shd, Val(16), Val(RT))
     w = _horner_rot(w, ds, bs, bms, c, cdn, rk_sm, kvs, hs, shs, Val(16), Val(RT))
 
     live && (@inbounds P[vox, c] = w * (vp * (@inbounds zph_bwd[c])))
+    nothing
+end
+
+# ⟨F⟩(ψ_mf) and the diagonal voxel phase, from ONE pass over ψ_mf.
+#
+# `_spin_density_kernel!` and `_diag_phase_kernel!` are both per-voxel reductions
+# over the same D components of the same array, and the half-step launched them
+# back to back with the same geometry — so the second re-read from HBM a sum the
+# first already had in registers (Σ_c|ψ_c|² is a term of both). At 128³ D = 13
+# F64 that re-read is 436 MB, four times per RTP step.
+#
+# Each accumulator is written exactly as its own kernel writes it — same terms,
+# same order — so the fused result is bit-identical rather than merely close, and
+# the fusion oracle asserts that with `==`. `dst` is the same voxel → buffer map
+# `_spin_density_kernel!` takes, so the padded corner is one argument, not a
+# second kernel.
+@inline function _chain_prepass_kernel!(
+    Fx, Fy, Fz, vph, db, Pmf, Vt, m_vals, fp, c0::T, clhy::T, dt::T,
+    ::Val{D}, ::Val{IT}, dst,
+) where {T, D, IT}
+    i = (CUDA.blockIdx().x - 1) * CUDA.blockDim().x + CUDA.threadIdx().x
+    i > size(Pmf, 1) && return nothing
+    n = zero(T)
+    fz = zero(T)
+    fxr = zero(T)
+    fyi = zero(T)
+    prev = @inbounds Pmf[i, 1]
+    n += abs2(prev)
+    fz += m_vals[1] * abs2(prev)
+    @inbounds for c in 2:D
+        cur = Pmf[i, c]
+        n += abs2(cur)
+        fz += m_vals[c] * abs2(cur)
+        pr = conj(prev) * cur
+        fxr += fp[c] * real(pr)
+        fyi += fp[c] * imag(pr)
+        prev = cur
+    end
+    lhy = clhy == zero(T) ? zero(T) : clhy * n * sqrt(n)
+    varg = (@inbounds(Vt[i]) + c0 * n + lhy) * dt
+    @inbounds begin
+        j = _voxel_index(dst, i)
+        Fx[j] = fxr
+        Fy[j] = fyi
+        Fz[j] = fz
+        db[i] = n
+        vph[i] = IT ? Complex{T}(exp(-varg), zero(T)) : cis(-varg)
+    end
+    return nothing
+end
+
+@inline function _launch_chain_prepass!(
+    Fx, Fy, Fz, vph, db, Pmf, Vt, m_vals, fp, c0::T, clhy::T, dt::T,
+    ::Val{D}, it::Bool, dst, N,
+) where {T, D}
+    threads = min(N, 256)
+    CUDA.@cuda threads = threads blocks = cld(N, threads) _chain_prepass_kernel!(
+        Fx, Fy, Fz, vph, db, Pmf, Vt, m_vals, fp, c0, clhy, dt,
+        Val(D), Val(it), dst)
     nothing
 end
 
@@ -72,6 +140,7 @@ SpinorBEC._spin_chain_available(psi::CuArray, ws::SpinorBEC.Workspace) =
 function SpinorBEC._apply_spin_chain!(
     psi::CuArray{Complex{T}}, ws::SpinorBEC.Workspace, dt_half, ndim,
     imaginary_time, ip, psi_mf, zeeman_diag_fwd, zeeman_diag_bwd,
+    psi_in::CuArray{Complex{T}}=psi,
 ) where {T <: AbstractFloat}
     sm = ws.spin_matrices
     D = sm.system.n_components
@@ -81,42 +150,53 @@ function SpinorBEC._apply_spin_chain!(
     it = imaginary_time === true
     dt_outer = T(dt_half) / 2                # the outer chain's substep dt
 
-    # ⟨F⟩(ψ_mf) and Φ_DDI, from ONE spin-density pass feeding both — the point of
-    # fusing. The convolution leaves ⟨F⟩ intact, and it is bit-identical to what
-    # the separate spin-mixing substep would have computed (same kernel, same
-    # coefficients, same frozen ψ_mf).
+    # ⟨F⟩(ψ_mf) feeds the two spin-mixing rotations directly AND the convolution
+    # on its way to Φ, and the midpoint freezes ψ_mf, so all three substeps want
+    # the same field — that is the point of fusing. It is bit-identical to what
+    # the separate spin-mixing substep computes: same terms, same order, same
+    # frozen ψ_mf.
     #
-    # With `ddi_padding` on — which is `DDI_PADDED_DEFAULT`, i.e. every
-    # `run_yaml` run — both fields live in the `[1:n_pts...]` corner of the
-    # padded buffers rather than in contiguous arrays of their own. That changes
-    # where the rotation reads them, which is an index map, not a reason to fall
-    # back to five separate operators. The corner ⟨F⟩ is the same kernel over the
-    # same values as the contiguous one (`_compute_spin_density!` dispatches on
-    # buffer shape and differs only in the destination index), so the
-    # bit-identity claim carries over — pinned by
-    # `test/gpu/test_gpu_padded_corner_parity.jl` on that side and by the padded
-    # arm of the fusion oracle on this one.
+    # With `ddi_padding` on — which is `DDI_PADDED_DEFAULT`, i.e. every `run_yaml`
+    # run — ⟨F⟩ and Φ live in the `[1:n_pts...]` corner of the padded buffers
+    # rather than in contiguous arrays of their own. That changes where they are
+    # written and read, which is an index map, not a reason to fall back to five
+    # separate operators. `_compute_spin_density!` dispatches on buffer shape and
+    # differs only in that index, so the corner and contiguous forms are the same
+    # kernel over the same values — `test/gpu/test_gpu_padded_corner_parity.jl`
+    # asserts that with `==`, and the padded arm of the fusion oracle asserts the
+    # consequence here.
     pad = ws.ddi_padded
-    if pad === nothing
-        SpinorBEC._compute_and_convolve_ddi!(
-            psi_mf, sm, ws.ddi, bufs, Val(D), ndim, n_pts)
-    else
-        SpinorBEC._compute_and_convolve_ddi_padded!(
-            psi_mf, sm, ws.ddi, pad, Val(D), ndim, n_pts)
-    end
 
     P = reshape(psi, N, D)
+    Pin = psi_in === psi ? P : reshape(psi_in, N, D)
     Pmf = reshape(psi_mf::CuArray{Complex{T}}, N, D)
 
-    # Diagonal phase, once, from the same frozen ψ_mf.
     c_lhy = ws.lhy !== nothing ? ws.lhy : ip.c_lhy
     clhy = c_lhy isa SpinorBEC.ScalarLHY ? T(c_lhy.c_lhy) :
            (c_lhy isa Float64 ? T(c_lhy) : zero(T))
     vph = _get_chain_vph(psi, N)
-    threads_v = min(N, 256)
-    CUDA.@cuda threads = threads_v blocks = cld(N, threads_v) _diag_phase_kernel!(
-        vph, reshape(ws.density_buf, N), Pmf, reshape(ws.potential_values, N),
-        T(ip[0]), clhy, dt_outer, Val(D), Val(it))
+    db = reshape(ws.density_buf, N)
+    Vt = reshape(ws.potential_values, N)
+    m_vals = SVector{D, T}(ntuple(c -> T(sm.system.F - (c - 1)), Val(D)))
+    fp = SVector{D, T}(SpinorBEC.fp_ladder_coeffs(T, sm.system.F, Val(D)))
+
+    # One pass over ψ_mf for ⟨F⟩ and the diagonal phase, then the k-space half of
+    # the convolution on the ⟨F⟩ just written. Two call sites rather than one
+    # with a Union-typed buffer/map tuple, so each launches a concretely-typed
+    # kernel.
+    if pad === nothing
+        _launch_chain_prepass!(
+            reshape(bufs.Fx_r, N), reshape(bufs.Fy_r, N), reshape(bufs.Fz_r, N),
+            vph, db, Pmf, Vt, m_vals, fp, T(ip[0]), clhy, dt_outer,
+            Val(D), it, nothing, N)
+        SpinorBEC._convolve_ddi!(ws.ddi, bufs, n_pts)
+    else
+        _launch_chain_prepass!(
+            pad.Fx_pad, pad.Fy_pad, pad.Fz_pad,
+            vph, db, Pmf, Vt, m_vals, fp, T(ip[0]), clhy, dt_outer,
+            Val(D), it, CartesianIndices(n_pts), N)
+        SpinorBEC._convolve_ddi_padded!(ws.ddi, pad)
+    end
 
     zf = _get_diag_zph(psi, zeeman_diag_fwd, dt_outer, it, 1)
     zb = _get_diag_zph(psi, zeeman_diag_bwd, dt_outer, it, 2)
@@ -132,25 +212,25 @@ function SpinorBEC._apply_spin_chain!(
         _launch_spin_chain!(
             P, reshape(bufs.Fx_r, N), reshape(bufs.Fy_r, N), reshape(bufs.Fz_r, N),
             reshape(bufs.Phi_x, N), reshape(bufs.Phi_y, N), reshape(bufs.Phi_z, N),
-            vph, zf, zb, coef, rk_sm, rk_dd, F, N, Val(D), it, nothing)
+            vph, zf, zb, coef, rk_sm, rk_dd, F, N, Val(D), it, nothing, Pin)
     else
         _launch_spin_chain!(
             P, pad.Fx_pad, pad.Fy_pad, pad.Fz_pad,
             pad.Phi_x_pad, pad.Phi_y_pad, pad.Phi_z_pad,
             vph, zf, zb, coef, rk_sm, rk_dd, F, N, Val(D), it,
-            CartesianIndices(n_pts))
+            CartesianIndices(n_pts), Pin)
     end
     nothing
 end
 
 @inline function _launch_spin_chain!(
     P, fx, fy, fz, px, py, pz, vph, zf, zb, coef, rk_sm, rk_dd, F::T, N,
-    ::Val{D}, it::Bool, src,
+    ::Val{D}, it::Bool, src, Pin,
 ) where {T, D}
     CUDA.@cuda threads = 256 blocks = cld(N, 16) _spin_chain_warp_kernel!(
         P, fx, fy, fz, px, py, pz, vph, zf, zb, coef.mz, coef.sxu, coef.syu,
         rk_sm, rk_dd, Int32(_SPIN_RK_MAX), T(_SPIN_TAYLOR_TOL[])^2, F * F,
-        T(_SPIN_TAYLOR_RSAFE[])^2, Val(D), Val(!it), src)
+        T(_SPIN_TAYLOR_RSAFE[])^2, Val(D), Val(!it), src, Pin)
     nothing
 end
 

--- a/src/hamiltonian/integrator/spin_chain.jl
+++ b/src/hamiltonian/integrator/spin_chain.jl
@@ -107,11 +107,18 @@ _spin_chain_available(psi, ws::Workspace) = false
 
 """
     _apply_spin_chain!(psi, ws, dt_half, ndim, imaginary_time, ip, psi_mf,
-                       zeeman_diag_fwd, zeeman_diag_bwd)
+                       zeeman_diag_fwd, zeeman_diag_bwd, psi_in)
 
-Apply the whole `diag · SM · DDI · SM · diag` half-step in one pass. Only
-called when `_spin_chain_reason` returned `nothing` AND `_spin_chain_available`
-was `true`, so there is no generic method: a missing one is a wiring bug, not a
-fallback.
+Apply the whole `diag · SM · DDI · SM · diag` half-step in one pass, reading
+`psi_in` and writing `psi`. Only called when `_spin_chain_reason` returned
+`nothing` AND `_spin_chain_available` was `true`, so there is no generic method:
+a missing one is a wiring bug, not a fallback.
+
+`psi_in === psi` is the in-place case, and every caller outside the Picard
+midpoint passes exactly that. A realization must produce identical values for
+both, which it does for free as long as each (voxel, component) is read once
+before it is written — the whole half-step is a per-voxel rotation sandwiched
+between per-voxel phases, so no lane ever needs a neighbour's amplitude. That is
+what lets the midpoint predictor start from ψ_orig without copying it first.
 """
 function _apply_spin_chain! end

--- a/src/hamiltonian/integrator/split_step.jl
+++ b/src/hamiltonian/integrator/split_step.jl
@@ -262,6 +262,7 @@ function _half_potential_step!(
     t_eval::Float64=ws.state.t,
     t_start::Float64=NaN,
     psi_mf::Union{Nothing, AbstractArray}=nothing,
+    psi_in::Union{Nothing, AbstractArray}=nothing,
 ) where {N}
     # Resolve time-dependent interactions (preserves c_lhy and the
     # higher-rank tensor couplings from the static params).
@@ -299,8 +300,18 @@ function _half_potential_step!(
         @timeit_debug TIMER "spin_chain" _apply_spin_chain!(
             ws.state.psi, ws, dt_half, ndim, imaginary_time, ip, psi_mf,
             zeeman_diag_fwd, zeeman_diag_bwd,
+            psi_in === nothing ? ws.state.psi : psi_in,
         )
         return nothing
+    end
+
+    # `psi_in` is an out-of-place REQUEST, and only the fused path above can
+    # honour it — the operator-by-operator chain below is in-place throughout.
+    # Materialising it here keeps the request a pure performance detail: callers
+    # get identical values either way, and a substep that makes the fused path
+    # ineligible degrades to the copy it would have paid anyway.
+    if psi_in !== nothing && psi_in !== ws.state.psi
+        copyto!(ws.state.psi, psi_in)
     end
 
     # Forward outer chain — shared with ITP via `_outer_operators_fwd!`.
@@ -467,13 +478,22 @@ function _half_potential_step_midpoint!(
     psi_orig = ws.state.psi
     psi_mid_prev, psi_mid_curr = _get_midpoint_scratch(psi_orig)
 
+    # Every Picard iterate starts from ψ_orig, so each one used to open with a
+    # full-ψ `copyto!(psi_mid_curr, psi_orig)`. `psi_in` hands that copy to the
+    # step itself: the fused kernel already reads each (voxel, component) exactly
+    # once before writing it, so reading ψ_orig and writing psi_mid_curr costs
+    # nothing over reading and writing one array — and the copy disappears rather
+    # than moving. At 128³ D=13 F64 one copy is 436 MB read + 436 MB written; a
+    # plain `split_step!` (n_picard = 1, set in `_half_potential!`) took two per
+    # step, `split_step_midpoint!` and the MPS/Yoshida composers (n_picard = 2)
+    # take four.
+    #
     # Iteration 1: predictor with frozen MF = ψ_orig.
-    copyto!(psi_mid_curr, psi_orig)
     ws.state.psi = psi_mid_curr
     try
         _half_potential_step!(
             ws, dt_half / 2, n_comp, ndim, imaginary_time;
-            t_eval=t_eval, t_start=t_start, psi_mf=psi_orig,
+            t_eval=t_eval, t_start=t_start, psi_mf=psi_orig, psi_in=psi_orig,
         )
     finally
         ws.state.psi = psi_orig
@@ -481,13 +501,16 @@ function _half_potential_step_midpoint!(
 
     # Refining Picard iterations: MF = previous midpoint estimate.
     for _ in 2:n_picard
-        copyto!(psi_mid_prev, psi_mid_curr)
-        copyto!(psi_mid_curr, psi_orig)
+        # This iteration's frozen mean field is the previous iterate, which is
+        # sitting in `psi_mid_curr`; this iteration must not write over it. Trade
+        # the two scratch roles so the write lands in the other buffer.
+        psi_mid_prev, psi_mid_curr = psi_mid_curr, psi_mid_prev
         ws.state.psi = psi_mid_curr
         try
             _half_potential_step!(
                 ws, dt_half / 2, n_comp, ndim, imaginary_time;
                 t_eval=t_eval, t_start=t_start, psi_mf=psi_mid_prev,
+                psi_in=psi_orig,
             )
         finally
             ws.state.psi = psi_orig

--- a/src/hamiltonian/terms/ddi/convolution.jl
+++ b/src/hamiltonian/terms/ddi/convolution.jl
@@ -187,6 +187,19 @@ function _compute_and_convolve_ddi!(
         apply_orszag_2_3_F_filter!(bufs.Fz_r, n_pts, ddi.box_size)
     end
 
+    _convolve_ddi!(ddi, bufs, n_pts)
+end
+
+"""
+    _convolve_ddi!(ddi, bufs, n_pts)
+
+The k-space half — `Φ = C · Q ⋆ F`, reading `bufs.F*_r`, writing `bufs.Phi_*`.
+Split out so a caller that already holds `⟨F⟩` can run the convolution without a
+second spin-density pass: the fused V half-step gets `⟨F⟩` from the same pass
+over ψ_mf that produces its diagonal voxel phase. Both entry points share this
+one body, so the 6-rFFT pipeline stays a single declaration.
+"""
+function _convolve_ddi!(ddi::DDIParams, bufs::DDIBuffers, n_pts)
     rp = bufs.rfft_plans
     mul!(bufs.Fx_rk, rp.forward, bufs.Fx_r)
     mul!(bufs.Fy_rk, rp.forward, bufs.Fy_r)

--- a/src/hamiltonian/terms/ddi/ddi_padded.jl
+++ b/src/hamiltonian/terms/ddi/ddi_padded.jl
@@ -167,6 +167,19 @@ function _compute_and_convolve_ddi_padded!(
         apply_orszag_2_3_F_filter!(ctx.Fz_pad, n_pts, ddi.box_size)
     end
 
+    _convolve_ddi_padded!(ddi, ctx)
+end
+
+"""
+    _convolve_ddi_padded!(ddi, ctx)
+
+The k-space half of the open-boundary convolution, reading `ctx.F*_pad` and
+writing `ctx.Phi_*_pad`. The padded twin of `_convolve_ddi!`, split out for the
+same reason: the fused V half-step already builds `⟨F⟩` in the pad corner while
+computing its diagonal voxel phase, and would otherwise pay a second pass over
+ψ_mf for a field it is holding.
+"""
+function _convolve_ddi_padded!(ddi::DDIParams, ctx::DDIPaddedContext)
     rp = ctx.rfft_plans
     mul!(ctx.Fx_pad_rk, rp.forward, ctx.Fx_pad)
     mul!(ctx.Fy_pad_rk, rp.forward, ctx.Fy_pad)


### PR DESCRIPTION
Stacks on #192 — review that one first; this PR's diff is only the two commits' difference.

## The H100 answer to Round 9's open question

The rotation kernel is **memory-bound** there, flatly. Sweeping the Horner degree at 128³ (`bench/micro_spin_taylor.jl`):

```
  K       1     2     4     8    16    24
 ms   0.864 0.865 0.865 0.864 0.864 0.864
```

`t(16)/t(4) = 1.00` against 4.0 for pure compute, ceiling 938.6 GB/s. That is the *opposite* of the consumer card, where Round 9 measured ~74 % of FP64 peak in the same body. So the lever is ψ traffic. Launches are not a target: at 128³ the GPU is busy 97.9 % of wall.

## The two cuts

**1. The midpoint's copy.** The Picard midpoint opened every iterate with a full-ψ `copyto!(psi_mid_curr, psi_orig)` — 436 MB each way at 128³ D=13 F64. The fused kernel reads each (voxel, component) exactly once before writing it, so it takes a separate *source* array for free: `psi_in` hands it ψ_orig and the copy disappears rather than moving. `psi_in` is a request, not a contract — the operator-by-operator chain is in-place throughout, so it materialises the copy it would have paid anyway, and callers get identical values either way.

**2. One pass over ψ_mf instead of two.** `_spin_density_kernel!` and `_diag_phase_kernel!` are both per-voxel reductions over the same D components of the same array, launched back to back with the same geometry — the second re-read 436 MB for a sum the first already had in registers (Σ|ψ_c|² is a term of both). Fused. Each accumulator keeps its own kernel's terms in its own order, so the result is bit-identical rather than close. `_convolve_ddi!` / `_convolve_ddi_padded!` are split out of the two `_compute_and_convolve_*` wrappers so the prepass can supply ⟨F⟩ without a second pass; both entry points share those bodies, so the 6-rFFT pipeline stays a single declaration.

## Measured

One H100, alternating arms, repeats agreeing to < 0.5 %, against #192:

| grid | bare | | padded (what `run_yaml` builds) | |
|---|---|---|---|---|
| 64³ | 2.068 → 1.79 | 1.15× | 3.309 → 3.05 | 1.09× |
| 96³ | 6.454 → 5.69 | 1.14× | 12.126 → 11.37 | 1.07× |
| 128³ | 14.570 → 12.79 | 1.14× | 28.688 → 26.95 | 1.06× |

The padded column is smaller because padding runs the convolution on a 2× grid per axis and those FFTs dilute a ψ-traffic saving. It is also the column production pays, so it is the one to quote. Combined with #192 the production shape is **1.58× / 1.50× / 1.49×** off `main`.

## Correctness

Bit-identity, not a tolerance. The fusion oracle runs the same five RTP steps fused and unfused under **both** DDI shapes and demands `==`. Green.

`bench/rtp_order_padded.jl` (new) additionally measures dt-order on the combination production actually runs — GPU, zero-padded, `split_step!`, fused kernel — which `bench/conv_order.jl` does not cover (CPU, N=12, unpadded, calls the half-potential helpers directly). Self-convergence at 24³:

```
padded, fused ON    order 2.000, 2.000
padded, fused OFF   order 2.000, 2.000
bare,   fused ON    order 2.000, 2.000
fused ≡ unfused at every dt, bit for bit: true
```

An order table alone cannot tell "same splitting" from "a different splitting of the same order", which is why the bit-identity line is printed beside it.

## A near-miss worth recording

The first draft of this change claimed six midpoint copies per RTP step. The measurement refutes it: 0.84 ms for six copies would need 6.2 TB/s, above HBM3 peak. `_half_potential!` passes `n_picard = 1`; only `split_step_midpoint!` and the MPS/Yoshida composers use 2. There is no free 1.5× hiding in that knob, and `bench/perf_targets.txt` now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)