### PR TITLE
fix(io): result.jld2 and point_NNN.jld2 each carried the whole snapshot payload

### DIFF
--- a/src/workflow/experiments/pipeline/run_registry.jl
+++ b/src/workflow/experiments/pipeline/run_registry.jl
@@ -694,6 +694,60 @@ function _snapshot_compression_kwargs(result)
     return (;)
 end
 
+# `run_pipeline` auto-saves the dashboard-canonical `result.jld2` at its end
+# (runner.jl), including the full streamed snapshot payload, and symlinks
+# `point_001.jld2` at it — with the comment "so we don't duplicate the multi-GB
+# snapshot data". `_run_yaml_single` then writes the real `point_NNN.jld2` over
+# that symlink, so the intent is defeated by ordering and BOTH files end up
+# carrying every frame. Measured on one Eu movie run: point_001 10.25 GB +
+# result 9.71 GB for one 753-frame dynamics, and 23 such pairs had accumulated
+# to 83.7 GB of pure duplication.
+#
+# Collapse it the other way round: keep the point file (it is the richer one —
+# analyze results, per-term energy, interactions, units, env) and make
+# `result.jld2` a symlink to it.
+#
+# ONLY when the point file provably contains everything `result.jld2` does.
+# That is not automatic: `save_rotating_basis_result!` writes `Lz`,
+# `per_m_history` and `integrator_meta` for rotating-basis runs, which the
+# point file does not carry. So compare key sets — top level and one level
+# into `dynamics` — and leave both files alone if the point file is missing
+# anything. Keys only; no frame is read, so this costs milliseconds.
+function _collapse_duplicate_result_jld2(run_dir::AbstractString,
+    psi_file::AbstractString; verbose::Bool=true)
+    res = joinpath(run_dir, "result.jld2")
+    (isfile(res) && !islink(res) && isfile(psi_file) && !islink(psi_file)) || return false
+    realpath(res) == realpath(psi_file) && return false
+
+    keyset(io, grp) =
+        grp === nothing ? Set(keys(io)) :
+        (haskey(io, grp) ? Set(keys(io[grp])) : Set{String}())
+    covered = try
+        jldopen(res, "r") do a
+            jldopen(psi_file, "r") do b
+                issubset(keyset(a, nothing), keyset(b, nothing)) &&
+                    issubset(keyset(a, "dynamics"), keyset(b, "dynamics"))
+            end
+        end
+    catch err
+        @warn "result.jld2 dedupe: could not compare key sets; leaving both files" run_dir exception=err
+        return false
+    end
+    covered || return false
+
+    freed = filesize(res)
+    try
+        rm(res; force=true)
+        symlink(basename(psi_file), res)
+    catch err
+        @warn "result.jld2 dedupe: symlink failed; result.jld2 may be missing" run_dir exception=err
+        return false
+    end
+    verbose && @printf("    result.jld2 -> %s (deduped, freed %.2f GB)\n",
+        basename(psi_file), freed / 1e9)
+    return true
+end
+
 function _run_yaml_single(data::Dict, run_dir, env, index, run_name; verbose=true)
     psi_file = joinpath(run_dir, _point_filename(index, run_name))
 
@@ -761,6 +815,13 @@ function _run_yaml_single(data::Dict, run_dir, env, index, run_name; verbose=tru
         write_run_summary(run_dir, psi_file; source="finish_hook")
     catch err
         @warn "run summary emit failed (non-fatal)" run_dir exception=err
+    end
+
+    # Must run AFTER the point file is in place — it is the survivor.
+    try
+        _collapse_duplicate_result_jld2(run_dir, psi_file; verbose)
+    catch err
+        @warn "result.jld2 dedupe failed (non-fatal)" run_dir exception=err
     end
 
     isdir(ckpt_dir) && rm(ckpt_dir; recursive=true, force=true)

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -36,6 +36,7 @@ const FAST_TESTS = [
     "workflow/test_loss_block_edge_cases.jl",
     "workflow/test_dynamics_lhy_plumbing.jl",
     "workflow/test_dynamics_lhy_normalisation.jl",
+    "workflow/test_result_jld2_dedupe.jl",
     "solvers/test_lbfgs_forward_coverage.jl",
     "oracles/test_lhy_table_path_coverage.jl",
     "workflow/test_lhy_texture_warning.jl",
@@ -546,6 +547,9 @@ const _COST = Dict{String, Float64}(
     "validation/test_L5_operator_rhs_compare.jl" => 22.6,
     "hamiltonian/test_ddi_padded.jl" => 97.8,
     "workflow/test_dynamics_lhy_normalisation.jl" => 3.0,
+    "workflow/test_result_jld2_dedupe.jl" => 2.0,
+    # No _COST entry before, so it fell back to the 3.0 default; measured 18.2 s.
+    "hamiltonian/test_interactions_constraint.jl" => 18.2,
     "solvers/test_lbfgs_forward_coverage.jl" => 2.0,
     "oracles/test_lhy_table_path_coverage.jl" => 2.0,
     "analysis/test_diagnostics.jl" => 21.3,

--- a/test/workflow/test_result_jld2_dedupe.jl
+++ b/test/workflow/test_result_jld2_dedupe.jl
@@ -1,0 +1,108 @@
+using Test
+using SpinorBEC
+using JLD2
+
+# `run_pipeline` auto-saves `result.jld2` with the full streamed snapshot payload
+# and symlinks `point_001.jld2` at it, explicitly "so we don't duplicate the
+# multi-GB snapshot data". `_run_yaml_single` then writes the real point file
+# over that symlink, so both end up carrying every frame. One 753-frame Eu movie
+# run measured 10.25 GB + 9.71 GB; 23 such pairs had reached 83.7 GB of pure
+# duplication on the TSUBAME work volume.
+#
+# `_collapse_duplicate_result_jld2` keeps the point file — the richer one — and
+# turns `result.jld2` into a symlink to it. The load-bearing precondition is that
+# the point file must contain EVERY key `result.jld2` has, top level and one
+# level into `dynamics`: `save_rotating_basis_result!` writes `Lz`,
+# `per_m_history` and `integrator_meta` for rotating-basis runs, which the point
+# file does not carry, and collapsing those would lose data.
+
+const _DEDUPE = SpinorBEC._collapse_duplicate_result_jld2
+
+function _write_pair(dir; point_extra=String[], result_dyn=["times", "norms"],
+    point_dyn=["times", "norms"])
+    res = joinpath(dir, "result.jld2")
+    pt = joinpath(dir, "point_001.jld2")
+    jldopen(res, "w") do f
+        f["psi"] = ComplexF64[1 2; 3 4]
+        for k in result_dyn
+            f["dynamics/$k"] = Float64[1.0, 2.0, 3.0]
+        end
+    end
+    jldopen(pt, "w") do f
+        f["psi"] = ComplexF64[1 2; 3 4]
+        for k in point_dyn
+            f["dynamics/$k"] = Float64[1.0, 2.0, 3.0]
+        end
+        for k in point_extra
+            f[k] = 1.0
+        end
+    end
+    (res, pt)
+end
+
+@testset "result.jld2 dedupe" begin
+    @testset "collapses when the point file is a superset" begin
+        d = mktempdir()
+        res, pt = _write_pair(d; point_extra=["energy", "converged"],
+            point_dyn=["times", "norms", "energies", "peak_density"])
+        before = filesize(res)
+        @test before > 0
+        @test !islink(res)
+
+        @test _DEDUPE(d, pt; verbose=false)
+        @test islink(res)                                 # now a symlink
+        @test realpath(res) == realpath(pt)               # ... to the point file
+        @test readlink(res) == "point_001.jld2"           # relative, so the dir can move
+
+        # Everything a reader of result.jld2 wanted is still reachable through it.
+        jldopen(res, "r") do f
+            @test haskey(f, "psi")
+            @test f["dynamics/times"] == Float64[1.0, 2.0, 3.0]
+            @test haskey(f, "energy")                     # bonus: the richer file
+        end
+    end
+
+    @testset "refuses when result.jld2 has a key the point file lacks" begin
+        # The rotating-basis shape: Lz / per_m_history / integrator_meta live in
+        # result.jld2 only. Collapsing here would silently lose them.
+        d = mktempdir()
+        res, pt = _write_pair(d;
+            result_dyn=["times", "norms", "Lz", "per_m_history"],
+            point_dyn=["times", "norms"])
+        @test !_DEDUPE(d, pt; verbose=false)
+        @test !islink(res)                                # untouched
+        jldopen(res, "r") do f
+            @test haskey(f, "dynamics/Lz")                # still there
+        end
+    end
+
+    @testset "top-level keys count too, not just dynamics" begin
+        d = mktempdir()
+        res = joinpath(d, "result.jld2")
+        pt = joinpath(d, "point_001.jld2")
+        jldopen(res, "w") do f
+            f["psi"] = ComplexF64[1 2; 3 4]
+            f["something_only_result_has"] = 7.0
+        end
+        jldopen(pt, "w") do f
+            f["psi"] = ComplexF64[1 2; 3 4]
+        end
+        @test !_DEDUPE(d, pt; verbose=false)
+        @test !islink(res)
+    end
+
+    @testset "idempotent and inert on the already-collapsed / absent cases" begin
+        d = mktempdir()
+        res, pt = _write_pair(d)
+        @test _DEDUPE(d, pt; verbose=false)
+        @test !_DEDUPE(d, pt; verbose=false)      # already a symlink → no-op
+        @test islink(res)
+
+        d2 = mktempdir()
+        pt2 = joinpath(d2, "point_001.jld2")
+        jldopen(pt2, "w") do f
+            f["psi"] = ComplexF64[1 2]
+        end
+        @test !_DEDUPE(d2, pt2; verbose=false)    # no result.jld2 at all
+    end
+end


### PR DESCRIPTION
Found while investigating why the TSUBAME personal work area sat at 161 GB against a 100 GiB quota.

## The duplication

`run_pipeline` auto-saves the dashboard-canonical `result.jld2` at its end (`runner.jl:217`), full streamed snapshot payload included, and symlinks `point_001.jld2` at it — with the comment *"so we don't duplicate the multi-GB snapshot data"*. Then `_run_yaml_single` writes the real `point_NNN.jld2` **over that symlink**. The intent is defeated by ordering and both files end up carrying every frame.

Measured on a live Eu movie run:

```
one 753-frame dynamics:  point_001.jld2  10.25 GB
                         result.jld2      9.71 GB
23 such pairs:                           83.7 GB of pure duplication
```

Still growing — a run that finished 30 minutes before I looked had just written 11.12 + 10.43 GB.

## Verified redundant before touching anything

- snapshot key sets identical (753 vs 753)
- 12 sampled frames **bit-identical**
- `times` / `Fz` / `norms` bit-identical
- `result.jld2`'s key set is a **strict subset** of the point file's
- every directory holding a `result.jld2` also holds a `point_001.jld2` (0 exceptions across 23)

## The fix

Collapse it the **other way round** from the existing attempt: keep the point file — the richer one (analyze results, per-term energy, interactions, units, env) — and make `result.jld2` a **relative symlink** to it. Everything that opens `result.jld2` keeps working and gets a superset.

**Not unconditional.** `save_rotating_basis_result!` writes `Lz`, `per_m_history` and `integrator_meta` for rotating-basis runs, which the point file does *not* carry — collapsing blindly would lose data. `_collapse_duplicate_result_jld2` compares key sets (top level and one level into `dynamics`) and leaves both files alone unless the point file provably covers `result.jld2`. Keys only, no frame is read, so it costs milliseconds.

## Gate

`test/workflow/test_result_jld2_dedupe.jl` — 18 assertions over four cases:

- collapses on a superset, and the link is **relative** so the directory can move
- **refuses** on the rotating-basis shape where `Lz` / `per_m_history` are result-only
- refuses on a top-level-only difference
- inert when already collapsed, or when `result.jld2` is absent

## Not in this PR

Existing duplicates are untouched. They sit next to jobs that are currently writing, so the backlog sweep needs its own interference-safe pass — completed runs only, skip directories where `point_001.jld2` is itself a symlink, verify per directory before deleting.

Also adds a `_COST` entry the runner asked for: `test_interactions_constraint.jl` had none, so it fell back to the 3.0 default while measuring 18.2 s.

`tier=fast`: 169 files, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)