### PR TITLE
Migrate the five icosahedral arms to full_bdg, and label the polar arms' ansatz mismatch

### DIFF
--- a/runs/eu_k3_lhy/LHY_full_bdg.yaml
+++ b/runs/eu_k3_lhy/LHY_full_bdg.yaml
@@ -1,13 +1,21 @@
 # Task #19C — LHY interference at K3=200× cigar regime.
 # Source: scripts/validation/eu_k3_lhy_gen.jl
-# LHY kind = icosahedral (applied outside nominal regime; see scope note).
+# LHY kind = full_bdg (general-spinor BdG; valid for this state and ladder).
+# Was `kind: icosahedral`, migrated 2026-07-30. The I_h closed form now
+# refuses this ladder: c1_ratio = -0.005 gives lambda_spin/c_0 = -0.07, i.e. a
+# negative spin-Goldstone stiffness, where it used to take |lambda_spin|^(5/2)
+# and overshoot full_bdg by up to 11%. `full_bdg` is the general-spinor path
+# the guard directs callers to and it is valid here. NOTE the state is
+# `m_minus_F`, so the matching CLOSED form would be `fm_contact` (any F since
+# 2026-07-27, gated against full_bdg at F=1..8) at ~100x less cost; full_bdg is
+# chosen to keep this suite's arms distinct from a future fm_contact arm.
 
 metadata:
   suite: eu_k3_lhy
   ladder_level: 12
   parent_regime: cigar_N30k_omz0p25
   K3_factor: 200.0
-  LHY_kind: icosahedral
+  LHY_kind: full_bdg
   generator: scripts/validation/eu_k3_lhy_gen.jl
 
 defaults:
@@ -27,7 +35,7 @@ pipeline:
       ddi:
         enabled: true
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
@@ -45,7 +53,7 @@ pipeline:
         phi: 0.0
       ddi:
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       loss:
         K3_per_m_si:
           ["2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s"]

--- a/runs/eu_k3_lhy/LHY_polar_contact.yaml
+++ b/runs/eu_k3_lhy/LHY_polar_contact.yaml
@@ -1,6 +1,19 @@
 # Task #19C — LHY interference at K3=200× cigar regime.
 # Source: scripts/validation/eu_k3_lhy_gen.jl
 # LHY kind = polar_contact (applied outside nominal regime; see scope note).
+#
+# ANSATZ MISMATCH, left in place deliberately (noted 2026-07-30). This arm's
+# state is `m_minus_F`, i.e. FM, while `polar_contact` is the closed form for
+# the polar state (zeta = delta_{m,0}). runs/eu_k3_lhy/*.yaml label this
+# "applied outside nominal regime", so the mismatch is the study design across
+# this family, not an accident — but the number it produces is NOT a validated
+# closure for this state and must not be read as one. The matching closed
+# form is `fm_contact` (any F since 2026-07-27, gated against full_bdg at
+# F=1..8); the general path is `full_bdg`. The sibling `icosahedral` arm had
+# the same defect and could no longer run at all once the I_h form began
+# refusing lambda_spin < 0, so it moved to full_bdg. This arm fails QUIETLY
+# instead, which is the more dangerous half. Neither the "scope note" nor any
+# generator named in these headers exists in the tree.
 
 metadata:
   suite: eu_k3_lhy

--- a/runs/eu_k3_lhy_control/LHY_full_bdg_K0.yaml
+++ b/runs/eu_k3_lhy_control/LHY_full_bdg_K0.yaml
@@ -1,7 +1,15 @@
 # K3=0 LHY model control — auto-generated.
 # Source: scripts/validation/eu_k3_lhy_control_gen.jl
-# LHY = icosahedral, K3 = 0, γ_dr = 0.
-# Compare to eu_k3_lhy/LHY_icosahedral.yaml (same LHY, K3=200) to isolate
+# LHY = full_bdg, K3 = 0, γ_dr = 0.
+# Compare to eu_k3_lhy/LHY_full_bdg.yaml (same LHY, K3=200) to isolate
+# Was `kind: icosahedral`, migrated 2026-07-30. The I_h closed form now
+# refuses this ladder: c1_ratio = -0.005 gives lambda_spin/c_0 = -0.07, i.e. a
+# negative spin-Goldstone stiffness, where it used to take |lambda_spin|^(5/2)
+# and overshoot full_bdg by up to 11%. `full_bdg` is the general-spinor path
+# the guard directs callers to and it is valid here. NOTE the state is
+# `m_minus_F`, so the matching CLOSED form would be `fm_contact` (any F since
+# 2026-07-27, gated against full_bdg at F=1..8) at ~100x less cost; full_bdg is
+# chosen to keep this suite's arms distinct from a future fm_contact arm.
 # LHY-alone vs LHY+K3 effects.
 
 metadata:
@@ -9,7 +17,7 @@ metadata:
   ladder_level: 12
   parent_regime: cigar_N30k_omz0p25
   K3_factor: 0
-  LHY_kind: icosahedral
+  LHY_kind: full_bdg
   generator: scripts/validation/eu_k3_lhy_control_gen.jl
 
 defaults:
@@ -29,7 +37,7 @@ pipeline:
       ddi:
         enabled: true
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
@@ -47,7 +55,7 @@ pipeline:
         phi: 0.0
       ddi:
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       # NO loss block — K3 = 0
       seed_amplitude: 1.0e-6
       seed_k_cut: 2.5

--- a/runs/eu_k3_lhy_control/LHY_polar_contact_K0.yaml
+++ b/runs/eu_k3_lhy_control/LHY_polar_contact_K0.yaml
@@ -3,6 +3,19 @@
 # LHY = polar_contact, K3 = 0, γ_dr = 0.
 # Compare to eu_k3_lhy/LHY_polar_contact.yaml (same LHY, K3=200) to isolate
 # LHY-alone vs LHY+K3 effects.
+#
+# ANSATZ MISMATCH, left in place deliberately (noted 2026-07-30). This arm's
+# state is `m_minus_F`, i.e. FM, while `polar_contact` is the closed form for
+# the polar state (zeta = delta_{m,0}). runs/eu_k3_lhy/*.yaml label this
+# "applied outside nominal regime", so the mismatch is the study design across
+# this family, not an accident — but the number it produces is NOT a validated
+# closure for this state and must not be read as one. The matching closed
+# form is `fm_contact` (any F since 2026-07-27, gated against full_bdg at
+# F=1..8); the general path is `full_bdg`. The sibling `icosahedral` arm had
+# the same defect and could no longer run at all once the I_h form began
+# refusing lambda_spin < 0, so it moved to full_bdg. This arm fails QUIETLY
+# instead, which is the more dangerous half. Neither the "scope note" nor any
+# generator named in these headers exists in the tree.
 
 metadata:
   suite: eu_k3_lhy_control

--- a/runs/eu_lhy_longtime/LHY_full_bdg_100ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_full_bdg_100ms.yaml
@@ -1,14 +1,22 @@
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
-# LHY = icosahedral, K3 = 0, duration = 31.42 ω_ref⁻¹ ≈ 50ms
+# LHY = full_bdg, K3 = 0, duration = 62.83 ω_ref⁻¹ ≈ 100ms
+# Was `kind: icosahedral`, migrated 2026-07-30. The I_h closed form now
+# refuses this ladder: c1_ratio = -0.005 gives lambda_spin/c_0 = -0.07, i.e. a
+# negative spin-Goldstone stiffness, where it used to take |lambda_spin|^(5/2)
+# and overshoot full_bdg by up to 11%. `full_bdg` is the general-spinor path
+# the guard directs callers to and it is valid here. NOTE the state is
+# `m_minus_F`, so the matching CLOSED form would be `fm_contact` (any F since
+# 2026-07-27, gated against full_bdg at F=1..8) at ~100x less cost; full_bdg is
+# chosen to keep this suite's arms distinct from a future fm_contact arm.
 
 metadata:
   suite: eu_lhy_longtime
   ladder_level: 12
   parent_regime: cigar_N30k_omz0p25
   K3_factor: 0
-  LHY_kind: icosahedral
-  target_ms: 50ms
+  LHY_kind: full_bdg
+  target_ms: 100ms
   generator: scripts/validation/eu_lhy_longtime_gen.jl
   caveat: |
     Tests whether "polar/icosa LHY → stable_arrest with N=1.000"
@@ -37,7 +45,7 @@ pipeline:
       ddi:
         enabled: true
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
@@ -47,7 +55,7 @@ pipeline:
       tol: 1.0e-9
 
   - dynamics:
-      duration: 31.415
+      duration: 62.83
       dt: 0.005
       B:
         Bz: {from: 0.01, to: 2.6e-5, duration: 0.0}
@@ -55,7 +63,7 @@ pipeline:
         phi: 0.0
       ddi:
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       # NO loss block — K3 = 0
       seed_amplitude: 1.0e-6
       seed_k_cut: 2.5

--- a/runs/eu_lhy_longtime/LHY_full_bdg_200ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_full_bdg_200ms.yaml
@@ -1,14 +1,22 @@
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
-# LHY = icosahedral, K3 = 0, duration = 62.83 ω_ref⁻¹ ≈ 100ms
+# LHY = full_bdg, K3 = 0, duration = 125.66 ω_ref⁻¹ ≈ 200ms
+# Was `kind: icosahedral`, migrated 2026-07-30. The I_h closed form now
+# refuses this ladder: c1_ratio = -0.005 gives lambda_spin/c_0 = -0.07, i.e. a
+# negative spin-Goldstone stiffness, where it used to take |lambda_spin|^(5/2)
+# and overshoot full_bdg by up to 11%. `full_bdg` is the general-spinor path
+# the guard directs callers to and it is valid here. NOTE the state is
+# `m_minus_F`, so the matching CLOSED form would be `fm_contact` (any F since
+# 2026-07-27, gated against full_bdg at F=1..8) at ~100x less cost; full_bdg is
+# chosen to keep this suite's arms distinct from a future fm_contact arm.
 
 metadata:
   suite: eu_lhy_longtime
   ladder_level: 12
   parent_regime: cigar_N30k_omz0p25
   K3_factor: 0
-  LHY_kind: icosahedral
-  target_ms: 100ms
+  LHY_kind: full_bdg
+  target_ms: 200ms
   generator: scripts/validation/eu_lhy_longtime_gen.jl
   caveat: |
     Tests whether "polar/icosa LHY → stable_arrest with N=1.000"
@@ -37,7 +45,7 @@ pipeline:
       ddi:
         enabled: true
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
@@ -47,7 +55,7 @@ pipeline:
       tol: 1.0e-9
 
   - dynamics:
-      duration: 62.83
+      duration: 125.66
       dt: 0.005
       B:
         Bz: {from: 0.01, to: 2.6e-5, duration: 0.0}
@@ -55,7 +63,7 @@ pipeline:
         phi: 0.0
       ddi:
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       # NO loss block — K3 = 0
       seed_amplitude: 1.0e-6
       seed_k_cut: 2.5

--- a/runs/eu_lhy_longtime/LHY_full_bdg_50ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_full_bdg_50ms.yaml
@@ -1,14 +1,22 @@
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
-# LHY = icosahedral, K3 = 0, duration = 125.66 ω_ref⁻¹ ≈ 200ms
+# LHY = full_bdg, K3 = 0, duration = 31.42 ω_ref⁻¹ ≈ 50ms
+# Was `kind: icosahedral`, migrated 2026-07-30. The I_h closed form now
+# refuses this ladder: c1_ratio = -0.005 gives lambda_spin/c_0 = -0.07, i.e. a
+# negative spin-Goldstone stiffness, where it used to take |lambda_spin|^(5/2)
+# and overshoot full_bdg by up to 11%. `full_bdg` is the general-spinor path
+# the guard directs callers to and it is valid here. NOTE the state is
+# `m_minus_F`, so the matching CLOSED form would be `fm_contact` (any F since
+# 2026-07-27, gated against full_bdg at F=1..8) at ~100x less cost; full_bdg is
+# chosen to keep this suite's arms distinct from a future fm_contact arm.
 
 metadata:
   suite: eu_lhy_longtime
   ladder_level: 12
   parent_regime: cigar_N30k_omz0p25
   K3_factor: 0
-  LHY_kind: icosahedral
-  target_ms: 200ms
+  LHY_kind: full_bdg
+  target_ms: 50ms
   generator: scripts/validation/eu_lhy_longtime_gen.jl
   caveat: |
     Tests whether "polar/icosa LHY → stable_arrest with N=1.000"
@@ -37,7 +45,7 @@ pipeline:
       ddi:
         enabled: true
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
@@ -47,7 +55,7 @@ pipeline:
       tol: 1.0e-9
 
   - dynamics:
-      duration: 125.66
+      duration: 31.415
       dt: 0.005
       B:
         Bz: {from: 0.01, to: 2.6e-5, duration: 0.0}
@@ -55,7 +63,7 @@ pipeline:
         phi: 0.0
       ddi:
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       # NO loss block — K3 = 0
       seed_amplitude: 1.0e-6
       seed_k_cut: 2.5

--- a/runs/eu_lhy_longtime/LHY_polar_contact_100ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_polar_contact_100ms.yaml
@@ -1,6 +1,19 @@
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = polar_contact, K3 = 0, duration = 62.83 ω_ref⁻¹ ≈ 100ms
+#
+# ANSATZ MISMATCH, left in place deliberately (noted 2026-07-30). This arm's
+# state is `m_minus_F`, i.e. FM, while `polar_contact` is the closed form for
+# the polar state (zeta = delta_{m,0}). runs/eu_k3_lhy/*.yaml label this
+# "applied outside nominal regime", so the mismatch is the study design across
+# this family, not an accident — but the number it produces is NOT a validated
+# closure for this state and must not be read as one. The matching closed
+# form is `fm_contact` (any F since 2026-07-27, gated against full_bdg at
+# F=1..8); the general path is `full_bdg`. The sibling `icosahedral` arm had
+# the same defect and could no longer run at all once the I_h form began
+# refusing lambda_spin < 0, so it moved to full_bdg. This arm fails QUIETLY
+# instead, which is the more dangerous half. Neither the "scope note" nor any
+# generator named in these headers exists in the tree.
 
 metadata:
   suite: eu_lhy_longtime

--- a/runs/eu_lhy_longtime/LHY_polar_contact_200ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_polar_contact_200ms.yaml
@@ -1,6 +1,19 @@
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = polar_contact, K3 = 0, duration = 125.66 ω_ref⁻¹ ≈ 200ms
+#
+# ANSATZ MISMATCH, left in place deliberately (noted 2026-07-30). This arm's
+# state is `m_minus_F`, i.e. FM, while `polar_contact` is the closed form for
+# the polar state (zeta = delta_{m,0}). runs/eu_k3_lhy/*.yaml label this
+# "applied outside nominal regime", so the mismatch is the study design across
+# this family, not an accident — but the number it produces is NOT a validated
+# closure for this state and must not be read as one. The matching closed
+# form is `fm_contact` (any F since 2026-07-27, gated against full_bdg at
+# F=1..8); the general path is `full_bdg`. The sibling `icosahedral` arm had
+# the same defect and could no longer run at all once the I_h form began
+# refusing lambda_spin < 0, so it moved to full_bdg. This arm fails QUIETLY
+# instead, which is the more dangerous half. Neither the "scope note" nor any
+# generator named in these headers exists in the tree.
 
 metadata:
   suite: eu_lhy_longtime

--- a/runs/eu_lhy_longtime/LHY_polar_contact_50ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_polar_contact_50ms.yaml
@@ -1,6 +1,19 @@
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = polar_contact, K3 = 0, duration = 31.42 ω_ref⁻¹ ≈ 50ms
+#
+# ANSATZ MISMATCH, left in place deliberately (noted 2026-07-30). This arm's
+# state is `m_minus_F`, i.e. FM, while `polar_contact` is the closed form for
+# the polar state (zeta = delta_{m,0}). runs/eu_k3_lhy/*.yaml label this
+# "applied outside nominal regime", so the mismatch is the study design across
+# this family, not an accident — but the number it produces is NOT a validated
+# closure for this state and must not be read as one. The matching closed
+# form is `fm_contact` (any F since 2026-07-27, gated against full_bdg at
+# F=1..8); the general path is `full_bdg`. The sibling `icosahedral` arm had
+# the same defect and could no longer run at all once the I_h form began
+# refusing lambda_spin < 0, so it moved to full_bdg. This arm fails QUIETLY
+# instead, which is the more dangerous half. Neither the "scope note" nor any
+# generator named in these headers exists in the tree.
 
 metadata:
   suite: eu_lhy_longtime

--- a/scripts/probe_lhy_closed_form_refusal_shapes.jl
+++ b/scripts/probe_lhy_closed_form_refusal_shapes.jl
@@ -1,0 +1,58 @@
+# Probe: is the |λ_spin| masking pattern shared by the polar and FM closed forms?
+#
+# Conclusion up front: NOT the same defect, but the FM form has a different one.
+# Every row prints the stiffness it is claiming to test, so the label cannot drift
+# from the condition — the first version of this script asserted "sigma_0 < 0"
+# while sigma_0 was in fact positive, and read a healthy number as a pass.
+
+using SpinorBEC
+using SpinorBEC: build_polar_lhy_coefs, lhy_energy_polar, build_fm_lhy_coefs,
+    lhy_energy_fm, phi_1_reg, _c0c1_to_gS
+
+println("I_h — λ_spin is a STIFFNESS; |λ_spin| reported the stable-branch value")
+for c1 in (0.1, -0.2)
+    g = _c0c1_to_gS(6, 10.0, c1)
+    c0s, lam = compute_c0_lambda_F6_Ih(g)
+    println("  c1=", rpad(c1, 6), " c_0=", rpad(round(c0s; sigdigits=5), 9),
+        " λ_spin=", rpad(round(lam; sigdigits=5), 9),
+        " ε=", epsilon_LHY_F6_Ih(1.0, g))
+end
+
+println()
+println("polar — κ_m = |δ_m| is an ANOMALOUS coupling; ω² = ξ² − |δ|² needs |δ|.")
+println("        The instability shows up as t = ξ/κ − 1 < 0, and phi_1_reg")
+println("        REGULARISES it (Petrov saturation) rather than masking it.")
+for t in (-2.0, -1.0, -0.5, 0.0, 1.0)
+    println("  t=", rpad(t, 6), " phi_1_reg=", phi_1_reg(t))
+end
+println("  φ₁^reg(−1) = 0.3177 is the documented droplet limit, not an accident.")
+
+println()
+println("polar — what actually happens to σ_0 when g_0 is driven negative:")
+for g0 in (1.0, -1.0, -20.0)
+    gd = Dict(S => (S == 0 ? g0 : 1.0) for S in 0:2:12)
+    coefs = build_polar_lhy_coefs(6, gd)
+    ok = coefs.sigma[1] > 0
+    print("  g_0=", rpad(g0, 7), " σ_0=", rpad(round(coefs.sigma[1]; sigdigits=6), 12),
+        ok ? " (still >0) " : " (NEGATIVE) ")
+    try
+        println("ε=", lhy_energy_polar(1.0, coefs))
+    catch e
+        println(typeof(e))
+    end
+end
+
+println()
+println("FM — DIFFERENT DEFECT, same class: `kappa < 1e-12 && return 0.0` was")
+println("     meant as \"negligible\" and also swallows NEGATIVE g_{2F}, so a")
+println("     negative stiffness silently reports NO LHY instead of refusing.")
+for c1 in (0.1, -0.005, -0.0278, -0.05)
+    g = _c0c1_to_gS(6, 10.0, c1 * 10.0)
+    coefs = build_fm_lhy_coefs(6, g)
+    g12 = g[12]
+    println("  c1/c0=", rpad(c1, 8), " g_12=", rpad(round(g12; sigdigits=6), 12),
+        " ε_fm=", lhy_energy_fm(1.0, coefs))
+end
+println("  Reachable at F=6 whenever c1/c0 < -1/36 = -0.0278 (g_2F = c0 + 36 c1).")
+println("  NOT fixed here: unlike the I_h guard this behaviour change was not")
+println("  measured against the runs that depend on it.")

--- a/scripts/submit_test_tier.sh
+++ b/scripts/submit_test_tier.sh
@@ -15,6 +15,12 @@
 # no-op without CUDA, which is the same "the gate never ran" failure in a
 # different costume.
 #
+# NB: the `-o` log only ever holds this wrapper's own echo lines. The suite's
+# output goes to $OUT_DIR/tier_<tier>.out, and OUT_DIR follows
+# SPINORBEC_TSUBAME_RUNS_ROOT, which scripts/spinorbec.env sets to
+# /gs/fs/tga-kozuma-kouhi/uk07267/runs — NOT $HOME. Watching the -o log alone
+# looks like a job that has produced nothing for half an hour.
+#
 # NB: -g and -o go on the qsub CLI, not as directives (UGE rejects `#$ -g` and
 # does not expand $HOME in directives).
 #$ -cwd
@@ -49,6 +55,19 @@ if [ -n "${T4_TMPDIR:-}" ] && [ -w "${T4_TMPDIR}" ]; then
 else
     export JULIA_DEPOT_PATH="$SHARED_DEPOT"
 fi
+# Pin BLAS to one thread. OpenBLAS sizes its level-1 thread team from the core
+# count, and a TSUBAME node reports 384 of them, so every `dot` on a few-MB
+# ComplexF64 array becomes spawn+barrier rather than arithmetic. Left unset, the
+# first attempt at the ci tier ran
+# `oracles/test_lhy_full_bdg_closed_form_parity.jl` for 18m52s against a 51.8s
+# estimate (24s measured on cpu_4 with this pinned), a worker hit the 1800s
+# per-file timeout mid-`test_term_properties.jl`, and the run aborted with 227
+# files never started — a tier job that measured nothing while looking like a
+# red tier. This is not tuning: the workers are already the parallelism, so a
+# BLAS team inside each one is pure contention.
+export OPENBLAS_NUM_THREADS=${OPENBLAS_NUM_THREADS:-1}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
+
 JULIA=${SPINORBEC_TSUBAME_JULIA:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia}
 
 echo "[sbec_tier] host=$(hostname)  tier=${TIER}  workers=${WORKERS}"


### PR DESCRIPTION
Follow-up to #203, which made the F=6 I_h closed form refuse `λ_spin < 0`. Five
configs could no longer run; this migrates them and reports what looking at them
turned up.

## The migration, measured rather than assumed

At the ladder these suites actually use — `c1_ratio: -0.005`, `N_atoms: 30000`,
Eu151 F=6:

```
c_0 = 2681.44   λ_spin = -187.70   λ_spin/c_0 = -0.070   ⇒  icosahedral: NaN
full_bdg, same ladder: table builds, all values finite, V_LHY(n=3.7e-3) = 0.2303
```

So they move to `kind: full_bdg`, the path the guard names, and the files are
renamed to match — a file called `LHY_icosahedral.yaml` carrying `full_bdg` would
be the naming lie the convention forbids. `cli.jl inspect` on the migrated configs
plus two siblings: parse clean, no `:block` / `:error` / `:warn`.

There was no generator to fix instead. The headers name
`scripts/validation/eu_k3_lhy_gen.jl`, `eu_k3_lhy_control_gen.jl` and
`eu_lhy_longtime_gen.jl` — **none of the three exists in the tree**, nor does the
"scope note" they refer to. Recorded in the annotations.

## What the migration exposed

All **twelve** arms across these three suites are `initial_state: m_minus_F`, an
FM state. The closures applied to them are `icosahedral` (I_h ansatz),
`polar_contact` (polar ansatz, ζ = δ_{m,0}) and `scalar`. Only `scalar` — the
fully-polarised approximation — matches the state. The guard exposed the
icosahedral half by making it error; **the polar half computes a number from the
wrong ansatz and says nothing.**

The polar arms are deliberately **not** rewritten. `runs/eu_k3_lhy/*.yaml` label
this "applied outside nominal regime", so the mismatch is this family's study
design rather than an accident, and replacing it would change what an
already-void suite measures. Each polar arm now carries a note that its number is
not a validated closure for this state, naming `fm_contact` as the matching closed
form and `full_bdg` as the general path — so the comparison is not read as three
valid closures.

## Does polar/fm need the same guard? No — but FM has a different one

`scripts/probe_lhy_closed_form_refusal_shapes.jl` measures all three.

**polar is not the same defect.** `kappa_m = abs(delta_m)` is correct: δ is an
anomalous coupling and ω² = ξ² − |δ|² depends on |δ|. The instability surfaces as
`t = ξ/κ − 1 < 0`, and `phi_1_reg` **regularises** it, saturating at
φ₁^reg(−1) = 0.3177 — the documented Petrov droplet limit. That is the opposite of
masking. Driving σ_0 negative (reachable at g_0 = −20) raises a bare
`DomainError`: less informative than the I_h refusal, but not silent.

**FM has a different defect of the same class — found, not fixed.**
`lhy_energy_fm`'s `kappa < 1e-12 && return 0.0` was meant as "negligible" and also
swallows negative `g_{2F}`, so a negative stiffness silently reports **no LHY**:

| c1/c0 | g_12 | ε_fm |
|---:|---:|---:|
| −0.005 | 8.2 | 10.4048 |
| −0.0278 | −0.008 | **0.0** |
| −0.05 | −8.0 | **0.0** |

Reachable at F=6 whenever `c1/c0 < −1/36 = −0.0278`, since `g_{2F} = c0 + 36 c1`.
Left alone on purpose: unlike the I_h guard this behaviour change has not been
measured against the runs that depend on it, and silent-zero LHY is exactly the
failure mode six other paths have already produced.

## A correction to my own probe

Its first version asserted "σ_0 < 0" while σ_0 was in fact **positive** (0.846 at
g_0 = −1) and read a healthy number as a pass. It now prints the stiffness it
claims to test, so the label cannot drift from the condition.

## Verification

`cli.jl inspect` on 5 configs and the `full_bdg` build at the production ladder,
TSUBAME jobs 8304437 / 8304465 (cpu_4). Config-only plus one probe script — no
source change, so #203's test evidence still stands.

The full `ci` tier is running separately against merged main (`10fb9121`, job
8304428) to close the gap #203 left open; that result is about main, not this
branch, and is reported when it lands.

Type A (code correctness) throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
