### PR TITLE
test(oracles): gate committed configs against their LHY mode's validity domain

### DIFF
--- a/runs/eu_k3_lhy/LHY_icosahedral.yaml
+++ b/runs/eu_k3_lhy/LHY_icosahedral.yaml
@@ -1,3 +1,10 @@
+# LHY kind was `icosahedral` until 2026-07-30. `IcosahedralLHY`'s closed form
+# is c0^(5/2) + 3|lambda_spin|^(5/2); the absolute value made it symmetric under
+# c1 -> -c1 and returned a real energy where the spin-Goldstone branch is
+# dynamically unstable. This config runs at c1_ratio < 0, i.e. OUTSIDE that
+# domain -- `epsilon_LHY_F6_Ih` now returns NaN and the table build throws.
+# `full_bdg` diagonalises the coupled problem with no ansatz and is valid here.
+# Gated by test/oracles/test_lhy_config_validity_domain.jl.
 # Task #19C — LHY interference at K3=200× cigar regime.
 # Source: scripts/validation/eu_k3_lhy_gen.jl
 # LHY kind = icosahedral (applied outside nominal regime; see scope note).
@@ -7,7 +14,7 @@ metadata:
   ladder_level: 12
   parent_regime: cigar_N30k_omz0p25
   K3_factor: 200.0
-  LHY_kind: icosahedral
+  LHY_kind: full_bdg
   generator: scripts/validation/eu_k3_lhy_gen.jl
 
 defaults:
@@ -27,7 +34,7 @@ pipeline:
       ddi:
         enabled: true
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
@@ -45,7 +52,7 @@ pipeline:
         phi: 0.0
       ddi:
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       loss:
         K3_per_m_si:
           ["2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s", "2.0e-39 m^6/s"]

--- a/runs/eu_k3_lhy_control/LHY_icosahedral_K0.yaml
+++ b/runs/eu_k3_lhy_control/LHY_icosahedral_K0.yaml
@@ -1,3 +1,10 @@
+# LHY kind was `icosahedral` until 2026-07-30. `IcosahedralLHY`'s closed form
+# is c0^(5/2) + 3|lambda_spin|^(5/2); the absolute value made it symmetric under
+# c1 -> -c1 and returned a real energy where the spin-Goldstone branch is
+# dynamically unstable. This config runs at c1_ratio < 0, i.e. OUTSIDE that
+# domain -- `epsilon_LHY_F6_Ih` now returns NaN and the table build throws.
+# `full_bdg` diagonalises the coupled problem with no ansatz and is valid here.
+# Gated by test/oracles/test_lhy_config_validity_domain.jl.
 # K3=0 LHY model control — auto-generated.
 # Source: scripts/validation/eu_k3_lhy_control_gen.jl
 # LHY = icosahedral, K3 = 0, γ_dr = 0.
@@ -9,7 +16,7 @@ metadata:
   ladder_level: 12
   parent_regime: cigar_N30k_omz0p25
   K3_factor: 0
-  LHY_kind: icosahedral
+  LHY_kind: full_bdg
   generator: scripts/validation/eu_k3_lhy_control_gen.jl
 
 defaults:
@@ -29,7 +36,7 @@ pipeline:
       ddi:
         enabled: true
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
@@ -47,7 +54,7 @@ pipeline:
         phi: 0.0
       ddi:
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       # NO loss block — K3 = 0
       seed_amplitude: 1.0e-6
       seed_k_cut: 2.5

--- a/runs/eu_lhy_longtime/LHY_icosahedral_100ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_icosahedral_100ms.yaml
@@ -1,3 +1,10 @@
+# LHY kind was `icosahedral` until 2026-07-30. `IcosahedralLHY`'s closed form
+# is c0^(5/2) + 3|lambda_spin|^(5/2); the absolute value made it symmetric under
+# c1 -> -c1 and returned a real energy where the spin-Goldstone branch is
+# dynamically unstable. This config runs at c1_ratio < 0, i.e. OUTSIDE that
+# domain -- `epsilon_LHY_F6_Ih` now returns NaN and the table build throws.
+# `full_bdg` diagonalises the coupled problem with no ansatz and is valid here.
+# Gated by test/oracles/test_lhy_config_validity_domain.jl.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = icosahedral, K3 = 0, duration = 62.83 ω_ref⁻¹ ≈ 100ms
@@ -7,7 +14,7 @@ metadata:
   ladder_level: 12
   parent_regime: cigar_N30k_omz0p25
   K3_factor: 0
-  LHY_kind: icosahedral
+  LHY_kind: full_bdg
   target_ms: 100ms
   generator: scripts/validation/eu_lhy_longtime_gen.jl
   caveat: |
@@ -37,7 +44,7 @@ pipeline:
       ddi:
         enabled: true
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
@@ -55,7 +62,7 @@ pipeline:
         phi: 0.0
       ddi:
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       # NO loss block — K3 = 0
       seed_amplitude: 1.0e-6
       seed_k_cut: 2.5

--- a/runs/eu_lhy_longtime/LHY_icosahedral_200ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_icosahedral_200ms.yaml
@@ -1,3 +1,10 @@
+# LHY kind was `icosahedral` until 2026-07-30. `IcosahedralLHY`'s closed form
+# is c0^(5/2) + 3|lambda_spin|^(5/2); the absolute value made it symmetric under
+# c1 -> -c1 and returned a real energy where the spin-Goldstone branch is
+# dynamically unstable. This config runs at c1_ratio < 0, i.e. OUTSIDE that
+# domain -- `epsilon_LHY_F6_Ih` now returns NaN and the table build throws.
+# `full_bdg` diagonalises the coupled problem with no ansatz and is valid here.
+# Gated by test/oracles/test_lhy_config_validity_domain.jl.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = icosahedral, K3 = 0, duration = 125.66 ω_ref⁻¹ ≈ 200ms
@@ -7,7 +14,7 @@ metadata:
   ladder_level: 12
   parent_regime: cigar_N30k_omz0p25
   K3_factor: 0
-  LHY_kind: icosahedral
+  LHY_kind: full_bdg
   target_ms: 200ms
   generator: scripts/validation/eu_lhy_longtime_gen.jl
   caveat: |
@@ -37,7 +44,7 @@ pipeline:
       ddi:
         enabled: true
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
@@ -55,7 +62,7 @@ pipeline:
         phi: 0.0
       ddi:
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       # NO loss block — K3 = 0
       seed_amplitude: 1.0e-6
       seed_k_cut: 2.5

--- a/runs/eu_lhy_longtime/LHY_icosahedral_50ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_icosahedral_50ms.yaml
@@ -1,3 +1,10 @@
+# LHY kind was `icosahedral` until 2026-07-30. `IcosahedralLHY`'s closed form
+# is c0^(5/2) + 3|lambda_spin|^(5/2); the absolute value made it symmetric under
+# c1 -> -c1 and returned a real energy where the spin-Goldstone branch is
+# dynamically unstable. This config runs at c1_ratio < 0, i.e. OUTSIDE that
+# domain -- `epsilon_LHY_F6_Ih` now returns NaN and the table build throws.
+# `full_bdg` diagonalises the coupled problem with no ansatz and is valid here.
+# Gated by test/oracles/test_lhy_config_validity_domain.jl.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = icosahedral, K3 = 0, duration = 31.42 ω_ref⁻¹ ≈ 50ms
@@ -7,7 +14,7 @@ metadata:
   ladder_level: 12
   parent_regime: cigar_N30k_omz0p25
   K3_factor: 0
-  LHY_kind: icosahedral
+  LHY_kind: full_bdg
   target_ms: 50ms
   generator: scripts/validation/eu_lhy_longtime_gen.jl
   caveat: |
@@ -37,7 +44,7 @@ pipeline:
       ddi:
         enabled: true
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
       initial_state: m_minus_F
@@ -55,7 +62,7 @@ pipeline:
         phi: 0.0
       ddi:
         secular: false
-      lhy: {kind: icosahedral}
+      lhy: {kind: full_bdg}
       # NO loss block — K3 = 0
       seed_amplitude: 1.0e-6
       seed_k_cut: 2.5

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -336,6 +336,10 @@ const CI_EXTRA = [
     # meta-test that would have RED-flagged padded-DDI and the absorbing
     # epilogue omission (each a gate-less variant of a "covered" term).
     "oracles/test_path_coverage.jl",
+    # Validity-DOMAIN sibling of the above: a config can name a live `lhy.kind`
+    # and still sit outside that mode's domain. The `icosa` cells did, and it
+    # reached a committed json, a figure and two claims before anyone noticed.
+    "oracles/test_lhy_config_validity_domain.jl",
     # Mode-coverage sibling of the above, one level down: LHYTerm is ONE
     # registry term with ten interchangeable tables behind it, so "the term
     # is gated" was true while three of its faces were broken at once.

--- a/test/oracles/test_lhy_config_validity_domain.jl
+++ b/test/oracles/test_lhy_config_validity_domain.jl
@@ -1,0 +1,122 @@
+# Meta-gate: every committed run config sits inside its LHY mode's validity domain.
+#
+# The closed forms have domains, and the domains are narrower than the schema
+# enum. `IcosahedralLHY` is `c₀^(5/2) + 3|λ_spin|^(5/2)`; the absolute value made
+# it symmetric under `c₁ → −c₁` and returned a real energy where the
+# spin-Goldstone branch is dynamically unstable, so it now returns NaN at
+# `λ_spin < 0` — which for these parameters means `c₁ < 0`.
+#
+# `runs/eu_k3_lhy*` use `c1_ratio = -0.005`. Their `icosa` cells had therefore
+# been measured OUTSIDE the domain, and that reached a committed
+# `factorial_2x4.json`, a committed figure, and two documented claims before
+# anyone noticed (PR #207). Nothing caught it: the schema validates that `kind`
+# is a known string, and `_tabulate_lhy` throws at BUILD time — which only fires
+# when a run is actually launched, long after the config is reviewed and merged.
+#
+# So this gate takes the configs that are already in the tree and evaluates each
+# one's closed form at ITS OWN (F, c₀, c₁). It is not a restatement of the domain
+# rules; it calls the same functions a run would and fails on the same NaN.
+#
+# Scope: the cheap closed forms only. `full_bdg` and `spatial` solve a BdG
+# problem per density node, which is minutes per config — they are also the
+# general-purpose paths with no ansatz to violate, so they are the ANSWER to a
+# domain failure rather than a source of one.
+
+using Test
+using YAML
+using SpinorBEC
+using SpinorBEC: _parse_gs_interactions, resolve_atom, _c0c1_to_gS,
+    epsilon_LHY_F6_Ih, lhy_energy_polar, lhy_energy_fm, build_fm_lhy_coefs
+
+const _RUNS = joinpath(@__DIR__, "..", "..", "runs")
+
+# kind => (F restriction, energy at n=1 from a g_dict). `nothing` for F means any.
+const _CLOSED_FORMS = Dict{String, Any}(
+    "icosahedral" => (6, (F, g) -> epsilon_LHY_F6_Ih(1.0, g)),
+    "polar_contact" => (nothing, (F, g) -> lhy_energy_polar(1.0, F, g)),
+    "fm_contact" => (nothing, (F, g) -> lhy_energy_fm(1.0, build_fm_lhy_coefs(F, g))),
+)
+
+"""Every `(path, kind, F, c₀, c₁)` a committed config asks for, closed forms only."""
+function _lhy_cells()
+    out = Tuple{String, String, Int, Float64, Float64}[]
+    isdir(_RUNS) || return out
+    for f in sort(
+        collect(
+            Iterators.filter(p -> endswith(p, ".yaml") || endswith(p, ".yml"),
+                (root * "/" * n for (root, _, ns) in walkdir(_RUNS) for n in ns)),
+        ),
+    )
+        cfg = try
+            YAML.load_file(f)
+        catch
+            continue
+        end
+        cfg isa Dict || continue
+        pipe = get(cfg, "pipeline", nothing)
+        pipe isa Vector || continue
+        for step in pipe
+            step isa Dict || continue
+            for (_, blk) in step
+                blk isa Dict || continue
+                l = get(blk, "lhy", nothing)
+                l isa Dict || continue
+                kind = String(get(l, "kind", "none"))
+                haskey(_CLOSED_FORMS, kind) || continue
+                atom_name = get(blk, "atom", nothing)
+                inter = get(blk, "interactions", nothing)
+                (atom_name === nothing || !(inter isa Dict)) && continue
+                atom = try
+                    resolve_atom(Symbol(atom_name))
+                catch
+                    continue
+                end
+                ip = try
+                    _parse_gs_interactions(
+                        Dict{String, Any}(string(k) => v for (k, v) in inter), atom)
+                catch
+                    continue
+                end
+                push!(out, (relpath(f, _RUNS), kind, atom.F, ip[0], ip[1]))
+            end
+        end
+    end
+    out
+end
+
+@testset "committed configs stay inside their LHY mode's validity domain" begin
+    cells = _lhy_cells()
+
+    @testset "the sweep found configs to check" begin
+        # A silent zero here would make the whole file vacuous — the exact
+        # failure shape it exists to catch.
+        @test !isempty(cells)
+    end
+
+    @testset "the domain guard is live (canary)" begin
+        # If `epsilon_LHY_F6_Ih` stops rejecting c₁ < 0, every assertion below
+        # passes for the wrong reason. Pin the guard itself.
+        g_bad = _c0c1_to_gS(6, 3270.05, -16.35)     # eu_k3_lhy's own numbers
+        @test isnan(epsilon_LHY_F6_Ih(1.0, g_bad))
+        g_ok = _c0c1_to_gS(6, 3270.05, +16.35)
+        @test isfinite(epsilon_LHY_F6_Ih(1.0, g_ok))
+    end
+
+    for (path, kind, F, c0, c1) in cells
+        @testset "$path [$kind]" begin
+            F_req, energy_at_1 = _CLOSED_FORMS[kind]
+            if F_req !== nothing && F != F_req
+                # The builder throws for this; a config asking for it is a bug
+                # whatever the couplings are.
+                @test F == F_req
+                continue
+            end
+            g = _c0c1_to_gS(F, c0, c1)
+            e = energy_at_1(F, g)
+            # NaN is how the closed forms say "outside my domain". A run would
+            # die at table-build time with an ArgumentError; this says so now.
+            @test isfinite(e)
+            @test e >= 0.0        # LHY is a repulsive correction
+        end
+    end
+end


### PR DESCRIPTION
## The gap

`IcosahedralLHY` returns NaN at `λ_spin < 0` — for these parameters, at `c₁ < 0`.
`runs/eu_k3_lhy*` use `c1_ratio = −0.005`, so their `icosa` cells had been
measured **outside the domain**, and that reached a committed
`factorial_2x4.json`, a committed figure and two documented claims before anyone
noticed (#207). I found it cleaning up after #199, not from a test.

Nothing was watching:

| layer | what it checks | why it missed this |
|---|---|---|
| schema | `kind` is a known string | `icosahedral` *is* known |
| `_tabulate_lhy` | NaN → `ArgumentError` | fires at **build** time, i.e. only when a run is launched — long after review and merge |
| — | the config vs the domain | **nothing** |

## The gate

Walks the configs already in the tree and evaluates each one's closed form at
**its own** `(F, c₀, c₁)`. Not a restatement of the domain rules — it calls the
same functions a run would and fails on the same NaN.

**It found five configs on its first execution**: the `icosahedral` cells in
`eu_k3_lhy/`, `eu_k3_lhy_control/` and `eu_lhy_longtime/` (×3). #207 corrected
the *artifacts* but left the configs naming an invalid mode, so a re-run would
have died at table build. All five now say `kind: full_bdg`, each with a header
explaining why so the next reader does not switch them back.

## Two guards against the gate going vacuous

- it asserts it **found configs at all** — a silent empty sweep is the exact
  failure shape this file exists to catch;
- it **canaries the domain guard itself** with `eu_k3_lhy`'s own numbers
  (`c₀ = 3270.05`, `c₁ = −16.35` must be NaN; `+16.35` must be finite). If
  `epsilon_LHY_F6_Ih` stops rejecting, every other assertion here would pass for
  the wrong reason.

## Scope

The cheap closed forms (`icosahedral`, `polar_contact`, `fm_contact`).
`full_bdg` and `spatial` cost minutes per config and are the general-purpose
paths with no ansatz to violate — they are the *answer* to a domain failure, not
a source of one.

## Verification

- fast tier: **173 files, all passed**
- oracles tier: one failure, `test_spin_chain_fusion_parity.jl` — **unrelated and
  pre-existing**. No LHY reference, and it fails identically with these changes
  stashed, under `--check-bounds=yes` (the runner's flag; it disables `@inbounds`
  and changes the SIMD reduction order the bit-exactness assertion depends on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)