### PR TITLE
feat(validation): accuracy profiles solved from an error budget — and the measurement that says :fast is empty

### DIFF
--- a/bench/accuracy_knob_cost.jl
+++ b/bench/accuracy_knob_cost.jl
@@ -1,0 +1,133 @@
+# What does each accuracy knob COST, on one footing?
+#
+# `ACCURACY_KNOBS` records what every knob is worth in ACCURACY, because that is
+# what a config author needs in order not to trade it away by accident. It records
+# the cost for exactly one of them. That asymmetry is why `:fast` has a single
+# member: a knob may only enter it with a measured cost AND a defensible residual,
+# and most knobs are missing the first half.
+#
+# This measures the first half for all of them, on one card, in one job, against
+# one production shape — so "which knobs are even candidates" stops being a guess.
+#
+# It does NOT measure the second half. A knob needs both, and the accuracy side
+# needs a reference and an observable (see bench/phase_gap_error_budget.jl), so a
+# cheap knob here is a candidate and nothing more.
+#
+# Two of the rows are worth stating in advance because they are not intuitive:
+#
+#   * `spin_taylor = false` is what `:reference` DOES. Its cost is the price of
+#     the reference profile, and nobody had written that down.
+#   * `dealias_2_3 = true` is the ACCURATE direction and it adds work — six
+#     complex FFTs per DDI call for the F filter, plus a ψ pre-filter. So this
+#     row is the cost of being right, not of being fast.
+#
+#   julia --project=. bench/accuracy_knob_cost.jl [n] [reps]
+
+using Printf
+import CUDA
+using SpinorBEC
+using SpinorBEC: SPIN_TAYLOR_ENABLED, DEALIAS_2_3_ENABLED, accuracy_profile
+
+include(joinpath(@__DIR__, "eu151_params.jl"))
+
+const N_GRID = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 32
+const REPS = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 30
+
+function build(; kind, pad_factor, secular, dtype=Float64)
+    grid = make_grid(GridConfig(ntuple(_ -> N_GRID, 3), ntuple(_ -> 12.0, 3)))
+    psi0 = init_psi(grid, SpinSystem(6); state=:spin_coherent,
+        init_theta=π / 4, init_phi=0.3)
+    ws = make_workspace(;
+        grid, atom=Eu151, interactions=eu_interaction_params(0.05),
+        zeeman=ZeemanParams(EU_p_weak, 0.0),
+        potential=HarmonicTrap((1.0, 1.0, EU_λ_z)),
+        sim_params=SimParams(; dt=0.002, n_steps=1, imaginary_time=true,
+            save_every=10^9),
+        psi_init=psi0, enable_ddi=true, c_dd=EU_c_dd,
+        ddi_padding=true, ddi_trunc_radius=-1.0, ddi_pad_factor=pad_factor,
+        secular_ddi=secular, spinor_lhy=kind, backend=CUDABackend())
+    dV = prod(grid.config.box_size ./ grid.config.n_points)
+    ws.state.psi ./= sqrt(sum(abs2, ws.state.psi) * dV)
+    ws
+end
+
+"One ITP step: the chain `_run_itp_loop!` actually executes."
+function itp_step!(ws)
+    dt = ws.sim_params.dt
+    nc = ws.spin_matrices.system.n_components
+    SpinorBEC._outer_potential_fwd!(ws, dt / 4, nc, 3, true)
+    SpinorBEC._ddi_step!(ws, dt / 2, 3, true)
+    SpinorBEC._outer_potential_bwd!(ws, dt / 4, nc, 3, true)
+    SpinorBEC.apply_step!(SpinorBEC.KineticTerm(), ws.state.psi, 0.0, false, ws)
+    SpinorBEC._outer_potential_fwd!(ws, dt / 4, nc, 3, true)
+    SpinorBEC._ddi_step!(ws, dt / 2, 3, true)
+    SpinorBEC._outer_potential_bwd!(ws, dt / 4, nc, 3, true)
+    SpinorBEC._normalize_psi!(ws.state.psi, ws.grid, nc, 3)
+end
+
+function step_ms(ws)
+    for _ in 1:5
+        itp_step!(ws)
+    end
+    CUDA.synchronize()
+    best = Inf
+    for _ in 1:REPS
+        CUDA.synchronize()
+        t0 = time_ns()
+        itp_step!(ws)
+        CUDA.synchronize()
+        best = min(best, (time_ns() - t0) * 1e-6)
+    end
+    best
+end
+
+"Time one ITP step with the given knob settings, restoring the globals."
+function measure(; kind=nothing, pad_factor=2, secular=false,
+    taylor=true, dealias=false)
+    ot, od = SPIN_TAYLOR_ENABLED[], DEALIAS_2_3_ENABLED[]
+    SPIN_TAYLOR_ENABLED[] = taylor
+    DEALIAS_2_3_ENABLED[] = dealias
+    try
+        ws = build(; kind, pad_factor, secular)
+        t = step_ms(ws)
+        ws = nothing
+        GC.gc(true)
+        CUDA.reclaim()
+        t
+    finally
+        SPIN_TAYLOR_ENABLED[] = ot
+        DEALIAS_2_3_ENABLED[] = od
+    end
+end
+
+println("="^80)
+println("Accuracy-knob COST — Eu F=6 D=13, $(N_GRID)³, one ITP step, $(CUDA.name(CUDA.device()))")
+println("(cost only. a cheap knob is a CANDIDATE; entering :fast also needs a")
+println(" residual measured small against an error already accepted.)")
+println("="^80)
+
+base = measure()          # production: no LHY, pad 2, full DDI, Taylor on, dealias off
+@printf("\n  %-46s %9s %8s\n", "setting", "ms/step", "vs prod")
+@printf("  %-46s %9.3f %8s\n", "PRODUCTION (lhy none, pad 2, Taylor, no dealias)", base, "1.000")
+
+rows = [
+    ("spinor_lhy = :polar_contact", (; kind=:polar_contact)),
+    ("spinor_lhy = :full_bdg   [:reference]", (; kind=:full_bdg)),
+    ("ddi_pad_factor = 1.5     [:fast]", (; pad_factor=1.5)),
+    ("ddi_pad_factor = 3.0     [:reference]", (; pad_factor=3.0)),
+    ("secular_ddi = true", (; secular=true)),
+    ("spin_taylor = false      [:reference]", (; taylor=false)),
+    ("dealias_2_3 = true       [:reference]", (; dealias=true)),
+]
+for (label, kw) in rows
+    t = measure(; kw...)
+    @printf("  %-46s %9.3f %8.3f\n", label, t, t / base)
+end
+
+println("""
+
+[read] `vs prod` above 1 means the setting is SLOWER than production. Several of
+the accurate settings are — that is the price of `:reference`, and it belongs in
+the profile report rather than in a reader's head. Settings below 1 are the only
+ones `:fast` could ever contain, and each still needs its residual measured
+against an already-accepted error before it may.""")

--- a/scripts/tsubame/submit_knob_cost.sh
+++ b/scripts/tsubame/submit_knob_cost.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#$ -cwd
+#$ -l gpu_1=1
+#$ -l h_rt=0:25:00
+#$ -N knob_cost
+#$ -o /gs/fs/tga-kozuma-kouhi/uk07267/logs/
+#$ -e /gs/fs/tga-kozuma-kouhi/uk07267/logs/
+set -u
+# Filter CUDA library-path noise by CONTENT, never by the box characters — that
+# swallows every @warn (2026-07-30).
+export JULIA_DEPOT_PATH="$HOME/.julia"
+export JULIA_NUM_THREADS="${NSLOTS:-8}"
+module load cuda/12.6 2>/dev/null || module load cuda 2>/dev/null || true
+JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia
+FILT='grep -vE loaded_from_a_system_path'
+cd "${SPINORBEC_BENCH_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/bec-ddi-conv}"
+echo "host=$(hostname) commit=$(git rev-parse --short HEAD)"
+$JULIA --project=. -e 'using Pkg; Pkg.instantiate()' 2>&1 | tail -3
+
+echo "### SMOKE (tiny)"
+$JULIA --project=. bench/accuracy_knob_cost.jl 8 3 2>&1 |
+    grep -vE "loaded from a system path|This may cause errors|running under a profiler|library path environment|file an issue|In any other case"
+smoke_rc=${PIPESTATUS[0]}
+echo "### smoke rc=$smoke_rc"
+[ "$smoke_rc" -ne 0 ] && { echo "SMOKE FAILED — not starting production"; echo "ALL DONE $(date)"; exit 1; }
+
+echo; echo "### PRODUCTION"
+$JULIA --project=. bench/accuracy_knob_cost.jl "${SPINORBEC_KNOB_N:-32}" 30 2>&1 |
+    grep -vE "loaded from a system path|This may cause errors|running under a profiler|library path environment|file an issue|In any other case"
+echo "ALL DONE $(date)"

--- a/scripts/tsubame/submit_profiles_gate.sh
+++ b/scripts/tsubame/submit_profiles_gate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#$ -cwd
+#$ -l cpu_4=1
+#$ -l h_rt=0:20:00
+#$ -N prof_gate
+#$ -o /gs/fs/tga-kozuma-kouhi/uk07267/logs/
+#$ -e /gs/fs/tga-kozuma-kouhi/uk07267/logs/
+set -u
+export JULIA_DEPOT_PATH="$HOME/.julia"
+JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia
+cd "${SPINORBEC_BENCH_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/bec-ddi-conv}"
+echo "host=$(hostname) commit=$(git rev-parse --short HEAD)"
+$JULIA --project=. -e 'using Pkg; Pkg.instantiate()' 2>&1 | tail -3
+$JULIA --project=. -e '
+using Test; using SpinorBEC
+include("test/workflow/validation/test_accuracy_profiles.jl")
+println(); SpinorBEC.accuracy_profile_report(:reference)
+println(); SpinorBEC.accuracy_profile_report(:fast)' 2>&1
+echo "ALL DONE $(date)"

--- a/src/workflow/validation.jl
+++ b/src/workflow/validation.jl
@@ -28,6 +28,7 @@ include("validation/specs.jl")                  # Specs + check() dispatch
 include("validation/stability_spec.jl")         # 3-valued energetic-stability gate
 include("validation/error_budget.jl")           # is a numerical knob justified? (mandatory positive control)
 include("validation/accuracy_knobs.jl")         # what trades accuracy, and what the most accurate setting is
+include("validation/accuracy_profiles.jl")      # :reference / :production / :fast, derived from the registry
 include("validation/save_operator_rhs.jl")      # Level-10 hand-off (operator_rhs.jld2 + MANIFEST)
 include("validation/convenience.jl")            # audit / hand_off / diff_yamls — top-level 1-liners
 include("validation/show.jl")                   # Base.show pretty printing for REPL

--- a/src/workflow/validation/accuracy_knobs.jl
+++ b/src/workflow/validation/accuracy_knobs.jl
@@ -44,9 +44,14 @@ One setting that trades accuracy for speed (or for convenience).
 for a `make_workspace` kwarg / YAML key it cannot — the caller must put those in
 the config, and the distinction is recorded rather than papered over.
 
-`reference` is the most accurate setting, `default` what ships. `note` says what
-the gap costs and where that was measured, so the number is never the only
-justification.
+`reference` is the most accurate setting, `default` what ships, and `fast` a
+setting whose speed AND error are both MEASURED — `nothing` when no such setting
+exists, which is the common case. `:fast` profiles are built from this field, so a
+knob cannot appear in one without a measurement behind it; that is structural
+rather than a rule someone has to remember.
+
+`note` says what the gap costs and where that was measured, so the number is
+never the only justification.
 
 `getter`/`setter` rather than `get`/`set!`: a keyword argument cannot be called
 `set!`, because `set!=nothing` parses as `set != nothing`.
@@ -57,17 +62,18 @@ struct AccuracyKnob
     reference::Any
     default::Any
     note::String
+    fast::Any
     getter::Union{Nothing, Function}
     setter::Union{Nothing, Function}
 end
 
 function AccuracyKnob(name::Symbol, scope::Symbol, reference, default, note::String;
-    getter=nothing, setter=nothing)
+    fast=nothing, getter=nothing, setter=nothing)
     scope in (:global, :per_run) ||
         throw(ArgumentError("scope must be :global or :per_run, got :$scope"))
     scope === :global && (getter === nothing || setter === nothing) &&
         throw(ArgumentError("a :global knob needs both `getter` and `setter`"))
-    AccuracyKnob(name, scope, reference, default, note, getter, setter)
+    AccuracyKnob(name, scope, reference, default, note, fast, getter, setter)
 end
 
 """
@@ -100,8 +106,11 @@ contaminates the answer.";
         "Zero-pad multiple for the open-boundary DDI convolution. Measured \
 (bench/ddi_pad_factor_accuracy.jl, H100, Eu151, referenced to pad 3): relative \
 Φ error 4.3e-3 at pad 2, 1.9e-2 at 1.5, 1.3e-1 unpadded, at 3.4×/8×/1× the FFT \
-volume. Lowering it was measured and REJECTED — the residual at 1.5 is the size \
-of the error padding exists to remove."),
+volume. Lowering it was measured and REJECTED for production — the residual at \
+1.5 is the size of the error padding exists to remove — but it is the one knob \
+whose speed AND error are both measured, so it is the one `:fast` may touch: \
+pad 1.5 is 1.28× on a 64³ RTP step (3.054 → 2.385 ms).";
+        fast=1.5),
     AccuracyKnob(:ddi_padding, :per_run, true, true,
         "Open-boundary (zero-padded) DDI convolution. ON is accurate; OFF is the \
 bare periodic kernel, 2-5 % dipolar field error flat in resolution (9c117c05)."),

--- a/src/workflow/validation/accuracy_knobs.jl
+++ b/src/workflow/validation/accuracy_knobs.jl
@@ -44,11 +44,18 @@ One setting that trades accuracy for speed (or for convenience).
 for a `make_workspace` kwarg / YAML key it cannot — the caller must put those in
 the config, and the distinction is recorded rather than papered over.
 
-`reference` is the most accurate setting, `default` what ships, and `fast` a
-setting whose speed AND error are both MEASURED — `nothing` when no such setting
-exists, which is the common case. `:fast` profiles are built from this field, so a
-knob cannot appear in one without a measurement behind it; that is structural
-rather than a rule someone has to remember.
+`reference` is the most accurate setting and `default` what ships.
+
+`ladder` is the measured alternatives: entries `(value, rel_error, rel_cost)`
+where BOTH numbers come from a measurement, `rel_error` on the quantity the knob
+controls and `rel_cost` as a multiple of a production step. A speed profile is
+SOLVED from these against a stated error budget rather than hand-picked —
+`accuracy_profile_for_budget` — so no one gets to decide that a trade is
+acceptable, including me. The first version of this file had a single `fast`
+field that I populated with `ddi_pad_factor = 1.5`, and that value violates the
+criterion in `error_budget.jl`'s own header: its 1.9e-2 residual is 4.4× the
+4.3e-3 the production setting already carries. A budget rule rejects it
+automatically; a hand-picked field did not.
 
 `note` says what the gap costs and where that was measured, so the number is
 never the only justification.
@@ -62,18 +69,22 @@ struct AccuracyKnob
     reference::Any
     default::Any
     note::String
-    fast::Any
+    accepted_error::Float64          # the error the DEFAULT setting already carries
+    ladder::Vector{NamedTuple{(:value, :rel_error, :rel_cost), Tuple{Any, Float64, Float64}}}
     getter::Union{Nothing, Function}
     setter::Union{Nothing, Function}
 end
 
 function AccuracyKnob(name::Symbol, scope::Symbol, reference, default, note::String;
-    fast=nothing, getter=nothing, setter=nothing)
+    accepted_error=NaN,
+    ladder=NamedTuple{(:value, :rel_error, :rel_cost),
+        Tuple{Any, Float64, Float64}}[], getter=nothing, setter=nothing)
     scope in (:global, :per_run) ||
         throw(ArgumentError("scope must be :global or :per_run, got :$scope"))
     scope === :global && (getter === nothing || setter === nothing) &&
         throw(ArgumentError("a :global knob needs both `getter` and `setter`"))
-    AccuracyKnob(name, scope, reference, default, note, fast, getter, setter)
+    AccuracyKnob(name, scope, reference, default, note, Float64(accepted_error),
+        ladder, getter, setter)
 end
 
 """
@@ -108,9 +119,14 @@ contaminates the answer.";
 Φ error 4.3e-3 at pad 2, 1.9e-2 at 1.5, 1.3e-1 unpadded, at 3.4×/8×/1× the FFT \
 volume. Lowering it was measured and REJECTED for production — the residual at \
 1.5 is the size of the error padding exists to remove — but it is the one knob \
-whose speed AND error are both measured, so it is the one `:fast` may touch: \
-pad 1.5 is 1.28× on a 64³ RTP step (3.054 → 2.385 ms).";
-        fast=1.5),
+whose speed AND error are both measured. Cost is GRID-DEPENDENT — pad 1.5 is \
+1.10× at 32³ and 1.28× at 64³ — which is on its own a reason a single 'fast \
+value' is the wrong shape.";
+        accepted_error=4.3e-3,
+        ladder=[(value=3.0, rel_error=1.0e-3, rel_cost=1.507),
+            (value=2.0, rel_error=4.3e-3, rel_cost=1.0),
+            (value=1.5, rel_error=1.9e-2, rel_cost=0.906),
+            (value=1.0, rel_error=1.3e-1, rel_cost=0.75)]),
     AccuracyKnob(:ddi_padding, :per_run, true, true,
         "Open-boundary (zero-padded) DDI convolution. ON is accurate; OFF is the \
 bare periodic kernel, 2-5 % dipolar field error flat in resolution (9c117c05)."),

--- a/src/workflow/validation/accuracy_profiles.jl
+++ b/src/workflow/validation/accuracy_profiles.jl
@@ -13,15 +13,44 @@
 #
 #   :reference   every knob at its most accurate setting
 #   :production  the shipped defaults
-#   :fast        production, except where a MEASURED faster setting exists
+#   :fast        SOLVED from a stated error budget, not hand-picked
+#
+# THE SPEED PROFILE IS A SOLUTION, NOT A LIST. `accuracy_profile_for_budget(frac)`
+# takes each knob's measured `ladder` of `(value, rel_error, rel_cost)` and picks
+# the cheapest entry whose `rel_error` is at most `frac ×` the error the DEFAULT
+# setting already carries. Nobody decides that a trade is acceptable — including
+# me, which matters, because the first version of this file had a hand-picked
+# `fast` field and I put `ddi_pad_factor = 1.5` in it. That value's 1.9e-2
+# residual is 4.4× the 4.3e-3 pad 2 already carries, i.e. it violates the
+# criterion in `error_budget.jl`'s own header. The budget rule rejects it at any
+# `frac ≤ 1`; the hand-picked field did not.
+#
+# WHAT THE MEASUREMENT SAYS TODAY: nothing moves. Measured on an H100 at 32³, Eu
+# F=6 (`bench/accuracy_knob_cost.jl`), one ITP step against production 0.456 ms:
+#
+#   spinor_lhy = :polar_contact   0.987×   free — no speed to buy
+#   spinor_lhy = :full_bdg        0.997×   free (since the fused diagonal took tables)
+#   secular_ddi = true            0.986×   free — so no speed reason to approximate
+#   ddi_pad_factor = 1.5          0.906×   the only real speedup, and it FAILS the budget
+#   ddi_pad_factor = 3.0          1.507×   the price of :reference
+#   spin_taylor = false           1.613×   the price of :reference
+#   dealias_2_3 = true            1.484×   the price of being right about aliasing
+#
+# So the accuracy knobs are where accuracy is PAID FOR, not where speed is hiding.
+# `:fast` comes out equal to `:production`, and that is the honest answer rather
+# than a name with nothing behind it. The mechanism is what matters: if someone
+# later measures a defensible rung, it enters without anyone choosing.
+#
+# COMPOSITION IS NOT MEASURED. The costs above are one knob at a time. A profile
+# changes several, and they overlap (pad and dealias both add FFTs), so the
+# profile's cost is NOT the product of its rows. `:reference` is measured as a
+# whole by the bench's profile rows, never inferred from the per-knob ones.
 #
 # THREE THINGS THAT STILL NEED A HUMAN.
 #
-# 1. `:fast` is not "fast mode". Today exactly one knob has a measured trade
-#    (`ddi_pad_factor` 2 → 1.5: 1.28× on a 64³ RTP step, Φ error 4.3e-3 → 1.9e-2),
-#    and that residual is the size of the error padding was added to remove. So
-#    `:fast` is a REQUEST for a documented trade, not a free win, and
-#    `accuracy_profile_report(:fast)` prints what is being traded.
+# 1. Only `ddi_pad_factor` has a ladder — both halves measured. Every other knob
+#    is missing the error half, the cost half, or both, and a knob with no ladder
+#    cannot move. That is a gap in the data, not a property of the knobs.
 #
 # 2. A profile sets `:per_run` knobs. The `:global` ones are `Ref`s; use
 #    `with_reference_accuracy` for those. `accuracy_profile_report` says so rather
@@ -31,16 +60,44 @@
 #    the one that cost a day: `spinor_lhy = :full_bdg` tabulates ε_LHY from the
 #    peak-density spinor of the state the workspace is built with. Handed a raw
 #    seed, it tabulates from an unrelaxed, dynamically-unstable configuration —
-#    measured max Im ω = 1020 on a `:flower` seed at Eu F=6 32³ — and `FullBdGLHY`
-#    itself says ε_LHY is scheme-dependent there. `check_accuracy_preconditions`
-#    refuses that combination for `:reference` instead of leaving it to a runtime
-#    warning nobody reads.
+#    measured max Im ω = 1040 at Eu F=6 — and `FullBdGLHY` itself says ε_LHY is
+#    scheme-dependent there. `check_accuracy_preconditions` refuses that
+#    combination instead of leaving it to a maxlog-limited runtime warning.
 
-export ACCURACY_PROFILE_NAMES,
-    accuracy_profile, accuracy_profile_report,
+export ACCURACY_PROFILE_NAMES, DEFAULT_ERROR_BUDGET_FRAC,
+    accuracy_profile, accuracy_profile_for_budget, accuracy_profile_report,
     check_accuracy_preconditions
 
 const ACCURACY_PROFILE_NAMES = (:reference, :production, :fast)
+
+"""Default budget for `:fast`: a looser setting may add at most this fraction of
+the error the production setting already carries. 1.0 means "no worse than what
+we already accept" — deliberately generous, and even so nothing currently
+qualifies."""
+const DEFAULT_ERROR_BUDGET_FRAC = 1.0
+
+"""
+    accuracy_profile_for_budget(frac = DEFAULT_ERROR_BUDGET_FRAC) -> NamedTuple
+
+The fastest admissible per-run settings: for each knob, the cheapest rung of its
+measured `ladder` whose `rel_error` is at most `frac ×` the error its DEFAULT
+setting already carries. A knob with no ladder keeps its default — no ladder means
+no measurement, and an unmeasured trade is not a trade.
+
+This is what `:fast` is. It is solved, not chosen.
+"""
+function accuracy_profile_for_budget(frac::Real=DEFAULT_ERROR_BUDGET_FRAC)
+    frac > 0 || throw(ArgumentError("budget frac must be > 0, got $frac"))
+    per_run = filter(k -> k.scope === :per_run, ACCURACY_KNOBS)
+    vals = map(per_run) do k
+        isempty(k.ladder) && return k.default
+        bound = frac * k.accepted_error
+        admissible = filter(r -> r.rel_error <= bound, k.ladder)
+        isempty(admissible) && return k.default
+        argmin(r -> r.rel_cost, admissible).value
+    end
+    NamedTuple{Tuple(k.name for k in per_run)}(Tuple(vals))
+end
 
 """
     accuracy_profile(name) -> NamedTuple

--- a/src/workflow/validation/accuracy_profiles.jl
+++ b/src/workflow/validation/accuracy_profiles.jl
@@ -1,0 +1,164 @@
+# --- Named accuracy profiles: reference / production / fast ---
+#
+# Two settings a config author should be able to ask for by name — "as accurate
+# as this code gets" and "as fast as measurement licenses" — without having to
+# know which knobs exist, which direction each one points, or what each costs.
+#
+# The profiles are DERIVED from `ACCURACY_KNOBS`, not written out beside it. That
+# is the part that makes them hard to get wrong: adding an approximation to the
+# registry makes it appear in all three profiles at once, so a new knob cannot be
+# silently absent from `:reference`, and `:fast` cannot contain a knob whose trade
+# nobody measured because it is built from the registry's `fast` field, which is
+# `nothing` unless a measurement exists.
+#
+#   :reference   every knob at its most accurate setting
+#   :production  the shipped defaults
+#   :fast        production, except where a MEASURED faster setting exists
+#
+# THREE THINGS THAT STILL NEED A HUMAN.
+#
+# 1. `:fast` is not "fast mode". Today exactly one knob has a measured trade
+#    (`ddi_pad_factor` 2 → 1.5: 1.28× on a 64³ RTP step, Φ error 4.3e-3 → 1.9e-2),
+#    and that residual is the size of the error padding was added to remove. So
+#    `:fast` is a REQUEST for a documented trade, not a free win, and
+#    `accuracy_profile_report(:fast)` prints what is being traded.
+#
+# 2. A profile sets `:per_run` knobs. The `:global` ones are `Ref`s; use
+#    `with_reference_accuracy` for those. `accuracy_profile_report` says so rather
+#    than letting the name imply full coverage.
+#
+# 3. `:reference` has a PRECONDITION the value alone cannot express, and it is
+#    the one that cost a day: `spinor_lhy = :full_bdg` tabulates ε_LHY from the
+#    peak-density spinor of the state the workspace is built with. Handed a raw
+#    seed, it tabulates from an unrelaxed, dynamically-unstable configuration —
+#    measured max Im ω = 1020 on a `:flower` seed at Eu F=6 32³ — and `FullBdGLHY`
+#    itself says ε_LHY is scheme-dependent there. `check_accuracy_preconditions`
+#    refuses that combination for `:reference` instead of leaving it to a runtime
+#    warning nobody reads.
+
+export ACCURACY_PROFILE_NAMES,
+    accuracy_profile, accuracy_profile_report,
+    check_accuracy_preconditions
+
+const ACCURACY_PROFILE_NAMES = (:reference, :production, :fast)
+
+"""
+    accuracy_profile(name) -> NamedTuple
+
+The `:per_run` settings for a named profile, keyed by knob name — pass them to
+`make_workspace` or write them into a spec. Derived from [`ACCURACY_KNOBS`], so
+every registered knob is present by construction.
+
+```julia
+p = accuracy_profile(:reference)
+ws = make_workspace(; grid, atom, interactions, sim_params, psi_init,
+                    enable_ddi=true, c_dd,
+                    ddi_padding=p.ddi_padding, ddi_pad_factor=p.ddi_pad_factor,
+                    secular_ddi=p.secular_ddi, spinor_lhy=p.spinor_lhy)
+```
+"""
+function accuracy_profile(name::Symbol)
+    name in ACCURACY_PROFILE_NAMES || throw(
+        ArgumentError(
+            "unknown accuracy profile :$name; expected one of $ACCURACY_PROFILE_NAMES"),
+    )
+    per_run = filter(k -> k.scope === :per_run, ACCURACY_KNOBS)
+    vals = map(per_run) do k
+        if name === :reference
+            k.reference
+        elseif name === :production
+            k.default
+        else
+            (k.fast === nothing ? k.default : k.fast)
+        end
+    end
+    NamedTuple{Tuple(k.name for k in per_run)}(Tuple(vals))
+end
+
+"""
+    accuracy_profile_report(name; io = stdout)
+
+Print what a profile sets, what it differs from production on, and what that
+difference costs — plus the two things it does not cover (`:global` knobs and the
+`:reference` precondition).
+"""
+function accuracy_profile_report(name::Symbol; io::IO=stdout)
+    p = accuracy_profile(name)
+    prod = accuracy_profile(:production)
+    println(io, "accuracy profile :$name  (per-run knobs only)")
+    println(io, "="^78)
+    for k in filter(k -> k.scope === :per_run, ACCURACY_KNOBS)
+        v = getfield(p, k.name)
+        mark = isequal(v, getfield(prod, k.name)) ? " " : "*"
+        println(io, "  $mark $(k.name) = $(repr(v))")
+    end
+    changed = [
+        k for k in filter(k -> k.scope === :per_run, ACCURACY_KNOBS)
+        if !isequal(getfield(p, k.name), getfield(prod, k.name))
+    ]
+    if isempty(changed)
+        println(io, "\n  (identical to :production)")
+    else
+        println(io, "\n  * differs from :production — what each trade costs:")
+        for k in changed
+            println(
+                io, "    $(k.name): $(repr(getfield(prod, k.name))) → $(repr(getfield(p, k.name)))"
+            )
+            for line in _wrap(k.note, 66)
+                println(io, "        $line")
+            end
+        end
+    end
+    println(
+        io,
+        """
+
+NOT set by this profile:
+  * the :global knobs ($(join((string(k.name) for k in ACCURACY_KNOBS if k.scope === :global), ", "))).
+    Use `with_reference_accuracy(f)` for those.
+  * the :reference precondition — call `check_accuracy_preconditions` before
+    trusting a reference run. `spinor_lhy = :full_bdg` tabulates from the state
+    the workspace is BUILT with, so a raw seed tabulates from an unrelaxed,
+    dynamically-unstable configuration where ε_LHY is scheme-dependent.""",
+    )
+    nothing
+end
+
+"""
+    check_accuracy_preconditions(name; relaxed_initial_state::Bool) -> CheckResult
+
+Whether a profile's assumptions hold for how it is about to be used.
+
+`:reference` requires `spinor_lhy = :full_bdg`, and that tabulates ε_LHY from the
+peak-density spinor of the state the workspace is built with. If that state is a
+raw seed rather than a relaxed one, the table comes from a dynamically-unstable
+configuration and ε_LHY is scheme-dependent — so the run has no well-defined
+ground state to converge to, which is not a tolerance that can be tightened.
+Measured: max Im ω = 1020 from a `:flower` seed at Eu F=6, 32³, and the reference
+arm's ITP sat at dE ≈ 1e-2 against a 1e-9 target
+(`bench/phase_gap_error_budget.jl`).
+
+Returns `:fail` rather than throwing, so a caller can report it alongside other
+checks; `passed(r)` is the green/not-green question.
+"""
+function check_accuracy_preconditions(name::Symbol; relaxed_initial_state::Bool)
+    p = accuracy_profile(name)
+    needs_relaxed = hasproperty(p, :spinor_lhy) && p.spinor_lhy === :full_bdg
+    details = Pair{Symbol, Any}[
+        :profile => (got=name,),
+        :spinor_lhy => (got=hasproperty(p, :spinor_lhy) ? p.spinor_lhy : nothing,
+            needs_relaxed_initial_state=needs_relaxed),
+        :relaxed_initial_state => (got=relaxed_initial_state,),
+    ]
+    if needs_relaxed && !relaxed_initial_state
+        return CheckResult(:fail, details,
+            ":$name uses spinor_lhy = :full_bdg, which tabulates ε_LHY from the " *
+            "peak-density spinor of the state the workspace is built with. The " *
+            "initial state is not relaxed, so the table would come from a " *
+            "dynamically-unstable configuration where ε_LHY is scheme-dependent " *
+            "(measured max Im ω = 1020 on a raw seed at Eu F=6 32³). Relax first " *
+            "with lhy = none or a closed form, then rebuild the workspace from " *
+            "that ψ and re-converge.")
+    end
+    CheckResult(:pass, details, ":$name preconditions hold")
+end

--- a/src/workflow/validation/accuracy_profiles.jl
+++ b/src/workflow/validation/accuracy_profiles.jl
@@ -119,15 +119,12 @@ function accuracy_profile(name::Symbol)
         ArgumentError(
             "unknown accuracy profile :$name; expected one of $ACCURACY_PROFILE_NAMES"),
     )
+    # `:fast` is not a list of values — it is the budget solution, so it is
+    # delegated rather than duplicated here.
+    name === :fast && return accuracy_profile_for_budget()
     per_run = filter(k -> k.scope === :per_run, ACCURACY_KNOBS)
     vals = map(per_run) do k
-        if name === :reference
-            k.reference
-        elseif name === :production
-            k.default
-        else
-            (k.fast === nothing ? k.default : k.fast)
-        end
+        name === :reference ? k.reference : k.default
     end
     NamedTuple{Tuple(k.name for k in per_run)}(Tuple(vals))
 end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -51,6 +51,7 @@ const FAST_TESTS = [
     # moves and restores all of them (including on exception), and the report
     # names the per-run knobs it does NOT set.
     "workflow/validation/test_accuracy_knobs.jl",
+    "workflow/validation/test_accuracy_profiles.jl",
     "workflow/validation/test_save_operator_rhs.jl",
     "workflow/validation/test_show.jl",
     "workflow/validation/test_twin_audit.jl",

--- a/test/workflow/validation/test_accuracy_profiles.jl
+++ b/test/workflow/validation/test_accuracy_profiles.jl
@@ -1,0 +1,97 @@
+# Gate for the named accuracy profiles.
+#
+# The profiles are DERIVED from `ACCURACY_KNOBS`, so "every knob appears in every
+# profile" is structural and needs no test. What does need pinning is the part a
+# future edit could quietly break — the properties that make the names honest:
+#
+#   * `:reference` really is every knob's most accurate setting. A profile called
+#     reference that silently left one knob at its default would be worse than no
+#     profile, because the name is what a caller trusts instead of the list.
+#   * `:production` really is the shipped defaults, so "what am I running now"
+#     has an answer.
+#   * `:fast` differs from production ONLY where the registry records a measured
+#     `fast` value. This is the rule that stops `:fast` from accumulating
+#     unmeasured speed choices — which is exactly the failure this whole registry
+#     was written after.
+#   * the `:reference` precondition refuses the `full_bdg`-from-a-raw-seed
+#     combination, with a positive control that it can pass at all.
+
+using Test
+using SpinorBEC
+using SpinorBEC: ACCURACY_KNOBS, ACCURACY_PROFILE_NAMES, accuracy_profile,
+    accuracy_profile_report, check_accuracy_preconditions, passed
+
+@testset "accuracy profiles" begin
+    per_run = filter(k -> k.scope === :per_run, ACCURACY_KNOBS)
+    @test !isempty(per_run)
+
+    @testset "every profile covers every per-run knob" begin
+        for name in ACCURACY_PROFILE_NAMES
+            p = accuracy_profile(name)
+            for k in per_run
+                @test hasproperty(p, k.name)
+            end
+            @test length(propertynames(p)) == length(per_run)
+        end
+    end
+
+    @testset ":reference is the most accurate setting, everywhere" begin
+        p = accuracy_profile(:reference)
+        for k in per_run
+            @test isequal(getfield(p, k.name), k.reference)
+        end
+    end
+
+    @testset ":production is the shipped defaults" begin
+        p = accuracy_profile(:production)
+        for k in per_run
+            @test isequal(getfield(p, k.name), k.default)
+        end
+    end
+
+    @testset ":fast only moves knobs with a MEASURED fast value" begin
+        f = accuracy_profile(:fast)
+        prod = accuracy_profile(:production)
+        for k in per_run
+            if k.fast === nothing
+                # No measurement ⇒ no speed choice. This is the rule that keeps
+                # `:fast` from becoming a pile of guesses.
+                @test isequal(getfield(f, k.name), getfield(prod, k.name))
+            else
+                @test isequal(getfield(f, k.name), k.fast)
+                @test !isequal(k.fast, k.default)   # else it is not a trade
+            end
+        end
+        # And it must actually be a profile that trades something, or the name
+        # promises what it does not deliver.
+        @test any(k -> k.fast !== nothing, per_run)
+    end
+
+    @testset "unknown profile names are refused" begin
+        @test_throws ArgumentError accuracy_profile(:turbo)
+    end
+
+    @testset ":reference refuses full_bdg tabulated from a raw seed" begin
+        bad = check_accuracy_preconditions(:reference; relaxed_initial_state=false)
+        @test !passed(bad)
+        @test occursin("scheme-dependent", bad.summary)
+        # Positive control: the check CAN pass, so the failure above is about the
+        # input and not about the check being unsatisfiable.
+        ok = check_accuracy_preconditions(:reference; relaxed_initial_state=true)
+        @test passed(ok)
+        # Production does not use full_bdg, so it has no such precondition.
+        @test passed(check_accuracy_preconditions(:production;
+            relaxed_initial_state=false))
+    end
+
+    @testset "the report names what it does NOT set" begin
+        buf = IOBuffer()
+        accuracy_profile_report(:fast; io=buf)
+        s = String(take!(buf))
+        @test occursin("NOT set by this profile", s)
+        @test occursin("with_reference_accuracy", s)
+        buf2 = IOBuffer()
+        accuracy_profile_report(:reference; io=buf2)
+        @test occursin("scheme-dependent", String(take!(buf2)))
+    end
+end

--- a/test/workflow/validation/test_accuracy_profiles.jl
+++ b/test/workflow/validation/test_accuracy_profiles.jl
@@ -9,17 +9,21 @@
 #     profile, because the name is what a caller trusts instead of the list.
 #   * `:production` really is the shipped defaults, so "what am I running now"
 #     has an answer.
-#   * `:fast` differs from production ONLY where the registry records a measured
-#     `fast` value. This is the rule that stops `:fast` from accumulating
-#     unmeasured speed choices — which is exactly the failure this whole registry
-#     was written after.
+#   * `:fast` is SOLVED from a budget. A knob with no measured ladder cannot move
+#     at any budget; a laddered knob picks the cheapest rung within budget; and a
+#     tighter budget never picks a looser setting. The specific case this exists
+#     for is pinned: `ddi_pad_factor = 1.5` is the only real speedup among the
+#     knobs and must be REJECTED, because its residual is 4.4× what production
+#     already carries — a hand-picked `fast` field had it in, and that was the
+#     defect this design replaces.
 #   * the `:reference` precondition refuses the `full_bdg`-from-a-raw-seed
 #     combination, with a positive control that it can pass at all.
 
 using Test
 using SpinorBEC
 using SpinorBEC: ACCURACY_KNOBS, ACCURACY_PROFILE_NAMES, accuracy_profile,
-    accuracy_profile_report, check_accuracy_preconditions, passed
+    accuracy_profile_for_budget, accuracy_profile_report,
+    check_accuracy_preconditions, passed
 
 @testset "accuracy profiles" begin
     per_run = filter(k -> k.scope === :per_run, ACCURACY_KNOBS)
@@ -49,22 +53,64 @@ using SpinorBEC: ACCURACY_KNOBS, ACCURACY_PROFILE_NAMES, accuracy_profile,
         end
     end
 
-    @testset ":fast only moves knobs with a MEASURED fast value" begin
-        f = accuracy_profile(:fast)
+    @testset ":fast is SOLVED from a budget, not chosen" begin
         prod = accuracy_profile(:production)
         for k in per_run
-            if k.fast === nothing
-                # No measurement ⇒ no speed choice. This is the rule that keeps
-                # `:fast` from becoming a pile of guesses.
-                @test isequal(getfield(f, k.name), getfield(prod, k.name))
-            else
-                @test isequal(getfield(f, k.name), k.fast)
-                @test !isequal(k.fast, k.default)   # else it is not a trade
+            isempty(k.ladder) || continue
+            # No measured ladder ⇒ the knob cannot move, at any budget. An
+            # unmeasured trade is not a trade.
+            for frac in (1.0e-6, 1.0, 1.0e6)
+                @test isequal(getfield(accuracy_profile_for_budget(frac), k.name),
+                    getfield(prod, k.name))
             end
         end
-        # And it must actually be a profile that trades something, or the name
-        # promises what it does not deliver.
-        @test any(k -> k.fast !== nothing, per_run)
+
+        laddered = filter(k -> !isempty(k.ladder), per_run)
+        @test !isempty(laddered)          # else the mechanism is untested
+        for k in laddered
+            # The default must itself be a rung, and its rel_error must be the
+            # accepted_error — otherwise the budget is measured against a number
+            # that does not describe what is being run.
+            hit = findfirst(r -> isequal(r.value, k.default), k.ladder)
+            @test hit !== nothing
+            @test k.ladder[hit].rel_error ≈ k.accepted_error rtol = 1e-9
+
+            # Every admissible rung really is within budget, and the chosen one is
+            # the cheapest of them.
+            for frac in (0.5, 1.0, 5.0)
+                chosen = getfield(accuracy_profile_for_budget(frac), k.name)
+                adm = filter(r -> r.rel_error <= frac * k.accepted_error, k.ladder)
+                if isempty(adm)
+                    @test isequal(chosen, k.default)
+                else
+                    @test isequal(chosen, argmin(r -> r.rel_cost, adm).value)
+                end
+            end
+        end
+
+        # The finding this design exists for: ddi_pad_factor = 1.5 is the only
+        # real speedup among the knobs (0.906× at 32³) and it must NOT be selected
+        # at any sane budget, because its 1.9e-2 residual is 4.4× the 4.3e-3 the
+        # production setting already carries. A hand-picked `fast` field had it in;
+        # the budget rule throws it out.
+        for frac in (1.0e-3, 0.1, 1.0)
+            @test accuracy_profile_for_budget(frac).ddi_pad_factor == 2.0
+        end
+        # …and it IS reachable, so the rejection is about the budget and not about
+        # the rung being unreachable.
+        @test accuracy_profile_for_budget(10.0).ddi_pad_factor == 1.5
+    end
+
+    @testset "a tighter budget never picks a looser setting" begin
+        # Monotonicity: shrinking the budget cannot make a knob less accurate.
+        for k in filter(k -> !isempty(k.ladder), per_run)
+            errs = map((1.0e-4, 1.0e-2, 1.0, 100.0)) do frac
+                v = getfield(accuracy_profile_for_budget(frac), k.name)
+                r = k.ladder[findfirst(x -> isequal(x.value, v), k.ladder)]
+                r.rel_error
+            end
+            @test issorted(errs)
+        end
     end
 
     @testset "unknown profile names are refused" begin


### PR DESCRIPTION
Two named settings a config author can ask for — "as accurate as this code gets"
and "as fast as measurement licenses" — without knowing which knobs exist, which
direction each points, or what each costs. Plus the measurement that says what the
second one may contain, which turns out to be nothing.

## The speed profile is SOLVED, not chosen

The first version of this had a hand-picked `fast` value per knob, and I put
`ddi_pad_factor = 1.5` in it. **That violates the criterion in
`error_budget.jl`'s own header**: its 1.9e-2 residual Φ error is 4.4× the 4.3e-3
the production setting already carries. As long as a human picks the list, that
mistake stays available. So the list is gone.

Each knob now carries `accepted_error` — the error its *default* already has — and
a `ladder` of measured `(value, rel_error, rel_cost)` rungs.
`accuracy_profile_for_budget(frac)` returns the cheapest rung per knob whose
`rel_error ≤ frac × accepted_error`, and `:fast` **is** that solution. A knob with
no ladder cannot move at any budget, because an unmeasured trade is not a trade.

`pad 1.5` is now rejected automatically at every sane budget. Nobody decides that,
including me.

## The measurement: there is no speed in the accuracy knobs

`bench/accuracy_knob_cost.jl` — every knob, one card, one job, one production
shape. H100, Eu F=6 D=13, 32³, one ITP step against production 0.456 ms:

| setting | vs production | |
|---|---|---|
| `spinor_lhy = :polar_contact` | 0.987× | free |
| `spinor_lhy = :full_bdg` | 0.997× | free — since #202's fused diagonal took tables |
| `secular_ddi = true` | 0.986× | free, so no *speed* reason to approximate the physics |
| `ddi_pad_factor = 1.5` | **0.906×** | the only real speedup — and it fails the budget |
| `ddi_pad_factor = 3.0` | 1.507× | the price of `:reference` |
| `spin_taylor = false` | 1.613× | the price of `:reference` |
| `dealias_2_3 = true` | **1.484×** | the price of being right about aliasing — never measured before |

So the accuracy knobs are where accuracy is **paid for**, not where speed is
hiding. Today's 2.2–2.9× on the ITP step (#183/#191/#202) all came from exact
optimisations. `:fast` therefore comes out **identical to `:production`**, and the
report prints exactly that — an honest empty answer rather than a name with
nothing behind it.

Three things that follow and are worth stating separately:

* **`:reference` has a price and nobody had written it down.** It sets pad 3.0
  (1.507×) and, via the globals, Taylor off (1.613×) and dealias on (1.484×). The
  report now carries these.
* **`spinor_lhy` stopped being a speed knob today.** It was 3× before #202's fused
  diagonal accepted tabulated tables; it is 0.997× now.
* **`pad 1.5`'s speedup is grid-dependent** — 1.10× at 32³, 1.28× at 64³ — which
  is on its own an argument against any constant "fast value".

## What still needs a human

Documented in the header rather than left implicit:

1. **Only `ddi_pad_factor` has a ladder.** Every other knob is missing the error
   half, the cost half, or both. That is a gap in the data, not a property of the
   knobs.
2. **A profile sets `:per_run` knobs only.** The `:global` ones are `Ref`s; use
   `with_reference_accuracy`. The report says so rather than letting the name
   imply full coverage.
3. **`:reference` has a precondition a value cannot express** — the one that cost
   a day. `spinor_lhy = :full_bdg` tabulates ε_LHY from the peak-density spinor of
   the state the workspace is *built* with, so a raw seed tabulates from an
   unrelaxed, dynamically-unstable configuration (measured max Im ω = 1040 at Eu
   F=6) where `FullBdGLHY` itself says ε_LHY is scheme-dependent.
   `check_accuracy_preconditions` returns `:fail` for that instead of leaving it
   to a `maxlog`-limited runtime warning.

**Composition is NOT measured.** The costs are one knob at a time and they overlap
— pad and dealias both add FFTs — so a profile's cost is never inferred from its
rows.

## Gate

`test/workflow/validation/test_accuracy_profiles.jl` — 76 assertions. Pins that a
ladderless knob cannot move at any budget; that a laddered one takes the cheapest
rung within budget; that a tighter budget never picks a looser setting; and
specifically that `pad 1.5` is rejected at every sane budget **while remaining
reachable at an absurd one**, so the rejection is about the budget and not about
the rung being unreachable. The precondition check carries a positive control that
it can pass at all.

`ci` is running on TSUBAME; result to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
