### PR TITLE
The FM closed form reported no LHY for a negative stiffness, and the new domain gate passed it

### DIFF
--- a/runs/eu_k3_lhy/LHY_icosahedral.yaml
+++ b/runs/eu_k3_lhy/LHY_icosahedral.yaml
@@ -7,7 +7,10 @@
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
 # Task #19C — LHY interference at K3=200× cigar regime.
 # Source: scripts/validation/eu_k3_lhy_gen.jl
-# LHY kind = icosahedral (applied outside nominal regime; see scope note).
+# LHY kind = full_bdg (was icosahedral; see the note at the top of this file).
+# The FILENAME still says icosahedral. Left as-is because docs cite these paths,
+# but it is a naming lie by this repo's own convention (file name = content) and
+# the next reader will believe the name before the body.
 
 metadata:
   suite: eu_k3_lhy

--- a/runs/eu_k3_lhy/LHY_polar_contact.yaml
+++ b/runs/eu_k3_lhy/LHY_polar_contact.yaml
@@ -1,6 +1,19 @@
 # Task #19C — LHY interference at K3=200× cigar regime.
 # Source: scripts/validation/eu_k3_lhy_gen.jl
 # LHY kind = polar_contact (applied outside nominal regime; see scope note).
+#
+# ANSATZ MISMATCH, left in place deliberately (noted 2026-07-30). This arm's
+# state is `m_minus_F`, i.e. FM, while `polar_contact` is the closed form for
+# the polar state (zeta = delta_{m,0}). runs/eu_k3_lhy/*.yaml label this
+# "applied outside nominal regime", so the mismatch is the study design across
+# this family, not an accident — but the number it produces is NOT a validated
+# closure for this state and must not be read as one. The matching closed
+# form is `fm_contact` (any F since 2026-07-27, gated against full_bdg at
+# F=1..8); the general path is `full_bdg`. The sibling `icosahedral` arm had
+# the same defect and could no longer run at all once the I_h form began
+# refusing lambda_spin < 0, so it moved to full_bdg. This arm fails QUIETLY
+# instead, which is the more dangerous half. Neither the "scope note" nor any
+# generator named in these headers exists in the tree.
 
 metadata:
   suite: eu_k3_lhy

--- a/runs/eu_k3_lhy_control/LHY_icosahedral_K0.yaml
+++ b/runs/eu_k3_lhy_control/LHY_icosahedral_K0.yaml
@@ -7,7 +7,7 @@
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
 # K3=0 LHY model control — auto-generated.
 # Source: scripts/validation/eu_k3_lhy_control_gen.jl
-# LHY = icosahedral, K3 = 0, γ_dr = 0.
+# LHY = full_bdg (was icosahedral), K3 = 0, γ_dr = 0. Filename unchanged.
 # Compare to eu_k3_lhy/LHY_icosahedral.yaml (same LHY, K3=200) to isolate
 # LHY-alone vs LHY+K3 effects.
 

--- a/runs/eu_k3_lhy_control/LHY_polar_contact_K0.yaml
+++ b/runs/eu_k3_lhy_control/LHY_polar_contact_K0.yaml
@@ -3,6 +3,19 @@
 # LHY = polar_contact, K3 = 0, γ_dr = 0.
 # Compare to eu_k3_lhy/LHY_polar_contact.yaml (same LHY, K3=200) to isolate
 # LHY-alone vs LHY+K3 effects.
+#
+# ANSATZ MISMATCH, left in place deliberately (noted 2026-07-30). This arm's
+# state is `m_minus_F`, i.e. FM, while `polar_contact` is the closed form for
+# the polar state (zeta = delta_{m,0}). runs/eu_k3_lhy/*.yaml label this
+# "applied outside nominal regime", so the mismatch is the study design across
+# this family, not an accident — but the number it produces is NOT a validated
+# closure for this state and must not be read as one. The matching closed
+# form is `fm_contact` (any F since 2026-07-27, gated against full_bdg at
+# F=1..8); the general path is `full_bdg`. The sibling `icosahedral` arm had
+# the same defect and could no longer run at all once the I_h form began
+# refusing lambda_spin < 0, so it moved to full_bdg. This arm fails QUIETLY
+# instead, which is the more dangerous half. Neither the "scope note" nor any
+# generator named in these headers exists in the tree.
 
 metadata:
   suite: eu_k3_lhy_control

--- a/runs/eu_lhy_longtime/LHY_icosahedral_100ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_icosahedral_100ms.yaml
@@ -7,7 +7,7 @@
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
-# LHY = icosahedral, K3 = 0, duration = 62.83 ω_ref⁻¹ ≈ 100ms
+# LHY = full_bdg (was icosahedral), K3 = 0, duration = 62.83 ω_ref⁻¹ ≈ 100ms
 
 metadata:
   suite: eu_lhy_longtime

--- a/runs/eu_lhy_longtime/LHY_icosahedral_200ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_icosahedral_200ms.yaml
@@ -7,7 +7,7 @@
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
-# LHY = icosahedral, K3 = 0, duration = 125.66 ω_ref⁻¹ ≈ 200ms
+# LHY = full_bdg (was icosahedral), K3 = 0, duration = 125.66 ω_ref⁻¹ ≈ 200ms
 
 metadata:
   suite: eu_lhy_longtime

--- a/runs/eu_lhy_longtime/LHY_icosahedral_50ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_icosahedral_50ms.yaml
@@ -7,7 +7,7 @@
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
-# LHY = icosahedral, K3 = 0, duration = 31.42 ω_ref⁻¹ ≈ 50ms
+# LHY = full_bdg (was icosahedral), K3 = 0, duration = 31.42 ω_ref⁻¹ ≈ 50ms
 
 metadata:
   suite: eu_lhy_longtime

--- a/runs/eu_lhy_longtime/LHY_polar_contact_100ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_polar_contact_100ms.yaml
@@ -1,6 +1,19 @@
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = polar_contact, K3 = 0, duration = 62.83 ω_ref⁻¹ ≈ 100ms
+#
+# ANSATZ MISMATCH, left in place deliberately (noted 2026-07-30). This arm's
+# state is `m_minus_F`, i.e. FM, while `polar_contact` is the closed form for
+# the polar state (zeta = delta_{m,0}). runs/eu_k3_lhy/*.yaml label this
+# "applied outside nominal regime", so the mismatch is the study design across
+# this family, not an accident — but the number it produces is NOT a validated
+# closure for this state and must not be read as one. The matching closed
+# form is `fm_contact` (any F since 2026-07-27, gated against full_bdg at
+# F=1..8); the general path is `full_bdg`. The sibling `icosahedral` arm had
+# the same defect and could no longer run at all once the I_h form began
+# refusing lambda_spin < 0, so it moved to full_bdg. This arm fails QUIETLY
+# instead, which is the more dangerous half. Neither the "scope note" nor any
+# generator named in these headers exists in the tree.
 
 metadata:
   suite: eu_lhy_longtime

--- a/runs/eu_lhy_longtime/LHY_polar_contact_200ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_polar_contact_200ms.yaml
@@ -1,6 +1,19 @@
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = polar_contact, K3 = 0, duration = 125.66 ω_ref⁻¹ ≈ 200ms
+#
+# ANSATZ MISMATCH, left in place deliberately (noted 2026-07-30). This arm's
+# state is `m_minus_F`, i.e. FM, while `polar_contact` is the closed form for
+# the polar state (zeta = delta_{m,0}). runs/eu_k3_lhy/*.yaml label this
+# "applied outside nominal regime", so the mismatch is the study design across
+# this family, not an accident — but the number it produces is NOT a validated
+# closure for this state and must not be read as one. The matching closed
+# form is `fm_contact` (any F since 2026-07-27, gated against full_bdg at
+# F=1..8); the general path is `full_bdg`. The sibling `icosahedral` arm had
+# the same defect and could no longer run at all once the I_h form began
+# refusing lambda_spin < 0, so it moved to full_bdg. This arm fails QUIETLY
+# instead, which is the more dangerous half. Neither the "scope note" nor any
+# generator named in these headers exists in the tree.
 
 metadata:
   suite: eu_lhy_longtime

--- a/runs/eu_lhy_longtime/LHY_polar_contact_50ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_polar_contact_50ms.yaml
@@ -1,6 +1,19 @@
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = polar_contact, K3 = 0, duration = 31.42 ω_ref⁻¹ ≈ 50ms
+#
+# ANSATZ MISMATCH, left in place deliberately (noted 2026-07-30). This arm's
+# state is `m_minus_F`, i.e. FM, while `polar_contact` is the closed form for
+# the polar state (zeta = delta_{m,0}). runs/eu_k3_lhy/*.yaml label this
+# "applied outside nominal regime", so the mismatch is the study design across
+# this family, not an accident — but the number it produces is NOT a validated
+# closure for this state and must not be read as one. The matching closed
+# form is `fm_contact` (any F since 2026-07-27, gated against full_bdg at
+# F=1..8); the general path is `full_bdg`. The sibling `icosahedral` arm had
+# the same defect and could no longer run at all once the I_h form began
+# refusing lambda_spin < 0, so it moved to full_bdg. This arm fails QUIETLY
+# instead, which is the more dangerous half. Neither the "scope note" nor any
+# generator named in these headers exists in the tree.
 
 metadata:
   suite: eu_lhy_longtime

--- a/scripts/probe_lhy_closed_form_refusal_shapes.jl
+++ b/scripts/probe_lhy_closed_form_refusal_shapes.jl
@@ -1,0 +1,61 @@
+# Probe: is the |λ_spin| masking pattern shared by the polar and FM closed forms?
+#
+# Conclusion up front: NOT the same defect, but the FM form has a different one.
+# Every row prints the stiffness it is claiming to test, so the label cannot drift
+# from the condition — the first version of this script asserted "sigma_0 < 0"
+# while sigma_0 was in fact positive, and read a healthy number as a pass.
+
+using SpinorBEC
+using SpinorBEC: build_polar_lhy_coefs, lhy_energy_polar, build_fm_lhy_coefs,
+    lhy_energy_fm, phi_1_reg, _c0c1_to_gS
+
+println("I_h — λ_spin is a STIFFNESS; |λ_spin| reported the stable-branch value")
+for c1 in (0.1, -0.2)
+    g = _c0c1_to_gS(6, 10.0, c1)
+    c0s, lam = compute_c0_lambda_F6_Ih(g)
+    println("  c1=", rpad(c1, 6), " c_0=", rpad(round(c0s; sigdigits=5), 9),
+        " λ_spin=", rpad(round(lam; sigdigits=5), 9),
+        " ε=", epsilon_LHY_F6_Ih(1.0, g))
+end
+
+println()
+println("polar — κ_m = |δ_m| is an ANOMALOUS coupling; ω² = ξ² − |δ|² needs |δ|.")
+println("        The instability shows up as t = ξ/κ − 1 < 0, and phi_1_reg")
+println("        REGULARISES it (Petrov saturation) rather than masking it.")
+for t in (-2.0, -1.0, -0.5, 0.0, 1.0)
+    println("  t=", rpad(t, 6), " phi_1_reg=", phi_1_reg(t))
+end
+println("  φ₁^reg(−1) = 0.3177 is the documented droplet limit, not an accident.")
+
+println()
+println("polar — what actually happens to σ_0 when g_0 is driven negative:")
+for g0 in (1.0, -1.0, -20.0)
+    gd = Dict(S => (S == 0 ? g0 : 1.0) for S in 0:2:12)
+    coefs = build_polar_lhy_coefs(6, gd)
+    ok = coefs.sigma[1] > 0
+    print("  g_0=", rpad(g0, 7), " σ_0=", rpad(round(coefs.sigma[1]; sigdigits=6), 12),
+        ok ? " (still >0) " : " (NEGATIVE) ")
+    try
+        println("ε=", lhy_energy_polar(1.0, coefs))
+    catch e
+        println(typeof(e))
+    end
+end
+
+println()
+println("FM — DIFFERENT DEFECT of the same class, FIXED 2026-07-30. Its")
+println("     `kappa < 1e-12 && return 0.0` meant \"negligible\" and also swallowed")
+println("     NEGATIVE g_{2F}, so a negative stiffness reported NO LHY. It now")
+println("     declines with NaN; the rows below are the fixed behaviour.")
+for c1 in (0.1, -0.005, -0.0278, -0.05)
+    g = _c0c1_to_gS(6, 10.0, c1 * 10.0)
+    coefs = build_fm_lhy_coefs(6, g)
+    g12 = g[12]
+    println("  c1/c0=", rpad(c1, 8), " g_12=", rpad(round(g12; sigdigits=6), 12),
+        " ε_fm=", lhy_energy_fm(1.0, coefs))
+end
+println("  Reachable at F=6 whenever c1/c0 < -1/36 = -0.0278 (g_2F = c0 + 36 c1).")
+println("  Zero committed config uses fm_contact/fm_dipolar, so this one had no")
+println("  blast radius — unlike the I_h guard, which errored five of them.")
+println("  A silent zero also passed test_lhy_config_validity_domain.jl, whose")
+println("  `isfinite(e) && e >= 0` both hold at 0.0; that gate now asserts e > 0.")

--- a/scripts/submit_test_tier.sh
+++ b/scripts/submit_test_tier.sh
@@ -15,6 +15,17 @@
 # no-op without CUDA, which is the same "the gate never ran" failure in a
 # different costume.
 #
+# NB: the `-o` log only ever holds this wrapper's own echo lines. The suite's
+# output goes to $OUT_DIR/tier_<tier>.out, and OUT_DIR follows
+# SPINORBEC_TSUBAME_RUNS_ROOT, which scripts/spinorbec.env sets to
+# /gs/fs/tga-kozuma-kouhi/uk07267/runs — NOT $HOME. Watching the -o log alone
+# looks exactly like a job that has produced nothing for half an hour.
+#
+# NB: the tree must include `runs/`. Config-scanning gates
+# (test_config_zeeman_seed_agreement.jl, test_lhy_config_validity_domain.jl) read
+# it, and an rsync that syncs only src/ and test/ makes them error on ENOENT
+# rather than skip — a red that is about the transfer, not the code.
+#
 # NB: -g and -o go on the qsub CLI, not as directives (UGE rejects `#$ -g` and
 # does not expand $HOME in directives).
 #$ -cwd
@@ -49,6 +60,21 @@ if [ -n "${T4_TMPDIR:-}" ] && [ -w "${T4_TMPDIR}" ]; then
 else
     export JULIA_DEPOT_PATH="$SHARED_DEPOT"
 fi
+# Pin BLAS to one thread. OpenBLAS sizes its level-1 thread team from the core
+# count, and a TSUBAME node reports 384 of them, so every `dot` on a few-MB
+# ComplexF64 array becomes spawn+barrier rather than arithmetic. Left unset, a
+# ci-tier attempt ran `oracles/test_lhy_full_bdg_closed_form_parity.jl` for
+# 18m52s against the 51.8s estimate in _tiers.jl (24s on cpu_4 with this pinned),
+# a worker then hit the 1800s per-file timeout mid-`test_term_properties.jl`, and
+# the suite aborted with 227 files never started — reporting FAIL while having
+# measured almost nothing, which reads like a tier result and is not one. With
+# the pin the same tier finishes 266 files in 11m20s.
+#
+# Not tuning: the workers already are the parallelism, so a BLAS team inside each
+# one is pure contention. `${VAR:-1}` so an explicit caller choice still wins.
+export OPENBLAS_NUM_THREADS=${OPENBLAS_NUM_THREADS:-1}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
+
 JULIA=${SPINORBEC_TSUBAME_JULIA:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia}
 
 echo "[sbec_tier] host=$(hostname)  tier=${TIER}  workers=${WORKERS}"

--- a/src/hamiltonian/terms/lhy/fm_contact.jl
+++ b/src/hamiltonian/terms/lhy/fm_contact.jl
@@ -83,6 +83,18 @@ function lhy_energy_fm(n::Float64, coefs::FMLHYCoefs;
     M_mass::Float64=1.0, hbar::Float64=1.0)::Float64
     prefactor = (8.0 * sqrt(M_mass^3)) / (15.0 * π^2 * hbar^3)
     kappa = coefs.delta_F
-    kappa < 1e-12 && return 0.0
+    # `kappa < 1e-12 && return 0.0` conflated two different things. "Negligible"
+    # and "negative" are not the same answer: κ = g_{2F} is the FM branch's own
+    # stiffness, so κ < 0 means the ansatz this closed form is built on has a
+    # negative stiffness, and returning 0.0 there reported NO LHY for a state
+    # whose LHY is undefined. Reachable at F=6 whenever c₁/c₀ < −1/36 = −0.0278,
+    # since g_{2F} = c₀ + 36 c₁ — measured ε_fm = 0.0 at c₁/c₀ = −0.0278 and
+    # −0.05, against 10.4048 at −0.005.
+    #
+    # NaN is how the closed forms decline (cf. `epsilon_LHY_F6_Ih`); `_tabulate_lhy`
+    # turns it into an ArgumentError naming the regime. A silent zero is worse
+    # than either, and is the same shape as the six paths that dropped `ws.lhy`.
+    kappa < -1e-12 && return NaN
+    kappa < 1e-12 && return 0.0      # genuinely negligible coupling
     return prefactor * (n * kappa)^2.5    # ν=1, t=0, φ_1^reg(0)=1
 end

--- a/test/oracles/test_lhy_config_validity_domain.jl
+++ b/test/oracles/test_lhy_config_validity_domain.jl
@@ -116,7 +116,29 @@ end
             # NaN is how the closed forms say "outside my domain". A run would
             # die at table-build time with an ArgumentError; this says so now.
             @test isfinite(e)
-            @test e >= 0.0        # LHY is a repulsive correction
+            # STRICTLY positive, not `>= 0`. A closed form can also leave its
+            # domain by returning zero, and `isfinite(0.0) && 0.0 >= 0` passes
+            # both assertions above — so the config would look gated while its
+            # LHY term was simply absent, which is precisely the failure mode six
+            # separate paths have already produced by dropping `ws.lhy`.
+            # `lhy_energy_fm` did exactly this until 2026-07-30: its
+            # `kappa < 1e-12 && return 0.0` swallowed NEGATIVE g_{2F} alongside
+            # negligible ones. These configs all have active couplings, so a zero
+            # here is a defect and never the physical answer.
+            @test e > 0.0
         end
+    end
+
+    @testset "a silent zero fails too (canary)" begin
+        # The assertion above is load-bearing only if zero is actually reachable.
+        # F=6: g_{2F} = c₀ + 36 c₁, so c₁/c₀ < −1/36 drives the FM stiffness
+        # negative. Before the fix that returned 0.0 and sailed through
+        # `isfinite` and `>= 0`; it now declines with NaN.
+        g_neg = _c0c1_to_gS(6, 10.0, -0.5)          # g_12 = −8.0
+        @test build_fm_lhy_coefs(6, g_neg).delta_F < 0
+        @test isnan(lhy_energy_fm(1.0, build_fm_lhy_coefs(6, g_neg)))
+        # ...and the healthy side still answers.
+        g_ok = _c0c1_to_gS(6, 10.0, -0.05)          # g_12 = +8.2
+        @test lhy_energy_fm(1.0, build_fm_lhy_coefs(6, g_ok)) > 0
     end
 end


### PR DESCRIPTION
Supersedes #205. #207 landed the same config migration in parallel, so this keeps
only what was not duplicated — and the main item is a hole in #209's brand-new
gate.

## #209's domain gate passes a silent zero

The gate evaluates every committed config's closed form at its own (F, c₀, c₁) and
fails on NaN. Good design, canary included. But:

```julia
@test isfinite(e)
@test e >= 0.0
```

**Both hold at `e == 0.0`.** A closed form that leaves its domain by returning
*zero* rather than NaN reads as gated while its LHY term is simply absent — which
is the exact failure six separate paths have already produced by dropping
`ws.lhy`.

`lhy_energy_fm` did that. `kappa < 1e-12 && return 0.0` conflated "negligible"
with "negative", and κ = g_{2F} is the FM branch's own stiffness, so κ < 0 means
the ansatz has a negative stiffness. Measured at F=6, c₀=10:

| c1/c0 | g_12 | ε_fm before | after |
|---:|---:|---:|---:|
| −0.005 | 8.2 | 10.4048 | 10.4048 |
| **−0.0278** | −0.008 | **0.0** | NaN |
| **−0.05** | −8.0 | **0.0** | NaN |

Reachable at F=6 whenever `c1/c0 < −1/36 = −0.0278`, since `g_{2F} = c₀ + 36 c₁`.
It now declines with NaN, which `_tabulate_lhy` converts to an `ArgumentError`
naming the regime — the mechanism `epsilon_LHY_F6_Ih` already uses.

**Zero committed config uses `fm_contact` or `fm_dipolar`**, so unlike the I_h
guard this has no blast radius. The gate is tightened to `@test e > 0.0` with a
canary that drives g_{2F} negative, so that assertion is load-bearing.

## The tier submitter measured nothing for 34 minutes

`scripts/submit_test_tier.sh` did not pin BLAS threads. OpenBLAS sizes its level-1
team from the core count and a TSUBAME node reports 384, so every `dot` on a
few-MB ComplexF64 array is spawn+barrier. Unpinned:
`oracles/test_lhy_full_bdg_closed_form_parity.jl` ran **18m52s** against the
51.8s estimate in `_tiers.jl` (24s on cpu_4 pinned), a worker hit the 1800s
per-file timeout mid-`test_term_properties.jl`, and the suite aborted with **227
files never started** — reporting FAIL while having measured almost nothing, which
reads like a tier result. Pinned, the same tier does **266 files in 11m20s**.

The script is the one place that knows it runs on a 384-core node, so it sets it
rather than expecting every caller to remember. Two more notes added, each of
which cost a wasted job:

- the `-o` log holds only the wrapper's echo lines; the suite writes to
  `$OUT_DIR/tier_<tier>.out`, and OUT_DIR follows `spinorbec.env`'s RUNS_ROOT,
  which is `/gs/fs/...` and **not** `$HOME`. Watching `-o` alone looks exactly
  like a job producing nothing for half an hour.
- the synced tree must include `runs/`, or the config-scanning gates
  (`test_config_zeeman_seed_agreement`, `test_lhy_config_validity_domain`) error
  on ENOENT instead of skipping — a red about the transfer, not the code.

## Two smaller things

**The migrated configs contradicted themselves.** Line 10 still said
`# LHY = icosahedral` while lines 1-7 and the body said `full_bdg`. Corrected.
Their *filenames* still say icosahedral, which is a naming lie by this repo's own
convention; left alone because `docs/validation/day_inventory_2026_05_26.md` cites
the paths, but now stated in the file instead of left for the next reader.

**The polar arms are ansatz-mismatched and nothing can see it.** All twelve arms
across `eu_k3_lhy` / `eu_k3_lhy_control` / `eu_lhy_longtime` run
`initial_state: m_minus_F` — an FM state — while `polar_contact` is the closed form
for ζ = δ_{m,0}. The domain gate cannot catch this: polar returns a finite positive
number from the wrong ansatz. Not rewritten, since the headers label this "applied
outside nominal regime" so the mismatch is the study design; each arm now carries
a note that its number is not a validated closure for this state, naming
`fm_contact` as the matching form.

## Verification

TSUBAME job 8304954 (cpu_4, `OPENBLAS_NUM_THREADS=1`), 9 files, all rc=0:
`test_lhy_config_validity_domain`, `test_lhy_polar`, `test_spinor_lhy`,
`test_lhy_full_bdg_closed_form_parity`, `test_lhy_mode_face_coverage`,
`test_lhy_magnitude_si_anchor`, `test_lhy_factory`, `test_lhy_gradient_all_modes`,
`test_config_zeeman_seed_agreement`.

Separately, the full `ci` tier passed on this worktree earlier today with the BLAS
pin — 266 files, no failures (job 8304829). That was before this commit; the diff
here is one guard, one strengthened assertion, and comments.

Type A (code correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
