### PR TITLE
feat(lhy): let a caller ask whether a mean field is dynamically stable

### DIFF
--- a/bench/lhy_stability_scan.jl
+++ b/bench/lhy_stability_scan.jl
@@ -1,0 +1,68 @@
+# Where is the Eu F=6 mean field dynamically STABLE?
+#
+# `full_bdg` cannot serve as an accuracy reference where `max Im ω ≠ 0`: the
+# zero-point sum drops the complex branches while the counterterms still subtract
+# all D of them, so ε_LHY is scheme-dependent, the ITP has nothing to converge to,
+# and no tolerance fixes it. The code says so in a warning; it now also ANSWERS,
+# via `lhy_mean_field_max_growth`, which is what a scan needs.
+#
+# This is the prerequisite the phase-gap budget was missing. That budget ran at
+# max Im ω = 1040 and its non-convergence was correct behaviour — I read it as
+# "unconverged" and then as "blocked on issue #172", and both were wrong.
+#
+#   julia --project=. bench/lhy_stability_scan.jl [n_c1]
+
+using Printf
+using SpinorBEC
+using SpinorBEC: lhy_mean_field_max_growth
+
+include(joinpath(@__DIR__, "eu151_params.jl"))
+
+const N_C1 = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 9
+const F = 6
+const D = 2F + 1
+
+"Unit spinors for the states the Eu texture work actually competes."
+function probe_spinors()
+    polar = zeros(ComplexF64, D); polar[F + 1] = 1.0
+    fm = zeros(ComplexF64, D); fm[1] = 1.0
+    (polar=polar, ferromagnetic=fm)
+end
+
+println("="^76)
+println("Eu F=6 mean-field stability — max Im ω (0 = stable)")
+println("c₀ + F²c₁ = c_total = $(round(EU_c_total; sigdigits=5)), c_dd = $(round(EU_c_dd; sigdigits=5))")
+println("="^76)
+
+c1_ratios = collect(range(-0.10, 0.10; length=N_C1))
+qs = (0.0, 1.0e-3, 1.0e-2)
+
+for (sname, spinor) in pairs(probe_spinors())
+    println("\n--- spinor: $sname")
+    @printf("  %-10s", "c1_ratio")
+    for q in qs
+        @printf(" %14s", "q=$q")
+    end
+    println()
+    for r in c1_ratios
+        ip = eu_interaction_params(r)
+        @printf("  %-10.4f", r)
+        for q in qs
+            g = try
+                lhy_mean_field_max_growth(; F, spinor, n0=1.0, interactions=ip,
+                    zeeman=ZeemanParams(EU_p_weak, q), c_dd=EU_c_dd)
+            catch e
+                NaN
+            end
+            @printf(" %14.4g", g)
+        end
+        println()
+    end
+end
+
+println("""
+
+[read] A column of zeros is a usable reference regime. Anything nonzero means
+`full_bdg` is scheme-dependent there, so it cannot be the accuracy reference and
+an ITP started there has no fixed point to reach — that is a property of the
+(F, c₀, c₁, q, c_dd) point, not of the seed or the tolerance.""")

--- a/bench/lhy_stability_scan.jl
+++ b/bench/lhy_stability_scan.jl
@@ -105,7 +105,8 @@ for n0 in (0.01, 0.1, 1.0, 10.0)
         growth(sp.polar, ip0, EU_c_dd, n0),
         growth(sp.ferromagnetic, ip0, EU_c_dd, n0))
 end
-println("  If max Im ω ∝ √n0 with no zero crossing, no density is a stable")
-println("  working point either — the sign of the instability is n-independent")
-println("  because it comes from a negative eigenvalue of the coupling matrix,")
-println("  and n only sets its rate.")
+println("  Measured EXACTLY linear in n0 with no crossing, which is what")
+println("  |Im ω| = n·|λ_min| looks like: ω² = ε_k(ε_k + 2nλ) is most negative at")
+println("  ε_k = −nλ, giving |Im ω| = n|λ|. So the SIGN of the instability is")
+println("  n-independent and no working density is a stable point either — n only")
+println("  sets the rate.")

--- a/bench/lhy_stability_scan.jl
+++ b/bench/lhy_stability_scan.jl
@@ -66,3 +66,46 @@ println("""
 `full_bdg` is scheme-dependent there, so it cannot be the accuracy reference and
 an ITP started there has no fixed point to reach — that is a property of the
 (F, c₀, c₁, q, c_dd) point, not of the seed or the tolerance.""")
+
+# --- controls: WHICH term makes it unstable, and does the density matter? -----
+#
+# "Everything is unstable" is not yet a finding — it could be the dipolar term
+# (physical and unavoidable at Eu: the textures exist BECAUSE the uniform state is
+# unstable), the spin channel, or an n-dependence that a different working density
+# would escape. These two controls separate those.
+println("\n" * "="^76)
+println("Controls — is it the DIPOLE, the spin channel, or the density?")
+println("="^76)
+
+sp = probe_spinors()
+ip0 = eu_interaction_params(0.05)
+zee0 = ZeemanParams(EU_p_weak, 0.0)
+
+growth(spinor, ip, cdd, n0) = try
+    lhy_mean_field_max_growth(; F, spinor, n0, interactions=ip, zeeman=zee0,
+        c_dd=cdd)
+catch
+    NaN
+end
+
+println("\n[control 1] c_dd scaled, at c1_ratio = 0.05, n0 = 1")
+@printf("  %-16s %14s %14s\n", "c_dd", "polar", "ferromagnetic")
+for f in (0.0, 0.01, 0.1, 0.5, 1.0)
+    @printf("  %-16.4g %14.4g %14.4g\n", f * EU_c_dd,
+        growth(sp.polar, ip0, f * EU_c_dd, 1.0),
+        growth(sp.ferromagnetic, ip0, f * EU_c_dd, 1.0))
+end
+println("  c_dd = 0 stable ⇒ the instability IS the dipole, and at Eu that is")
+println("  physics, not a parameter to move away from.")
+
+println("\n[control 2] working density, at c1_ratio = 0.05, full c_dd")
+@printf("  %-16s %14s %14s\n", "n0", "polar", "ferromagnetic")
+for n0 in (0.01, 0.1, 1.0, 10.0)
+    @printf("  %-16.4g %14.4g %14.4g\n", n0,
+        growth(sp.polar, ip0, EU_c_dd, n0),
+        growth(sp.ferromagnetic, ip0, EU_c_dd, n0))
+end
+println("  If max Im ω ∝ √n0 with no zero crossing, no density is a stable")
+println("  working point either — the sign of the instability is n-independent")
+println("  because it comes from a negative eigenvalue of the coupling matrix,")
+println("  and n only sets its rate.")

--- a/bench/phase_gap_error_budget.jl
+++ b/bench/phase_gap_error_budget.jl
@@ -70,6 +70,25 @@
 #     unusable — the honest verdict, and one that costs milliseconds instead of a
 #     30000-step ITP that was never going to land.
 #
+# v4 (2026-07-31). Two defects the v3 run exposed in itself:
+#
+#   * THE dt/2 ARM WAS CONFOUNDED. Every arm got the same step cap, so halving dt
+#     halved the imaginary time reached. Its `state sep` staying at 5e-2 where the
+#     dt arm collapsed to 4e-5 therefore says "less relaxed", not "dt matters" —
+#     the arm meant to measure the discretisation error was measuring its own
+#     shorter run. Steps now scale as DT/dt, so all arms cover the same τ.
+#   * 30000 STEPS DOES NOT CONVERGE THIS PROBLEM. Every arm finished at
+#     dE ≈ 1e-6..1e-5 against a 1e-9 target, and a gap between two unconverged
+#     runs is a gap between two points on two trajectories. The cap is raised.
+#
+# What v3 DID establish, and what to keep looking at: ΔE is not the usable
+# observable here. The reference arm and its own dt/2 baseline disagree by ~7 at
+# a B where ΔE itself is ~8-15, so the discretisation error is of order the
+# observable. `state sep` — how far apart the two converged states are — moved
+# monotonically and by four orders across the B scan, which is a signal. And the
+# positive control fired: with the spin rotation removed, final dE ran 1e-1
+# instead of 1e-6, so the instrument is not blind.
+#
 #   julia --project=. bench/phase_gap_error_budget.jl [n] [max_steps]
 
 using Printf
@@ -82,7 +101,7 @@ using LinearAlgebra: norm
 include(joinpath(@__DIR__, "eu151_params.jl"))
 
 const N_GRID = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 32
-const MAX_STEPS = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 30000
+const MAX_STEPS = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 120000
 const ITP_TOL = 1.0e-9
 # The DENSITY-based, gauge-invariant convergence gate. A texture carries a gauge
 # orbit — a global U(1) phase and a spin rotation about z — that leaves ρ and the
@@ -91,6 +110,9 @@ const ITP_TOL = 1.0e-9
 # `converged = false` after 30000 steps at 32³, so nothing it measured was a gap.
 const ITP_TOL_DRHO = 1.0e-7
 const SEEDS = (:flower, :chiral_spin_vortex)
+# Defined here rather than beside the arms: `relax` scales its step count by
+# DT/dt, so the reference dt has to exist before the first arm runs.
+const DT = 0.002
 
 grid_of() = make_grid(GridConfig(ntuple(_ -> N_GRID, 3), ntuple(_ -> 12.0, 3)))
 
@@ -126,9 +148,14 @@ function relax(; seed::Symbol, B::Float64, kind, dt, taylor::Bool, cap::Int)
     try
         grid = grid_of()
         seed_psi = init_psi(grid, SpinSystem(6); state=seed)
+        # Steps scale INVERSELY with dt, so every arm covers the same imaginary
+        # time. Without this the dt/2 arm reaches half the τ of the others and
+        # its "smaller error" is just a shorter run — which is exactly what v3
+        # measured and nearly reported as a dt effect.
+        nsteps = round(Int, MAX_STEPS * (DT / dt))
         # Stage 1: mean field only. Half the step budget — it starts from a seed
         # and only has to reach a physical texture, not the final fixed point.
-        pre = itp(; psi0=seed_psi, B, kind=nothing, dt, steps=MAX_STEPS ÷ 2)
+        pre = itp(; psi0=seed_psi, B, kind=nothing, dt, steps=nsteps ÷ 2)
         psi_pre = Array(pre.workspace.state.psi)
 
         # Ask, before spending the second stage, whether a reference is even
@@ -144,7 +171,7 @@ function relax(; seed::Symbol, B::Float64, kind, dt, taylor::Bool, cap::Int)
         end
 
         # Stage 2: the arm's own LHY, tabulated from the relaxed ψ.
-        gs = itp(; psi0=psi_pre, B, kind, dt, steps=MAX_STEPS)
+        gs = itp(; psi0=psi_pre, B, kind, dt, steps=nsteps)
         psi_h = Array(gs.workspace.state.psi)
         _, _, fz = spin_density_vector(psi_h, gs.workspace.spin_matrices, 3)
         w = _winding_vector(psi_h, gs.workspace.grid, 13)
@@ -229,7 +256,6 @@ end
 
 # --- gap: a small B scan, so the boundary can be located rather than assumed ---
 const BS = (2.6e-9, 3.5e-9, 4.4e-9, 5.2e-9)
-const DT = 0.002
 
 arms = [
     ("reference (Euler, full_bdg)", (kind=:full_bdg, dt=DT, taylor=false,
@@ -265,6 +291,34 @@ for (label, a) in arms, B in BS
 end
 
 # --- verdict --------------------------------------------------------------
+#
+# The classification, not ΔE, is what the claims rest on — so the first thing to
+# report is whether the ARMS AGREE about it. If two accuracy settings put the
+# same (B, seeds) in different winding classes, that disagreement IS the accuracy
+# requirement, stated in the units the claim is made in, and it does not need a
+# converged ΔE or a slope to be meaningful.
+println("\n[classification] does the accuracy setting change the ANSWER?")
+@printf("  %-36s %s\n", "arm", join((@sprintf("%9.2e", B) for B in BS), " "))
+for (label, _) in arms
+    @printf("  %-36s %s\n", label,
+        join((results[(label, B)].distinct ? "  distinct" : "      same" for B in BS), " "))
+end
+let base = [results[(arms[1][1], B)].distinct for B in BS]
+    dis = [(label, B) for (label, _) in arms[2:end], B in BS
+           if results[(label, B)].distinct != base[findfirst(==(B), BS)]]
+    if isempty(dis)
+        println("  All arms agree on every point — so no setting tested here changes")
+        println("  the classification, and the requirement is looser than the coarsest.")
+    else
+        println("  DISAGREEMENT at $(length(dis)) point(s): " *
+                join(("$(l) @ B=$(b)" for (l, b) in dis), "; "))
+        println("  Each is a setting that changes the answer, i.e. an accuracy floor —")
+        println("  but read it against `state sep` in the table: a pair that is already")
+        println("  4 orders closer at that B is a near-degenerate crossover, where any")
+        println("  setting can flip the label and none of them is wrong.")
+    end
+end
+
 println()
 ref = [results[("reference (Euler, full_bdg)", B)] for B in BS]
 usable = [i for i in eachindex(BS)

--- a/bench/phase_gap_error_budget.jl
+++ b/bench/phase_gap_error_budget.jl
@@ -45,13 +45,38 @@
 #     land in DIFFERENT classes. Same-class rows are printed as "no gap here",
 #     which is information, not a failure.
 #
+# v3 (2026-07-30). v2 still answered nothing, and this time the run had TOLD me
+# why in a line I had filtered out of the log:
+#
+#     FullBdG LHY: mean field is dynamically unstable (max Im ω = 1040.0)
+#
+# `:full_bdg` tabulates ε_LHY from the peak-density spinor of the state the
+# workspace is BUILT with, and the reference arm handed it a raw `:flower` seed.
+# Where the mean field is dynamically unstable ε_LHY is scheme-dependent — the
+# zero-point sum drops the complex branches while the counterterms still subtract
+# all D of them — so the reference arm's ITP had no fixed point to converge to.
+# Non-convergence was the CORRECT behaviour of a well-posed code on an ill-posed
+# request. I read it as "unconverged", then as "blocked on issue #172", and both
+# were wrong.
+#
+# So v3 changes what is asked, not the tolerances:
+#
+#   * TWO-STAGE relaxation. Stage 1 relaxes with no LHY at all; stage 2 rebuilds
+#     the workspace from that RELAXED ψ, so the table is tabulated from a
+#     physical state rather than a seed, and re-converges. Both stages run for
+#     every arm, so the staging itself is not a confound between them.
+#   * the stability is now ASKED, not inferred. `lhy_mean_field_max_growth` at the
+#     relaxed peak spinor is printed per row, and a nonzero value marks the row
+#     unusable — the honest verdict, and one that costs milliseconds instead of a
+#     30000-step ITP that was never going to land.
+#
 #   julia --project=. bench/phase_gap_error_budget.jl [n] [max_steps]
 
 using Printf
 import CUDA
 using SpinorBEC
 using SpinorBEC: SPIN_TAYLOR_ENABLED, SPIN_TAYLOR_DEGREE_CAP, spin_density_vector,
-    _winding_vector
+    _winding_vector, _extract_spinor, lhy_mean_field_max_growth
 using LinearAlgebra: norm
 
 include(joinpath(@__DIR__, "eu151_params.jl"))
@@ -69,29 +94,61 @@ const SEEDS = (:flower, :chiral_spin_vortex)
 
 grid_of() = make_grid(GridConfig(ntuple(_ -> N_GRID, 3), ntuple(_ -> 12.0, 3)))
 
-"""ITP from one seed, run to its OWN fixed point. Returns the energy, the
-convergence state (a gap between unconverged runs means nothing) and the
-per-component winding vector that classifies the state."""
+"One ITP run at fixed knobs. `psi0` is a state, so a caller can chain stages."
+function itp(; psi0, B::Float64, kind, dt, steps::Int)
+    grid = grid_of()
+    find_ground_state(;
+        grid, atom=Eu151, interactions=eu_interaction_params(0.05),
+        zeeman=ZeemanParams(linear_zeeman_p(Eu151, B, EU_ω_ref), 0.0),
+        potential=HarmonicTrap((1.0, 1.0, EU_λ_z)), psi_init=psi0,
+        dt, n_steps=steps, tol=ITP_TOL, tol_drho=ITP_TOL_DRHO, save_every=200,
+        enable_ddi=true, c_dd=EU_c_dd, ddi_padding=true, ddi_trunc_radius=-1.0,
+        spinor_lhy=kind, backend=CUDABackend(), verbose=false,
+    )
+end
+
+"""TWO-STAGE ITP from one seed.
+
+Stage 1 relaxes with NO LHY, so stage 2 can tabulate ε_LHY from a relaxed state
+rather than from the seed. That ordering is the whole point: a tabulated LHY is
+built once, at `make_workspace` time, from the peak-density spinor it is handed,
+and a seed's peak spinor is not a physical mean field. Both stages run for every
+arm so the staging cannot differ between them.
+
+Returns the energy, the convergence state, the winding vector that classifies the
+state — and `growth`, the `max Im ω` of the mean field the table was built from.
+`growth > 0` means ε_LHY is scheme-dependent for this row and the row is not a
+measurement of anything, whatever its ΔE says."""
 function relax(; seed::Symbol, B::Float64, kind, dt, taylor::Bool, cap::Int)
     old_t, old_c = SPIN_TAYLOR_ENABLED[], SPIN_TAYLOR_DEGREE_CAP[]
     SPIN_TAYLOR_ENABLED[] = taylor
     SPIN_TAYLOR_DEGREE_CAP[] = cap
     try
         grid = grid_of()
-        psi0 = init_psi(grid, SpinSystem(6); state=seed)
-        gs = find_ground_state(;
-            grid, atom=Eu151, interactions=eu_interaction_params(0.05),
-            zeeman=ZeemanParams(linear_zeeman_p(Eu151, B, EU_ω_ref), 0.0),
-            potential=HarmonicTrap((1.0, 1.0, EU_λ_z)), psi_init=psi0,
-            dt, n_steps=MAX_STEPS, tol=ITP_TOL, tol_drho=ITP_TOL_DRHO,
-            save_every=200,
-            enable_ddi=true, c_dd=EU_c_dd, ddi_padding=true, ddi_trunc_radius=-1.0,
-            spinor_lhy=kind, backend=CUDABackend(), verbose=false,
-        )
+        seed_psi = init_psi(grid, SpinSystem(6); state=seed)
+        # Stage 1: mean field only. Half the step budget — it starts from a seed
+        # and only has to reach a physical texture, not the final fixed point.
+        pre = itp(; psi0=seed_psi, B, kind=nothing, dt, steps=MAX_STEPS ÷ 2)
+        psi_pre = Array(pre.workspace.state.psi)
+
+        # Ask, before spending the second stage, whether a reference is even
+        # defined at the state stage 2 would tabulate from.
+        ip = eu_interaction_params(0.05)
+        zee = ZeemanParams(linear_zeeman_p(Eu151, B, EU_ω_ref), 0.0)
+        n_peak = maximum(sum(abs2, psi_pre; dims=4))
+        growth = try
+            lhy_mean_field_max_growth(; F=6, spinor=_extract_spinor(psi_pre),
+                n0=n_peak, interactions=ip, zeeman=zee, c_dd=EU_c_dd)
+        catch
+            NaN
+        end
+
+        # Stage 2: the arm's own LHY, tabulated from the relaxed ψ.
+        gs = itp(; psi0=psi_pre, B, kind, dt, steps=MAX_STEPS)
         psi_h = Array(gs.workspace.state.psi)
         _, _, fz = spin_density_vector(psi_h, gs.workspace.spin_matrices, 3)
         w = _winding_vector(psi_h, gs.workspace.grid, 13)
-        (E=gs.energy, fz=fz, converged=gs.converged,
+        (E=gs.energy, fz=fz, converged=gs.converged, growth=growth,
             # The final dE VALUE, not just the boolean. Without it "not
             # converged" cannot be told apart from "converged, but this
             # criterion never fires" — which is the whole question when a gauge
@@ -119,6 +176,9 @@ function gap(; B, kind, dt, taylor, cap)
     distinct = !isequal(a.wind, b.wind)   # the classification the claims rest on
     (dE=b.E - a.E, sep=sep, distinct=distinct,
         conv=a.converged && b.converged,
+        # The WORSE of the two, because a reference is only defined where BOTH
+        # states have one.
+        growth=max(a.growth, b.growth),
         dEf=max(a.dE_final, b.dE_final), steps=max(a.steps, b.steps),
         wa=a.wind, wb=b.wind)
 end
@@ -189,15 +249,17 @@ println("  thing that did not fire — read it before believing 'not converged'.
 println("  `distinct` = the two seeds ended in DIFFERENT winding classes. Only")
 println("  those rows are gaps between phases; the rest say there is no second")
 println("  minimum there, which is information rather than a failed measurement.")
-@printf("\n  %-36s %8s %13s %6s %9s %6s %9s\n",
-    "arm", "B", "ΔE", "conv", "final dE", "dist", "state sep")
+println("  `max Imω` is the mean field the LHY table was built from. Nonzero ⇒")
+println("  ε_LHY is scheme-dependent for that row and its ΔE is not a gap.")
+@printf("\n  %-36s %8s %13s %6s %9s %6s %9s %9s\n",
+    "arm", "B", "ΔE", "conv", "final dE", "dist", "state sep", "max Imω")
 results = Dict{Tuple{String, Float64}, Any}()
 for (label, a) in arms, B in BS
     g = gap(; B, a.kind, a.dt, a.taylor, a.cap)
     results[(label, B)] = g
-    @printf("  %-36s %8.2e %13.6e %6s %9.2e %6s %9.3e\n",
+    @printf("  %-36s %8.2e %13.6e %6s %9.2e %6s %9.3e %9.3g\n",
         label, B, g.dE, g.conv ? "yes" : "NO", g.dEf,
-        g.distinct ? "yes" : "no", g.sep)
+        g.distinct ? "yes" : "no", g.sep, g.growth)
     GC.gc(true);
     CUDA.reclaim()
 end
@@ -205,12 +267,19 @@ end
 # --- verdict --------------------------------------------------------------
 println()
 ref = [results[("reference (Euler, full_bdg)", B)] for B in BS]
-usable = [i for i in eachindex(BS) if ref[i].conv && ref[i].distinct]
+usable = [i for i in eachindex(BS)
+          if ref[i].conv && ref[i].distinct && (ref[i].growth == 0)]
 if length(usable) < 2
+    nconv = count(r -> r.conv, ref)
+    ndist = count(r -> r.distinct, ref)
+    nstab = count(r -> r.growth == 0, ref)
     println("""[verdict] The reference arm has $(length(usable)) usable B point(s) — a point is
-usable only if BOTH seeds converged AND ended in different winding classes.
-Fewer than two means the boundary cannot be located here and no δB can be
-quoted. That is the honest outcome, not a number to report.""")
+usable only if BOTH seeds converged, ended in DIFFERENT winding classes, AND the
+mean field the LHY table came from is dynamically stable. Of $(length(BS)) points:
+$(nconv) converged, $(ndist) distinct, $(nstab) stable. Fewer than two usable means
+the boundary cannot be located here and no δB can be quoted — and the breakdown
+says WHICH of the three is missing, so the next run changes that one rather than
+the tolerances.""")
 else
     dEs = [ref[i].dE for i in usable]
     Bs = [BS[i] for i in usable]

--- a/scripts/tsubame/submit_lhy_stability_scan.sh
+++ b/scripts/tsubame/submit_lhy_stability_scan.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#$ -cwd
+#$ -l cpu_4=1
+#$ -l h_rt=0:30:00
+#$ -N lhy_stab
+#$ -o /gs/fs/tga-kozuma-kouhi/uk07267/logs/
+#$ -e /gs/fs/tga-kozuma-kouhi/uk07267/logs/
+set -u
+export JULIA_DEPOT_PATH="$HOME/.julia"
+JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia
+cd "${SPINORBEC_BENCH_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/bec-ddi-conv}"
+echo "host=$(hostname) commit=$(git rev-parse --short HEAD)"
+$JULIA --project=. -e 'using Pkg; Pkg.instantiate()' 2>&1 | tail -3
+echo "### SMOKE"
+$JULIA --project=. bench/lhy_stability_scan.jl 3 2>&1
+smoke_rc=${PIPESTATUS[0]}
+echo "### smoke rc=$smoke_rc"
+[ "$smoke_rc" -ne 0 ] && { echo "SMOKE FAILED"; echo "ALL DONE $(date)"; exit 1; }
+echo; echo "### PRODUCTION"
+$JULIA --project=. bench/lhy_stability_scan.jl 9 2>&1
+echo "ALL DONE $(date)"

--- a/scripts/tsubame/submit_phase_gap_budget.sh
+++ b/scripts/tsubame/submit_phase_gap_budget.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #$ -cwd
 #$ -l gpu_1=1
-#$ -l h_rt=1:00:00
+#$ -l h_rt=4:00:00
 #$ -N phase_gap
 #$ -o /gs/fs/tga-kozuma-kouhi/uk07267/logs/
 #$ -e /gs/fs/tga-kozuma-kouhi/uk07267/logs/
@@ -40,5 +40,5 @@ if [ "$smoke_rc" -ne 0 ]; then
 fi
 
 echo; echo "### PRODUCTION"
-$JULIA --project=. bench/phase_gap_error_budget.jl "${SPINORBEC_GAP_N:-32}" "${SPINORBEC_GAP_STEPS:-30000}" 2>&1 | grep -vE "loaded from a system path|This may cause errors|If you.re running under a profiler|ensure that your library path|In any other case, please file an issue|^│ *$|^└ @ CUDA|^┌ Warning: CUDA runtime library"
+$JULIA --project=. bench/phase_gap_error_budget.jl "${SPINORBEC_GAP_N:-32}" "${SPINORBEC_GAP_STEPS:-120000}" 2>&1 | grep -vE "loaded from a system path|This may cause errors|If you.re running under a profiler|ensure that your library path|In any other case, please file an issue|^│ *$|^└ @ CUDA|^┌ Warning: CUDA runtime library"
 echo "ALL DONE $(date)"

--- a/src/hamiltonian/terms/lhy/full_bdg.jl
+++ b/src/hamiltonian/terms/lhy/full_bdg.jl
@@ -44,7 +44,7 @@
 #     norm |u|² − |v|² > 0 instead, which is what makes the FM-at-c₁>0
 #     case agree (89% error → 2.6e-4).
 
-export compute_spinor_lhy_table
+export compute_spinor_lhy_table, lhy_mean_field_max_growth
 
 """
     compute_spinor_lhy_table(; spinor, F, interactions, zeeman, c_dd,
@@ -154,7 +154,7 @@ function compute_spinor_lhy_table(;
         n_points >= 3 || throw(ArgumentError("n_points must be >= 3"))
         n_max > 0 || throw(ArgumentError("n_max must be positive"))
         n_atoms >= 1 || throw(ArgumentError("n_atoms must be >= 1"))
-        eps_1 = _lhy_bdg_energy_density(spinor, 1.0, F, interactions, zeeman,
+        eps_1, _ = _lhy_bdg_energy_density(spinor, 1.0, F, interactions, zeeman,
             c_dd, k_max, n_k, n_dir; rtol)
         densities = collect(range(0.0, n_max; length=n_points))
         # `/ n_atoms` for the same reason `_tabulate_lhy` divides: `g` comes from
@@ -168,8 +168,10 @@ function compute_spinor_lhy_table(;
     end
 
     _tabulate_lhy(FullBdGLHY; n_max, n_points, n_atoms) do n0
-        _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman,
-            c_dd, k_max, n_k, n_dir; rtol)
+        first(
+            _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman,
+                c_dd, k_max, n_k, n_dir; rtol),
+        )
     end
 end
 
@@ -385,10 +387,20 @@ end
 
 """
     _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman, c_dd,
-                            k_max, n_k, n_dir) → Float64
+                            k_max, n_k, n_dir) → (ε_LHY, max_growth)
 
-`ε_LHY(n₀)` for the given spinor: UV-subtracted BdG zero-point energy
-density, spherically averaged over `k̂` when the DDI is active.
+`ε_LHY(n₀)` for the given spinor — UV-subtracted BdG zero-point energy density,
+spherically averaged over `k̂` when the DDI is active — together with
+`max Im ω`, the dynamical-instability diagnostic.
+
+The diagnostic is RETURNED and not only warned about. `ε_LHY` is
+scheme-dependent wherever `max Im ω ≠ 0`, so a caller choosing a parameter point
+needs to ask BEFORE committing to it, and a `maxlog`-limited `@warn` cannot be
+asked. On 2026-07-30 that cost two full measurement rounds: a phase-gap budget
+tabulated `full_bdg` from an unrelaxed seed at max Im ω = 1040, reported
+"unconverged" and then "blocked on issue #172", and both readings were wrong —
+the warning that said so had been eaten by a log filter. See
+[`lhy_mean_field_max_growth`].
 """
 function _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman, c_dd,
     k_max, n_k, n_dir; rtol::Float64=1e-4, max_refine::Int=5)
@@ -508,5 +520,31 @@ function _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman, c_dd,
             "mean-field-stable (F, c₀, c₁, q) point." maxlog=1
     end
 
-    E / length(dirs)
+    E / length(dirs), max_growth
+end
+
+"""
+    lhy_mean_field_max_growth(; F, spinor, n0, interactions, zeeman, c_dd, rtol) → Float64
+
+`max Im ω` of the Bogoliubov spectrum for this mean field: zero when it is
+dynamically stable, positive when it is not.
+
+Ask this BEFORE committing to a parameter point. Wherever it is nonzero, ε_LHY is
+scheme-dependent — the zero-point sum drops the complex branches while the
+counterterms still subtract all `D` of them — so `full_bdg` cannot serve as an
+accuracy reference there and neither can any closed form. The ITP has nothing to
+converge to, and no tolerance fixes that.
+
+The same number drives the `@warn` in `_lhy_bdg_energy_density`, but a
+`maxlog`-limited warning is not something a caller can ASK, and it is something a
+log filter can eat — which is exactly how a phase-gap budget spent two rounds
+reporting "unconverged" and then "blocked on #172" while running at
+max Im ω = 1040 (2026-07-30).
+"""
+function lhy_mean_field_max_growth(; F::Int, spinor, n0::Real=1.0,
+    interactions::InteractionParams, zeeman=ZeemanParams(), c_dd::Real=0.0,
+    rtol::Float64=1.0e-4)
+    _, g = _lhy_bdg_energy_density(spinor, Float64(n0), F, interactions, zeeman,
+        Float64(c_dd), nothing, nothing, nothing; rtol)
+    g
 end

--- a/src/hamiltonian/terms/lhy/full_bdg.jl
+++ b/src/hamiltonian/terms/lhy/full_bdg.jl
@@ -154,7 +154,7 @@ function compute_spinor_lhy_table(;
         n_points >= 3 || throw(ArgumentError("n_points must be >= 3"))
         n_max > 0 || throw(ArgumentError("n_max must be positive"))
         n_atoms >= 1 || throw(ArgumentError("n_atoms must be >= 1"))
-        eps_1, _ = _lhy_bdg_energy_density(spinor, 1.0, F, interactions, zeeman,
+        eps_1 = _lhy_bdg_energy_density(spinor, 1.0, F, interactions, zeeman,
             c_dd, k_max, n_k, n_dir; rtol)
         densities = collect(range(0.0, n_max; length=n_points))
         # `/ n_atoms` for the same reason `_tabulate_lhy` divides: `g` comes from
@@ -168,10 +168,8 @@ function compute_spinor_lhy_table(;
     end
 
     _tabulate_lhy(FullBdGLHY; n_max, n_points, n_atoms) do n0
-        first(
-            _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman,
-                c_dd, k_max, n_k, n_dir; rtol),
-        )
+        _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman,
+            c_dd, k_max, n_k, n_dir; rtol)
     end
 end
 
@@ -386,8 +384,8 @@ function _lhy_k_panel(C, B, D::Int, a::Float64, b::Float64, n::Int,
 end
 
 """
-    _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman, c_dd,
-                            k_max, n_k, n_dir) → (ε_LHY, max_growth)
+    _lhy_bdg_energy_and_growth(spinor, n0, F, interactions, zeeman, c_dd,
+                               k_max, n_k, n_dir) → (ε_LHY, max_growth)
 
 `ε_LHY(n₀)` for the given spinor — UV-subtracted BdG zero-point energy density,
 spherically averaged over `k̂` when the DDI is active — together with
@@ -402,7 +400,7 @@ tabulated `full_bdg` from an unrelaxed seed at max Im ω = 1040, reported
 the warning that said so had been eaten by a log filter. See
 [`lhy_mean_field_max_growth`].
 """
-function _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman, c_dd,
+function _lhy_bdg_energy_and_growth(spinor, n0, F, interactions, zeeman, c_dd,
     k_max, n_k, n_dir; rtol::Float64=1e-4, max_refine::Int=5)
     D = 2F + 1
     nd = _lhy_n_dir(rtol, c_dd, n_dir)
@@ -524,6 +522,17 @@ function _lhy_bdg_energy_density(spinor, n0, F, interactions, zeeman, c_dd,
 end
 
 """
+    _lhy_bdg_energy_density(args...; kwargs...) → Float64
+
+`ε_LHY` alone. The body computes it together with `max Im ω`, so the pair-returning
+[`_lhy_bdg_energy_and_growth`] is the real function and this is its projection —
+which is why this is one line rather than a second declaration of the same physics.
+Every caller that only wants the energy keeps this name and this signature.
+"""
+_lhy_bdg_energy_density(args...; kwargs...) =
+    first(_lhy_bdg_energy_and_growth(args...; kwargs...))
+
+"""
     lhy_mean_field_max_growth(; F, spinor, n0, interactions, zeeman, c_dd, rtol) → Float64
 
 `max Im ω` of the Bogoliubov spectrum for this mean field: zero when it is
@@ -535,7 +544,7 @@ counterterms still subtract all `D` of them — so `full_bdg` cannot serve as an
 accuracy reference there and neither can any closed form. The ITP has nothing to
 converge to, and no tolerance fixes that.
 
-The same number drives the `@warn` in `_lhy_bdg_energy_density`, but a
+The same number drives the `@warn` in `_lhy_bdg_energy_and_growth`, but a
 `maxlog`-limited warning is not something a caller can ASK, and it is something a
 log filter can eat — which is exactly how a phase-gap budget spent two rounds
 reporting "unconverged" and then "blocked on #172" while running at
@@ -544,7 +553,7 @@ max Im ω = 1040 (2026-07-30).
 function lhy_mean_field_max_growth(; F::Int, spinor, n0::Real=1.0,
     interactions::InteractionParams, zeeman=ZeemanParams(), c_dd::Real=0.0,
     rtol::Float64=1.0e-4)
-    _, g = _lhy_bdg_energy_density(spinor, Float64(n0), F, interactions, zeeman,
+    _, g = _lhy_bdg_energy_and_growth(spinor, Float64(n0), F, interactions, zeeman,
         Float64(c_dd), nothing, nothing, nothing; rtol)
     g
 end

--- a/src/workflow/initialization/make_workspace.jl
+++ b/src/workflow/initialization/make_workspace.jl
@@ -275,6 +275,16 @@ function make_workspace(;
         # experiments live deep in this regime (ω_L ~ kHz, c_dd × n ~ Hz).
         # Only @info, not error: the user may intentionally want the full
         # kernel to study transverse Larmor-coherent dynamics.
+        #
+        # This used to say "faster + more physical". It is NOT faster, and saying
+        # so invited an accuracy trade for nothing. Measured 0.986× on one ITP
+        # step, H100 32³ Eu F=6 (`bench/accuracy_knob_cost.jl`) — inside the
+        # noise, and structurally so: secular zeroes the off-diagonal Q
+        # components, but Q_xx = Q_yy = −Q_zz/2 are all still nonzero, so the
+        # kernel remains a 3-component convolution with all 6 FFTs. Only 6 of the
+        # 9 pointwise multiplies in the contraction disappear, and the contraction
+        # is not what the step costs. The case for `secular` is entirely the
+        # physics one below.
         p_now = linear_p(zfield)   # uniform arm → bz; spatial arm → 0 (advisory only)
         if !secular_ddi && is_active(p_now, ROTATION_TOL) && is_active(c_dd_val)
             n_peak_est =
@@ -283,7 +293,11 @@ function make_workspace(;
             larmor_ratio = abs(p_now) / max(c_dd_val * n_peak_est, 1e-30)
             if larmor_ratio > 100.0
                 @info "DDI Larmor regime: ω_L / (c_dd · ⟨n⟩) ≈ $(round(larmor_ratio; sigdigits=3)). " *
-                    "Consider `secular_ddi=true` (faster + more physical for ω_L ≫ c_dd·n)."
+                    "Consider `secular_ddi=true` — the Larmor cycle averages the " *
+                    "off-diagonal DDI to zero here, so it is the more physical kernel " *
+                    "for time-averaged observables. It is NOT faster (measured 0.986× " *
+                    "at 32³): all 6 FFTs remain, so choose it for the physics or not " *
+                    "at all."
             end
         end
 

--- a/src/workflow/validation/accuracy_knobs.jl
+++ b/src/workflow/validation/accuracy_knobs.jl
@@ -133,7 +133,10 @@ bare periodic kernel, 2-5 % dipolar field error flat in resolution (9c117c05).")
     AccuracyKnob(:secular_ddi, :per_run, false, false,
         "Larmor-averaged DDI, dropping the off-diagonal components. A physics \
 approximation valid when ω_L ≫ c_dd⟨n⟩; make_workspace advises when that holds. \
-Required (ArgumentError) when spin_rotating_frame_omega ≠ 0."),
+Required (ArgumentError) when spin_rotating_frame_omega ≠ 0, so this knob cannot \
+be removed without removing the rotating-basis path. Buys NO speed — measured \
+0.986× at 32³, i.e. noise, because Q_xx = Q_yy = −Q_zz/2 keeps the kernel a \
+3-component convolution with all 6 FFTs. Choose it for the physics or not at all."),
     AccuracyKnob(:spinor_lhy, :per_run, :full_bdg, :none,
         "LHY functional. The closed forms assume a fixed ansatz — \
 polar_two_channel is ~1 % off at F=2 and 30-70 % off at F=6. full_bdg is the \

--- a/src/workflow/validation/accuracy_profiles.jl
+++ b/src/workflow/validation/accuracy_profiles.jl
@@ -56,13 +56,38 @@
 #    `with_reference_accuracy` for those. `accuracy_profile_report` says so rather
 #    than letting the name imply full coverage.
 #
-# 3. `:reference` has a PRECONDITION the value alone cannot express, and it is
-#    the one that cost a day: `spinor_lhy = :full_bdg` tabulates ε_LHY from the
-#    peak-density spinor of the state the workspace is built with. Handed a raw
-#    seed, it tabulates from an unrelaxed, dynamically-unstable configuration —
-#    measured max Im ω = 1040 at Eu F=6 — and `FullBdGLHY` itself says ε_LHY is
-#    scheme-dependent there. `check_accuracy_preconditions` refuses that
-#    combination instead of leaving it to a maxlog-limited runtime warning.
+# 3. `:reference` has PRECONDITIONS the value alone cannot express, and they are
+#    what cost a day. `spinor_lhy = :full_bdg` tabulates ε_LHY from the
+#    peak-density spinor of the state the workspace is built with, and
+#    `FullBdGLHY` is scheme-dependent wherever that mean field is dynamically
+#    unstable. Two separate measurements, both via `lhy_mean_field_max_growth`
+#    (`bench/lhy_stability_scan.jl`, `bench/phase_gap_error_budget.jl`):
+#
+#      * a RAW SEED tabulates from an unrelaxed configuration — max Im ω = 1040 at
+#        Eu F=6 32³ from `:flower`. Relaxing first cuts that to ≈ 9.8, two orders
+#        better.
+#      * and it does not reach zero, because the DIPOLE is what makes it nonzero.
+#        Scaled c_dd at Eu F=6, n₀ = 1, c₁/c₀ = 0.05: c_dd = 0 gives EXACTLY 0,
+#        and every nonzero c_dd is unstable, roughly linearly (2.11 → 319,
+#        21.1 → 1060, 211 → 4371 for polar). Scanned over c₁/c₀ ∈ [−0.1, 0.1] and
+#        q ∈ {0, 1e-3, 1e-2}: not one stable point. Over n₀ ∈ [0.01, 10]:
+#        max Im ω is exactly linear in n₀ with no crossing, which is what
+#        |Im ω| = n|λ_min| looks like — so no working density escapes it either.
+#
+#    So at Eu F=6 with the real c_dd, `:reference` has NO valid instance, and
+#    "relax first" is not a workaround. `check_accuracy_preconditions` takes
+#    `c_dd` and refuses on it. That makes the reference profile honest at the cost
+#    of leaving the dipolar production problem without one — which is the true
+#    state of affairs, and is the same fact as issue #172 seen from another side:
+#    the term that is 97 % of the Eu F=6 total energy is built on a linearisation
+#    with no stable point.
+#
+#    SCOPE. This is a statement about the UNIFORM (local-density) mean field every
+#    tabulated LHY is built from, not about the trapped texture. A trap and a
+#    texture's own gradients gap the low-k modes; whether the trapped state is
+#    stable is a trapped-BdG question and a different instrument
+#    (`solvers/hessian`'s λ_min). What is measured here is that the construction
+#    of ε_LHY is ill-posed at Eu, not that the ground state does not exist.
 
 export ACCURACY_PROFILE_NAMES, DEFAULT_ERROR_BUDGET_FRAC,
     accuracy_profile, accuracy_profile_for_budget, accuracy_profile_report,
@@ -179,40 +204,68 @@ NOT set by this profile:
 end
 
 """
-    check_accuracy_preconditions(name; relaxed_initial_state::Bool) -> CheckResult
+    check_accuracy_preconditions(name; relaxed_initial_state::Bool, c_dd = 0.0)
+        -> CheckResult
 
 Whether a profile's assumptions hold for how it is about to be used.
 
-`:reference` requires `spinor_lhy = :full_bdg`, and that tabulates ε_LHY from the
-peak-density spinor of the state the workspace is built with. If that state is a
-raw seed rather than a relaxed one, the table comes from a dynamically-unstable
-configuration and ε_LHY is scheme-dependent — so the run has no well-defined
-ground state to converge to, which is not a tolerance that can be tightened.
-Measured: max Im ω = 1020 from a `:flower` seed at Eu F=6, 32³, and the reference
-arm's ITP sat at dE ≈ 1e-2 against a 1e-9 target
-(`bench/phase_gap_error_budget.jl`).
+`:reference` requires `spinor_lhy = :full_bdg`, which tabulates ε_LHY from the
+peak-density spinor of the state the workspace is built with — and is
+scheme-dependent wherever that mean field is dynamically unstable, because the
+zero-point sum drops the complex branches while the counterterms still subtract
+all `D` of them. Two independent ways to land there, and the second one is fatal:
+
+  * an UNRELAXED initial state. Measured max Im ω = 1040 from a `:flower` seed at
+    Eu F=6 32³; relaxing with `lhy = none` first brings it to ≈ 9.8.
+  * an ACTIVE DIPOLE, which cannot be relaxed away. `c_dd = 0` gives exactly
+    zero; every nonzero `c_dd` is unstable, roughly linearly in it, at every
+    `c₁/c₀ ∈ [−0.1, 0.1]`, every `q ∈ {0, 1e-3, 1e-2}` and every
+    `n₀ ∈ [0.01, 10]` scanned (`bench/lhy_stability_scan.jl`). So there is no
+    stable point to move to, and this returns `:fail` rather than advice.
+
+`c_dd` defaults to 0 so a non-dipolar caller is unaffected; pass the real value
+and a dipolar `:reference` run is refused before it is spent.
 
 Returns `:fail` rather than throwing, so a caller can report it alongside other
 checks; `passed(r)` is the green/not-green question.
 """
-function check_accuracy_preconditions(name::Symbol; relaxed_initial_state::Bool)
+function check_accuracy_preconditions(name::Symbol; relaxed_initial_state::Bool,
+    c_dd::Real=0.0)
     p = accuracy_profile(name)
-    needs_relaxed = hasproperty(p, :spinor_lhy) && p.spinor_lhy === :full_bdg
+    needs_stable = hasproperty(p, :spinor_lhy) && p.spinor_lhy === :full_bdg
     details = Pair{Symbol, Any}[
         :profile => (got=name,),
         :spinor_lhy => (got=hasproperty(p, :spinor_lhy) ? p.spinor_lhy : nothing,
-            needs_relaxed_initial_state=needs_relaxed),
+            needs_stable_mean_field=needs_stable),
         :relaxed_initial_state => (got=relaxed_initial_state,),
+        :c_dd => (got=Float64(c_dd),),
     ]
-    if needs_relaxed && !relaxed_initial_state
+    # The dipole comes FIRST: it is the unfixable one, and reporting the
+    # relaxation advice for a dipolar run would send the caller after a
+    # workaround that has been measured not to work.
+    if needs_stable && c_dd != 0
+        return CheckResult(:fail, details,
+            ":$name uses spinor_lhy = :full_bdg with c_dd = $(Float64(c_dd)) ≠ 0. " *
+            "full_bdg tabulates ε_LHY from a uniform BdG spectrum, and an active " *
+            "dipole makes that spectrum dynamically unstable at every c₁, q and " *
+            "density scanned at Eu F=6 (c_dd = 0 gives exactly 0; 2.11 → 319, " *
+            "21.1 → 1060, 211 → 4371), so ε_LHY is scheme-dependent and no " *
+            "relaxation or tolerance reaches a stable point. There is currently " *
+            "NO reference LHY for a dipolar spinor gas — the closed forms do not " *
+            "detect this but are not derived for an unstable mean field either. " *
+            "Quote the closed form you used and its own residual instead of " *
+            "claiming a reference. Scope: this is the uniform local-density mean " *
+            "field, not the trapped state.")
+    end
+    if needs_stable && !relaxed_initial_state
         return CheckResult(:fail, details,
             ":$name uses spinor_lhy = :full_bdg, which tabulates ε_LHY from the " *
             "peak-density spinor of the state the workspace is built with. The " *
             "initial state is not relaxed, so the table would come from a " *
             "dynamically-unstable configuration where ε_LHY is scheme-dependent " *
-            "(measured max Im ω = 1020 on a raw seed at Eu F=6 32³). Relax first " *
-            "with lhy = none or a closed form, then rebuild the workspace from " *
-            "that ψ and re-converge.")
+            "(measured max Im ω = 1040 on a raw seed at Eu F=6 32³, against ≈ 9.8 " *
+            "after relaxing). Relax first with lhy = none or a closed form, then " *
+            "rebuild the workspace from that ψ and re-converge.")
     end
     CheckResult(:pass, details, ":$name preconditions hold")
 end

--- a/src/workflow/validation/accuracy_profiles.jl
+++ b/src/workflow/validation/accuracy_profiles.jl
@@ -195,10 +195,13 @@ function accuracy_profile_report(name::Symbol; io::IO=stdout)
 NOT set by this profile:
   * the :global knobs ($(join((string(k.name) for k in ACCURACY_KNOBS if k.scope === :global), ", "))).
     Use `with_reference_accuracy(f)` for those.
-  * the :reference precondition — call `check_accuracy_preconditions` before
-    trusting a reference run. `spinor_lhy = :full_bdg` tabulates from the state
-    the workspace is BUILT with, so a raw seed tabulates from an unrelaxed,
-    dynamically-unstable configuration where ε_LHY is scheme-dependent.""",
+  * the :reference preconditions — call `check_accuracy_preconditions(name;
+    relaxed_initial_state, c_dd)` before trusting a reference run.
+    `spinor_lhy = :full_bdg` tabulates from a uniform BdG spectrum, which is
+    dynamically unstable (⇒ ε_LHY scheme-dependent) in two cases: a raw seed
+    rather than a relaxed state, and — measured at Eu F=6, unfixable by any
+    relaxation — ANY nonzero c_dd. So :reference has no valid instance for a
+    dipolar gas; quote the closed form you used and its own residual.""",
     )
     nothing
 end

--- a/test/workflow/validation/test_accuracy_profiles.jl
+++ b/test/workflow/validation/test_accuracy_profiles.jl
@@ -162,6 +162,10 @@ using SpinorBEC: ACCURACY_KNOBS, ACCURACY_PROFILE_NAMES, accuracy_profile,
         s = String(take!(buf))
         @test occursin("NOT set by this profile", s)
         @test occursin("with_reference_accuracy", s)
+        # The footer must name BOTH ways :reference fails, or it reads as though
+        # relaxing the state were enough — which is the thing that was measured
+        # not to be.
+        @test occursin("c_dd", s)
         buf2 = IOBuffer()
         accuracy_profile_report(:reference; io=buf2)
         @test occursin("scheme-dependent", String(take!(buf2)))

--- a/test/workflow/validation/test_accuracy_profiles.jl
+++ b/test/workflow/validation/test_accuracy_profiles.jl
@@ -16,8 +16,11 @@
 #     knobs and must be REJECTED, because its residual is 4.4× what production
 #     already carries — a hand-picked `fast` field had it in, and that was the
 #     defect this design replaces.
-#   * the `:reference` precondition refuses the `full_bdg`-from-a-raw-seed
-#     combination, with a positive control that it can pass at all.
+#   * the `:reference` preconditions refuse BOTH ways `full_bdg` lands on an
+#     unstable mean field — a raw seed, and an active dipole — with a positive
+#     control that the check can pass at all. The dipole case is ordered first
+#     deliberately: it is the one no relaxation fixes, so a dipolar caller must
+#     not be handed the relaxation advice.
 
 using Test
 using SpinorBEC
@@ -117,17 +120,40 @@ using SpinorBEC: ACCURACY_KNOBS, ACCURACY_PROFILE_NAMES, accuracy_profile,
         @test_throws ArgumentError accuracy_profile(:turbo)
     end
 
-    @testset ":reference refuses full_bdg tabulated from a raw seed" begin
+    @testset ":reference refuses an unstable mean field, both ways in" begin
         bad = check_accuracy_preconditions(:reference; relaxed_initial_state=false)
         @test !passed(bad)
         @test occursin("scheme-dependent", bad.summary)
-        # Positive control: the check CAN pass, so the failure above is about the
-        # input and not about the check being unsatisfiable.
+        @test occursin("Relax first", bad.summary)
+
+        # An active dipole is the case no relaxation fixes: measured unstable at
+        # every c₁, q and density scanned at Eu F=6. So a relaxed dipolar caller
+        # must STILL be refused, and must NOT be told to relax.
+        dip = check_accuracy_preconditions(:reference; relaxed_initial_state=true,
+            c_dd=211.0)
+        @test !passed(dip)
+        @test occursin("dipole", dip.summary)
+        @test !occursin("Relax first", dip.summary)
+        # Ordering: the dipole reason wins even when both hold, because the
+        # relaxation advice would send the caller after a measured non-fix.
+        both = check_accuracy_preconditions(:reference; relaxed_initial_state=false,
+            c_dd=211.0)
+        @test occursin("dipole", both.summary)
+
+        # Positive control: the check CAN pass, so the failures above are about
+        # the input and not about the check being unsatisfiable.
         ok = check_accuracy_preconditions(:reference; relaxed_initial_state=true)
         @test passed(ok)
-        # Production does not use full_bdg, so it has no such precondition.
-        @test passed(check_accuracy_preconditions(:production;
-            relaxed_initial_state=false))
+        # …and c_dd = 0 really is the discriminator, not the relaxation flag
+        # doing all the work.
+        @test passed(check_accuracy_preconditions(:reference;
+            relaxed_initial_state=true, c_dd=0.0))
+        # Production does not use full_bdg, so it has no such precondition — with
+        # or without a dipole.
+        @test passed(
+            check_accuracy_preconditions(:production;
+                relaxed_initial_state=false, c_dd=211.0),
+        )
     end
 
     @testset "the report names what it does NOT set" begin


### PR DESCRIPTION
## Why

The phase-gap error budget refused to answer three times. Each time I diagnosed it differently — unconverged, then a tolerance problem, then blocked on #172 — and each time I was wrong. The first run had printed the answer:

```
FullBdG LHY: mean field is dynamically unstable (max Im ω = 1040.0)
```

and my log filter (`grep -vE "^│|^└|^┌"`, meant for CUDA warning boxes) had removed it.

`:full_bdg` tabulates ε_LHY from the peak-density spinor of the state the workspace is **built** with. The reference arm handed it a raw `:flower` seed. Where the mean field is dynamically unstable, the zero-point sum drops the complex branches while the counterterms still subtract all `D` of them, so ε_LHY is scheme-dependent — the ITP had **no fixed point to converge to**. Non-convergence was correct behaviour on an ill-posed request.

## What

**The diagnostic is now askable.** `_lhy_bdg_energy_density` computed `max Im ω`, warned with `maxlog=1`, and discarded it. It now returns it, and `lhy_mean_field_max_growth` exposes it as a public query. A `maxlog`-limited warning is not something a caller can ask for, and it is something a log filter can eat.

This makes stability a **precondition** you check before spending a run, not a diagnostic you read afterwards.

**`bench/lhy_stability_scan.jl`** — scans `(c1_ratio, q)` at Eu F=6 for the polar and ferromagnetic spinors to find where a reference is even defined. CPU, seconds per point, no ITP.

**`bench/phase_gap_error_budget.jl` v3** — two changes, both to the *request* rather than the tolerances:

- **two-stage relaxation**: stage 1 with no LHY, stage 2 rebuilding the workspace from that relaxed ψ, so the table is tabulated from a physical state. Both stages run for every arm, so the staging is not a confound between them.
- `max Im ω` at the relaxed peak spinor is printed per row and marks the row unusable when nonzero, whatever its ΔE says. The verdict breaks its refusal down by cause — how many points converged, how many were distinct, how many were stable — so the next run fixes the missing one.

## Verification

- `submit_load_check.sh` on TSUBAME (job 8305287): loads, `accuracy knob registry 51/51`.
- `ci` tier on merged main `376e9895` (job 8305260): 270 files / 8 workers, all passed.
- Stability scan (job 8305328) and phase-gap v3 (job 8305329) are running; results go in a follow-up comment. **Nothing in this PR claims a phase-boundary accuracy number** — that is what these jobs are for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)