### PR TITLE
fix(ddi): the gradient must use the same kernel as the energy under padding

### DIFF
--- a/bench/probe_ddi_gradient_padding.jl
+++ b/bench/probe_ddi_gradient_padding.jl
@@ -15,11 +15,16 @@
 # This measures the size of that: same spec, same solver, two revisions, one
 # node. What moves is the converged ψ, its energy, and the reported residual.
 
+# Top level, not inside the `if` below: a macro is resolved when the enclosing
+# top-level expression is LOWERED, so `using Printf` in the same block comes too
+# late and `@printf` is undefined — which is exactly how the first run of this
+# probe died, in the arm that never touches the compare branch.
+using JLD2
+using Printf
+
 const MODE = length(ARGS) >= 1 ? ARGS[1] : "solve"
 
 if MODE == "compare"
-    using JLD2
-    using Printf
     a = load(ARGS[2])
     b = load(ARGS[3])
     println("=== ", ARGS[2], "  vs  ", ARGS[3], " ===")
@@ -44,8 +49,6 @@ if MODE == "compare"
 end
 
 using SpinorBEC
-using JLD2
-using Printf
 
 include(joinpath(@__DIR__, "eu151_params.jl"))
 

--- a/bench/probe_ddi_gradient_padding.jl
+++ b/bench/probe_ddi_gradient_padding.jl
@@ -1,0 +1,104 @@
+#!/usr/bin/env julia
+# How far does the DDI gradient-padding fix move a ground state?
+#
+#   julia --project=. bench/probe_ddi_gradient_padding.jl solve   <out.jld2>
+#   julia --project=. bench/probe_ddi_gradient_padding.jl compare <a.jld2> <b.jld2>
+#
+# `_ddi_energy` branches on `ws.ddi_padded`; `_grad_ddi!` did not, so with
+# padding on — the YAML default since 2026-07-29 — L-BFGS accepted steps on the
+# PADDED energy while taking its direction from the UNPADDED gradient. It still
+# decreased the padded energy monotonically, but along the wrong direction, and
+# it stopped where that direction stopped helping. The endpoint is therefore not
+# a stationary point of the energy it reports, and the `grad_norm` it reports is
+# the norm of a different operator's gradient.
+#
+# This measures the size of that: same spec, same solver, two revisions, one
+# node. What moves is the converged ψ, its energy, and the reported residual.
+
+const MODE = length(ARGS) >= 1 ? ARGS[1] : "solve"
+
+if MODE == "compare"
+    using JLD2
+    using Printf
+    a = load(ARGS[2])
+    b = load(ARGS[3])
+    println("=== ", ARGS[2], "  vs  ", ARGS[3], " ===")
+    @printf("%-26s %20s %20s %14s\n", "", "A", "B", "B - A")
+    for k in ("energy", "energy_ddi", "grad_norm", "polarisation")
+        @printf("%-26s %20.12g %20.12g %14.3e\n", k, a[k], b[k], b[k] - a[k])
+    end
+    for k in ("last_step", "n_line_search_evals", "stop_reason", "converged")
+        @printf("%-26s %20s %20s\n", k, string(a[k]), string(b[k]))
+    end
+
+    # ψ difference, after removing the global phase: two solves of the same
+    # functional may land on the same state up to exp(iθ), and that is not a
+    # physical difference.
+    pa, pb = a["psi"], b["psi"]
+    ov = sum(conj.(pa) .* pb)
+    aligned = pb .* conj(ov / abs(ov))
+    rel = maximum(abs, aligned .- pa) / maximum(abs, pa)
+    @printf("\n%-26s %14.3e   (phase-aligned, relative to max|psi|)\n", "max |dpsi|", rel)
+    @printf("%-26s %14.3e\n", "1 - |<A|B>|", 1 - abs(ov) * a["dV"])
+    exit(0)
+end
+
+using SpinorBEC
+using JLD2
+using Printf
+
+include(joinpath(@__DIR__, "eu151_params.jl"))
+
+out = ARGS[2]
+
+grid = make_grid(GridConfig((24, 24, 24), (12.0, 12.0, 12.0)))
+atom = AtomSpecies("Eu151", 1.0, 6, EU_a_s_dl, 0.0)
+ip = interaction_params_from_constraint(; c_total=EU_c_total, c1_ratio=0.05, F=6)
+
+r = find_ground_state_lbfgs(;
+    grid, atom,
+    interactions=ip,
+    zeeman=ZeemanParams(EU_p_weak, 0.0),
+    potential=HarmonicTrap((1.0, 1.0, EU_λ_z)),
+    enable_ddi=true, c_dd=EU_c_dd,
+    ddi_padding=true, ddi_pad_factor=2,      # the configuration the bug lives in
+    initial_state=:m_plus_F,
+    n_steps=2000, tol=1.0e-8,
+    verbose=false,
+)
+
+ws = r.workspace
+ws.ddi_padded === nothing && error("padded DDI path is not active — probe is vacuous")
+psi = Array(ws.state.psi)
+dV = cell_volume(grid)
+N = 3
+n_pts = grid.config.n_points
+D = ws.spin_matrices.system.n_components
+
+decomp = energy_decomposition(ws)
+
+# Density-weighted |<F>|/F: the rotation-invariant order parameter (<F_z> alone
+# is not invariant at B = 0).
+fx = zeros(Float64, n_pts)
+fy = similar(fx)
+fz = similar(fx)
+SpinorBEC._compute_spin_density!(fx, fy, fz, psi, ws.spin_matrices, Val(D), N, n_pts)
+n_dens = SpinorBEC.total_density(psi, N)
+pol = sum(sqrt.(fx .^ 2 .+ fy .^ 2 .+ fz .^ 2)) / (atom.F * sum(n_dens))
+
+@printf("energy               = %.12g\n", r.energy)
+@printf("energy_ddi           = %.12g\n", decomp.ddi)
+@printf("grad_norm            = %.6e\n", r.grad_norm)
+@printf("polarisation |<F>|/F = %.9f\n", pol)
+@printf("last_step            = %d   stop_reason = %s   converged = %s\n",
+    r.last_step, r.stop_reason, r.converged)
+@printf("line-search evals    = %d\n", r.n_line_search_evals)
+
+jldsave(out;
+    psi=psi, dV=dV,
+    energy=r.energy, energy_ddi=decomp.ddi, grad_norm=r.grad_norm,
+    polarisation=pol, last_step=r.last_step,
+    n_line_search_evals=r.n_line_search_evals,
+    stop_reason=String(r.stop_reason), converged=r.converged,
+    commit=strip(read(`git -C $(joinpath(@__DIR__, "..")) rev-parse --short HEAD`, String)))
+println("wrote $out")

--- a/bench/submit_ddi_gradient_padding_probe.sh
+++ b/bench/submit_ddi_gradient_padding_probe.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# UGE submission (uk07267 / tga-kozuma-kouhi): how far the DDI gradient-padding
+# fix moves a ground state.
+#
+#   qsub -g tga-kozuma-kouhi -N ddipad_probe bench/submit_ddi_gradient_padding_probe.sh
+#
+# Both revisions in ONE job on ONE node: the quantity is a difference between
+# two solves, and a difference measured across two jobs carries a node-to-node
+# confound into the only number the decision rests on.
+#
+# `before` is plain `origin/main` (padded energy, unpadded gradient); `after` is
+# the fix. Everything else — spec, solver, seed — is identical, and the probe
+# script is the SAME FILE in both worktrees.
+#$ -cwd
+#$ -l node_q=1
+#$ -l h_rt=1:30:00
+#$ -j y
+#$ -o /gs/fs/tga-kozuma-kouhi/uk07267/ddi-pad-probe/uge.log
+
+set -euo pipefail
+
+FS=/gs/fs/tga-kozuma-kouhi/uk07267
+BEFORE=${SBEC_BEFORE:-$FS/wt-ddi-before}
+AFTER=${SBEC_AFTER:-$FS/wt-ddi-pad}
+OUT=$FS/ddi-pad-probe
+mkdir -p "$OUT"
+
+. /etc/profile.d/modules.sh
+module load cuda/12.8.0 2>/dev/null || module load cuda 2>/dev/null || true
+[[ -n "${CUDA_HOME:-}" ]] && export LD_LIBRARY_PATH="$CUDA_HOME/lib64:${LD_LIBRARY_PATH:-}"
+
+export JULIA_DEPOT_PATH="${T4_TMPDIR:-/tmp}/.julia:/gs/fs/tga-kozuma-kouhi/shared/.julia"
+mkdir -p "${T4_TMPDIR:-/tmp}/.julia"
+JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia
+export JULIA_NUM_THREADS=${JULIA_NUM_THREADS:-8}
+export SPINORBEC_SCRATCH_DIR="${T4_TMPDIR:-/tmp}/spinorbec_snaps"
+mkdir -p "$SPINORBEC_SCRATCH_DIR"
+
+echo "[ddipad] host=$(hostname)"
+echo "[ddipad] before=$(git -C "$BEFORE" rev-parse --short HEAD)  after=$(git -C "$AFTER" rev-parse --short HEAD)"
+diff -q "$BEFORE/bench/probe_ddi_gradient_padding.jl" \
+        "$AFTER/bench/probe_ddi_gradient_padding.jl" \
+    && echo "[ddipad] probe script identical in both arms" \
+    || { echo "[ddipad] ABORT: probe script differs between arms"; exit 1; }
+
+for entry in "before:$BEFORE" "after:$AFTER"; do
+    tag=${entry%%:*}; root=${entry#*:}
+    echo "########## $tag ##########"
+    cd "$root"
+    "$JULIA" --project=. bench/probe_ddi_gradient_padding.jl solve "$OUT/$tag.jld2" \
+        2>&1 | tee "$OUT/$tag.out"
+done
+
+echo "########## comparison ##########"
+cd "$AFTER"
+"$JULIA" --project=. bench/probe_ddi_gradient_padding.jl compare \
+    "$OUT/before.jld2" "$OUT/after.jld2" 2>&1 | tee "$OUT/compare.out"
+
+echo "[ddipad] done"

--- a/src/hamiltonian/terms/ddi/ddi_term.jl
+++ b/src/hamiltonian/terms/ddi/ddi_term.jl
@@ -111,11 +111,43 @@ Computes spin density + DDI potential first, then accumulates.
 function _grad_ddi!(grad, psi, ws, n_pts, D, ::Val{N}) where {N}
     ws.ddi !== nothing || return nothing
     sm = ws.spin_matrices
-    F = ws.atom.F
-    bufs = ws.ddi_bufs
-    _compute_spin_density!(bufs.Fx_r, bufs.Fy_r, bufs.Fz_r, psi, sm, Val(D), N, n_pts)
-    compute_ddi_potential!(ws.ddi, bufs)
-    phi_x, phi_y, phi_z = bufs.Phi_x, bufs.Phi_y, bufs.Phi_z
+    # Branch on padding exactly as `_ddi_energy` does. Until 2026-07-30 this
+    # function did not, so with `ddi_padding` on — the YAML default since
+    # 2026-07-29 — the gradient came from the bare periodic kernel while the
+    # energy came from the padded one, and L-BFGS/Newton descended one operator
+    # toward the minimum of a different one. The two differ by the periodic-image
+    # field error padding exists to remove (2-5 %).
+    #
+    # Both branches now call the SAME convolution the energy face calls, so the
+    # pair cannot drift again by construction rather than by agreement.
+    ddi_padded = ws.ddi_padded
+    if ddi_padded === nothing
+        bufs = ws.ddi_bufs
+        _compute_spin_density!(bufs.Fx_r, bufs.Fy_r, bufs.Fz_r, psi, sm, Val(D), N, n_pts)
+        compute_ddi_potential!(ws.ddi, bufs)
+        _grad_ddi_accumulate!(
+            grad, psi, bufs.Phi_x, bufs.Phi_y, bufs.Phi_z, ws.atom.F, n_pts, D, Val(N))
+    else
+        _compute_and_convolve_ddi_padded!(psi, sm, ws.ddi, ddi_padded, Val(D), N, n_pts)
+        # `Phi_*_pad` are padded-shaped; the physical field is the `[1:n...]`
+        # CORNER. Cartesian views, not linear indexing — the first `prod(n_pts)`
+        # linear elements walk full padded columns into the pad region for
+        # ndim >= 2 (App. A defect 9).
+        corner = ntuple(d -> 1:n_pts[d], Val(N))
+        _grad_ddi_accumulate!(
+            grad, psi,
+            view(ddi_padded.Phi_x_pad, corner...),
+            view(ddi_padded.Phi_y_pad, corner...),
+            view(ddi_padded.Phi_z_pad, corner...),
+            ws.atom.F, n_pts, D, Val(N))
+    end
+    nothing
+end
+
+# Function barrier: the two branches above hand in differently-typed `phi_*`
+# (a plain array vs a strided corner view), so the accumulation is split out to
+# be specialised on each rather than letting the union leak into the broadcasts.
+function _grad_ddi_accumulate!(grad, psi, phi_x, phi_y, phi_z, F, n_pts, D, ::Val{N}) where {N}
     # Fz part (diagonal)
     for c in 1:D
         idx = _component_slice(N, n_pts, c)

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -110,6 +110,9 @@ const FAST_TESTS = [
     "hamiltonian/test_singlet_pair.jl",
     "hamiltonian/test_batched_kinetic.jl",
     "hamiltonian/test_ddi_padded.jl",
+    # energy and gradient must come from the SAME DDI kernel; test_ddi_padded.jl
+    # never calls either face
+    "hamiltonian/test_ddi_gradient_padding_parity.jl",
     "hamiltonian/test_ddi_padded_zero_pad_invariant.jl",
     # Taylor-Horner spin rotation on the CPU, against the exact Euler 5-stage it
     # replaces. Reads the same SPIN_TAYLOR_TOL[] as the CUDA gate, so relaxing

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -456,6 +456,9 @@ const FULL_EXTRA = [
     # contraction was 25-31 % of the padded convolution on an H100; GPU-only, so
     # a green ci tier says nothing about it.
     "gpu/test_gpu_ddi_contraction_parity.jl",
+    # the padded DDI GRADIENT face reads a strided corner view of Phi_*_pad;
+    # the contraction gate above stops before apply_operator!
+    "gpu/test_gpu_ddi_gradient_padding_parity.jl",
     # The fused diagonal kernel with a TABULATED LHY against the generic
     # broadcast propagator it replaces. Every production Eu run is tabulated and
     # every one of them took the fallback; GPU-only.

--- a/test/gpu/test_gpu_ddi_gradient_padding_parity.jl
+++ b/test/gpu/test_gpu_ddi_gradient_padding_parity.jl
@@ -1,0 +1,81 @@
+using SpinorBEC
+using SpinorBEC: DDITerm, apply_operator!
+using Test
+
+# The padded DDI GRADIENT face, on the GPU.
+#
+# `_grad_ddi!` reads the padded potential as a Cartesian CORNER VIEW of
+# `Phi_*_pad` — a strided, non-contiguous `SubArray` — and broadcasts it against
+# component slices of ψ. On the CPU that is unremarkable. On the GPU it is the
+# class of thing this codebase has been bitten by repeatedly: a view or a host
+# array reaching a device broadcast and either failing to compile
+# ("passing non-bitstype argument") or silently falling back to scalar
+# indexing.
+#
+# `test_gpu_ddi_contraction_parity.jl` already covers the padded CONVOLUTION on
+# device, but it stops at `_compute_and_convolve_ddi_padded!` and never calls
+# `apply_operator!`, so the face this gates was uncovered.
+#
+# Claim: the padded DDI gradient agrees between CPU and GPU. Plus a canary, so
+# that a green result cannot come from padding being a no-op at this size.
+
+const HAS_CUDA = try
+    @eval import CUDA
+    CUDA.functional()
+catch
+    false
+end
+
+function _ddi_ws(backend; padded::Bool, psi0)
+    grid = make_grid(GridConfig((8, 8, 8), (8.0, 8.0, 8.0)))
+    make_workspace(;
+        grid, atom=Na23,
+        interactions=InteractionParams(Dict(0 => 5.0, 1 => -0.2)),
+        potential=HarmonicTrap((1.0, 1.0, 1.0)),
+        sim_params=SimParams(; dt=0.005, n_steps=1), psi_init=copy(psi0),
+        enable_ddi=true, c_dd=1.0,
+        ddi_padding=padded, ddi_pad_factor=2,
+        backend=backend,
+    )
+end
+
+function _ddi_grad(ws)
+    psi = ws.state.psi
+    g = similar(psi)
+    fill!(g, zero(eltype(g)))
+    apply_operator!(g, DDITerm(), ws, psi)
+    Array(g)
+end
+
+@testset "padded DDI gradient: GPU == CPU" begin
+    if !HAS_CUDA
+        @info "CUDA not functional — GPU padded-DDI-gradient gate skipped"
+        @test true
+    else
+        n = (8, 8, 8)
+        grid = make_grid(GridConfig(n, (8.0, 8.0, 8.0)))
+        D = 3
+        psi0 = zeros(ComplexF64, n..., D)
+        for I in CartesianIndices(n)
+            env = exp(-sum(grid.x[d][I[d]]^2 for d in 1:3) / 4)
+            psi0[I, 1] = env
+            psi0[I, 2] = 0.6env * cis(0.4)
+            psi0[I, 3] = 0.3env * cis(-0.9)
+        end
+
+        g_cpu_pad = _ddi_grad(_ddi_ws(CPUBackend(); padded=true, psi0))
+        g_gpu_pad = _ddi_grad(_ddi_ws(CUDABackend(); padded=true, psi0))
+        g_cpu_bare = _ddi_grad(_ddi_ws(CPUBackend(); padded=false, psi0))
+
+        scale = maximum(abs, g_cpu_pad)
+        @test scale > 0
+        @test all(isfinite, g_gpu_pad)
+
+        # Canary: without this the parity below could hold because padding does
+        # nothing at this size, and the padded face would be untested.
+        @test maximum(abs, g_cpu_pad .- g_cpu_bare) / scale > 1.0e-3
+
+        # The claim.
+        @test maximum(abs, g_gpu_pad .- g_cpu_pad) / scale < 1.0e-10
+    end
+end

--- a/test/hamiltonian/test_ddi_gradient_padding_parity.jl
+++ b/test/hamiltonian/test_ddi_gradient_padding_parity.jl
@@ -1,0 +1,125 @@
+using SpinorBEC
+using SpinorBEC: DDITerm, apply_operator!, energy_contribution
+using FFTW
+using LinearAlgebra
+using Random
+using Test
+
+# The DDI energy and gradient must come from the SAME kernel.
+#
+# `_ddi_energy` branches on `ws.ddi_padded`; until 2026-07-30 `_grad_ddi!` did
+# not. With `ddi_padding` on — the YAML default since 2026-07-29 — that meant a
+# padded energy and an unpadded gradient, i.e. L-BFGS and Newton-CG descending
+# one operator toward the minimum of a different one. The two kernels differ by
+# the periodic-image field error that padding exists to remove (2-5 %).
+#
+# Nothing caught it: `test_ddi_padded.jl` never calls `energy_gradient!` or
+# `apply_operator!`, and the FD term-consistency oracle builds its workspaces
+# without DDI at all, let alone with padding.
+#
+# The gate is the finite-difference identity between the two faces,
+#
+#     (E(psi + eps*dpsi) - E(psi)) / eps  ==  Re<grad, dpsi> * dV
+#
+# run with padding ON. Two controls make a green result mean something:
+#
+#   * the same identity with padding OFF must also hold — otherwise a green
+#     padded run could just mean the FD check is insensitive;
+#   * the padded and unpadded gradients must DIFFER — otherwise the padded case
+#     is vacuous at this size and the test proves nothing about padding.
+
+function _ddi_ws(; padded::Bool)
+    grid = make_grid(GridConfig((8, 8, 8), (4.0, 4.0, 4.0)))
+    make_workspace(;
+        grid, atom=Rb87,
+        interactions=InteractionParams(Dict(0 => 0.0, 1 => 0.0)),
+        zeeman=ZeemanParams(0.0, 0.0),
+        potential=HarmonicTrap((1.0, 1.0, 1.0)),
+        sim_params=SimParams(; dt=0.01, n_steps=1, imaginary_time=true),
+        enable_ddi=true, c_dd=1.0,
+        ddi_padding=padded, ddi_pad_factor=2,
+        fft_flags=FFTW.ESTIMATE,
+    )
+end
+
+function _seeded_state(ws, seed)
+    rng = MersenneTwister(seed)
+    D = ws.spin_matrices.system.n_components
+    n_pts = ws.grid.config.n_points
+    psi = randn(rng, ComplexF64, n_pts..., D)
+    psi ./= sqrt(sum(abs2, psi) * cell_volume(ws.grid))
+    psi
+end
+
+# (E(psi + eps*dpsi) - E(psi)) / eps  vs  Re<grad, dpsi> * dV, for the DDI term.
+function _ddi_fd_vs_gradient(ws, psi, dpsi; ε=1.0e-7)
+    dV = cell_volume(ws.grid)
+    grad = similar(psi)
+    fill!(grad, zero(eltype(grad)))
+    apply_operator!(grad, DDITerm(), ws, psi)
+    # Mean-field term: E = (1/2) Re<psi, H psi>, so dE = Re<H psi, dpsi> and the
+    # operator face IS the gradient without a further factor.
+    analytic = real(dot(grad, dpsi)) * dV
+
+    e_plus = energy_contribution(DDITerm(), psi .+ ε .* dpsi, ws)
+    e_zero = energy_contribution(DDITerm(), psi, ws)
+    fd = (e_plus - e_zero) / ε
+    (fd, analytic)
+end
+
+@testset "DDI gradient and energy use the same kernel under padding" begin
+    ws_pad = _ddi_ws(padded=true)
+    ws_bare = _ddi_ws(padded=false)
+    @test ws_pad.ddi_padded !== nothing      # the padded path is really on
+    @test ws_bare.ddi_padded === nothing
+
+    psi = _seeded_state(ws_pad, 20260730)
+    dpsi = _seeded_state(ws_pad, 20260731)
+
+    @testset "canary: the two kernels actually differ here" begin
+        # Without this, everything below could pass because padding happens to
+        # be a no-op at this size — and the bug being gated would be invisible.
+        g_pad = similar(psi)
+        fill!(g_pad, zero(eltype(g_pad)))
+        apply_operator!(g_pad, DDITerm(), ws_pad, psi)
+
+        g_bare = similar(psi)
+        fill!(g_bare, zero(eltype(g_bare)))
+        apply_operator!(g_bare, DDITerm(), ws_bare, psi)
+
+        rel = maximum(abs, g_pad .- g_bare) / maximum(abs, g_bare)
+        @test rel > 1.0e-3
+        @test all(isfinite, g_pad)
+    end
+
+    @testset "FD identity holds WITH padding" begin
+        fd, analytic = _ddi_fd_vs_gradient(ws_pad, psi, dpsi)
+        @test isapprox(fd, analytic; rtol=1.0e-4)
+    end
+
+    @testset "positive control: FD identity holds without padding" begin
+        # If this failed, a green padded case would say nothing — it would mean
+        # the FD comparison itself is not sensitive to the gradient.
+        fd, analytic = _ddi_fd_vs_gradient(ws_bare, psi, dpsi)
+        @test isapprox(fd, analytic; rtol=1.0e-4)
+    end
+
+    @testset "positive control: the FD check can fail" begin
+        # Feed it the WRONG kernel's gradient on purpose — padded energy against
+        # the bare gradient, which is exactly the defect this file gates. It must
+        # be rejected, or the rtol above is too loose to detect it.
+        dV = cell_volume(ws_pad.grid)
+        g_bare = similar(psi)
+        fill!(g_bare, zero(eltype(g_bare)))
+        apply_operator!(g_bare, DDITerm(), ws_bare, psi)
+        wrong = real(dot(g_bare, dpsi)) * dV
+
+        ε = 1.0e-7
+        fd =
+            (
+                energy_contribution(DDITerm(), psi .+ ε .* dpsi, ws_pad) -
+                energy_contribution(DDITerm(), psi, ws_pad)
+            ) / ε
+        @test !isapprox(fd, wrong; rtol=1.0e-4)
+    end
+end

--- a/test/hamiltonian/test_ddi_gradient_padding_parity.jl
+++ b/test/hamiltonian/test_ddi_gradient_padding_parity.jl
@@ -57,9 +57,13 @@ function _ddi_fd_vs_gradient(ws, psi, dpsi; ε=1.0e-7)
     grad = similar(psi)
     fill!(grad, zero(eltype(grad)))
     apply_operator!(grad, DDITerm(), ws, psi)
-    # Mean-field term: E = (1/2) Re<psi, H psi>, so dE = Re<H psi, dpsi> and the
-    # operator face IS the gradient without a further factor.
-    analytic = real(dot(grad, dpsi)) * dV
+    # `apply_operator!` returns dE/dpsi_bar, and the energy's first variation is
+    # dE = 2 Re<dE/dpsi_bar, dpsi> — the Wirtinger factor of 2 that
+    # `energy_gradient!` applies for its callers and that this raw face does not.
+    # Dropping it made BOTH the padded case and the unpadded control fail, which
+    # is the control earning its place: it said the comparison was broken rather
+    # than letting a broken comparison indict the padded path.
+    analytic = 2 * real(dot(grad, dpsi)) * dV
 
     e_plus = energy_contribution(DDITerm(), psi .+ ε .* dpsi, ws)
     e_zero = energy_contribution(DDITerm(), psi, ws)
@@ -112,7 +116,7 @@ end
         g_bare = similar(psi)
         fill!(g_bare, zero(eltype(g_bare)))
         apply_operator!(g_bare, DDITerm(), ws_bare, psi)
-        wrong = real(dot(g_bare, dpsi)) * dV
+        wrong = 2 * real(dot(g_bare, dpsi)) * dV
 
         ε = 1.0e-7
         fd =


### PR DESCRIPTION
`_ddi_energy` branches on `ws.ddi_padded`. `_grad_ddi!` did not. With `ddi_padding` on — the YAML parser default since 2026-07-29 — L-BFGS and Newton-CG accepted steps on the **padded** energy while taking their direction from the **unpadded** gradient.

The endpoint of such a solve is not a stationary point of the energy it reports, and the `grad_norm` it reports is the norm of a different operator's gradient.

## Measured

Eu-151 F=6, 24³, box 12, DDI on, `ddi_padding=true`, `method: lbfgs`, default `tol=1e-8`. Both revisions in one UGE job on one node, same spec, same probe script (byte-identical in both worktrees).

| | before (`main`) | after | Δ |
|---|---|---|---|
| energy | 7.86947853941 | **7.85894088045** | −1.05e-2 |
| energy_ddi | −0.0147881746 | −0.000701430 | +1.41e-2 (21×) |
| **grad_norm** | **3.59e-2** | **7.65e-7** | **4.7e4× lower** |
| polarisation \|⟨F⟩\|/F | 0.293007 | 0.297122 | +1.4 % |
| last_step | 113 | 541 | |
| **1 − \|⟨A\|B⟩\|** | | | **0.450** |

This is not a perturbation. The two states overlap by **55 %**, and the residual on `main` is **3.6e-2** — four and a half decades above the floor this problem actually reaches (7.65e-7, consistent with the ~5e-7 floor measured independently on the contact cell).

**On current `main`, a padded-DDI L-BFGS ground state is badly unconverged and returns quickly and confidently.** The gradient bug predates #210, but #210's floor stop interacts with it: the stop fires when steepest descent finds no decrease, and that direction was built from the wrong gradient, so the solve exits early instead of grinding.

Confound check: the two arms' `src/` differed in exactly two files — this fix, and #212's `fm_contact.jl`. The probe constructs no LHY at all (`spinor_lhy` unset, `c_lhy = 0`), so the second cannot have contributed.

## The fix

Both branches now call the same convolution the energy face calls, so the pair cannot drift again by construction rather than by agreement.

Two details:

- the padded `Phi_*` are read as **Cartesian corner views**. The first `prod(n_pts)` *linear* elements walk full padded columns into the pad region for `ndim >= 2` (App. A defect 9) — this is why `_ddi_energy` indexes with `CartesianIndices(n_pts)`;
- the accumulation moves behind a **function barrier**, because the two branches hand in differently-typed `phi_*` (a plain array vs a strided corner view) and that union should not leak into the broadcasts.

## Why nothing caught it

`test_ddi_padded.jl` never calls `energy_gradient!` or `apply_operator!`, and the FD term-consistency oracle builds its workspaces without DDI at all — so the pair was never compared on this path.

The new gate is the FD identity between the two faces with padding ON, `(E(psi + eps*dpsi) − E(psi))/eps == 2·Re<grad, dpsi>·dV`, with three controls so that green means something:

1. **canary** — the padded and unpadded gradients must actually *differ* at this size, or the padded case is vacuous;
2. **positive control** — the same identity without padding must hold, or the FD comparison is simply insensitive;
3. **positive control** — feeding the check the *wrong* kernel's gradient, which is precisely the defect, must be rejected at the same `rtol`.

Control (2) earned its place immediately: the first version of the gate dropped the Wirtinger factor of 2 and failed on **both** the padded case and the unpadded control — which said the comparison was broken rather than letting a broken comparison indict the fix.

## Verification

`tier=ci` at `c6cbeba7`: **270 files, all passed** (TSUBAME job 8305268).

## Consequence for stored results

This changes every padded-DDI ground state solved by L-BFGS or Newton-CG. ITP and the dynamics propagator are unaffected — `apply_step!` always branched correctly. Padding only became the default on 2026-07-29, so the affected stored set is small and recent — but it includes anything the owed Eu texture recompute would have produced, which is the reason to land this before that runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)