### PR TITLE
docs(runs): cross-reference the duplicated LHY arms, and correct "full_bdg is valid here"

### DIFF
--- a/runs/eu_k3_lhy/LHY_fm_dipolar.yaml
+++ b/runs/eu_k3_lhy/LHY_fm_dipolar.yaml
@@ -31,6 +31,16 @@
 # `icosahedral` while carrying `full_bdg`, which the naming convention forbids.
 # Record: docs/validation/full_bdg_scheme_dependence_eu_f6.md
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
+#
+# ┌ PAIRED ARM (2026-07-31). A sibling `LHY_full_bdg*` config runs the SAME cell
+# │ with `kind: full_bdg`. Both exist because two independent renames of the old
+# │ `LHY_icosahedral*` file chose different targets; kept deliberately, because
+# │ the pair measures the size of full_bdg's scheme dependence at this ladder:
+# │ 0.59327 there vs 0.553422 here, a 7 % spread. THIS arm is the one whose
+# │ ansatz matches the state; that one is the comparator.
+# │
+# └ `factorial_2x4.json` has NO row for either arm — it predates them and its
+#   rows are measured values nobody has re-run.
 # Task #19C — LHY interference at K3=200× cigar regime.
 # Source: scripts/validation/eu_k3_lhy_gen.jl
 # LHY kind = full_bdg (was icosahedral; see the note at the top of this file).

--- a/runs/eu_k3_lhy/LHY_full_bdg.yaml
+++ b/runs/eu_k3_lhy/LHY_full_bdg.yaml
@@ -5,6 +5,30 @@
 # domain -- `epsilon_LHY_F6_Ih` now returns NaN and the table build throws.
 # `full_bdg` diagonalises the coupled problem with no ansatz and is valid here.
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
+#
+# ┌ PAIRED ARM (2026-07-31). A sibling `LHY_fm_dipolar*` config runs the SAME cell
+# │ (same K3, same `initial_state: m_minus_F`) with `kind: fm_dipolar`. Both exist
+# │ because two independent renames of the old `LHY_icosahedral*` file chose
+# │ different targets; kept deliberately, because the pair MEASURES how much the
+# │ scheme dependence below is worth: V_LHY(n=3.7e-3) = 0.59327 here vs 0.553422
+# │ for fm_dipolar, a 7 % spread.
+# │
+# │ CORRECTION to the line above: "`full_bdg` … is valid here" is true about the
+# │ ANSATZ and false about the state. full_bdg has its own validity condition —
+# │ mean-field stability — and this ladder breaks it: max Im omega = 0.396 at
+# │ (c0=3270.05, c1=-16.3502, m_minus_F). Its own warning: the zero-point sum
+# │ drops the complex branches while the counterterms still subtract all 13, so
+# │ eps_LHY is SCHEME-DEPENDENT here. THIS ARM IS THE COMPARATOR, NOT THE ANSWER.
+# │
+# │ The instability is entirely dipolar — DDI off gives max Im omega exactly 0 at
+# │ eps_dd = 0.5402, and full_bdg then agrees with the FM closed form to six
+# │ significant figures. The fm_dipolar sibling is the arm whose ansatz matches
+# │ the state (c1 < 0 makes FM the mean-field ground state) and whose eps_dd sits
+# │ inside Petrov's domain. Record: docs/validation/full_bdg_scheme_dependence_eu_f6.md
+# │
+# └ `factorial_2x4.json` has NO row for either arm — it predates them, and its
+#   rows are measured values that nobody has re-run. Do not read the manifest as
+#   covering this cell's LHY axis.
 # Task #19C — LHY interference at K3=200× cigar regime.
 # Source: scripts/validation/eu_k3_lhy_gen.jl
 # LHY kind = full_bdg. Renamed from LHY_icosahedral.yaml 2026-07-30 so the file

--- a/runs/eu_k3_lhy_control/LHY_fm_dipolar_K0.yaml
+++ b/runs/eu_k3_lhy_control/LHY_fm_dipolar_K0.yaml
@@ -31,6 +31,16 @@
 # `icosahedral` while carrying `full_bdg`, which the naming convention forbids.
 # Record: docs/validation/full_bdg_scheme_dependence_eu_f6.md
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
+#
+# ┌ PAIRED ARM (2026-07-31). A sibling `LHY_full_bdg*` config runs the SAME cell
+# │ with `kind: full_bdg`. Both exist because two independent renames of the old
+# │ `LHY_icosahedral*` file chose different targets; kept deliberately, because
+# │ the pair measures the size of full_bdg's scheme dependence at this ladder:
+# │ 0.59327 there vs 0.553422 here, a 7 % spread. THIS arm is the one whose
+# │ ansatz matches the state; that one is the comparator.
+# │
+# └ `factorial_2x4.json` has NO row for either arm — it predates them and its
+#   rows are measured values nobody has re-run.
 # K3=0 LHY model control — auto-generated.
 # Source: scripts/validation/eu_k3_lhy_control_gen.jl
 # LHY = fm_dipolar (was icosahedral, then full_bdg), K3 = 0, γ_dr = 0. Filename unchanged.

--- a/runs/eu_k3_lhy_control/LHY_full_bdg_K0.yaml
+++ b/runs/eu_k3_lhy_control/LHY_full_bdg_K0.yaml
@@ -5,6 +5,30 @@
 # domain -- `epsilon_LHY_F6_Ih` now returns NaN and the table build throws.
 # `full_bdg` diagonalises the coupled problem with no ansatz and is valid here.
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
+#
+# ┌ PAIRED ARM (2026-07-31). A sibling `LHY_fm_dipolar*` config runs the SAME cell
+# │ (same K3, same `initial_state: m_minus_F`) with `kind: fm_dipolar`. Both exist
+# │ because two independent renames of the old `LHY_icosahedral*` file chose
+# │ different targets; kept deliberately, because the pair MEASURES how much the
+# │ scheme dependence below is worth: V_LHY(n=3.7e-3) = 0.59327 here vs 0.553422
+# │ for fm_dipolar, a 7 % spread.
+# │
+# │ CORRECTION to the line above: "`full_bdg` … is valid here" is true about the
+# │ ANSATZ and false about the state. full_bdg has its own validity condition —
+# │ mean-field stability — and this ladder breaks it: max Im omega = 0.396 at
+# │ (c0=3270.05, c1=-16.3502, m_minus_F). Its own warning: the zero-point sum
+# │ drops the complex branches while the counterterms still subtract all 13, so
+# │ eps_LHY is SCHEME-DEPENDENT here. THIS ARM IS THE COMPARATOR, NOT THE ANSWER.
+# │
+# │ The instability is entirely dipolar — DDI off gives max Im omega exactly 0 at
+# │ eps_dd = 0.5402, and full_bdg then agrees with the FM closed form to six
+# │ significant figures. The fm_dipolar sibling is the arm whose ansatz matches
+# │ the state (c1 < 0 makes FM the mean-field ground state) and whose eps_dd sits
+# │ inside Petrov's domain. Record: docs/validation/full_bdg_scheme_dependence_eu_f6.md
+# │
+# └ `factorial_2x4.json` has NO row for either arm — it predates them, and its
+#   rows are measured values that nobody has re-run. Do not read the manifest as
+#   covering this cell's LHY axis.
 # K3=0 LHY model control — auto-generated.
 # Source: scripts/validation/eu_k3_lhy_control_gen.jl
 # LHY = full_bdg (was icosahedral), K3 = 0, γ_dr = 0. Renamed to match 2026-07-30.

--- a/runs/eu_lhy_longtime/LHY_fm_dipolar_100ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_fm_dipolar_100ms.yaml
@@ -31,6 +31,16 @@
 # `icosahedral` while carrying `full_bdg`, which the naming convention forbids.
 # Record: docs/validation/full_bdg_scheme_dependence_eu_f6.md
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
+#
+# ┌ PAIRED ARM (2026-07-31). A sibling `LHY_full_bdg*` config runs the SAME cell
+# │ with `kind: full_bdg`. Both exist because two independent renames of the old
+# │ `LHY_icosahedral*` file chose different targets; kept deliberately, because
+# │ the pair measures the size of full_bdg's scheme dependence at this ladder:
+# │ 0.59327 there vs 0.553422 here, a 7 % spread. THIS arm is the one whose
+# │ ansatz matches the state; that one is the comparator.
+# │
+# └ `factorial_2x4.json` has NO row for either arm — it predates them and its
+#   rows are measured values nobody has re-run.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = fm_dipolar (was icosahedral, then full_bdg), K3 = 0, duration = 62.83 ω_ref⁻¹ ≈ 100ms

--- a/runs/eu_lhy_longtime/LHY_fm_dipolar_200ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_fm_dipolar_200ms.yaml
@@ -31,6 +31,16 @@
 # `icosahedral` while carrying `full_bdg`, which the naming convention forbids.
 # Record: docs/validation/full_bdg_scheme_dependence_eu_f6.md
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
+#
+# ┌ PAIRED ARM (2026-07-31). A sibling `LHY_full_bdg*` config runs the SAME cell
+# │ with `kind: full_bdg`. Both exist because two independent renames of the old
+# │ `LHY_icosahedral*` file chose different targets; kept deliberately, because
+# │ the pair measures the size of full_bdg's scheme dependence at this ladder:
+# │ 0.59327 there vs 0.553422 here, a 7 % spread. THIS arm is the one whose
+# │ ansatz matches the state; that one is the comparator.
+# │
+# └ `factorial_2x4.json` has NO row for either arm — it predates them and its
+#   rows are measured values nobody has re-run.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = fm_dipolar (was icosahedral, then full_bdg), K3 = 0, duration = 125.66 ω_ref⁻¹ ≈ 200ms

--- a/runs/eu_lhy_longtime/LHY_fm_dipolar_50ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_fm_dipolar_50ms.yaml
@@ -31,6 +31,16 @@
 # `icosahedral` while carrying `full_bdg`, which the naming convention forbids.
 # Record: docs/validation/full_bdg_scheme_dependence_eu_f6.md
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
+#
+# ┌ PAIRED ARM (2026-07-31). A sibling `LHY_full_bdg*` config runs the SAME cell
+# │ with `kind: full_bdg`. Both exist because two independent renames of the old
+# │ `LHY_icosahedral*` file chose different targets; kept deliberately, because
+# │ the pair measures the size of full_bdg's scheme dependence at this ladder:
+# │ 0.59327 there vs 0.553422 here, a 7 % spread. THIS arm is the one whose
+# │ ansatz matches the state; that one is the comparator.
+# │
+# └ `factorial_2x4.json` has NO row for either arm — it predates them and its
+#   rows are measured values nobody has re-run.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = fm_dipolar (was icosahedral, then full_bdg), K3 = 0, duration = 31.42 ω_ref⁻¹ ≈ 50ms

--- a/runs/eu_lhy_longtime/LHY_full_bdg_100ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_full_bdg_100ms.yaml
@@ -5,6 +5,30 @@
 # domain -- `epsilon_LHY_F6_Ih` now returns NaN and the table build throws.
 # `full_bdg` diagonalises the coupled problem with no ansatz and is valid here.
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
+#
+# ┌ PAIRED ARM (2026-07-31). A sibling `LHY_fm_dipolar*` config runs the SAME cell
+# │ (same K3, same `initial_state: m_minus_F`) with `kind: fm_dipolar`. Both exist
+# │ because two independent renames of the old `LHY_icosahedral*` file chose
+# │ different targets; kept deliberately, because the pair MEASURES how much the
+# │ scheme dependence below is worth: V_LHY(n=3.7e-3) = 0.59327 here vs 0.553422
+# │ for fm_dipolar, a 7 % spread.
+# │
+# │ CORRECTION to the line above: "`full_bdg` … is valid here" is true about the
+# │ ANSATZ and false about the state. full_bdg has its own validity condition —
+# │ mean-field stability — and this ladder breaks it: max Im omega = 0.396 at
+# │ (c0=3270.05, c1=-16.3502, m_minus_F). Its own warning: the zero-point sum
+# │ drops the complex branches while the counterterms still subtract all 13, so
+# │ eps_LHY is SCHEME-DEPENDENT here. THIS ARM IS THE COMPARATOR, NOT THE ANSWER.
+# │
+# │ The instability is entirely dipolar — DDI off gives max Im omega exactly 0 at
+# │ eps_dd = 0.5402, and full_bdg then agrees with the FM closed form to six
+# │ significant figures. The fm_dipolar sibling is the arm whose ansatz matches
+# │ the state (c1 < 0 makes FM the mean-field ground state) and whose eps_dd sits
+# │ inside Petrov's domain. Record: docs/validation/full_bdg_scheme_dependence_eu_f6.md
+# │
+# └ `factorial_2x4.json` has NO row for either arm — it predates them, and its
+#   rows are measured values that nobody has re-run. Do not read the manifest as
+#   covering this cell's LHY axis.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = full_bdg (was icosahedral), K3 = 0, duration = 62.83 ω_ref⁻¹ ≈ 100ms

--- a/runs/eu_lhy_longtime/LHY_full_bdg_200ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_full_bdg_200ms.yaml
@@ -5,6 +5,30 @@
 # domain -- `epsilon_LHY_F6_Ih` now returns NaN and the table build throws.
 # `full_bdg` diagonalises the coupled problem with no ansatz and is valid here.
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
+#
+# ┌ PAIRED ARM (2026-07-31). A sibling `LHY_fm_dipolar*` config runs the SAME cell
+# │ (same K3, same `initial_state: m_minus_F`) with `kind: fm_dipolar`. Both exist
+# │ because two independent renames of the old `LHY_icosahedral*` file chose
+# │ different targets; kept deliberately, because the pair MEASURES how much the
+# │ scheme dependence below is worth: V_LHY(n=3.7e-3) = 0.59327 here vs 0.553422
+# │ for fm_dipolar, a 7 % spread.
+# │
+# │ CORRECTION to the line above: "`full_bdg` … is valid here" is true about the
+# │ ANSATZ and false about the state. full_bdg has its own validity condition —
+# │ mean-field stability — and this ladder breaks it: max Im omega = 0.396 at
+# │ (c0=3270.05, c1=-16.3502, m_minus_F). Its own warning: the zero-point sum
+# │ drops the complex branches while the counterterms still subtract all 13, so
+# │ eps_LHY is SCHEME-DEPENDENT here. THIS ARM IS THE COMPARATOR, NOT THE ANSWER.
+# │
+# │ The instability is entirely dipolar — DDI off gives max Im omega exactly 0 at
+# │ eps_dd = 0.5402, and full_bdg then agrees with the FM closed form to six
+# │ significant figures. The fm_dipolar sibling is the arm whose ansatz matches
+# │ the state (c1 < 0 makes FM the mean-field ground state) and whose eps_dd sits
+# │ inside Petrov's domain. Record: docs/validation/full_bdg_scheme_dependence_eu_f6.md
+# │
+# └ `factorial_2x4.json` has NO row for either arm — it predates them, and its
+#   rows are measured values that nobody has re-run. Do not read the manifest as
+#   covering this cell's LHY axis.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = full_bdg (was icosahedral), K3 = 0, duration = 125.66 ω_ref⁻¹ ≈ 200ms

--- a/runs/eu_lhy_longtime/LHY_full_bdg_50ms.yaml
+++ b/runs/eu_lhy_longtime/LHY_full_bdg_50ms.yaml
@@ -5,6 +5,30 @@
 # domain -- `epsilon_LHY_F6_Ih` now returns NaN and the table build throws.
 # `full_bdg` diagonalises the coupled problem with no ansatz and is valid here.
 # Gated by test/oracles/test_lhy_config_validity_domain.jl.
+#
+# ┌ PAIRED ARM (2026-07-31). A sibling `LHY_fm_dipolar*` config runs the SAME cell
+# │ (same K3, same `initial_state: m_minus_F`) with `kind: fm_dipolar`. Both exist
+# │ because two independent renames of the old `LHY_icosahedral*` file chose
+# │ different targets; kept deliberately, because the pair MEASURES how much the
+# │ scheme dependence below is worth: V_LHY(n=3.7e-3) = 0.59327 here vs 0.553422
+# │ for fm_dipolar, a 7 % spread.
+# │
+# │ CORRECTION to the line above: "`full_bdg` … is valid here" is true about the
+# │ ANSATZ and false about the state. full_bdg has its own validity condition —
+# │ mean-field stability — and this ladder breaks it: max Im omega = 0.396 at
+# │ (c0=3270.05, c1=-16.3502, m_minus_F). Its own warning: the zero-point sum
+# │ drops the complex branches while the counterterms still subtract all 13, so
+# │ eps_LHY is SCHEME-DEPENDENT here. THIS ARM IS THE COMPARATOR, NOT THE ANSWER.
+# │
+# │ The instability is entirely dipolar — DDI off gives max Im omega exactly 0 at
+# │ eps_dd = 0.5402, and full_bdg then agrees with the FM closed form to six
+# │ significant figures. The fm_dipolar sibling is the arm whose ansatz matches
+# │ the state (c1 < 0 makes FM the mean-field ground state) and whose eps_dd sits
+# │ inside Petrov's domain. Record: docs/validation/full_bdg_scheme_dependence_eu_f6.md
+# │
+# └ `factorial_2x4.json` has NO row for either arm — it predates them, and its
+#   rows are measured values that nobody has re-run. Do not read the manifest as
+#   covering this cell's LHY axis.
 # Long-time LHY stability ladder — auto-generated.
 # Source: scripts/validation/eu_lhy_longtime_gen.jl
 # LHY = full_bdg (was icosahedral), K3 = 0, duration = 31.42 ω_ref⁻¹ ≈ 50ms


### PR DESCRIPTION
## What happened

Two independent renames of the same five `LHY_icosahedral*` configs picked different targets:

- `9c891b84` → `LHY_full_bdg*`, keeping `kind: full_bdg`
- #215 (mine) → `LHY_fm_dipolar*`, retargeting to `kind: fm_dipolar`

git records a rename as delete+add, so differing destinations **do not conflict** and both landed. Five pairs now run the same cell — same K3, same `initial_state: m_minus_F` — differing only in LHY mode, and neither file mentioned the other.

**My share:** #215 renamed without first running `git log -- runs/eu_k3_lhy*`, which would have shown `9c891b84` already there. That is the same check this session learned to do for stored *results*, not applied to my own rename target.

## Kept as a pair, deliberately

The pair measures something real: `V_LHY(n=3.7e-3)` = **0.59327** (full_bdg) vs **0.553422** (fm_dipolar) — a **7 % spread that is the size of full_bdg's scheme dependence** at this ladder. Deduplicating would throw that away.

So each file now names its sibling and says which one it is.

**The `full_bdg` headers correct their own earlier line** — *"`full_bdg` … is valid here"*. True about the **ansatz**, false about the **state**: `full_bdg` has its own validity condition, mean-field stability, and this ladder breaks it (`max Im ω = 0.396` at `c0=3270.05, c1=−16.3502, m_minus_F`), so ε_LHY is scheme-dependent by its own warning's words. Marked **the comparator, not the answer**.

**The `fm_dipolar` headers** name the sibling so neither reads as the only arm, and state that theirs is the one whose ansatz matches the state (`c₁ < 0` makes FM the mean-field ground state; `ε_dd = 0.5402` is inside Petrov's domain).

## `factorial_2x4.json` deliberately untouched

Its rows are **measured values** — `peak_max`, `ratio`, `classification` — and nobody has run either arm, so a fifth row would be fabricated. Both headers say instead that the manifest has no row for either arm and must not be read as covering this cell's LHY axis.

## Still ungated — stated, not implied

`test_lhy_config_validity_domain.jl` does **not** cover `full_bdg`. It is not a closed form, and its validity condition is a *runtime* property needing the spinor and the density, so it cannot be a config-level assertion. Keeping these five arms makes that follow-up — build each config's table at a small grid and read `max Im ω`, in a slower tier — more worth doing, not less.

Docs-only (comments in `runs/*.yaml`). `tier=fast`: **174 files, all passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)