### PR TITLE
The citation census over-counted by 40%, and only four of the survivors back a claim

### DIFF
--- a/docs/campaign/doc_run_citation_inventory.md
+++ b/docs/campaign/doc_run_citation_inventory.md
@@ -1,85 +1,120 @@
-# Live claims cite evidence that was never in the repository
+# Which cited run directories are missing, and which of them back a claim
 
-**Measured 2026-07-31 on `f2352c7f`.** Closes the gap
-`docs/campaign/CAMPAIGN.md` §1 leaves open — "a guard written to scan only
-`runs/` on main would miss ~251 files. Worth pinning down before S-G0 writes the
-pre-flight check."
+Closes the gap `docs/campaign/CAMPAIGN.md` §1 leaves open — "a guard written to
+scan only `runs/` on main would miss ~251 files. Worth pinning down before S-G0
+writes the pre-flight check."
 
-Pinning it down changed the question. The vintage audit
-([`stored_results_vintage_audit.md`](../validation/stored_results_vintage_audit.md))
-asks whether the 481 stored summaries are current. It presumes the evidence for a
-claim can be found and compared. For a large share of live claims it cannot,
-because the directory the claim cites has never existed in git.
+> ## Correction, same day
+>
+> The first version of this page (PR #220) reported **43 absent of 70 cited, 27
+> never committed**. Re-measured on the same commit with a corrected pattern the
+> numbers are **26 absent of 66**. The over-count was 40 %, and it was mine:
+>
+> 1. `runs/` matched the **tail of a longer token**, so
+>    `spinorbec-runs/fig2_k3zero_v2` — a TSUBAME path, one of them annotated
+>    *"(862 MB, off-repo)"* — read as a broken in-repo citation. Those documents
+>    had recorded their storage location honestly and I marked them delinquent.
+>    4 hits.
+> 2. A family citation `runs/eu_k3_*` was resolved as a **literal directory
+>    named `eu_k3_`**, which does not exist, while `runs/eu_k3_lhy` sits right
+>    there. 3 hits.
+>
+> Both were visible in the hit list and invisible in the count. The lesson is the
+> same one that produced two false alarms in the memory index the same day: **read
+> the matches, not the total.**
 
-## The measurement
+## The census
 
-| | |
-|---|---|
-| distinct top-level `runs/` dirs cited across `docs/**.md` | 70 |
-| …that do not exist in the tree | **43** |
-| …of those, tutorial placeholders (`runs/foo`, `runs/today`, …) | 10 |
-| **real missing directories** | **33** |
-| of which **never committed at any point in history** | **27** |
-| of which once tracked and since removed | 6 |
-| real missing dirs cited by manuscript / validation / research docs | **24** |
+Measured on current `main`, which is moving — several sessions add documents that
+name runs not yet produced, so the absolute number drifts by a few per day.
 
-The 6 that were once tracked are `_loop` (retired 2026-06-08 and moved outside
-the repo), `eu151_edh_ext`, `eu151_mz_scan`, `eu151_phase_pq`,
-`klaus_eu151_v2_full`, `option_gamma_micro`.
+| | on `f2352c7f` (as first reported) | corrected |
+|---|---:|---:|
+| distinct top-level `runs/` names cited | 70 | **66** |
+| absent, excluding tutorial placeholders | 43 | **26** |
+| never committed at any point in history | 27 | **23** |
+| cited by manuscript / validation / research docs | 24 | **21** |
 
-The other **27 were never committed**. They existed in someone's working tree,
-were cited by a document, and the citation is all that remains. A fresh clone has
-never had them. That is not staleness — a stale run can at least be located,
-dated and disqualified. These cannot be compared against anything.
+The headline finding survives the correction: **most of the absent directories
+were never in git at all.** They existed in a working tree, a document cited
+them, and the citation is what remains. That is not staleness — a stale run can
+be located, dated and disqualified, which is exactly what
+[`stored_results_vintage_audit.md`](../validation/stored_results_vintage_audit.md)
+does.
 
-## Where it bites hardest
+## The part that actually matters: only four back a live claim
 
-`manuscript/shared/figures.md` — the thesis figure registry — cites **five**
-missing directories (`lyapunov_diagnostic_round6`, `sigma_mu_scan_round5`,
-`species_scan_round6`, `paper4_meanfield`, `ensemble_traces_round5`) and carries
-no vintage pointer. Each row names a figure and the run its data came from; none
-of those runs is in the repo.
+The first version implied 24 wounded claims. Reading the citing context rather
+than counting the citations gives a very different split.
 
-Other evidence citations resolving to nothing:
+### Planned, not claimed — 6
 
-| cited path | claimed by |
-|---|---|
-| `runs/lhy_mode_ablation/` (+5 mode subdirs) | `Ch2_framework.md`, `Ch5_TWA_chaotic_dynamics_integrated.md`, `AppendixB_spinorbec_api.md` — the LHY-insufficiency result (Ch.5 §5.2, T3.1) |
-| `runs/fig2_k3zero_v2`, `runs/fig2_k3zero_v3` | `four_figure_spec_2026_05_26.md` — Figure 2, whose premise a re-derivation already found gone |
-| `runs/twa_sinatra/` | `figures_update_2026-05-11.md`, `AppendixB`, `Ch5_TWA` |
-| `runs/lhy_ablation_v2` | `research_notes/eu_collapse_lhy_insufficient.md` |
-| `runs/ddi_convention_factorial/results.jld2` | `self_contained_validation_report.md` |
-| `runs/fortress_compare/spinorbec_side/` | `fortress_cross_check_scope.md` |
-| `runs/sprint5_M1_multistart_groundstate/` | `m1_groundstate_audit_2026-06-08.md` |
-| `runs/_loop/{theorist,sim}/turn_115.md` | `paper3_universal_theorem/sign_pattern_lemma1_general_S.md` — the derivation provenance for Lemma 1, in a tree deliberately moved outside this repo |
-| `runs/{Cr,Er,Eu,Dy}_eps*_*/`, `runs/Eu151_GS_64g` | `AppendixB_spinorbec_api.md` |
+Five rows in `manuscript/shared/figures.md` (`paper4_meanfield`,
+`sigma_mu_scan_round5`, `species_scan_round6`, `lyapunov_diagnostic_round6`,
+`ensemble_traces_round5`) plus `sigma_mu_scan_*` in
+`paper4_chaotic_dynamics/main.md`. **Every one of those figure rows carries status
+`placeholder`** — 22 of the file's ~33 rows do. They name the data source a figure
+is *intended* to use. Nothing is claimed, nothing needs retracting; the run has to
+exist by the time the figure does.
+
+*(The first version called this file "the worst single file". It is not. It is a
+plan, and reading its status column would have said so.)*
+
+### Recoverable, wrong path — 1
+
+`runs/_loop/{theorist,sim}/turn_115.md`, the derivation provenance for Lemma 1 in
+`paper3_universal_theorem`. The loop was retired 2026-06-08 and moved
+**deliberately** to `BEC-simulation-archive/loop_record_2026_06_08/`, where
+`sim/turn_115.md` and `judge/turn_115.json` are present — verified. Nothing is
+lost; the citation points at the pre-move path. Repointing it is a doc fix.
+
+### Index and example rows — 15
+
+`AppendixB_spinorbec_api.md`'s run-directory table (`Cr_eps0.15_*`, `Dy_eps1.39_*`,
+`Er_eps0.88_*`, `Eu_eps0.55_*`, `Eu151_GS_64g`, `eu151_klaus_lab_units`,
+`lhy_mode_ablation/*` subdirs), and command examples in `guides/` and
+`design/scan_group_redesign.md` (`eu151_edh_ext`, `eu151_mz_scan`,
+`eu151_phase_pq`, `eu151_phi_omega`, `klaus_eu151_v2_full`, `option_gamma_micro`,
+`12174e883326ecac`). These describe a tree the reader does not have. They mislead,
+but they assert no result.
+
+### Live claims with a stated result — 4
+
+**This is the regenerate-or-retract list.**
+
+| run | claim | where |
+|---|---|---|
+| `lhy_mode_ablation` | LHY-insufficiency | `Ch5_TWA_chaotic_dynamics_integrated.md` §5.2 gives the config inline (Eu F=6, a_s=110a_B, N=10⁴, 32³ box=10) and the summary table records the verdict "LHY-insufficient"; indexed from `Ch2_framework.md` |
+| `twa_sinatra` | GS-resolution artifact | `Ch5` §5.7 table row, and `figures_update_2026-05-11.md` sources `thesis_FIG-5.6` from it (32³ vs 2×16³) |
+| `sprint5_M1_multistart_groundstate` | multistart ground-state audit (B × Ω, Eu F=6, 24³) | `research_notes/m1_groundstate_audit_2026-06-08.md` |
+| `ddi_convention_factorial` | the DDI convention factorial | `self_contained_validation_report.md`: "Output: `runs/ddi_convention_factorial/results.jld2`" |
+
+`fortress_compare` is a fifth citation but the document is a **scope** doc naming
+an output path for work not yet done, so it is a plan like the figure rows.
+
+For these four there is no config to re-run and no output to compare, so the
+decision cannot be made by looking at the run. Each needs a judgement: is the
+claim load-bearing enough to regenerate the run from its inline parameters — §5.2
+does state them — or should the claim be marked as resting on evidence the
+repository does not hold?
 
 ## The vintage pointer covers 5 documents, not 7
 
-The audit states that each of the documents citing stored runs "now carries a
-one-line pointer here". Of the seven it lists, **five do**. Two never got it:
-`manuscript/shared/figures.md` and
-`manuscript/klaus_quench_protocol_spec_2026_05_26.md`. Across all 27 documents
-that cite `runs/` paths, 5 carry the pointer.
+The audit states that each document citing stored runs "now carries a one-line
+pointer here". Of the seven it lists, five do; `manuscript/shared/figures.md` and
+`manuscript/klaus_quench_protocol_spec_2026_05_26.md` never got it.
 
-## What this means for the campaign
+## The gate, and what is wrong with its shape
 
-The charter's framing — *"not to re-run 230 suites; to make every live claim
-re-derivable"* — still holds, but the work splits in two, and only one half is
-re-derivation:
+`test/oracles/test_doc_run_citations_resolve.jl` fails when a document cites a
+`runs/` path that does not resolve, as a ratchet: existing breakage is pinned in
+`KNOWN_UNRESOLVED`, and what is asserted is that the set does not grow. It is
+checked in both directions so the list cannot rot.
 
-1. **Claims whose run exists somewhere** (the 481, in five worktrees). Locate,
-   check ancestry against the fix-list, re-run what a live document claims.
-   `project_stored_results_inventory_2026_07_30` in memory has the locations.
-2. **Claims whose run never existed in the repo** (27 directories, 24 of them
-   cited by manuscript/validation/research docs). Nothing to compare to and no
-   config to re-run from. Each is a regenerate-or-retract decision, and it cannot
-   be made by looking at the run — the run is gone. This is the half nobody has
-   scoped.
-
-Neither half is started here. What is installed is the gate that stops the
-population growing: `test/oracles/test_doc_run_citations_resolve.jl` fails when a
-document cites a `runs/` path that does not resolve, unless the path is an
-allowlisted tutorial placeholder or an explicitly recorded external/retired tree.
-A citation that cannot be followed is not evidence, and the cheapest moment to
-say so is before it merges.
+**A name list is the wrong shape and should be replaced.** Every session that adds
+a document naming a run it has not produced yet must edit a central list in a test
+file — churn, and an invitation to append rather than think. The right shape is a
+marker at the citation site (`(planned)`, `(off-repo)`, `(archived)`), so the
+knowledge lives where the author is and the list shrinks to the genuinely
+unexplained. Not done here: it means editing ~30 citation sites in documents
+several sessions are actively rewriting, and it would collide.

--- a/test/oracles/test_doc_run_citations_resolve.jl
+++ b/test/oracles/test_doc_run_citations_resolve.jl
@@ -1,11 +1,19 @@
 # Gate: a document may not cite a `runs/` path that does not exist.
 #
-# Measured 2026-07-31: of 70 distinct top-level `runs/` directories cited across
-# `docs/**.md`, 43 are absent, and 27 of those were NEVER COMMITTED at any point
-# in history — they lived in someone's working tree, a document cited them, and
-# the citation is all that survives. `manuscript/shared/figures.md`, the thesis
-# figure registry, names five of them. See
-# `docs/campaign/doc_run_citation_inventory.md`.
+# CORRECTED 2026-07-31 (same day): the first version of this file over-counted by
+# 40 %. Its pattern had two defects, both found by reading the hits rather than
+# the count.
+#
+#   1. `runs/` matched the TAIL of a longer token, so `spinorbec-runs/fig2_k3zero_v2`
+#      — a TSUBAME path a document was recording honestly, one of them annotated
+#      "(862 MB, off-repo)" — was read as a broken in-repo citation. 4 of them.
+#   2. A glob citation like `runs/eu_k3_*` was resolved as a literal directory
+#      named `eu_k3_`, which of course does not exist, while `runs/eu_k3_lhy` sits
+#      right there. 3 of them.
+#
+# At the commit the inventory measured, absent goes 43 -> 26 once both are fixed.
+# See `docs/campaign/doc_run_citation_inventory.md` for the corrected census and
+# for which of the survivors actually back a claim — most do not.
 #
 # That is a different failure from the one `stored_results_vintage_audit.md`
 # tracks. A stale run can be located, dated and disqualified; these cannot be
@@ -29,29 +37,49 @@ const PLACEHOLDERS = Set([
     "tsubame_scan", "_dashboard_cache",
 ])
 
-# Cited, absent, and known. Each is a claim whose evidence cannot be followed.
-# Shrinking this list is the campaign's job; growing it is what this gate stops.
+# Cited, absent, and known. Regenerated 2026-07-31 with the corrected pattern.
+#
+# A NAME list churns: every session that adds a document naming a run it has not
+# produced yet has to edit this file. The better shape is a marker at the citation
+# site — `(planned)`, `(off-repo)`, `(archived)` — so the knowledge lives where the
+# author is, and this list shrinks to the genuinely unexplained. That redesign is
+# deliberately NOT done here, because it means editing ~30 citation sites across
+# documents several sessions are actively rewriting, and it would collide.
 const KNOWN_UNRESOLVED = Set([
-    # never committed — no config, no output, no history
-    "Cr_eps0.15_", "Dy_eps1.39_", "Er_eps0.88_", "Eu_eps0.55_", "Eu151_GS_64g",
-    "ddi_convention_factorial", "ensemble_traces_round5", "eu151_",
-    "eu_k3_", "eu_shape_optimization", "fig2_k3zero_v2", "fig2_k3zero_v3",
-    "fortress_compare", "klaus_", "lhy_ablation_v2", "lhy_mode_ablation",
-    "lyapunov_diagnostic_round6", "paper4_meanfield", "sigma_mu_scan_",
-    "sigma_mu_scan_round5", "species_scan_round6", "sprint5_M1_",
-    "sprint5_M1_multistart_groundstate", "twa_sinatra", "eu151_klaus_lab_units",
-    "eu151_phi_omega", "12174e883326ecac",
-    # once tracked, since removed. `_loop` was retired 2026-06-08 and moved to
-    # BEC-simulation-archive/ deliberately; the rest simply went.
-    "_loop", "eu151_edh_ext", "eu151_mz_scan", "eu151_phase_pq",
-    "klaus_eu151_v2_full", "option_gamma_micro",
+    "12174e883326ecac", "Cr_eps0.15_", "Dy_eps1.39_", "Er_eps0.88_",
+    "Eu151_GS_64g", "Eu_eps0.55_", "_loop", "ddi_convention_factorial",
+    "ensemble_traces_round5", "eu151_b1_c1_sweep_template", "eu151_edh_ext",
+    "eu151_klaus_lab_units", "eu151_mz_scan", "eu151_phase_pq",
+    "eu151_phi_omega", "fortress_compare", "klaus_eu151_mechanism_",
+    "klaus_eu151_spin_excitation", "klaus_eu151_v2_full", "klaus_option_gamma",
+    "klaus_option_gamma_full", "lhy_mode_ablation", "lyapunov_diagnostic_round6",
+    "option_gamma_micro", "option_gamma_smoke", "paper4_meanfield",
+    "sigma_mu_scan_", "sigma_mu_scan_round5", "species_scan_round6",
+    "sprint5_M1_", "sprint5_M1_multistart_groundstate", "twa_sinatra",
+    "validation_level",
 ])
+
+"""A citation resolves if the directory exists, or — for a family written
+`runs/foo_*` — if anything matches the prefix. Treating the stem as a literal
+directory name is what made `runs/eu_k3_*` look broken next to `runs/eu_k3_lhy`."""
+function _resolves(d)
+    isdir(joinpath(_RUNS_DIR, d)) && return true
+    # Prefix-match ONLY for a family stem — the `*` is stripped above, so the
+    # trailing underscore is what is left of `runs/foo_*`. Applying the prefix
+    # rule to every name would let `runs/eu151_edh_ext` resolve against any
+    # directory that merely starts with it, which is a different claim.
+    endswith(d, '_') || return false
+    isdir(_RUNS_DIR) || return false
+    any(startswith(n, d) for n in readdir(_RUNS_DIR))
+end
 
 """Top-level `runs/<dir>` names cited by each doc, with the citing file."""
 function _cited_run_dirs()
     out = Dict{String, Vector{String}}()
     isdir(_DOCS) || return out
-    pat = r"runs/([A-Za-z0-9_][A-Za-z0-9_.*-]*)"
+    # `(?<![\w/-])` keeps `spinorbec-runs/x` and `some/runs/x` out. Without it
+    # the tail of any longer token reads as an in-repo citation.
+    pat = r"(?<![\w/-])runs/([A-Za-z0-9_][A-Za-z0-9_.*-]*)"
     for (root, _, names) in walkdir(_DOCS), n in names
         endswith(n, ".md") || continue
         path = joinpath(root, n)
@@ -75,10 +103,8 @@ end
         @test length(cited) > 20
     end
 
-    unresolved = sort([
-        d for d in keys(cited)
-              if !(d in PLACEHOLDERS) && !isdir(joinpath(_RUNS_DIR, d))
-    ])
+    unresolved = sort([d for d in keys(cited)
+                             if !(d in PLACEHOLDERS) && !_resolves(d)])
 
     @testset "no NEW unresolved citation" begin
         fresh = [d for d in unresolved if !(d in KNOWN_UNRESOLVED)]
@@ -94,8 +120,7 @@ end
         # An entry that now resolves, or that nothing cites any more, is an
         # excuse outliving its reason. Both directions, so the list tracks
         # reality instead of accumulating.
-        resolved_again = sort([d for d in KNOWN_UNRESOLVED
-                                     if isdir(joinpath(_RUNS_DIR, d))])
+        resolved_again = sort([d for d in KNOWN_UNRESOLVED if _resolves(d)])
         @test resolved_again == String[]
         uncited = sort([d for d in KNOWN_UNRESOLVED if !haskey(cited, d)])
         @test uncited == String[]


### PR DESCRIPTION
Corrects #220, which I merged this morning. It over-counted by 40 %, and — more
importantly — it mis-read what the survivors mean.

## The count

#220: **43 absent of 70 cited, 27 never committed.** Same commit, corrected
pattern: **26 absent of 66, 23 never committed.**

Two defects, both mine, both visible in the hit list and invisible in the count:

1. `runs/` matched the **tail of a longer token**, so
   `spinorbec-runs/fig2_k3zero_v2` — a TSUBAME path, one of them annotated
   *"(862 MB, off-repo)"* — read as a broken in-repo citation. **Those documents
   had recorded their storage location honestly and I marked them delinquent.**
   4 hits.
2. A family citation `runs/eu_k3_*` resolved as a literal directory named
   `eu_k3_`, which does not exist, while `runs/eu_k3_lhy` sits right there. 3 hits.

Fixed: `(?<![\w/-])runs/`, and prefix-matching only for a family stem. The
inventory carries a correction notice rather than a quiet edit.

## The interpretation was worse than the count

#220 implied **24 wounded claims**. Reading the citing *context* instead of
counting citations:

| bucket | n | what it means |
|---|---:|---|
| **Planned, not claimed** | 6 | Five rows of `manuscript/shared/figures.md` + one in `paper4/main.md`. **Every one carries status `placeholder`** — as do 22 of that file's ~33 rows. They name the data source a figure is *intended* to use. #220 called this "the worst single file"; it is a plan, and reading its status column would have said so. |
| **Recoverable, wrong path** | 1 | Lemma 1's provenance cites `runs/_loop/…`. The loop was retired 2026-06-08 and moved **deliberately** to `BEC-simulation-archive/loop_record_2026_06_08/`, where `sim/turn_115.md` and `judge/turn_115.json` are present — verified. A doc fix, not a lost claim. |
| **Index / example rows** | 15 | `AppendixB`'s run-directory table, command examples in `guides/`. They describe a tree the reader lacks; they assert no result. |
| **Live claims with a stated result** | **4** | the actual regenerate-or-retract list |

The four:

| run | claim | where |
|---|---|---|
| `lhy_mode_ablation` | LHY-insufficiency | `Ch5` §5.2 — config stated inline (Eu F=6, a_s=110a_B, N=10⁴, 32³ box=10), verdict in the summary table |
| `twa_sinatra` | GS-resolution artifact | `Ch5` §5.7 + `thesis_FIG-5.6` |
| `sprint5_M1_multistart_groundstate` | multistart GS audit (B × Ω, 24³) | `m1_groundstate_audit_2026-06-08.md` |
| `ddi_convention_factorial` | DDI convention factorial | `self_contained_validation_report.md` |

**Four, not twenty-four.** §5.2 states its parameters inline, so regeneration is
possible there; what remains is a judgement about whether the claim is
load-bearing enough to spend on.

## Two smaller things

**The gate's name list is the wrong shape**, recorded in the doc. Every session
that adds a document naming an unproduced run must edit a central list in a test
file — churn, and an invitation to append rather than think. The right shape is a
marker at the citation site (`(planned)`, `(off-repo)`, `(archived)`). Not done
here: ~30 sites in documents several sessions are actively rewriting, and it would
collide.

**One self-reference removed.** The inventory wrote `runs/fig2_k3zero_v2` in
prose, so the document *about* broken citations was counted as one. Rewritten
without the prefix rather than exempting the file — an exemption is how a blind
spot starts.

## Verification

TSUBAME job 8308036 (cpu_4, `OPENBLAS_NUM_THREADS=1`): **14/14** against current
main. Docs + one test; no source diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
