### PR TITLE
fix(test): the citation gate went red on an archive import, not on a new claim

### DIFF
--- a/test/oracles/test_doc_run_citations_resolve.jl
+++ b/test/oracles/test_doc_run_citations_resolve.jl
@@ -56,6 +56,20 @@ function _cited_run_dirs()
         endswith(n, ".md") || continue
         path = joinpath(root, n)
         rel = relpath(path, _DOCS)
+        # `docs/archive/` is out of scope, deliberately. An archive is a RECORD of
+        # what was thought at a date, not a live claim, so requiring its citations
+        # to resolve contradicts what archiving it means — and the alternative,
+        # pinning them in KNOWN_UNRESOLVED, grows the very list this gate exists to
+        # stop growing.
+        #
+        # Not hypothetical: #221 imported research notes into docs/archive/ AFTER
+        # #220 measured this gate's baseline, which put main red on 7 names
+        # (eu151_b1_c1_sweep_template, klaus_eu151_mechanism_,
+        # klaus_eu151_spin_excitation, klaus_option_gamma, klaus_option_gamma_full,
+        # option_gamma_smoke, validation_level) cited from exactly two archived
+        # files and from nothing live. Nobody saw it because the required checks do
+        # not cover the ci or oracles tiers.
+        startswith(rel, "archive/") && continue
         for m in eachmatch(pat, read(path, String))
             # Trim trailing punctuation and the glob star a doc writes for a family.
             d = rstrip(m.captures[1], ['*', '.', ',', ')', ';', ':', '`'])


### PR DESCRIPTION
`test_doc_run_citations_resolve.jl` has been failing on **main** since #221. The required checks do not cover the tiers it runs in (`ci` / `oracles`), so nothing on a PR page showed it — and any PR touching `test/oracles/` inherits the red. #222 is currently blocked on exactly this.

## Ordering, not content

- **#220** (`02149280`) added the gate and measured its `KNOWN_UNRESOLVED` baseline
- **#221** (`39f67729`) then imported research notes into `docs/archive/`, and the gate walks `docs/**`, so those came into scope — adding seven names:

```
eu151_b1_c1_sweep_template, klaus_eu151_mechanism_, klaus_eu151_spin_excitation,
klaus_option_gamma, klaus_option_gamma_full, option_gamma_smoke, validation_level
```

Checked before deciding: **all seven are cited from exactly two files, both under `docs/archive/`, and from nothing live.**

## Excluded rather than pinned

`docs/archive/` leaves the sweep. An archive is a *record of what was thought at a date*, not a live claim — requiring its citations to resolve contradicts what archiving it means. The alternative, adding the seven to `KNOWN_UNRESOLVED`, would grow the very list this gate exists to keep from growing, and would do it for citations nobody is making any more.

## Verified the exclusion does not hollow the gate out

A narrower sweep is exactly how this kind of fix goes wrong, so:

| check | before | after |
|---|---:|---:|
| cited directories | 81 | **71** |
| gate's own anti-vacuity floor | `> 20` | still far above |

- only the 10 archive-only names leave
- **the reverse direction still holds**: `uncited` is empty, so every `KNOWN_UNRESOLVED` entry is still cited from a **live** document. Had the exclusion orphaned an entry, that check would have caught it — which is why it is there.

14/14.

## Not fixed here, and not what CI was failing on

`test_spin_chain_fusion_parity.jl` also fails locally, at **1e-10 against a bit-identity claim**. It is GPU-only (`if !CUDA.functional()` skips it), so **CI never ran it** and it does not block anything. Both the fused half-step (`35db9a68`) and the DDI kernel (#216) moved recently, so which one moved it needs separating. #209's body already reported this failure as unrelated to its own work; I am looking at it next, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)