### PR TITLE
fix(campaign): drop the seven allowlist entries nothing cites any more

### DIFF
--- a/test/oracles/test_doc_run_citations_resolve.jl
+++ b/test/oracles/test_doc_run_citations_resolve.jl
@@ -48,15 +48,14 @@ const PLACEHOLDERS = Set([
 const KNOWN_UNRESOLVED = Set([
     "12174e883326ecac", "Cr_eps0.15_", "Dy_eps1.39_", "Er_eps0.88_",
     "Eu151_GS_64g", "Eu_eps0.55_", "_loop", "ddi_convention_factorial",
-    "ensemble_traces_round5", "eu151_b1_c1_sweep_template", "eu151_edh_ext",
+    "ensemble_traces_round5", "eu151_edh_ext",
     "eu151_klaus_lab_units", "eu151_mz_scan", "eu151_phase_pq",
-    "eu151_phi_omega", "fortress_compare", "klaus_eu151_mechanism_",
-    "klaus_eu151_spin_excitation", "klaus_eu151_v2_full", "klaus_option_gamma",
-    "klaus_option_gamma_full", "lhy_mode_ablation", "lyapunov_diagnostic_round6",
-    "option_gamma_micro", "option_gamma_smoke", "paper4_meanfield",
+    "eu151_phi_omega", "fortress_compare",
+    "klaus_eu151_v2_full",
+    "lhy_mode_ablation", "lyapunov_diagnostic_round6",
+    "option_gamma_micro", "paper4_meanfield",
     "sigma_mu_scan_", "sigma_mu_scan_round5", "species_scan_round6",
     "sprint5_M1_", "sprint5_M1_multistart_groundstate", "twa_sinatra",
-    "validation_level",
 ])
 
 """A citation resolves if the directory exists, or — for a family written


### PR DESCRIPTION
`main` is red at `2d19ce00` on `the known-unresolved list does not rot`.

Two changes, each correct against the tree it was measured on, are not correct together:

| | |
|---|---|
| **#227** | re-censused the citations and added seven names to `KNOWN_UNRESOLVED`. All seven were cited by `docs/archive/option_gamma_rotating_basis_design.md` and `docs/archive/validation_ladder_2026-05-22.md`. |
| **#228** | removed those two documents from the repository — which is what put the seven citations there in the first place. |

So the entries sit pinned as known-unresolved while nothing cites them. That is precisely the rot the second half of the gate exists to catch:

```
the known-unresolved list does not rot: Test Failed
  Evaluated: ["eu151_b1_c1_sweep_template", "klaus_eu151_mechanism_",
              "klaus_eu151_spin_excitation", "klaus_option_gamma",
              "klaus_option_gamma_full", "option_gamma_smoke",
              "validation_level"] == String[]
```

Removing them is what the gate asks for, and it moves the list in the shrinking direction. Verified against `origin/main`: `documents cite runs/ paths that resolve | 14 pass, 14 total`.

## How it got in

Neither PR's CI could have seen it. #228's branch was cut from `bc23d150`, before #227 existed; the merge order was #227 then #228; and GitHub does not re-run a PR's checks against the base it will actually land on. #228 was green on a base that no longer existed by the time it merged.

The gate caught the combination on the very next run, which is the outcome it was built for — but it caught it on `main` rather than on a PR. Worth noting alongside #226: required checks currently say "this branch was green against *some* base", not "main will be green after this merges".

I collided with another session's work here; #227 and #228 were two sessions fixing the same red in opposite directions, unaware of each other.