### PR TITLE
ci: stop cancelling main's post-merge verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs on a PR — pushing a fixup should not leave the previous
+# commit's run burning a runner. Never cancel a push to `main`: that run is the
+# only verification the merged commit ever gets, and `github.ref` is
+# `refs/heads/main` for every one of them, so back-to-back merges were killing
+# each other's. Measured 2026-07-31: 13 of the last 30 `main` runs ended
+# `cancelled`, i.e. 43 % of merges landed with no completed check of the tree
+# they produced. Same group, so rapid merges queue instead of racing; each one
+# still runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Opt into Node.js 24 ahead of the September 2026 forced migration so we
 # don't carry deprecation warnings on every run.


### PR DESCRIPTION
`cancel-in-progress: true` applies to every trigger, and `github.ref` is `refs/heads/main` for *every* push to main — so back-to-back merges cancel each other's run.

Measured over the last 30 `main` runs:

| conclusion | count |
|---|---|
| success | 16 |
| **cancelled** | **13** |
| failure | 1 |

**43 % of merges landed with no completed check of the tree they produced.**

## Why that matters more than it looks

A PR's checks run against the base it was *cut from*, not the base it *lands on*, and GitHub does not re-run them at merge time. That is exactly how #227 and #228 were each green and still left `main` red: #227 added seven names to the citation allowlist, #228 removed the two documents that cited them, and the combination — which no PR run ever saw — is what the gate rejects.

The post-merge run on `main` is the only thing that looks at the merged tree. It is being killed 43 % of the time.

## Change

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Cancellation stays on for `pull_request`, where it is doing the right thing — pushing a fixup should not leave the superseded commit's run burning a runner. The group is unchanged, so rapid merges queue rather than race; every commit still gets a run.

## Not in this PR

Enabling "Require branches to be up to date before merging" would close the #227 × #228 class at the source rather than detecting it after the fact. That is a branch-protection setting with a real cost — every PR needs an update button press when main moves — so it is a call for the repo owner, not a file in this diff.