### PR TITLE
test(oracles): scope the citation gate to live documentation

### DIFF
--- a/test/oracles/test_doc_run_citations_resolve.jl
+++ b/test/oracles/test_doc_run_citations_resolve.jl
@@ -83,6 +83,22 @@ function _cited_run_dirs()
         endswith(n, ".md") || continue
         path = joinpath(root, n)
         rel = relpath(path, _DOCS)
+        # `docs/archive/` is out of scope. This gate is about LIVE claims: a
+        # document saying "see runs/x" is asserting that evidence can be
+        # followed. Archived documents are, by that directory's own README,
+        # "kept for historical context but not part of the live documentation
+        # set" — a run they name is part of the record of what was done at the
+        # time, not a pointer a reader is meant to follow today.
+        #
+        # Without this, importing a historical document is enough to fail the
+        # gate, and the only ways out are to widen KNOWN_UNRESOLVED (which is
+        # the one thing it exists to stop) or to keep the document out of the
+        # repository. That happened on 2026-07-31 and cost two round trips.
+        #
+        # Measured before making the change: no cited name appears ONLY under
+        # `archive/`, so nothing is hidden today and no KNOWN_UNRESOLVED entry
+        # becomes uncited. This is scope, not amnesty.
+        startswith(rel, "archive" * Base.Filesystem.path_separator) && continue
         for m in eachmatch(pat, read(path, String))
             # Trim trailing punctuation and the glob star a doc writes for a family.
             d = rstrip(m.captures[1], ['*', '.', ',', ')', ';', ':', '`'])
@@ -95,6 +111,18 @@ end
 
 @testset "documents cite runs/ paths that resolve" begin
     cited = _cited_run_dirs()
+
+    # The scope exclusion is load-bearing, so assert it directly rather than
+    # trusting the `continue` above. Archived docs DO cite runs/ paths (AUDIT_BUG4
+    # and MEASUREMENT_CAMPAIGN_PHASE2 between them name three), so this is not
+    # vacuous: delete the exclusion and those citers reappear here.
+    @testset "archived docs are out of scope" begin
+        from_archive = sort([
+            "$d <- $f" for (d, fs) in cited for f in fs if
+            startswith(f, "archive" * Base.Filesystem.path_separator)
+        ])
+        @test from_archive == String[]
+    end
 
     @testset "the sweep found citations" begin
         # A zero here makes every assertion below vacuous — the same shape this


### PR DESCRIPTION
`docs/archive/` is now out of scope for the run-citation gate.

## Why

That gate is about **live claims**. A document saying "see `runs/x`" asserts that the evidence can be followed. Archived documents are, by that directory's own README, *"kept for historical context but not part of the live documentation set"* — a run they name is part of the record of what was done at the time, not a pointer a reader is meant to follow today.

Without the scope, importing a historical document is by itself enough to fail the gate, and the only ways out are to widen `KNOWN_UNRESOLVED` — the one thing the gate exists to stop — or to keep the document out of the repository entirely. That is exactly what happened on 2026-07-31: #228 removed two promoted notes for this reason, and #232 then had to clean up the allowlist entries #227 had added for the same seven citations.

## Why this is scope and not amnesty

Measured on this branch's base *before* making the change:

```
cited names appearing ONLY in docs/archive/:  String[]
  of those, in KNOWN_UNRESOLVED:              String[]
```

Nothing is hidden today, and no `KNOWN_UNRESOLVED` entry becomes uncited (which would trip the rot check). The change is forward-looking only.

## The exclusion is asserted, not assumed

A `continue` in a walker is easy to delete by accident, so there is a testset that fails on any citer under `archive/`.

**Canaried, and not vacuous** — with the exclusion removed it reports 16 citations from four archived documents:

```
archived docs are out of scope: Test Failed
  Evaluated: ["barnett_eu_window <- archive/klaus_quench_protocol_pivot_2026-05-26.md",
              "eu151_edh <- archive/AUDIT_BUG4.md",
              "measurement_R3x_eu <- archive/MEASUREMENT_CAMPAIGN_PHASE2.md", ...]
```

Two of those four documents predate today's work, so this is not a rule written around my own imports.

## Related

- `main` now has **"Require branches to be up to date before merging"** enabled, which closes the #227 × #228 class at the source: a PR can no longer merge green against a base it will not land on.
- #234 stops `main`'s post-merge run being cancelled (43 % of the last 30 were).