### PR TITLE
fix(mixed-precision,cuda): a k-space buffer that ignored ψ's precision, and a reclaim hook that assumed a driver

### DIFF
--- a/ext/SpinorBECCUDAExt/SpinorBECCUDAExt.jl
+++ b/ext/SpinorBECCUDAExt/SpinorBECCUDAExt.jl
@@ -56,7 +56,16 @@ function __init__()
     # memory back to the device. Without this, ~96 64³ ComplexF64
     # workspaces accumulate on a 16 GB GPU (~150 MB pinned per point
     # across psi/fft_buf/k²/ddi_kernel) and a long scan will OOM mid-run.
-    SpinorBEC._cuda_reclaim_callback[] = () -> (CUDA.reclaim(); nothing)
+    #
+    # The `functional()` guard is load-bearing, not defensive: this extension
+    # loads whenever CUDA.jl is imported, driver or no driver, so a CPU-only
+    # machine that merely has CUDA.jl installed reached `CUDA.reclaim()`
+    # between scan points and got `ERROR: CUDA driver not functional`. Its two
+    # sibling callbacks below were guarded from the start; this one drifted.
+    SpinorBEC._cuda_reclaim_callback[] = function ()
+        CUDA.functional() && CUDA.reclaim()
+        nothing
+    end
     SpinorBEC._cuda_functional_callback[] = () -> CUDA.functional()
     SpinorBEC._cuda_state_lines_callback[] = function ()
         if !CUDA.functional()

--- a/src/hamiltonian/terms/base.jl
+++ b/src/hamiltonian/terms/base.jl
@@ -108,7 +108,7 @@ spatial-spin density (`fx, fy, fz`) so DensityC0Term, SpinC1Term,
 LHYTerm, ZeemanTerm, CoriolisTerm and others do not
 duplicate that work.
 """
-struct EnergyContext{ND, PsiT, FFTPlan, SM, NRho, NF}
+struct EnergyContext{ND, PsiT, CT, FFTPlan, SM, NRho, NF}
     # NOTE: the original definition typed psi_host as Array{ComplexF64, ND}
     # while n_pts/fft_buf are ND-dimensional SPATIAL objects — ψ has ND+1
     # dims, so the constructor could never be called. It had zero callers
@@ -116,7 +116,13 @@ struct EnergyContext{ND, PsiT, FFTPlan, SM, NRho, NF}
     # when the latent mismatch surfaced (dead scaffolding cannot be wrong
     # in a detectable way until something consumes it).
     psi_host::PsiT
-    fft_buf::Array{ComplexF64, ND}
+    # `CT`, not a hard-coded ComplexF64: `plans` follows ψ's precision, and an
+    # in-place FFTW plan applied to a buffer of a DIFFERENT eltype silently
+    # falls back to the out-of-place `*`, leaving `fft_buf` untransformed. The
+    # k-space reduction then sums k²|ψ(r)|² over real space and returns a
+    # finite, wrong number — measured 0.115 against an exact 0.500 for the
+    # kinetic energy of a Float32 workspace.
+    fft_buf::Array{CT, ND}
     plans::FFTPlan
     spin_matrices::SM
     n_density::NRho

--- a/src/hamiltonian/terms/registry.jl
+++ b/src/hamiltonian/terms/registry.jl
@@ -132,7 +132,11 @@ function build_energy_context(psi_host::Array{<:Complex, ND_psi}, ws) where {ND_
         :energy_context, (eltype(psi_host), n_pts)
     ) do
         (
-            zeros(ComplexF64, n_pts), zeros(Float64, n_pts),
+            # `eltype(psi_host)`, not ComplexF64: the scratch key already
+            # discriminates on it, and `ws.fft_plans` follows ψ's precision —
+            # a mismatched buffer turns the in-place FFT into an out-of-place
+            # one and the k-space reduction reads real-space ψ.
+            zeros(eltype(psi_host), n_pts), zeros(Float64, n_pts),
             zeros(Float64, n_pts), zeros(Float64, n_pts), zeros(Float64, n_pts),
         )
     end

--- a/src/solvers/lbfgs/energy_gradient.jl
+++ b/src/solvers/lbfgs/energy_gradient.jl
@@ -22,11 +22,14 @@ using Printf
 function _energy_gradient_scratch(psi, n_pts)
     scratch_get!(:energy_gradient, (typeof(psi), n_pts)) do
         (
-            similar(psi, ComplexF64, n_pts),  # fft_buf
-            similar(psi, Float64, n_pts),     # fx scratch
-            similar(psi, Float64, n_pts),     # fy scratch
-            similar(psi, Float64, n_pts),     # fz scratch
-            similar(psi, ComplexF64, n_pts),  # Coriolis derivative scratch
+            # eltype(psi), not ComplexF64 — `ws.fft_plans` follows ψ's
+            # precision and an in-place plan on a mismatched buffer degrades
+            # to out-of-place, so the k-space work silently reads real-space ψ.
+            similar(psi, eltype(psi), n_pts),  # fft_buf
+            similar(psi, Float64, n_pts),      # fx scratch
+            similar(psi, Float64, n_pts),      # fy scratch
+            similar(psi, Float64, n_pts),      # fz scratch
+            similar(psi, eltype(psi), n_pts),  # Coriolis derivative scratch
         )
     end
 end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -119,6 +119,15 @@ const FAST_TESTS = [
     # replaces. Reads the same SPIN_TAYLOR_TOL[] as the CUDA gate, so relaxing
     # the accuracy contract turns both red.
     "hamiltonian/test_cpu_spin_rotation_taylor_parity.jl",
+    # A k-space scratch buffer must carry ψ's precision, because the FFT plan
+    # beside it does. Pairing a ComplexF32 in-place plan with a ComplexF64
+    # buffer degrades `plan * buf` to the out-of-place method, so the buffer is
+    # never transformed and the reduction reads real-space ψ: the F32 kinetic
+    # energy came out 77 % low, silently, on both the energy and the gradient
+    # face. CPU-only and ~10 s, so it belongs where it will actually run —
+    # `gpu/test_mixed_precision*.jl` DID catch this, in a nightly that had not
+    # been green since 2026-05-08.
+    "hamiltonian/test_mixed_precision_kinetic_buffer.jl",
     "foundation/test_clebsch_gordan.jl",
     "foundation/test_general_f.jl",
     "foundation/test_optical_pumping_rate_eq.jl",
@@ -409,6 +418,13 @@ const CI_EXTRA = [
     # rests on; exact number conservation + monotone energy decay (Eq. 29) —
     # the sign oracle for the scattering term.
     "dynamics/test_spgpe.jl",
+    # The configuration every CI runner is in: CUDA.jl loaded, no driver. Runs
+    # a `CUDA_VISIBLE_DEVICES=-1` subprocess, so it is a real skip-path test
+    # even when the host has a GPU. Gates the unguarded scan-loop
+    # `CUDA.reclaim()` and the three GPU test files whose top-level
+    # `return nothing` guard never stopped their own include — between them,
+    # four of the standing `full`-tier reds.
+    "gpu/test_cpu_only_runner.jl",
 ]
 
 # ── Full tier: everything (ci + remaining heavy tests) ──
@@ -666,6 +682,10 @@ const _COST = Dict{String, Float64}(
     "analysis/test_physics_level0.jl" => 6.1,
     "oracles/test_gpu_cpu_per_term_parity.jl" => 6.1,
     "analysis/test_imaging.jl" => 6.0,
+    "hamiltonian/test_mixed_precision_kinetic_buffer.jl" => 9.7,
+    # 4.8 s here against a warm depot; the CI runner pays a cold precompile
+    # inside the subprocess, so reserve for that rather than under-book it.
+    "gpu/test_cpu_only_runner.jl" => 60.0,
     # ── Heavy `ci`/`full`-tier files, not exercised by the per-push CI jobs;
     # estimates carried over from the full-tier measurement.
     "workflow/test_multi_fidelity_bo.jl" => 161.0,

--- a/test/gpu/test_cpu_only_runner.jl
+++ b/test/gpu/test_cpu_only_runner.jl
@@ -1,0 +1,62 @@
+using Test
+
+# CUDA.jl loaded, no working driver — the configuration every CI runner is in.
+#
+# The extension loads whenever CUDA.jl is imported, driver or no driver. Two
+# things assumed a driver anyway:
+#
+#   * `_cuda_reclaim_callback` called `CUDA.reclaim()` unguarded, so a CPU-only
+#     YAML scan died between points with `ERROR: CUDA driver not functional`.
+#     Its two sibling callbacks in the same `__init__` were guarded from the
+#     start; this one drifted.
+#   * `test/hamiltonian/test_tdhfb_gpu_phase5*.jl` guarded with a top-level
+#     `try … return nothing … end`. `return` does not stop an `include` —
+#     Julia evaluates each top-level expression on its own — so all three
+#     logged "skipping" and then ran `CUDA.reclaim()` anyway.
+#
+# Both were red in the nightly `full` tier for months and neither was visible,
+# because that job had not gone green since at least 2026-05-08.
+#
+# This has to be a subprocess: the point is a session in which
+# `CUDA.functional()` is false, and the parent may well be running on a GPU.
+# `CUDA_VISIBLE_DEVICES=-1` produces exactly that (verified below — a session
+# that reports `functional() == true` would make the whole gate vacuous, so it
+# is asserted, not assumed).
+
+const _PROBE = """
+import CUDA
+using Test
+using SpinorBEC
+
+CUDA.functional() && error("CUDA_VISIBLE_DEVICES=-1 did not disable the driver")
+
+# 1. the scan-loop reclaim hook must be a no-op, not an error
+SpinorBEC._maybe_cuda_reclaim()
+
+# 2. each GPU-only test file must LOAD and skip, not throw
+for f in ("test_tdhfb_gpu_phase5ab.jl", "test_tdhfb_gpu_phase5c_expm.jl",
+          "test_tdhfb_gpu_phase5c_hf.jl")
+    include(joinpath(@__DIR__, "..", "hamiltonian", f))
+end
+
+println("CPU_ONLY_RUNNER_OK")
+"""
+
+@testset "CPU-only runner: CUDA.jl loaded, no driver" begin
+    # `@__DIR__` inside the probe must resolve to test/gpu/, so hand it the
+    # real path rather than relying on where the temp file happens to live.
+    probe = joinpath(mktempdir(), "cpu_only_probe.jl")
+    write(probe, replace(_PROBE, "@__DIR__" => repr(@__DIR__)))
+
+    out = IOBuffer()
+    cmd = Cmd(
+        `$(Base.julia_cmd()) --project=$(Base.active_project()) --startup-file=no $probe`;
+        env=copy(ENV),
+    )
+    cmd = addenv(cmd, "CUDA_VISIBLE_DEVICES" => "-1", "JULIA_NUM_THREADS" => "1")
+    ok = success(pipeline(ignorestatus(cmd); stdout=out, stderr=out))
+    log = String(take!(out))
+    ok || @info "CPU-only probe output" log
+    @test ok
+    @test occursin("CPU_ONLY_RUNNER_OK", log)
+end

--- a/test/hamiltonian/test_b_block_builders.jl
+++ b/test/hamiltonian/test_b_block_builders.jl
@@ -191,7 +191,11 @@ pipeline:
       interactions: {omega_ref: 314.159}
       B:
         B_mag: 1.0e-4
-        theta_deg: {from: 0.0, to: 35.0}
+        # `theta`, in RADIANS — 0.611 rad = 35°. `theta_deg` is the internal
+        # magnitude-dict spelling `_detect_b_coord` reads AFTER
+        # `_split_B_block!` has run; as a user-facing `B:` key it is rejected,
+        # which is what this testset asserted for as long as no tier ran it.
+        theta: {from: 0.0, to: 0.611}
 """)
         result = SpinorBEC.run_config(cfg)
         @test result.dynamics_result !== nothing

--- a/test/hamiltonian/test_mixed_precision_kinetic_buffer.jl
+++ b/test/hamiltonian/test_mixed_precision_kinetic_buffer.jl
@@ -1,0 +1,107 @@
+using Test
+using FFTW
+using SpinorBEC
+
+# A k-space scratch buffer must carry ψ's precision, because `ws.fft_plans`
+# does.
+#
+# `build_energy_context` allocated `zeros(ComplexF64, n_pts)` while the plan it
+# handed alongside it followed ψ. On a Float32 workspace that pairs a
+# ComplexF32 in-place plan with a ComplexF64 buffer, and `plan * buf` then
+# falls back to the OUT-of-place method: it transforms a converted copy,
+# returns it, and leaves `buf` holding real-space ψ. `_kinetic_energy`
+# discards the return value and reduces `buf`, so it summed k²|ψ(r)|² over
+# real space and reported 0.1152 where the answer is 0.5000 — finite, silent,
+# and 77 % low. The L-BFGS gradient scratch had the same shape, so an F32 ITP
+# descended that same wrong kinetic term: F32 and F64 ground states came out
+# 19 % apart in energy and stayed 19 % apart at full convergence.
+#
+# Nothing caught it. `test/gpu/test_mixed_precision*.jl` DID go red, but only
+# in the nightly `full` tier, which had been failing continuously since at
+# least 2026-05-08 — a red signal carries no information.
+#
+# The gate is the one comparison the bug cannot survive: the production
+# kinetic energy against an independent Float64 FFT of the SAME ψ on the SAME
+# k², at each precision. Two controls make a green result mean something:
+#
+#   * the F64 arm must also pass — otherwise the reference itself is broken
+#     and the F32 arm proves nothing;
+#   * the buffer eltype is asserted structurally, so re-hardcoding
+#     ComplexF64 turns this red even on a future path where the numeric
+#     effect happens to cancel.
+
+_CFG = GridConfig((16, 16), (8.0, 8.0))
+
+function _ws_at(::Type{T}) where {T}
+    grid = make_grid(_CFG; dtype=T)
+    make_workspace(;
+        grid, atom=Rb87,
+        interactions=InteractionParams(Dict(0 => 0.0, 1 => 0.0)),
+        zeeman=ZeemanParams(0.0, 0.0),
+        potential=HarmonicTrap(1.0, 1.0),
+        sim_params=SimParams(; dt=0.01, n_steps=1, imaginary_time=true),
+        fft_flags=FFTW.ESTIMATE,
+    )
+end
+
+# E_kin = ½ Σ_c ∫ |k|²|ψ̂_c|² — written out here, in Float64, from the
+# workspace's own ψ and k². Independent of every production buffer.
+function _reference_kinetic(ws)
+    psi = Array{ComplexF64}(ws.state.psi)
+    k2 = Float64.(Array(ws.grid.k_squared))
+    n = prod(ws.grid.config.n_points)
+    dV = Float64(cell_volume(ws.grid))
+    E = 0.0
+    for c in axes(psi, ndims(psi))
+        E += sum(k2 .* abs2.(fft(selectdim(psi, ndims(psi), c))))
+    end
+    0.5 * E * dV / n
+end
+
+@testset "mixed precision: the k-space scratch follows ψ's precision" begin
+    psi0 = init_psi(make_grid(_CFG), SpinSystem(1); state=:m_plus_F)
+
+    @testset "kinetic energy is right at $T" for T in (Float64, Float32)
+        ws = _ws_at(T)
+        @test eltype(ws.state.psi) == Complex{T}
+        @test eltype(ws.fft_plans.forward) == Complex{T}   # the plan follows ψ …
+        copyto!(ws.state.psi, Complex{T}.(psi0))
+
+        reported = energy_decomposition(ws).kinetic
+        reference = _reference_kinetic(ws)
+        # F32 round-off on a 16² grid is ~1e-7 relative; the defect was 77 %.
+        @test isapprox(reported, reference; rtol=T === Float64 ? 1.0e-12 : 1.0e-5)
+    end
+
+    @testset "structural: … and so does the scratch buffer" begin
+        # The numeric arms above are the claim; this is the canary that keeps
+        # the FIX visible. A buffer whose eltype has been pinned back to
+        # ComplexF64 fails here even if some later path masks the number.
+        for T in (Float64, Float32)
+            ws = _ws_at(T)
+            copyto!(ws.state.psi, Complex{T}.(psi0))
+            ctx = SpinorBEC.build_energy_context(ws.state.psi, ws)
+            @test eltype(ctx.fft_buf) == eltype(ws.state.psi)
+            @test eltype(ctx.fft_buf) == eltype(ctx.plans.forward)
+        end
+    end
+
+    @testset "positive control: the comparison can fail" begin
+        # Reduce an UNtransformed buffer — exactly what the out-of-place
+        # fallback left behind — and confirm the reference rejects it. Without
+        # this, a green result above could just mean the two numbers are
+        # insensitive to the k-space step.
+        ws = _ws_at(Float32)
+        copyto!(ws.state.psi, ComplexF32.(psi0))
+        psi = Array{ComplexF64}(ws.state.psi)
+        k2 = Float64.(Array(ws.grid.k_squared))
+        n = prod(ws.grid.config.n_points)
+        dV = Float64(cell_volume(ws.grid))
+        untransformed =
+            0.5 * sum(
+                k2 .* abs2.(selectdim(psi, ndims(psi), c)) for c in axes(psi, ndims(psi))
+            ) |> sum
+        untransformed *= dV / n
+        @test !isapprox(untransformed, _reference_kinetic(ws); rtol=1.0e-2)
+    end
+end

--- a/test/hamiltonian/test_tdhfb_conservation.jl
+++ b/test/hamiltonian/test_tdhfb_conservation.jl
@@ -3,7 +3,9 @@
 # C1: ρ Hermiticity preserved across N=200 coupled Strang steps
 # C2: κ symmetry preserved across N=200 coupled Strang steps
 # C3: Particle number N = ∫(|φ|² + tr ρ) conserved, finite g_S, finite κ
-# C4: Total energy E[φ, ρ, κ] relative drift < 1e-6 over T = 5 ω⁻¹
+# C4: Total energy E[φ, ρ, κ] does NOT drift by more or less than it does
+#     today — the engine has an open EOM/E inconsistency and the measured
+#     1.52e-2 is pinned as a band, not passed as a tolerance. See the testset.
 # C5: ρ=κ=0 limit ⇒ pure F=1 GP equivalence (catches BdG-vs-GP factor errors)
 # C6: κ kinematic motion — starting from κ=0 with finite g_S and nonzero φ,
 #     after one BdG step κ ≠ 0 AND κ symmetric (proves κ evolution is wired,
@@ -134,14 +136,17 @@ using SpinorBEC
         # Particle number is conserved by the FULL coupled TDHFB dynamics
         # (Δ^φ φ* condensate loss balanced by Δ^R κ̄ - κ Δ̄^R quasi-particle
         # gain).
-        # 2026-05-12: with the current EOM/E factor mismatch (under audit),
-        # observed N drift is ~4.7e-2 at g_S = (0.5, 0.1), T=2. Relaxed to
-        # 1e-1 until the variational consistency fix lands. Should be
-        # tightened back to 1e-6 once corrected.
-        @test abs(N1 - N0) < 1e-1
+        # The `< 1e-1` bound and its "observed ~4.7e-2" justification were
+        # written on 2026-05-12 and never revisited. Re-measured 2026-07-31,
+        # bit-identical over three runs: |ΔN| = 1.2951e-4 at N₀ = 2.6317, i.e.
+        # 4.9e-5 relative — 360x better than the comment claimed and 772x
+        # inside the bound, so a 700x regression in N conservation would have
+        # passed. Pinned at the measured value with ~8x headroom for
+        # FFTW-plan variation across machines.
+        @test abs(N1 - N0) < 1e-3
     end
 
-    @testset "C4: Energy conservation (relative drift < 1e-6 over T=5)" begin
+    @testset "C4: Energy is NOT conserved — the drift is pinned, not passed" begin
         nx = 16
         F = 1
         D = 3
@@ -177,15 +182,18 @@ using SpinorBEC
         E1 = tdhfb_energy(state, F, gS, V_ext)
 
         rel_drift = abs(E1 - E0) / max(abs(E0), 1e-12)
-        # 2026-05-12: observed drift is dt-INDEPENDENT and scales linearly
-        # with g_S, indicating a per-step EOM/E functional inconsistency
-        # (under investigation — see memory/tdhfb_perf_findings.md). At
-        # g_S = (0.3, 0.05) and T=2 the drift is ~1.4e-2; at g_S × 0.1 it
-        # is ~1.1e-3. Once the EOM/E factor is identified and fixed, this
-        # tolerance should be tightened back to 1e-3. The current relaxed
-        # bound (2e-2) is the operational ceiling that still catches O(1)
-        # sign-flip / wrong-channel bugs.
-        @test rel_drift < 2e-2
+        # The engine does not conserve E. The drift is dt-INDEPENDENT and
+        # linear in g_S — a per-step EOM/E-functional inconsistency open since
+        # 2026-05-12. Measured 2026-07-31, bit-identical over three runs:
+        # 1.5215e-2 at g_S = (0.3, 0.05), T = 2.
+        #
+        # The old one-sided `< 2e-2` sat 1.31x from red, so it was both close
+        # to flaking and unable to notice a fix. A BAND is the honest
+        # instrument for a known-broken quantity: it fails on a regression AND
+        # on an improvement, so the number cannot drift in either direction
+        # without someone coming back to this comment. Tighten the band —
+        # do not widen it — when the EOM/E factor is corrected.
+        @test 1.0e-2 < rel_drift < 2.0e-2
     end
 
     @testset "C5: ρ=κ=0 ⇒ pure GP equivalence (F=1 c0/c1, perturbative)" begin

--- a/test/hamiltonian/test_tdhfb_gpu_phase5ab.jl
+++ b/test/hamiltonian/test_tdhfb_gpu_phase5ab.jl
@@ -9,22 +9,24 @@ using Printf
 #
 # Tests skip on missing CUDA (CI without GPU).
 
-try
+# `return` at the top level of an included file does not stop the include —
+# Julia evaluates each top-level expression on its own, so the old
+# `try … return nothing … end` guard logged "skipping" and then fell straight
+# through to `CUDA.reclaim()`. On every CPU-only runner this file died with
+# `LoadError: CUDA driver not functional` instead of skipping. The guard has to
+# sit inside each `@testset`, whose body IS a function.
+const HAS_CUDA = try
     @eval using CUDA
-    if !CUDA.functional()
-        @info "CUDA not functional — skipping TDHFB GPU phase5ab tests"
-        return nothing
-    end
-catch e
-    @info "CUDA not available — skipping TDHFB GPU phase5ab tests"
-    return nothing
+    CUDA.functional()
+catch
+    false
 end
 
 # Reset GPU state between tests
-GC.gc()
-CUDA.reclaim()
+HAS_CUDA && (GC.gc(); CUDA.reclaim())
 
 @testset "TDHFB GPU phase5a: state allocation" begin
+    HAS_CUDA || (@test true; return nothing)
     psi = CUDA.zeros(ComplexF32, 16, 16, 16, 13)
     state = init_tdhfb_vacuum(psi)
     @test typeof(state.phi) <: CuArray
@@ -41,6 +43,7 @@ CUDA.reclaim()
 end
 
 @testset "TDHFB GPU phase5a: 32³ F=6 memory budget" begin
+    HAS_CUDA || (@test true; return nothing)
     psi = CUDA.zeros(ComplexF32, 32, 32, 32, 13)
     state = init_tdhfb_vacuum(psi)
     total_mb = (sizeof(state.phi) + sizeof(state.rho) + sizeof(state.kappa)) / 1024 / 1024
@@ -49,6 +52,7 @@ end
 end
 
 @testset "TDHFB GPU phase5a: Hermiticity check on vacuum" begin
+    HAS_CUDA || (@test true; return nothing)
     psi = CUDA.zeros(ComplexF32, 8, 8, 8, 13)
     state = init_tdhfb_vacuum(psi)
     rho_dev, kappa_dev = tdhfb_hermiticity_check(state)
@@ -57,6 +61,7 @@ end
 end
 
 @testset "TDHFB GPU phase5a: V-step broadcast" begin
+    HAS_CUDA || (@test true; return nothing)
     psi = CUDA.zeros(ComplexF32, 8, 8, 8, 13)
     psi .= ComplexF32(1.0) + 0.0im * ComplexF32(0.0)
     state = init_tdhfb_vacuum(psi; alias=true)
@@ -70,6 +75,7 @@ end
 end
 
 @testset "TDHFB GPU phase5b: K-step matches CPU at F64" begin
+    HAS_CUDA || (@test true; return nothing)
     N_grid = 16
     D = 13
     # Deterministic random state to compare CPU vs GPU
@@ -87,6 +93,7 @@ end
 end
 
 @testset "TDHFB GPU phase5b: K-step preserves norm" begin
+    HAS_CUDA || (@test true; return nothing)
     psi = CUDA.zeros(ComplexF32, 16, 16, 16, 13)
     psi .= randn(ComplexF32) * Float32(0.1)
     phi = copy(psi)
@@ -99,6 +106,7 @@ end
 end
 
 @testset "TDHFB GPU phase5b: K-step F32 standalone" begin
+    HAS_CUDA || (@test true; return nothing)
     psi = CuArray(randn(ComplexF32, 16, 16, 16, 13))
     phi_before = copy(psi)
     SpinorBEC._tdhfb_kinetic_step!(psi, 0.01)
@@ -108,5 +116,4 @@ end
 end
 
 # Cleanup
-GC.gc()
-CUDA.reclaim()
+HAS_CUDA && (GC.gc(); CUDA.reclaim())

--- a/test/hamiltonian/test_tdhfb_gpu_phase5c_expm.jl
+++ b/test/hamiltonian/test_tdhfb_gpu_phase5c_expm.jl
@@ -13,24 +13,26 @@ using Printf
 # For ‖W·dt‖ < 0.5, Taylor with N=14 reaches F32 precision (1e-7) — adequate
 # for the typical TDHFB regime where g·n·dt ~ 1e-3 → ‖W·dt‖ ~ 1e-2 → 1e-3.
 
-try
+# `return` at the top level of an included file does not stop the include —
+# Julia evaluates each top-level expression on its own, so the old
+# `try … return nothing … end` guard logged "skipping" and then fell straight
+# through to the CUDA calls below. On every CPU-only runner this file died with
+# `LoadError: CUDA driver not functional` instead of skipping. The guard has to
+# sit inside each `@testset`, whose body IS a function.
+const HAS_CUDA = try
     @eval using CUDA
-    if !CUDA.functional()
-        @info "CUDA not functional — skipping TDHFB GPU phase5c tests"
-        return nothing
-    end
-catch e
-    @info "CUDA not available — skipping TDHFB GPU phase5c tests"
-    return nothing
+    CUDA.functional()
+catch
+    false
 end
 
-ext = Base.get_extension(SpinorBEC, :SpinorBECCUDAExt)
-batched_expm = ext.batched_expm_neg_i_dt!
+ext = HAS_CUDA ? Base.get_extension(SpinorBEC, :SpinorBECCUDAExt) : nothing
+batched_expm = HAS_CUDA ? ext.batched_expm_neg_i_dt! : nothing
 
-GC.gc()
-CUDA.reclaim()
+HAS_CUDA && (GC.gc(); CUDA.reclaim())
 
 @testset "TDHFB GPU phase5c: F=1 batched expm vs CPU Base.exp" begin
+    HAS_CUDA || (@test true; return nothing)
     D = 6  # twoD for F=1
     N_vox = 50
     dt = 0.01
@@ -58,6 +60,7 @@ CUDA.reclaim()
 end
 
 @testset "TDHFB GPU phase5c: F=6 batched expm sample voxel F32" begin
+    HAS_CUDA || (@test true; return nothing)
     D = 26  # twoD for F=6
     N_vox = 32 * 32 * 32  # production scale
     dt = 0.001
@@ -82,6 +85,7 @@ end
 end
 
 @testset "TDHFB GPU phase5c: identity preserved when W = 0" begin
+    HAS_CUDA || (@test true; return nothing)
     D = 8
     N_vox = 10
     W = CUDA.zeros(ComplexF64, D, D, N_vox)
@@ -100,6 +104,7 @@ end
 end
 
 @testset "TDHFB GPU phase5c: dt=0 returns identity" begin
+    HAS_CUDA || (@test true; return nothing)
     D = 6
     N_vox = 5
     W = CuArray(randn(ComplexF64, D, D, N_vox))
@@ -117,6 +122,7 @@ end
 end
 
 @testset "TDHFB GPU phase5c: unitary preservation for Hermitian W" begin
+    HAS_CUDA || (@test true; return nothing)
     # If W is Hermitian, exp(-i W dt) is unitary: M M† = I
     D = 8
     N_vox = 20
@@ -144,5 +150,4 @@ end
     end
 end
 
-GC.gc()
-CUDA.reclaim()
+HAS_CUDA && (GC.gc(); CUDA.reclaim())

--- a/test/hamiltonian/test_tdhfb_gpu_phase5c_hf.jl
+++ b/test/hamiltonian/test_tdhfb_gpu_phase5c_hf.jl
@@ -13,19 +13,20 @@ using Printf
 #   - Hermitian projection on ρ, symmetric projection on κ
 #   - Norm preservation on a vacuum-(ρ=κ=0) initial state
 
-try
+# `return` at the top level of an included file does not stop the include —
+# Julia evaluates each top-level expression on its own, so the old
+# `try … return nothing … end` guard logged "skipping" and then fell straight
+# through to the CUDA calls below. On every CPU-only runner this file died with
+# `LoadError: CUDA driver not functional` instead of skipping. The guard has to
+# sit inside each `@testset`, whose body IS a function.
+const HAS_CUDA = try
     @eval using CUDA
-    if !CUDA.functional()
-        @info "CUDA not functional — skipping TDHFB GPU phase5c HF tests"
-        return nothing
-    end
-catch e
-    @info "CUDA not available — skipping TDHFB GPU phase5c HF tests"
-    return nothing
+    CUDA.functional()
+catch
+    false
 end
 
-GC.gc()
-CUDA.reclaim()
+HAS_CUDA && (GC.gc(); CUDA.reclaim())
 
 function _make_states(F::Int, spatial::Tuple; with_rho::Real=0.0, with_kappa::Real=0.0)
     D = 2F + 1
@@ -59,6 +60,7 @@ function _make_states(F::Int, spatial::Tuple; with_rho::Real=0.0, with_kappa::Re
 end
 
 @testset "TDHFB GPU phase5c HF: φ subupdate vs CPU (F=1, vacuum)" begin
+    HAS_CUDA || (@test true; return nothing)
     state_cpu, state_gpu = _make_states(1, (4, 4, 4))
     g_S = Dict{Int, Float64}(0 => 0.5)
     V_cpu = SpinorBEC.channel_kernel(1, g_S)
@@ -70,6 +72,7 @@ end
 end
 
 @testset "TDHFB GPU phase5c HF: R subupdate vs CPU (F=1, thermal)" begin
+    HAS_CUDA || (@test true; return nothing)
     state_cpu, state_gpu = _make_states(1, (4, 4, 4); with_rho=0.05, with_kappa=0.01)
     g_S = Dict{Int, Float64}(0 => 0.5)
     V_cpu = SpinorBEC.channel_kernel(1, g_S)
@@ -83,6 +86,7 @@ end
 end
 
 @testset "TDHFB GPU phase5c HF: full HF step vs CPU (F=1, thermal)" begin
+    HAS_CUDA || (@test true; return nothing)
     state_cpu, state_gpu = _make_states(1, (4, 4, 4); with_rho=0.05, with_kappa=0.01)
     g_S = Dict{Int, Float64}(0 => 0.5)
     SpinorBEC._tdhfb_hf_step!(state_cpu, 1, g_S, 0.01; hfb_mode=:full_hfb)
@@ -97,6 +101,7 @@ end
 end
 
 @testset "TDHFB GPU phase5c HF: Hermitian rho + symmetric kappa preserved" begin
+    HAS_CUDA || (@test true; return nothing)
     _, state_gpu = _make_states(1, (4, 4, 4); with_rho=0.05, with_kappa=0.01)
     g_S = Dict{Int, Float64}(0 => 0.5)
     SpinorBEC._tdhfb_hf_step!(state_gpu, 1, g_S, 0.01; hfb_mode=:full_hfb)
@@ -107,6 +112,7 @@ end
 end
 
 @testset "TDHFB GPU phase5c HF: Popov mode (drop anomalous in phi sub)" begin
+    HAS_CUDA || (@test true; return nothing)
     state_cpu, state_gpu = _make_states(1, (4, 4, 4); with_rho=0.05, with_kappa=0.01)
     g_S = Dict{Int, Float64}(0 => 0.5)
     SpinorBEC._tdhfb_hf_step!(state_cpu, 1, g_S, 0.01; hfb_mode=:popov)
@@ -118,6 +124,7 @@ end
 end
 
 @testset "TDHFB GPU phase5c HF: 10 HF steps vs CPU end-to-end" begin
+    HAS_CUDA || (@test true; return nothing)
     state_cpu, state_gpu = _make_states(1, (4, 4, 4); with_rho=0.05, with_kappa=0.01)
     g_S = Dict{Int, Float64}(0 => 0.5)
     for _ in 1:10
@@ -133,6 +140,7 @@ end
 end
 
 @testset "TDHFB GPU phase5c HF: F=6 Eu sample voxel" begin
+    HAS_CUDA || (@test true; return nothing)
     state_cpu, state_gpu = _make_states(6, (4, 4, 4); with_rho=0.01, with_kappa=0.0)
     # Eu-typical g_S (rough order-of-magnitude)
     g_S = Dict{Int, Float64}(0 => 0.1, 2 => 0.05, 4 => 0.02)
@@ -145,5 +153,4 @@ end
     @test maximum(abs.(Array(state_gpu.kappa) .- state_cpu.kappa)) < 1e-11
 end
 
-GC.gc()
-CUDA.reclaim()
+HAS_CUDA && (GC.gc(); CUDA.reclaim())

--- a/test/workflow/test_infrastructure.jl
+++ b/test/workflow/test_infrastructure.jl
@@ -561,9 +561,15 @@ pipeline:
         @test sum(abs2, psi) * cell_volume(grid2d) ≈ 1.0 atol=1e-10
     end
 
-    @testset "P1.1: Schema accepts all 22 init states" begin
+    @testset "P1.1: Schema accepts every init state it advertises" begin
+        # `ferromagnetic` / `ferromagnetic_min` became `m_plus_F` / `m_minus_F`
+        # in c2b0bece. The rename deleted the old names from the schema, as the
+        # naming convention requires, and this list kept them — for 2½ months,
+        # because no tier ran this file and the nightly that did was already
+        # red. The set-equality below is what makes the next rename fail HERE,
+        # with both sides named, instead of inside `validate_config!`.
         all_states = [
-            "polar", "ferromagnetic", "ferromagnetic_min",
+            "polar", "m_plus_F", "m_minus_F",
             "uniform", "antiferromagnetic", "random",
             "spin_coherent", "radial_spin_vortex", "flower", "spin_helix",
             "cyclic", "biaxial_nematic", "polar_core_vortex",
@@ -572,6 +578,11 @@ pipeline:
             "chiral_spin_vortex", "magnetic_domain",
             "vortex_lattice", "skyrmion_lattice",
         ]
+        # `from_jld2` is a loader, not a named state — the one enum entry this
+        # list deliberately omits.
+        @test Set(all_states) ==
+            setdiff(Set(SpinorBEC.GS_SCHEMA["initial_state"].enum), Set(["from_jld2"]))
+
         for s in all_states
             d = Dict{String, Any}(
                 "atom" => "Rb87", "grid" => Dict("n" => 32, "box" => 10.0),


### PR DESCRIPTION
Four of `main`'s standing `tier=full` failing assertions, and the silent wrong
number behind two of them. Independent of #198 and #225, which between them hold
the other nine.

## The k-space scratch ignored ψ's precision

`build_energy_context` allocated `zeros(ComplexF64, n_pts)` while handing
`ws.fft_plans` alongside it — and the plans follow ψ. On a Float32 workspace
that pairs a ComplexF32 in-place plan with a ComplexF64 buffer, so `plan * buf`
falls back to the OUT-of-place method: it transforms a converted copy and leaves
`buf` holding real-space ψ. `_kinetic_energy` discards the return value and
reduces `buf`, i.e. it summed `k²|ψ(r)|²` over real space.

Measured on a 16² F=1 workspace, the same ψ on both sides, against an
independent Float64 FFT of that ψ on that k²:

| | reported | independent reference |
|---|---|---|
| F64 | 0.4999992780067462 | 0.4999992780067464 |
| F32 before | **0.11518271654952712** | 0.49999930126820136 |
| F32 after | 0.49999930052311375 | 0.49999930126820136 |

77 % low, finite, silent. `_energy_gradient_scratch` had the same shape, so an
F32 ITP descended that same wrong kinetic term: F32 and F64 ground states came
out 19 % apart in energy and stayed 19 % apart at full convergence (1.1624 vs
1.4335 — both fully polarised in m=+1, so the same state with two energies).
After the fix, at a common `tol`, 9.9e-9.

F64 is bit-identical: the fully-converged F64 energy is 1.433515442996006 before
and after, and `master_oracle`, `registry_{energy,gradient}_parity`,
`term_consistency` and `energy_decomposition_sum` all pass unchanged.

## The scan-loop reclaim hook assumed a driver

`_cuda_reclaim_callback` called `CUDA.reclaim()` unguarded. The extension loads
whenever CUDA.jl is imported, driver or no driver, so a CPU-only machine that
merely has CUDA.jl installed died between scan points with `ERROR: CUDA driver
not functional`. Its two sibling callbacks in the same `__init__` were guarded
from the start; this one drifted.

## Three skip guards that never stopped their own file

`test/hamiltonian/test_tdhfb_gpu_phase5*.jl` guarded with a top-level
`try … return nothing … end`. **`return` does not stop an `include`** — Julia
evaluates each top-level expression on its own — so all three logged "skipping"
and then ran `CUDA.reclaim()` anyway. The guard now sits inside each `@testset`,
whose body IS a function, which is the idiom the working GPU files already use.

## Gates

Both defects were already caught by tests. Both of those tests live in the
nightly `full` tier, which **has not gone green in 69 scheduled runs** (no
success since at least 2026-05-08), so a red signal there carries no
information. Two new gates, each canaried against the reverted fix:

- `hamiltonian/test_mixed_precision_kinetic_buffer.jl` (fast) — production
  kinetic energy vs an independent F64 FFT at each precision, a structural
  assertion that the buffer eltype tracks the plan's, and a positive control
  that the comparison can fail. Reverting the fix turns 3 of its 11 assertions
  red **while the F64 arm stays green**, so the reference is not what moved.
- `gpu/test_cpu_only_runner.jl` (ci ⇒ the new `integration` job from #226) — a
  `CUDA_VISIBLE_DEVICES=-1` subprocess, so it is a real skip-path test even on a
  GPU host. It asserts the driver really is disabled first (otherwise the gate
  is vacuous), then that `_maybe_cuda_reclaim()` is a no-op and all three
  phase5 files load and skip. Reverting the reclaim guard turns it red with the
  exact `CUDA_ERROR_NO_DEVICE` stack.

## Three stale tests, none of which any tier ran

- `test_infrastructure.jl` P1.1 still listed `ferromagnetic` /
  `ferromagnetic_min`, renamed to `m_plus_F` / `m_minus_F` in c2b0bece. Added a
  set-equality against `GS_SCHEMA["initial_state"].enum` so the next rename
  fails here, with both sides named.
- `test_b_block_builders.jl` wrote `B.theta_deg` in user YAML. `theta_deg` is
  the internal magnitude-dict spelling `_detect_b_coord` reads AFTER
  `_split_B_block!`; the user-facing key is `theta`, in radians, and all 748
  occurrences under `runs/` spell it that way.
- `test_tdhfb_conservation.jl` C3/C4 were relaxed on 2026-05-12 with a "tighten
  back once fixed" note and never revisited. Re-measured, bit-identical over
  three runs: `|ΔN| = 1.2951e-4` against a `1e-1` bound — **772× of slack**, and
  the comment's "observed ~4.7e-2" was 360× stale — now `1e-3`. Energy drift
  `1.5215e-2` against a one-sided `< 2e-2` that sat **1.31× from red** — now a
  BAND, because the engine's EOM/E inconsistency is open and a one-sided bound
  can notice neither a regression nor a fix. The testset name claimed `< 1e-6`;
  it was the only name-vs-assertion mismatch in 353 test files.

## Verified

`fast` tier 176/176; phase5 ×3 pass on a real GPU and skip cleanly without one;
`test_dealias_2_3.jl` passes CPU-only with CUDA.jl loaded;
`test_b_block_builders.jl` and `test_tdhfb_conservation.jl` pass under
`SPINORBEC_RUN_HEAVY_YAML=true`; both mixed-precision gates pass. Re-verified
after rebasing onto #226 — `test_cpu_only_runner.jl` lands in the new
`integration` job, so it runs per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
