### PR TITLE
test: make every test file a standalone unit, and gate it

### DIFF
--- a/test/analysis/test_analytic_ground_states.jl
+++ b/test/analysis/test_analytic_ground_states.jl
@@ -1,3 +1,5 @@
+using Test
+using SpinorBEC
 using FFTW
 
 @testset "F=1 analytic ground states" begin

--- a/test/analysis/test_analytical_validation.jl
+++ b/test/analysis/test_analytical_validation.jl
@@ -1,3 +1,4 @@
+using SpinorBEC
 using Test
 using FFTW
 using Random

--- a/test/analysis/test_bogoliubov.jl
+++ b/test/analysis/test_bogoliubov.jl
@@ -1,3 +1,5 @@
+using Test
+using SpinorBEC
 using LinearAlgebra: normalize
 
 @testset "Bogoliubov-de Gennes" begin

--- a/test/analysis/test_bogoliubov_enhanced.jl
+++ b/test/analysis/test_bogoliubov_enhanced.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "BdG enhancements" begin
     @testset "detect_roton: stable system" begin
         spinor = ComplexF64[1.0, 0.0, 0.0]

--- a/test/analysis/test_diagnostics.jl
+++ b/test/analysis/test_diagnostics.jl
@@ -1,3 +1,5 @@
+using Test
+using SpinorBEC
 using SpinorBEC: _elliptic_k
 using FFTW
 

--- a/test/analysis/test_fisher.jl
+++ b/test/analysis/test_fisher.jl
@@ -1,6 +1,7 @@
 using Test
 using LinearAlgebra
 using Random
+using SpinorBEC
 using SpinorBEC: fisher_jacobian, fisher_information, identifiable_directions
 
 @testset "Fisher information utilities" begin

--- a/test/analysis/test_nematic_tensor.jl
+++ b/test/analysis/test_nematic_tensor.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Nematic Tensor Eigenvalues" begin
     using LinearAlgebra
 

--- a/test/analysis/test_phase_classification_polyhedral.jl
+++ b/test/analysis/test_phase_classification_polyhedral.jl
@@ -7,6 +7,8 @@
 # those features as `:octahedral` / `:cubic` / `:cube_octahedral` /
 # `:dodecahedral` instead of falling back to `:unknown`.
 
+using Test
+using SpinorBEC
 using SpinorBEC: make_grid, GridConfig, spin_matrices, canonical_polyhedral_spinor,
     classify_phase_detailed, classify_phase_distance, DEFAULT_PHASE_REFERENCES,
     canonical_polyhedral_point_group

--- a/test/analysis/test_polyhedral_classifier.jl
+++ b/test/analysis/test_polyhedral_classifier.jl
@@ -1,4 +1,5 @@
 using Test
+using SpinorBEC
 using SpinorBEC: polyhedral_fingerprint, polyhedral_candidate_spinors,
     classify_polyhedral, direct_eff_coupling, direct_eff_coupling_delta
 

--- a/test/analysis/test_spectral.jl
+++ b/test/analysis/test_spectral.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Spectral Analysis" begin
     @testset "Single frequency detection" begin
         f0 = 5.0

--- a/test/analysis/test_spinor_utils.jl
+++ b/test/analysis/test_spinor_utils.jl
@@ -1,7 +1,7 @@
 using Test
 using SpinorBEC
 using StaticArrays
-using LinearAlgebra: norm, normalize
+using LinearAlgebra: I, norm, normalize
 
 @testset "Spinor Utils" begin
     @testset "_get_spinor and _set_spinor! round-trip" begin

--- a/test/analysis/test_tof.jl
+++ b/test/analysis/test_tof.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "TOF / Stern-Gerlach" begin
     @testset "1D Gaussian TOF width" begin
         F = 1

--- a/test/foundation/test_atoms.jl
+++ b/test/foundation/test_atoms.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Atom Species Library" begin
     all_atoms = [
         Li7, Na23, K39, K41, Rb85, Rb87, Cs133,

--- a/test/foundation/test_clebsch_gordan.jl
+++ b/test/foundation/test_clebsch_gordan.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Clebsch-Gordan / Wigner coefficients" begin
     @testset "Wigner 3j known values" begin
         # (1,1,0; 0,0,0) = -1/√3 (standard Condon-Shortley convention)

--- a/test/foundation/test_general_f.jl
+++ b/test/foundation/test_general_f.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "General-F interactions" begin
     @testset "AtomSpecies backward compatibility" begin
         a = AtomSpecies("test", 1.0, 1, 0.1, 0.2)

--- a/test/foundation/test_no_unguarded_fft_derivative.jl
+++ b/test/foundation/test_no_unguarded_fft_derivative.jl
@@ -5,6 +5,7 @@
 # to either route through the nulling helpers or consciously extend the allow-list
 # AND add a Nyquist oracle. Closes the token-comment loophole of a grep guard.
 
+using SpinorBEC
 using Test
 
 @testset "odd FFT derivative: exact allow-list (Nyquist-null enforced)" begin

--- a/test/foundation/test_optical_pumping_rate_eq.jl
+++ b/test/foundation/test_optical_pumping_rate_eq.jl
@@ -1,5 +1,6 @@
 using Test
 using LinearAlgebra
+using SpinorBEC
 using SpinorBEC: OpticalPumpingParams, build_sigma_eff_table, polarization_q
 
 @testset "Optical pumping rate equation" begin

--- a/test/foundation/test_spherical_harmonics.jl
+++ b/test/foundation/test_spherical_harmonics.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Spherical Harmonics" begin
     @testset "Y_00 = 1/√(4π)" begin
         val = spherical_harmonic(0, 0, 0.5, 1.0)

--- a/test/gpu/test_cuda.jl
+++ b/test/gpu/test_cuda.jl
@@ -31,7 +31,7 @@ using Test
             backend=CUDABackend(),
         )
 
-        @test ws.state.psi isa CuArray
+        @test ws.state.psi isa CUDA.CuArray
         @test ws.backend isa CUDABackend
     end
 

--- a/test/hamiltonian/test_b_block_builders.jl
+++ b/test/hamiltonian/test_b_block_builders.jl
@@ -1,6 +1,9 @@
 # YAML run_config blocks below trip the same JIT inference cascade
 # documented in CLAUDE.md ("Type stability boundaries") on Julia 1.11+.
 # Skip them by default — set SPINORBEC_RUN_HEAVY_YAML=true to opt in.
+using Test
+using SpinorBEC
+
 const _SKIP_HEAVY_YAML_ZEEMAN =
     get(ENV, "SPINORBEC_RUN_HEAVY_YAML", "false") != "true"
 

--- a/test/hamiltonian/test_batched_kinetic.jl
+++ b/test/hamiltonian/test_batched_kinetic.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Batched Kinetic Step" begin
     @testset "Batched matches per-component 1D" begin
         config = GridConfig(64, 20.0)

--- a/test/hamiltonian/test_combined_spin_step.jl
+++ b/test/hamiltonian/test_combined_spin_step.jl
@@ -7,6 +7,7 @@
 # 3. ITP convergence: same ground state energy as sequential, within
 #    the order-2 splitting tolerance.
 
+using SpinorBEC
 using Test, SpinorBEC, LinearAlgebra
 
 const _N = 16

--- a/test/hamiltonian/test_ddi.jl
+++ b/test/hamiltonian/test_ddi.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "DDI" begin
     @testset "Q tensor symmetry and tracelessness" begin
         config = GridConfig((16, 16, 16), (10.0, 10.0, 10.0))

--- a/test/hamiltonian/test_ddi_nyquist_xy_symmetry.jl
+++ b/test/hamiltonian/test_ddi_nyquist_xy_symmetry.jl
@@ -10,6 +10,9 @@
 # `_build_q_tensor!` zeros the off-diagonals on every odd-axis Nyquist
 # plane. See scripts/ddi_nyquist_xy_asymmetry_probe.jl.
 
+using Test
+using SpinorBEC
+
 @testset "DDI Nyquist x↔y symmetry" begin
     swap_xy(A) = permutedims(A, (2, 1, 3))
 

--- a/test/hamiltonian/test_ddi_padded.jl
+++ b/test/hamiltonian/test_ddi_padded.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "DDI Zero-Padding" begin
     @testset "make_ddi_padded creates correct shapes" begin
         config = GridConfig(64, 20.0)

--- a/test/hamiltonian/test_interactions_constraint.jl
+++ b/test/hamiltonian/test_interactions_constraint.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Constraint-based interactions" begin
     @testset "interaction_params_from_constraint basic" begin
         ip = interaction_params_from_constraint(; c_total=4689.0, c1_ratio=0.0, F=6)

--- a/test/hamiltonian/test_lhy.jl
+++ b/test/hamiltonian/test_lhy.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "LHY Beyond-Mean-Field" begin
     @testset "c_lhy=0 regression: identical to original" begin
         config = GridConfig(64, 20.0)

--- a/test/hamiltonian/test_lhy_2d.jl
+++ b/test/hamiltonian/test_lhy_2d.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "LHY abstraction and Quasi-2D LHY" begin
     @testset "_lhy_V dispatch" begin
         @test SpinorBEC._lhy_V(1.0, nothing) == 0.0

--- a/test/hamiltonian/test_lhy_modes_round45.jl
+++ b/test/hamiltonian/test_lhy_modes_round45.jl
@@ -3,6 +3,7 @@
 # phase verifications.
 
 using Test
+using SpinorBEC
 using SpinorBEC: lhy_F2_BN, lhy_F3_octa, lhy_F4_cube, lhy_F8_octa, lhy_F10_dodec
 
 @testset "LHY modes (Round 4-5 closed forms)" begin

--- a/test/hamiltonian/test_potentials.jl
+++ b/test/hamiltonian/test_potentials.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Potentials" begin
     @testset "GravityPotential evaluate_potential" begin
         grid_cfg = GridConfig((32,), (10.0,))

--- a/test/hamiltonian/test_singlet_pair.jl
+++ b/test/hamiltonian/test_singlet_pair.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Singlet Pair (S=0) — Amplitude + Step" begin
     @testset "F=1 polar state: |A₀₀|² = n²/3" begin
         config = GridConfig(64, 20.0)

--- a/test/hamiltonian/test_spinor_lhy.jl
+++ b/test/hamiltonian/test_spinor_lhy.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Spinor-dependent LHY" begin
     @testset "two_channel: basic construction" begin
         table = compute_spinor_lhy_polar_two_channel(;

--- a/test/hamiltonian/test_tensor_interaction.jl
+++ b/test/hamiltonian/test_tensor_interaction.jl
@@ -1,6 +1,7 @@
 using Test
 using SpinorBEC
 using LinearAlgebra: Hermitian, tr
+using Random
 
 @testset "Tensor interaction" begin
     @testset "make_tensor_interaction_cache returns nothing for c2-only" begin

--- a/test/hamiltonian/test_zeeman_midpoint.jl
+++ b/test/hamiltonian/test_zeeman_midpoint.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Zeeman midpoint evaluation" begin
     @testset "Time-dependent Zeeman: O(dt^2) convergence" begin
         grid = make_grid(GridConfig((16,), (10.0,)))

--- a/test/manuscript/test_D2_H_irrep_character_proof.jl
+++ b/test/manuscript/test_D2_H_irrep_character_proof.jl
@@ -12,6 +12,7 @@
 #
 # Reference: docs/manuscript/papers/paper3_universal_theorem/rank2_vanishing_analytical_proof.md
 
+using SpinorBEC
 using Test
 using Printf
 

--- a/test/manuscript/test_f12_icosahedral.jl
+++ b/test/manuscript/test_f12_icosahedral.jl
@@ -15,6 +15,7 @@
 #
 # Run: julia --project=. scripts/manuscript/f12_icosahedral_verification.jl
 
+using Test
 using SpinorBEC
 using LinearAlgebra
 using Printf

--- a/test/manuscript/test_f12_rational.jl
+++ b/test/manuscript/test_f12_rational.jl
@@ -16,6 +16,7 @@
 # Limitation: Julia's clebsch_gordan returns Float64. For rational exact values,
 # need to bypass Float64 path or use rational CG implementation.
 
+using Test
 using SpinorBEC
 using LinearAlgebra
 using Printf

--- a/test/manuscript/test_f5_f7_polyhedral.jl
+++ b/test/manuscript/test_f5_f7_polyhedral.jl
@@ -16,6 +16,7 @@
 #
 # Run: julia --project=. scripts/manuscript/f5_f7_polyhedral_verification.jl
 
+using Test
 using SpinorBEC
 using LinearAlgebra
 using Printf

--- a/test/manuscript/test_f9_f11_polyhedral.jl
+++ b/test/manuscript/test_f9_f11_polyhedral.jl
@@ -15,6 +15,7 @@
 #
 # Run: julia --project=. scripts/manuscript/f9_f11_polyhedral_verification.jl
 
+using Test
 using SpinorBEC
 using LinearAlgebra
 using Printf

--- a/test/manuscript/test_f_systematic_lemma1_predictions.jl
+++ b/test/manuscript/test_f_systematic_lemma1_predictions.jl
@@ -9,6 +9,7 @@
 # Outputs: predicted β_S^(λ_spin) per channel; identifies sign-change boundary
 # in the discrete channel set; gives Feshbach engineering recipe for high-F species.
 
+using Test
 using SpinorBEC
 using LinearAlgebra
 using Printf

--- a/test/manuscript/test_lemma1_general_S.jl
+++ b/test/manuscript/test_lemma1_general_S.jl
@@ -8,6 +8,7 @@
 #
 # Reference: docs/manuscript/papers/paper3_universal_theorem/sign_pattern_lemma1_general_S.md
 
+using SpinorBEC
 using Test
 
 println("=== Lemma 1 General-S closed form verification ===\n")

--- a/test/manuscript/test_sign_pattern_6j.jl
+++ b/test/manuscript/test_sign_pattern_6j.jl
@@ -11,6 +11,7 @@
 # Sign pattern in S emerges from the competition. Tabulate explicitly for paper3 cases
 # F = 3, 4, 6, 8, 10 and compare to paper3 stated β_S^{λ_spin} signs.
 
+using Test
 using SpinorBEC
 using LinearAlgebra
 using Printf

--- a/test/oracles/test_doc_run_citations_resolve.jl
+++ b/test/oracles/test_doc_run_citations_resolve.jl
@@ -25,6 +25,7 @@
 # direction: an entry that starts resolving must be removed from the list, or the
 # list rots into a permanent excuse the way a stale KNOWN-LIMIT does.
 
+using SpinorBEC
 using Test
 
 const _DOCS = joinpath(@__DIR__, "..", "..", "docs")

--- a/test/oracles/test_lhy_no_bare_device_broadcast.jl
+++ b/test/oracles/test_lhy_no_bare_device_broadcast.jl
@@ -1,3 +1,4 @@
+using SpinorBEC
 using Test
 
 # A `TabulatedLHY` holds host `Vector{Float64}` tables, so it cannot be captured

--- a/test/oracles/test_spin_operator_algebra.jl
+++ b/test/oracles/test_spin_operator_algebra.jl
@@ -11,6 +11,7 @@
 
 using Test
 using LinearAlgebra
+using SpinorBEC
 using SpinorBEC: spin_matrices
 
 @testset "Spin operator algebra (su(2))" begin

--- a/test/solvers/test_3d.jl
+++ b/test/solvers/test_3d.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "3D Support" begin
     @testset "3D grid construction" begin
         config = GridConfig((16, 16, 16), (10.0, 10.0, 10.0))

--- a/test/solvers/test_absorbing_boundary.jl
+++ b/test/solvers/test_absorbing_boundary.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Absorbing Boundary" begin
     @testset "AbsorbingBoundary constructors" begin
         ab = AbsorbingBoundary(10.0, 3.0, 2)

--- a/test/solvers/test_checkpoint.jl
+++ b/test/solvers/test_checkpoint.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Checkpoint/Restart" begin
     F = 1
     grid = make_grid(GridConfig((16,), (10.0,)))

--- a/test/solvers/test_continuation.jl
+++ b/test/solvers/test_continuation.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Parameter Continuation" begin
     F = 1
     grid = make_grid(GridConfig((16,), (10.0,)))

--- a/test/solvers/test_pause_resume.jl
+++ b/test/solvers/test_pause_resume.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Pause/Resume/Refine" begin
     @testset "ITP checkpoint save and load" begin
         ckpt_dir = mktempdir()

--- a/test/solvers/test_quasi_2d.jl
+++ b/test/solvers/test_quasi_2d.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Quasi-2D dimensional reduction" begin
     @testset "parsing quasi_2d + l_z in pipeline" begin
         yaml_str = """

--- a/test/solvers/test_quasi_2d_api.jl
+++ b/test/solvers/test_quasi_2d_api.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Quasi-2D direct API" begin
     @testset "make_workspace scales interactions" begin
         grid = make_grid(GridConfig((16, 16), (10.0, 10.0)))

--- a/test/test_tier_membership.jl
+++ b/test/test_tier_membership.jl
@@ -29,6 +29,12 @@
 using Test
 using SpinorBEC
 
+# The runner include()s `_tiers.jl` into global scope before this file, so under
+# `Pkg.test()` these are already bound. Pull them in when they are not, so the
+# file that holds the "every test file is a dependency-free unit" contract
+# satisfies it — it was the last one that did not.
+isdefined(Main, :FAST_TESTS) || include(joinpath(@__DIR__, "_tiers.jl"))
+
 @testset "Tier membership is total and exact" begin
     test_root = @__DIR__
 
@@ -94,6 +100,41 @@ end
     ])
     @test length(stale) == 1
     @test stale[1].file == "solvers/test_3d.jl"
+end
+
+# CLAUDE.md: "Parallel mode requires each test file to stay a dependency-free
+# unit (own `using` / `@testset` / `@__DIR__` helpers)". It was not true of 45
+# files, which relied on `_run_files.jl` leaking `Test` (and the other stdlibs)
+# into `Main` from whichever file `using`d them first. Two consequences:
+#
+#   * the single-test command CLAUDE.md documents —
+#     `julia --project=. -e 'using SpinorBEC; include("test/test_X.jl")'` —
+#     died with `UndefVarError: @testset` on 13 % of the suite;
+#   * the leak is order-dependent, so which files work standalone depends on
+#     what the claim queue happened to hand out first.
+#
+# Static, so it costs nothing: a file that uses `@testset` must say so.
+@testset "Every test file declares its own dependencies" begin
+    test_root = @__DIR__
+    missing_test, missing_pkg = String[], String[]
+    for (root, _, files) in walkdir(test_root), f in files
+        (startswith(f, "test_") && endswith(f, ".jl")) || continue
+        rel = relpath(joinpath(root, f), test_root)
+        src = read(joinpath(root, f), String)
+        occursin(r"^\s*(?:using|import)\s+[^\n]*\bTest\b"m, src) || push!(missing_test, rel)
+        # The PLAIN form. `using SpinorBEC: _elliptic_k` does not bring the
+        # package's exports into scope, and `analysis/test_diagnostics.jl` had
+        # exactly that while calling the exported `spin_mixing_period` — it ran
+        # only because some other file in the worker had already `using`d the
+        # package into `Main`. Selective imports are welcome ON TOP of this.
+        occursin(r"^\s*using\s+SpinorBEC\s*(?:,|$)"m, src) || push!(missing_pkg, rel)
+    end
+    isempty(missing_test) ||
+        @info "test files using @testset without `using Test`" missing_test
+    isempty(missing_pkg) ||
+        @info "test files without `using SpinorBEC`" missing_pkg
+    @test isempty(missing_test)
+    @test isempty(missing_pkg)
 end
 
 # Test files share a worker process (SPINORBEC_TEST_WORKERS > 1) and which files

--- a/test/workflow/test_config.jl
+++ b/test/workflow/test_config.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Unified Config" begin
     @testset "parsing - ground_state type" begin
         yaml = """

--- a/test/workflow/test_config_zeeman_seed_agreement.jl
+++ b/test/workflow/test_config_zeeman_seed_agreement.jl
@@ -20,6 +20,7 @@
 # Scope: only configs that pin a fully-stretched seed AND set a non-zero B_z.
 # Everything else is a legitimate choice and is not the business of this test.
 
+using SpinorBEC
 using Test
 using YAML
 

--- a/test/workflow/test_experiment.jl
+++ b/test/workflow/test_experiment.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Experiment" begin
     @testset "interpolate_value" begin
         c = ConstantValue(3.0)

--- a/test/workflow/test_infrastructure.jl
+++ b/test/workflow/test_infrastructure.jl
@@ -4,6 +4,9 @@
 # abstract dispatch over `PipelineStep`. The fix is the deferred
 # concrete-step refactor described in pipeline_runner.jl. Until that
 # lands, skip the affected blocks unless the user explicitly opts in.
+using Test
+using SpinorBEC
+
 const _SKIP_HEAVY_YAML_INFRA =
     get(ENV, "SPINORBEC_RUN_HEAVY_YAML", "false") != "true"
 

--- a/test/workflow/test_losses.jl
+++ b/test/workflow/test_losses.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Losses" begin
     @testset "LossParams constructors" begin
         lp = LossParams(1e-3, 1e-5)

--- a/test/workflow/test_phase_boundary.jl
+++ b/test/workflow/test_phase_boundary.jl
@@ -1,3 +1,6 @@
+using Test
+using SpinorBEC
+
 @testset "Phase Boundary Bisection" begin
     F = 1
     grid = make_grid(GridConfig((16,), (10.0,)))

--- a/test/workflow/test_phase_scan.jl
+++ b/test/workflow/test_phase_scan.jl
@@ -1,3 +1,5 @@
+using Test
+using SpinorBEC
 using FFTW
 
 @testset "Phase Scan" begin

--- a/test/workflow/test_phi_omega_convention.jl
+++ b/test/workflow/test_phi_omega_convention.jl
@@ -8,6 +8,7 @@
 # the 2π drop silently.
 
 using Test
+using SpinorBEC
 using SpinorBEC: _parse_dimless_freq
 
 @testset "phi_omega Hz convention (Klaus 2022 magnetostir 2π footgun)" begin

--- a/test/workflow/test_pipeline.jl
+++ b/test/workflow/test_pipeline.jl
@@ -1,3 +1,5 @@
+using Test
+using SpinorBEC
 using JLD2
 using JSON
 using Dates: Date

--- a/test/workflow/test_recommend_backend_dtype.jl
+++ b/test/workflow/test_recommend_backend_dtype.jl
@@ -1,3 +1,4 @@
+using SpinorBEC
 using Test, SpinorBEC
 
 @testset "recommend_backend_dtype" begin

--- a/test/workflow/test_schema_validation_edge_cases.jl
+++ b/test/workflow/test_schema_validation_edge_cases.jl
@@ -6,6 +6,7 @@
 # instead of an early ArgumentError.
 
 using Test
+using SpinorBEC
 using SpinorBEC: load_config_from_string
 
 @testset "Schema validation edge cases" begin

--- a/test/workflow/test_vtk_export.jl
+++ b/test/workflow/test_vtk_export.jl
@@ -1,5 +1,7 @@
 # `WriteVTK` is a weak dep loaded via SpinorBECVTKExt; we explicitly
 # `using` it here so `export_vtk` resolves to the extension method.
+using Test
+using SpinorBEC
 using WriteVTK
 
 @testset "VTK Export" begin


### PR DESCRIPTION
CLAUDE.md states the contract: *"Parallel mode requires each test file to stay a
dependency-free unit (own `using` / `@testset` / `@__DIR__` helpers)"*. 45 files
had no `using Test`, 46 no `using SpinorBEC`. They ran only because
`test/_run_files.jl` leaks stdlibs into `Main` from whichever file `using`d them
first — a comment there says so explicitly.

Two consequences, both measured:

- the single-test command CLAUDE.md documents,
  `julia --project=. -e 'using SpinorBEC; include("test/test_X.jl")'`, died with
  `UndefVarError: @testset` on **13 % of the suite**;
- the leak is order-dependent, so which files work standalone depends on what
  the claim queue happened to hand out first — it is not a property of the file
  at all.

## Measured, not assumed

Every one of the 348 `test_*.jl` files was run in its own process with **no
preamble whatever** — `julia --project=. --startup-file=no -e 'include(f)'` —
and the first `UndefVarError` recorded. That is what a self-contained file has
to survive, and it is the only way to tell a real gap from a false positive: a
static scan flagged 91 files, but most `LinearAlgebra` hits were
`for I in CartesianIndices(...)`, not `LinearAlgebra.I`.

The run found four gaps a bulk edit would have missed:

- `analysis/test_diagnostics.jl` had `using SpinorBEC: _elliptic_k` and called
  the exported `spin_mixing_period`. A selective import does not bring the
  package's exports into scope; it worked only on the leak. Nine files were in
  that shape, so the plain `using SpinorBEC` is now required alongside.
- `analysis/test_spinor_utils.jl` used `LinearAlgebra.I` with only
  `using LinearAlgebra: norm, normalize`.
- `hamiltonian/test_tensor_interaction.jl` used `MersenneTwister` with no
  `using Random`.
- `gpu/test_cuda.jl` wrote a bare `CuArray` after only `import CUDA` — its
  sibling `gpu/test_cuda_equivalence.jl` binds `CuArray = CUDA.CuArray` for
  exactly this reason. Qualified as `CUDA.CuArray`.

`test_tier_membership.jl` itself was the last file that needed the runner (for
`_tiers.jl`); it now includes it when the binding is absent, so the file holding
the contract satisfies it.

**All 348 files now run standalone.**

## The gate

A fourth meta-testset in `test_tier_membership.jl` (fast tier, static, free):
every `test_*.jl` must declare `using Test` and a PLAIN `using SpinorBEC`.
Canaried — deleting `using Test` from `analysis/test_bogoliubov.jl` turns it red
and names the file.

It cannot catch the stdlib cases (`I`, `MersenneTwister`) — a static check
cannot tell `LinearAlgebra.I` from a loop variable, which is the whole reason
the standalone run is the instrument and this is only the cheap tripwire. The
run is reproducible:

```bash
find test -name 'test_*.jl' | xargs -P 5 -I{} \
  timeout -s KILL 60 julia --project=. --startup-file=no -e 'include("{}")'
```

watching for `UndefVarError`. Note `timeout` alone does not bound it — Julia
sits in CUDA teardown ignoring SIGTERM, so the GPU files need `-s KILL`.

## Verified

`fast` tier green (176 files on the branch it was developed on; re-running on
this rebase). No behavioural change: the edits are `using` lines plus one
`CUDA.CuArray` qualification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
