### PR TITLE
ci: surface the nightly result instead of discarding it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,3 +46,84 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: false   # see .github/workflows/ci.yml for rationale
+
+  # A result nobody reads is not a gate. This workflow failed 100+ consecutive
+  # times — every run in the API's history — with no notification of any kind,
+  # so the heavy-YAML surface it exists to cover went unverified for months and
+  # the failures were found only by accident, from an unrelated PR.
+  #
+  # A per-run ping would be the wrong fix: the interesting event is the
+  # TRANSITION, and a job that pings every night for a month trains everyone to
+  # filter it. So this keeps exactly one issue that mirrors the current state —
+  # opened on the first failure, its body refreshed (not commented) on each
+  # subsequent one so the streak is visible without a notification, and closed
+  # automatically when nightly goes green again.
+  report:
+    name: Report the nightly result
+    needs: heavy
+    if: always() && github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      OUTCOME: ${{ needs.heavy.result }}
+      MARKER: "<!-- nightly-heavy-status -->"
+    steps:
+      - name: Open, refresh or close the status issue
+        run: |
+          set -euo pipefail
+
+          # The one issue this workflow owns, found by a marker in the body so
+          # the title stays free to edit by hand.
+          existing=$(gh issue list --repo "$REPO" --state open --limit 100 \
+            --json number,body \
+            --jq "[.[] | select(.body | contains(\"$MARKER\"))] | .[0].number // empty")
+
+          if [ "$OUTCOME" = "success" ]; then
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --repo "$REPO" \
+                --comment "Nightly is green again: $RUN_URL"
+              echo "closed #$existing"
+            else
+              echo "green, nothing open - no action"
+            fi
+            exit 0
+          fi
+
+          # How long has this been broken? A red that has been red for weeks
+          # reads very differently from a fresh one, and that distinction is
+          # exactly what was missing.
+          streak=$(gh run list --repo "$REPO" --workflow=nightly.yml --limit 100 \
+            --json conclusion --jq '[.[].conclusion] | index("success") // length')
+
+          # printf, not a heredoc: a heredoc inside a YAML block scalar carries
+          # the block's indentation into the body, and 10 leading spaces render
+          # the whole issue as a code block.
+          body=$(printf '%s\n' \
+            "$MARKER" \
+            "**Nightly \`full\` tier + \`SPINORBEC_RUN_HEAVY_YAML=true\` is failing.**" \
+            "" \
+            "- latest run: $RUN_URL" \
+            "- consecutive failures: **$streak** (capped at the last 100 runs)" \
+            "" \
+            "This issue is maintained by the workflow: the body is refreshed on every" \
+            "failing run and the issue closes itself when nightly goes green. Closing" \
+            "it by hand only hides the streak." \
+            "" \
+            "The nightly tier covers what per-PR checks cannot: the heavy YAML pipeline" \
+            "blocks behind \`SPINORBEC_RUN_HEAVY_YAML\`, which are SKIPPED in \`fast\` /" \
+            "\`oracles\` / \`integration\` even though the files containing them are" \
+            "gated. While this is red, that surface is unverified.")
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --repo "$REPO" --body "$body"
+            echo "refreshed #$existing (streak $streak)"
+          else
+            gh issue create --repo "$REPO" \
+              --title "Nightly heavy YAML is failing" --body "$body"
+            echo "opened a new status issue (streak $streak)"
+          fi


### PR DESCRIPTION
## `nightly.yml` has never been green

Every run in its recorded history ended `failure`:

```
$ gh run list --workflow=nightly.yml --limit 100 --json conclusion --jq 'length'
70
$ ... --jq '[.[].conclusion] | group_by(.) | map({(.[0]//"null"): length}) | add'
{"failure": 70}          # back to 2026-04-27
```

The workflow has **no notification of any kind** — no Slack, no issue, nothing. So nothing said so, and the heavy-YAML surface it exists to cover has been unverified for three months.

## That surface is not covered anywhere else

The blocks behind `SPINORBEC_RUN_HEAVY_YAML` are **skipped** in `fast` / `oracles` / `integration`, even though the files containing them *are* gated. So a per-PR green says nothing about them.

Three of the current failures are in files those tiers gate:

| file | tier | why it passes per PR |
|---|---|---|
| `hamiltonian/test_b_block_builders.jl` | **fast** (a required check) | the failing block is `SPINORBEC_RUN_HEAVY_YAML`-guarded |
| `test_dealias_2_3.jl` | integration (#226) | same |
| `workflow/test_infrastructure.jl` | integration (#226) | same |

Gating the file is not gating its contents.

## What this adds

A `report` job — deliberately **not** a per-run ping. The interesting event is the *transition*, and a nightly alert every day for three months is a filter rule waiting to happen. It maintains exactly one issue mirroring current state:

- opened on the first failure,
- **body refreshed, not commented,** on each subsequent failure — the streak stays visible without generating a notification,
- **closed automatically** when nightly goes green.

The consecutive-failure count is in the body on purpose. A red that has been red for three months and a red that appeared last night call for different responses, and that distinction is exactly what was missing here.

Uses `secrets.GITHUB_TOKEN` with `issues: write`; no new secret. Skips on `workflow_dispatch` so a manual run cannot churn the issue.

Verified locally: `bash -n` on the step script, `yaml.safe_load` on the workflow, the body rendered with no leading indentation (a heredoc inside a YAML block scalar would have indented it into a code block — this uses `printf`), and the streak expression checked against the live API with a **positive control** (`ci.yml` on `main` → `0`, nightly → `70`).

## Not in scope

The failures themselves. #238 (mixed precision / CPU runner) and #239 (standalone test files — which is what makes the GPU files' top-level `return` actually skip, since `return` at the top level of an `include`d file does not stop the include) are in flight on two of the classes. This PR is about the result being readable at all; it will report red until those land, which is the correct behaviour.