### PR TITLE
fix(raman): the term had an energy and no gradient, so L-BFGS descended a different functional

### DIFF
--- a/docs/design/hamiltonian_layered_architecture.md
+++ b/docs/design/hamiltonian_layered_architecture.md
@@ -186,7 +186,7 @@ share nothing.
 | order slopes | split-step vs dumb RK4 / dense expm (§2), limit-class dt-valley |
 | parity | resume == straight; CPU == GPU per term (tolerance, not bit); F32 == F64 (~1e-5); alloc == 0 in hot loops; basis round-trips |
 | conservation, commute-gated | norm / energy / M_z / J_z checked **iff every active term commutes** (boolean per term): full DDI → J_z only; secular DDI → + F_z (the secular approximation's content, machine-checked); Loss → norm gate off |
-| KNOWN-LIMIT gaps, loud | AD-on-dumb produces gradients production lacks (Tensor, Raman) — the dumb-vs-fast gradient gate *legitimately* fails there, so the gap is declared per term and `energy ≠ 0 ∧ gradient ≡ 0` is a loud error at LBFGS entry, never a silent wrong landscape. AD makes the gap visible; the policy makes it loud |
+| KNOWN-LIMIT gaps, loud | AD-on-dumb produced gradients production lacked (Tensor, Raman), so the gap was declared per term and `energy ≠ 0 ∧ gradient ≡ 0` had to be loud at LBFGS entry rather than a silent wrong landscape. **Both gaps are now closed** (Tensor 2026-06-09, Raman 2026-07-31) and `PRODUCTION_RHS_GAPS` is empty, so the dumb-vs-fast gradient gate covers every slot. The policy stands for the next term that lands energy-first |
 | Euler factor | `energy_factor = 2/d` derived from homogeneity degree; guarded by the scaling oracle `ε(λψ) = λ^d ε(ψ)` (free, F-independent; mixed-degree terms fail by construction) |
 | convergence gating | quoted numbers require `‖∇E‖`-gated states (never disk-cached gate status — fresh re-eval; M1 lesson) |
 

--- a/ext/SpinorBECCUDAExt/gpu_energy.jl
+++ b/ext/SpinorBECCUDAExt/gpu_energy.jl
@@ -12,7 +12,7 @@
 # shift, magnetic gradient), 1/2 for the density mean-field terms
 # (c0, c1, DDI). LHY is a density mapreduce (kind-specific power). The two
 # gradient-blind terms — Tensor (scalar-loop singlet + tensor-cache accumulate)
-# and Raman (apply_operator! is a declared no-op) — keep the host helpers,
+# and Raman (per-voxel ladder loop, host fallback) — keep the host helpers,
 # behind a single ψ→host copy taken only when either is active.
 #
 # The terms are drawn from `build_h_terms_registry(ws)` so the RF-corrected
@@ -102,9 +102,9 @@ function _gpu_energy_and_optional_grad(ws::SpinorBEC.Workspace{N}, grad) where {
     end
 
     (
-        kin_t, trap_t, zee_t, c0_t, c1_t, ddi_t, lhy_t, tensor_t, raman_t,
-        ls_t, cor_t, mg_t, sz_t, loss_t,
-    ) = SpinorBEC.build_h_terms_registry(ws)
+    kin_t, trap_t, zee_t, c0_t, c1_t, ddi_t, lhy_t, tensor_t, raman_t,
+    ls_t, cor_t, mg_t, sz_t, loss_t
+) = SpinorBEC.build_h_terms_registry(ws)
 
     # Inactive linear/mean-field terms are skipped: their apply_operator!
     # contributes exactly 0 to the gradient (gate-first), so skipping the
@@ -129,7 +129,7 @@ function _gpu_energy_and_optional_grad(ws::SpinorBEC.Workspace{N}, grad) where {
     # makes it a no-op, and magnetic_gradient is absent in most configs.
     E_mg = ws.magnetic_gradient !== nothing ? op_energy(mg_t, 1.0) : 0.0
 
-    # Gradient-blind terms — Tensor (scalar-loop) + Raman (no-op grad):
+    # Scalar-loop terms — Tensor + Raman, both host-side:
     # host helpers behind a single ψ→host copy, only when active.
     F = ws.spin_matrices.system.F
     c2 = SpinorBEC.get_cn(ws.interactions, 2)
@@ -143,9 +143,11 @@ function _gpu_energy_and_optional_grad(ws::SpinorBEC.Workspace{N}, grad) where {
             SpinorBEC.is_active(c2) &&
                 (E_tensor += SpinorBEC._singlet_pair_energy(psi_h, F, c2, N, n_pts, dV))
             ws.tensor_cache !== nothing &&
-                (E_tensor += SpinorBEC._tensor_interaction_energy(
-                    psi_h, ws.tensor_cache, N, n_pts, dV
-                ))
+                (
+                    E_tensor += SpinorBEC._tensor_interaction_energy(
+                        psi_h, ws.tensor_cache, N, n_pts, dV
+                    )
+                )
         end
         if need_raman
             E_raman = SpinorBEC._raman_energy(
@@ -154,8 +156,8 @@ function _gpu_energy_and_optional_grad(ws::SpinorBEC.Workspace{N}, grad) where {
             )
         end
     end
-    # Gradient faces for the gradient-blind terms (Tensor gate-first host
-    # fallback; Raman/Loss no-op; SpatialZeeman inactive on GPU) — accumulate
+    # Gradient faces for the scalar-loop terms (Tensor and Raman gate-first
+    # host fallbacks; Loss no-op; SpatialZeeman inactive on GPU) — accumulate
     # into grad to match apply_operator_via_registry! exactly.
     accum_grad(tensor_t)
     accum_grad(raman_t)

--- a/ext/SpinorBECCUDAExt/gpu_raman.jl
+++ b/ext/SpinorBECCUDAExt/gpu_raman.jl
@@ -105,3 +105,19 @@ function SpinorBEC.apply_raman_step!(
 
     nothing
 end
+
+# RamanTerm gradient face on GPU — CPU fallback, the same shape as the tensor
+# one in `gpu_tensor.jl`. The per-voxel ladder loop is scalar-indexed, and the
+# energy face already pays a host round-trip for this term, so correctness comes
+# first and a device kernel is a perf follow-on. Gate-first: an inactive Raman
+# term is the common L-BFGS case and must not pay a copy. ACCUMULATES, matching
+# the CPU contract.
+function SpinorBEC.apply_operator!(
+    out::CuArray, term::SpinorBEC.RamanTerm, ws, psi::CuArray
+)
+    ws.raman === nothing && return out
+    out_h = Array(out)
+    SpinorBEC.apply_operator!(out_h, term, ws, Array(psi))
+    copyto!(out, out_h)
+    out
+end

--- a/src/hamiltonian/terms/raman.jl
+++ b/src/hamiltonian/terms/raman.jl
@@ -2,8 +2,8 @@
 #
 # Engine `apply_raman_step!` is the production propagator (called by
 # integrator/split_step.jl and the GPU ext); `RamanTerm` is the registry
-# face (energy + KNOWN-LIMIT nil gradient). One file = engine + face
-# cohesion.
+# face (energy + gradient, both from the same H_R). One file = engine +
+# face cohesion.
 
 # ============================================================================
 # Engine — Raman propagator + time-dependent resolution
@@ -70,7 +70,8 @@ raman_at(::Nothing, ::Float64) = nothing
 
 # ============================================================================
 # RamanTerm — registry face. Sign convention is encoded in
-# apply_raman_step! + _raman_energy above. Gradient not implemented.
+# apply_raman_step! + _raman_energy above; the gradient derives from the
+# same H_R and is FD-gated against the energy.
 # ============================================================================
 
 """Raman two-photon coupling."""
@@ -129,13 +130,64 @@ function energy_contribution(::RamanTerm, psi::AbstractArray{<:Complex}, ws)
     )
 end
 
-# Operator-trinity KNOWN-LIMIT: Raman gradient not implemented in legacy
-# (LBFGS skip). apply_operator! nil to match; ITP path (apply_step!)
-# remains active.
-apply_operator!(out, ::RamanTerm, ws, psi) = out
+"""
+    _accumulate_raman_operator!(out, psi, sm, raman, grid, ndim, n_pts)
 
-# Directional oracle anchored on the PROPAGATOR (apply_raman_step!), since the
-# gradient face is a declared no-op. With δ·F_z the dominant term, ITP minimises
+`out .+= H_R·ψ` for the SAME `H_R` whose expectation `_raman_energy` sums.
+Writing that Hermitian matrix out,
+
+    H_R = δ·F_z + (Ω_R/2)·(e^{i k·r}·F₊ + e^{−i k·r}·F₋),
+
+since `E = δ·⟨F_z⟩ + Ω_R·Re(e^{i k·r}⟨F₊⟩)` and `⟨F₊⟩ = Σ_c a_c ψ̄_{c−1} ψ_c`
+means the off-diagonal entries are `H[c−1, c] = (Ω_R/2)·e^{i k·r}·a_c` and its
+adjoint. Hence, per voxel and component,
+
+    g_j = δ·m_j·ψ_j + (Ω_R/2)·(e^{i k·r}·a_{j+1}·ψ_{j+1} + e^{−i k·r}·a_j·ψ_{j−1})
+
+with `a_c = fp_ladder_coeffs(F)[c]` and `a_1 = a_{D+1} = 0` at the ends.
+"""
+function _accumulate_raman_operator!(psi_out, psi, sm::SpinMatrices{D},
+    raman::RamanCoupling{N}, grid::Grid{N}, ndim, n_pts) where {D, N}
+    F = sm.system.F
+    m_vals = ntuple(c -> Float64(F - (c - 1)), Val(D))
+    fp_coeffs = fp_ladder_coeffs(F, Val(D))
+    half_omega = raman.Omega_R / 2
+
+    @inbounds for I in CartesianIndices(n_pts)
+        kr = sum(ntuple(d -> raman.k_eff[d] * grid.x[d][I[d]], Val(N)))
+        phase = exp(1im * kr)
+        for c in 1:D
+            g = raman.delta * m_vals[c] * psi[I, c]
+            # c is the ψ̄ index: the ⟨F₊⟩ sum contributes ψ_{c+1} through the
+            # e^{+ikr} branch and ψ_{c−1} through its adjoint.
+            c < D && (g += half_omega * phase * fp_coeffs[c + 1] * psi[I, c + 1])
+            c > 1 && (g += half_omega * conj(phase) * fp_coeffs[c] * psi[I, c - 1])
+            psi_out[I, c] += g
+        end
+    end
+    psi_out
+end
+
+# Gradient face = δE/δψ̄. Was a declared no-op until 2026-07-31 ("KNOWN-LIMIT:
+# Raman gradient not implemented in legacy (LBFGS skip)"), which meant that with
+# a Raman coupling active `energy_gradient!` — registry-only since 2026-06-09,
+# so L-BFGS and Newton-CG both ride it — descended a functional EXCLUDING the
+# Raman term while `total_energy` reported one INCLUDING it, with no warning.
+# The converged state was not a stationary point of the energy printed beside
+# it. Gated by the FD identity in `oracles/test_term_fd_registry_coverage.jl`.
+function apply_operator!(out, ::RamanTerm, ws, psi)
+    ws.raman === nothing && return out
+    raman_now = raman_at(ws.raman, ws.state.t)
+    N = ndims(psi) - 1
+    n_pts = ntuple(d -> size(psi, d), Val(N))
+    return _accumulate_raman_operator!(
+        out, psi, ws.spin_matrices, raman_now, ws.grid, N, n_pts
+    )
+end
+
+# Directional oracle anchored on the PROPAGATOR (apply_raman_step!) — it predates
+# the gradient face and stays there because it is the face ITP uses. With δ·F_z
+# the dominant term, ITP minimises
 # the energy δ·⟨F_z⟩, so the converged ⟨F_z⟩ takes the sign opposite to δ. A
 # flipped δ sign in the propagator inverts ⟨F_z⟩ and trips this. (δ = 0 — pure
 # transverse drive — has no F_z anchor and short-circuits to true.)

--- a/src/validation/dumb_reference.jl
+++ b/src/validation/dumb_reference.jl
@@ -41,7 +41,9 @@
 #   conventions: c_dd = μ₀μ², no 4π, no 1/(4π)).
 #   The PADDED (non-periodic) DDI variant is a follow-up sub-unit
 #   (App. A defect 9 verdict lives there).
-# - DECLARED PRODUCTION GAPS made visible here: raman and tensor RHS
+# - DECLARED PRODUCTION GAPS made visible here: none left — the raman
+#   and tensor RHS gaps both closed (2026-07-31 / 2026-06-09) and the
+#   master oracle now compares every slot's RHS against these statements
 #   exist on the dumb side while production apply_operator! is nil
 #   (KNOWN-LIMIT) — the master oracle asserts both sides of that gap.
 
@@ -668,10 +670,11 @@ end
 """
     dumb_rhs_breakdown(ws, ψ; ddi_secular=nothing) -> NamedTuple of arrays
 
-Per-slot canonical gradients. Production KNOWN-LIMIT gaps (raman,
-tensor) are present HERE — the master oracle asserts production is nil
-where these are not. `ddi_secular` is required when ws has active DDI
-(model declaration, see `dumb_ddi_potential`).
+Per-slot canonical gradients. Every slot is now compared against
+production by the master oracle — the raman and tensor KNOWN-LIMIT gaps
+that this file used to be the only statement of are both closed.
+`ddi_secular` is required when ws has active DDI (model declaration, see
+`dumb_ddi_potential`).
 """
 function dumb_rhs_breakdown(
     ws, ψ::AbstractArray{<:Complex}; ddi_secular::Union{Nothing, Bool}=nothing

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -352,7 +352,7 @@ const CI_EXTRA = [
     # Master oracle: dumb reference vs production registry per term —
     # the gated-redundancy mechanism behind commitment #3. Includes the
     # set-equivalence meta-test and both sides of the declared
-    # KNOWN-LIMIT gaps (raman/tensor RHS).
+    # KNOWN-LIMIT gaps (empty since the raman RHS landed 2026-07-31).
     "oracles/test_master_oracle.jl",
     # Propagator references: per-term dt-valleys (step residual vs the
     # dumb RHS, slope ≈ 1) + Strang order slope vs dumb RK4 (slope ≈ 2).

--- a/test/oracles/test_imag_time_propagator_generator.jl
+++ b/test/oracles/test_imag_time_propagator_generator.jl
@@ -127,11 +127,12 @@ end
         _check(SpatialZeemanTerm, ws, _textured_state(ws))
     end
 
-    @testset "Raman propagator: gate vs INDEPENDENT dumb RHS (gradient face is nil)" begin
-        # RamanTerm.apply_operator! is a declared no-op, so _check (which targets
-        # apply_operator!) cannot gate the propagator. The Raman direction (δ, Ω,
-        # ±k phase, F₊↔F₋) was only pinned on the energy face. Gate the PROPAGATOR
-        # generator against the independent dumb Raman RHS H_R·ψ instead.
+    @testset "Raman propagator: gate vs INDEPENDENT dumb RHS" begin
+        # Kept pointed at the dumb RHS rather than switched to `_check` when the
+        # production gradient landed (2026-07-31): comparing the propagator
+        # generator against an INDEPENDENT statement of H_R·ψ is the stronger
+        # gate, and it is what pins the Raman direction (δ, Ω, ±k phase, F₊↔F₋)
+        # on the propagator face.
         raman = RamanCoupling{3}(1.3, -0.7, (0.6, -0.3, 0.9))
         ws = make_workspace(; grid, atom=Eu151,
             interactions=InteractionParams(Dict(0 => 0.0, 1 => 0.0)),

--- a/test/oracles/test_master_oracle.jl
+++ b/test/oracles/test_master_oracle.jl
@@ -10,11 +10,12 @@
 # Gap discipline (arch doc §4 KNOWN-LIMIT row):
 # - DUMB_DEFERRED_SLOTS — dumb statement deferred to its own unit;
 #   explicitly skipped, never silently. Empty since the DDI unit landed.
-# - PRODUCTION_RHS_GAPS (:raman) — production apply_operator! is
-#   declared-nil; the oracle asserts BOTH sides of the gap
-#   (production ≡ 0 AND dumb ≠ 0 when active), so the gap closing or
-#   widening is a test event either way. :tensor left the list when its
-#   gradient face was implemented 2026-06-09.
+# - PRODUCTION_RHS_GAPS — production apply_operator! declared-nil; the
+#   oracle asserts BOTH sides of the gap (production ≡ 0 AND dumb ≠ 0
+#   when active), so the gap closing or widening is a test event either
+#   way. EMPTY since 2026-07-31: :tensor left when its gradient face was
+#   implemented (2026-06-09) and :raman when its was (2026-07-31), so
+#   every slot's RHS is now compared against the dumb statement.
 # - Slot coverage is not KIND coverage. The `lhy` slot's dumb statement
 #   implements the scalar form only; see the declaration testset below.
 #
@@ -48,7 +49,7 @@ const SLOT_TERM = (;
     loss=LossTerm,
 )
 
-const PRODUCTION_RHS_GAPS = (:raman,)  # :tensor gradient implemented 2026-06-09
+const PRODUCTION_RHS_GAPS = ()  # :tensor 2026-06-09, :raman 2026-07-31
 
 """Source-faithful sign mutant: a copy of `term` with every numeric
 field negated. The registry term carries its coefficients in struct

--- a/test/oracles/test_physics_aware_sign_oracles.jl
+++ b/test/oracles/test_physics_aware_sign_oracles.jl
@@ -242,7 +242,7 @@ end
 # (5) RamanTerm:  +δ → ⟨F_z⟩ < 0  (energy δ·⟨F_z⟩ minimised by ITP)
 # ============================================================================
 #
-# RamanTerm's gradient face is a declared no-op, so the previous in-term
+# RamanTerm's gradient face was a declared no-op until 2026-07-31, so the previous in-term
 # sign_oracle was the placeholder `predicate=true` — it could not detect a
 # δ-sign flip in the PROPAGATOR (apply_raman_step!), the face production
 # actually runs. Here we anchor on the propagator: ITP under H = δ·F_z (Ω=0,

--- a/test/oracles/test_raman_analytic.jl
+++ b/test/oracles/test_raman_analytic.jl
@@ -6,11 +6,10 @@
 # and the registry energy face is
 #   E_Raman = ∫ d³r [ δ·⟨F_z⟩ + Ω_R·Re(e^{ik·r}·⟨F_+⟩) ].
 #
-# KNOWN-LIMIT: RamanTerm.apply_operator! is a NO-OP (gradient not
-# implemented — LBFGS skips Raman; src/hamiltonian/terms/raman.jl:136).
-# So we cannot pin the gradient face. Instead we pin energy_contribution
-# against its explicit closed form, voxel-wise, at machine precision,
-# AND assert the documented no-op contract for apply_operator!.
+# Both faces are pinned against explicit spin matrices, voxel-wise, at machine
+# precision. The gradient face used to be a declared NO-OP and this file
+# asserted that contract; it was implemented 2026-07-31 because a term with an
+# energy and no gradient made L-BFGS descend a functional it did not report.
 #
 # The energy test is NON-TRIVIAL: a wrong sign on δ or Ω_R, a flipped
 # k·r phase, or F_+ ↔ F_- would all break it (the e^{ik·r}·⟨F_+⟩ term is
@@ -24,7 +23,7 @@ using SpinorBEC:
     RamanTerm, RamanCoupling, apply_operator!, energy_contribution,
     spin_matrices, cell_volume
 
-@testset "RamanTerm energy = ∫[δ⟨Fz⟩ + Ω_R Re(e^{ik·r}⟨F₊⟩)], grad = nil" begin
+@testset "RamanTerm energy and gradient vs explicit spin matrices" begin
     for (atom, F) in ((Rb87, 1), (Eu151, 6))
         grid = make_grid(GridConfig((6, 6, 6), (4.0, 4.0, 4.0)))
         D = 2F + 1
@@ -71,12 +70,36 @@ using SpinorBEC:
             @test abs(expected_E) > 1e-6
         end
 
-        @testset "F=$F apply_operator! is KNOWN-LIMIT no-op" begin
+        @testset "F=$F gradient = H_R·ψ from the explicit matrices" begin
+            # Same construction as the energy above, one derivative up:
+            # H_R = δ·F_z + (Ω_R/2)(e^{ik·r}F₊ + e^{−ik·r}F₋). Built here from
+            # `Fz`/`Fp` rather than from the production ladder coefficients, so
+            # the two statements share nothing but the physics.
+            Fm = Fp'
+            expected_g = zeros(ComplexF64, 6, 6, 6, D)
+            @inbounds for I in CartesianIndices((6, 6, 6))
+                kr =
+                    k_eff[1] * grid.x[1][I[1]] +
+                    k_eff[2] * grid.x[2][I[2]] +
+                    k_eff[3] * grid.x[3][I[3]]
+                H = delta * Fz + (Omega_R / 2) * (exp(im * kr) * Fp + exp(-im * kr) * Fm)
+                expected_g[I, :] = H * psi[I, :]
+            end
+
+            # ACCUMULATE contract: a pre-filled `out` must gain H_R·ψ, not be
+            # overwritten — the defect class `test_apply_operator_accumulates.jl`
+            # gates generally, checked here on the term this file owns.
             out = randn(ComplexF64, 6, 6, 6, D)
             before = copy(out)
             ret = apply_operator!(out, RamanTerm(), ws, psi)
-            @test out == before          # leaves accumulator untouched
             @test ret === out
+            @test isapprox(out, before .+ expected_g; rtol=1e-12, atol=1e-13)
+
+            # And the two faces are the same operator: E = Re⟨ψ, H_R ψ⟩·dV.
+            @test isapprox(
+                real(sum(conj.(psi) .* expected_g)) * dV, expected_E;
+                rtol=1e-10, atol=1e-12,
+            )
         end
     end
 end

--- a/test/oracles/test_term_fd_registry_coverage.jl
+++ b/test/oracles/test_term_fd_registry_coverage.jl
@@ -34,27 +34,17 @@ include(joinpath(@__DIR__, "..", "helpers", "oracle_fixtures.jl"))
 #      stops activating a term takes its coverage with it and the suite stays
 #      green — which is exactly how "for every HamTerm" came to mean three.
 #
-# Two slots are excluded, each with a ratchet below so the exclusion cannot
-# outlive its reason:
+# One slot is excluded: `:loss`. `LossTerm` is non-Hermitian and declares both
+# faces nil on purpose (`apply_operator!(out, ::LossTerm, …) = out`,
+# `energy_contribution = 0.0`), so there is no variational gradient to
+# difference. Non-unitarity is gated by `oracles/test_loss_nonunitarity.jl`, and
+# the ratchet below keeps the exclusion honest.
 #
-# `:loss` — LossTerm is non-Hermitian and declares both faces nil on purpose
-# (`apply_operator!(out, ::LossTerm, …) = out`, `energy_contribution = 0.0`), so
-# there is no variational gradient to difference. Non-unitarity is gated by
-# `oracles/test_loss_nonunitarity.jl`.
-#
-# `:raman` — RamanTerm has an ENERGY and no gradient: `apply_operator!` is nil
-# by an explicit KNOWN-LIMIT at `terms/raman.jl:132`. That is not a harmless
-# omission, and the ratchet below states it rather than the comment doing so:
-# with a Raman coupling active, `energy_gradient!` (registry-only since
-# 2026-06-09, so L-BFGS and Newton-CG both ride it) descends a functional that
-# EXCLUDES the Raman term while `total_energy` reports one that INCLUDES it, and
-# nothing warns. The Tensor slot was in the same state until 2026-06-09 and was
-# fixed rather than excluded; this one should go the same way. Fixing it means
-# CPU + GPU together — `ext/.../gpu_energy.jl` accumulates Raman's gradient
-# through the same nil `apply_operator!` while computing its energy on a host
-# copy — so it is out of scope here, but it is now a red test away, not a
-# comment away.
-const _FD_EXCLUDED = Set([:loss, :raman])
+# `:raman` was the other one when this file landed: it had an energy and a nil
+# gradient, so L-BFGS descended a functional excluding the Raman term while
+# `total_energy` reported one including it. The gradient landed 2026-07-31 and
+# the slot is now differenced like every other.
+const _FD_EXCLUDED = Set([:loss])
 
 # A term is exercised here only if it actually acts on this fixture's ψ. The
 # threshold is on ‖g‖ relative to ‖ψ‖, so it does not silently pass a term
@@ -140,16 +130,16 @@ end
         union!(covered, _fd_check_fixture("spatial_zeeman", ws, psi; rng))
     end
 
-    # Ratchet on the one excluded slot that is NOT nil on both faces. When the
-    # Raman gradient lands this goes red, which is the point: the exclusion
-    # cannot outlive the limitation quietly.
-    @testset "ratchet: :raman has an energy and no gradient" begin
+    # Ratchet on the excluded slot: nil on BOTH faces is what earns an
+    # exclusion. A slot with an energy and no gradient does not — that was
+    # `:raman` until its gradient landed.
+    @testset "ratchet: :loss is nil on both faces" begin
         ws, psi = aux_ws()
-        term = registry_term(ws, SpinorBEC.RamanTerm)
+        term = registry_term(ws, SpinorBEC.LossTerm)
         g = zero(psi)
         apply_operator!(g, term, ws, psi)
-        @test sqrt(sum(abs2, g)) == 0.0                     # gradient: nil
-        @test abs(energy_contribution(term, psi, ws)) > 1.0e-6   # energy: not
+        @test sqrt(sum(abs2, g)) == 0.0
+        @test energy_contribution(term, psi, ws) == 0.0
     end
 
     @testset "coverage: every slot differenced, or declared excluded" begin


### PR DESCRIPTION

`apply_operator!(out, ::RamanTerm, ws, psi) = out` was a declared KNOWN-LIMIT
("Raman gradient not implemented in legacy (LBFGS skip)"). `energy_gradient!`
has been registry-only since 2026-06-09, so both L-BFGS and Newton-CG ride that
face: with a Raman coupling active they minimised a functional EXCLUDING the
Raman term while `total_energy` reported one INCLUDING it, and nothing warned.
The converged state was not a stationary point of the energy printed beside it.

Measured on the `aux` oracle fixture before the fix: `E = 0.3346737`, `‖g‖ = 0`
exactly. Found by `oracles/test_term_fd_registry_coverage.jl` (#243), which
could only record it as a declared exclusion; that exclusion is now gone.

## The gradient

`_raman_energy` sums `⟨ψ|H_R|ψ⟩` for

    H_R = δ·F_z + (Ω_R/2)·(e^{i k·r}·F₊ + e^{−i k·r}·F₋)

— the same operator `apply_raman_step!` exponentiates. Differentiating gives,
per voxel and component,

    g_j = δ·m_j·ψ_j + (Ω_R/2)·(e^{i k·r}·a_{j+1}·ψ_{j+1} + e^{−i k·r}·a_j·ψ_{j−1})

with `a_c = fp_ladder_coeffs(F)[c]`, so the ladder coefficient stays
single-sourced.

GPU: a host round-trip, the same shape as `gpu_tensor.jl`'s tensor gradient and
gate-first so an inactive Raman term pays no copy. The energy face already paid
that round-trip for this term. A device kernel is a perf follow-on, not a
correctness one — doing CPU only would have split GPU/CPU parity, which is why
this was left open in #243.

## Verification

- **FD identity**: `kind = :exact_floor`, residual `2.0e-16`. H_R is linear, so
  central differences are exact — stronger than a valley.
- **`E == Re⟨ψ,g⟩·dV`**: 0.3346737040131694 vs 0.3346737040131696.
- **Independent statement**: `PRODUCTION_RHS_GAPS` is now empty, so
  `test_master_oracle.jl` compares this gradient against
  `dumb_reference.jl`'s `raman` slot — written separately, in full F₊/F₋ matrix
  form rather than the ladder-index form here. It agrees at identity tolerance.
  That gap list is empty for the first time: `:tensor` left it 2026-06-09,
  `:raman` leaves it here.
- **Canary**: doubling `half_omega` turns both the FD gate and the master
  oracle red.
- Green: `test_term_fd_registry_coverage`, `test_master_oracle`,
  `test_term_properties`, `test_term_consistency`, `test_hamiltonian_sign_oracles`,
  `test_gpu_cpu_per_term_parity` (on a real GPU), `test_registry_gradient_parity`,
  `test_reference_rhs`, and `fast` 178/178.

`sign_oracle(::Type{RamanTerm})` stays anchored on the propagator — it is the
face ITP uses, and it predates this.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
