### PR TITLE
refactor(hamiltonian): name the FFT buffer's element type

### DIFF
--- a/src/hamiltonian/terms/base.jl
+++ b/src/hamiltonian/terms/base.jl
@@ -108,7 +108,7 @@ spatial-spin density (`fx, fy, fz`) so DensityC0Term, SpinC1Term,
 LHYTerm, ZeemanTerm, CoriolisTerm and others do not
 duplicate that work.
 """
-struct EnergyContext{ND, PsiT, CT, FFTPlan, SM, NRho, NF}
+struct EnergyContext{ND, PsiT, FFTEltT, FFTPlan, SM, NRho, NF}
     # NOTE: the original definition typed psi_host as Array{ComplexF64, ND}
     # while n_pts/fft_buf are ND-dimensional SPATIAL objects — ψ has ND+1
     # dims, so the constructor could never be called. It had zero callers
@@ -116,13 +116,18 @@ struct EnergyContext{ND, PsiT, CT, FFTPlan, SM, NRho, NF}
     # when the latent mismatch surfaced (dead scaffolding cannot be wrong
     # in a detectable way until something consumes it).
     psi_host::PsiT
-    # `CT`, not a hard-coded ComplexF64: `plans` follows ψ's precision, and an
-    # in-place FFTW plan applied to a buffer of a DIFFERENT eltype silently
-    # falls back to the out-of-place `*`, leaving `fft_buf` untransformed. The
-    # k-space reduction then sums k²|ψ(r)|² over real space and returns a
-    # finite, wrong number — measured 0.115 against an exact 0.500 for the
-    # kinetic energy of a Float32 workspace.
-    fft_buf::Array{CT, ND}
+    # The ELEMENT type of the buffer, parameterised rather than hard-coded to
+    # ComplexF64: `plans` follows ψ's precision, and an in-place FFTW plan
+    # applied to a buffer of a DIFFERENT eltype silently falls back to the
+    # out-of-place `*`, leaving `fft_buf` untransformed. The k-space reduction
+    # then sums k²|ψ(r)|² over real space and returns a finite, wrong number —
+    # measured 0.115 against an exact 0.500 for the kinetic energy of a Float32
+    # workspace.
+    #
+    # Named for what it is, not `CT`. It is not the same object as
+    # `GradientContext`'s `TC`, which is the whole ARRAY type — two parameters
+    # one letter apart meaning different things is how they get swapped.
+    fft_buf::Array{FFTEltT, ND}
     plans::FFTPlan
     spin_matrices::SM
     n_density::NRho


### PR DESCRIPTION
`EnergyContext{ND, PsiT, CT, …}` — `CT` says nothing. Among `PsiT`, `FFTPlan`, `SM`, `NRho` it is the one parameter whose name does not tell you what it is, and it is the one that matters most: it is the **element** type of `fft_buf`, and it exists precisely because hard-coding `ComplexF64` there fed a ComplexF64 buffer to a ComplexF32 in-place plan and returned a finite, wrong kinetic energy (#238).

`FFTEltT`. Element type, said out loud.

It also now says that it is **not** the same object as `GradientContext`'s `TC`, which is the whole *array* type. Two parameters one letter apart meaning different things in the same file is how they get swapped.

`CT` elsewhere in the tree (the Taylor spin-rotation kernels) is a local binding written directly under `CT = Complex{T}` — self-explanatory where it stands, and left alone.

Verified: `test/oracles/test_registry_energy_decomposition_parity.jl` passes at this commit on TSUBAME (job 8309885), which is the gate that actually constructs an `EnergyContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)