### PR TITLE
refactor(hamiltonian): the two scratch containers name the same things the same

### DIFF
--- a/src/hamiltonian/terms/base.jl
+++ b/src/hamiltonian/terms/base.jl
@@ -108,7 +108,7 @@ spatial-spin density (`fx, fy, fz`) so DensityC0Term, SpinC1Term,
 LHYTerm, ZeemanTerm, CoriolisTerm and others do not
 duplicate that work.
 """
-struct EnergyContext{ND, PsiT, FFTEltT, FFTPlan, SM, NRho, NF}
+struct EnergyContext{ND, PsiT, FFTEltT, FFTPlan, SM, DensityT, SpinFieldT}
     # NOTE: the original definition typed psi_host as Array{ComplexF64, ND}
     # while n_pts/fft_buf are ND-dimensional SPATIAL objects — ψ has ND+1
     # dims, so the constructor could never be called. It had zero callers
@@ -130,10 +130,10 @@ struct EnergyContext{ND, PsiT, FFTEltT, FFTPlan, SM, NRho, NF}
     fft_buf::Array{FFTEltT, ND}
     plans::FFTPlan
     spin_matrices::SM
-    n_density::NRho
-    fx::NF
-    fy::NF
-    fz::NF
+    n_density::DensityT
+    fx::SpinFieldT
+    fy::SpinFieldT
+    fz::SpinFieldT
     dV::Float64
     n_pts::NTuple{ND, Int}
 end
@@ -147,12 +147,16 @@ density, FFT buffer, and a `deriv_buf` scratch so the registry path
 matches the legacy `_grad_*` helpers' allocation pattern (no extra
 allocs vs the hand-written sum in `energy_gradient!`).
 """
-struct GradientContext{N, TF, TC, TD}
-    fft_buf::TC
-    deriv_buf::TC
-    fx::TF
-    fy::TF
-    fz::TF
-    n_density::TD
-    n_pts::NTuple{N, Int}
+struct GradientContext{ND, ComplexBufT, DensityT, SpinFieldT}
+    # These are the SAME objects `EnergyContext` carries, so they carry the same
+    # names. They used to be `TF`, `TC`, `TD` here and `NF`, `NRho` there —
+    # one struct's `TC` was the whole ARRAY type while the other's `CT` was an
+    # ELEMENT type, which is a swap waiting to happen.
+    fft_buf::ComplexBufT
+    deriv_buf::ComplexBufT
+    fx::SpinFieldT
+    fy::SpinFieldT
+    fz::SpinFieldT
+    n_density::DensityT
+    n_pts::NTuple{ND, Int}
 end


### PR DESCRIPTION
Follow-up to #249. `EnergyContext` and `GradientContext` carry the same objects — a density, the three spin-density components, a complex buffer — and named them differently:

| | density | spin field | complex buffer |
|---|---|---|---|
| `EnergyContext` | `NRho` | `NF` | `CT` — **element** type |
| `GradientContext` | `TD` | `TF` | `TC` — whole **array** type |

So `CT` and `TC` sat in one file, one letter apart, meaning different kinds of thing. That is a swap waiting to happen, and the bug it would cause is the one #238 just fixed: a buffer whose eltype does not match ψ's silently degrades an in-place FFTW plan to out-of-place, and the k-space reduction reads real-space ψ — finite, wrong, no error.

Now `DensityT`, `SpinFieldT`, `ComplexBufT`, and `ND` for the spatial rank in both (`GradientContext` called it `N`). `FFTEltT` keeps saying element type.

Names only — no field, order or type changes.

Verified: `test/oracles/test_registry_gradient_parity.jl` passes at this commit on TSUBAME (job 8310029), which is the gate that constructs a `GradientContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)