### PR TITLE
test(infrastructure): migrate the pulse-sequence round-trip to `apply: B`

### DIFF
--- a/test/workflow/test_infrastructure.jl
+++ b/test/workflow/test_infrastructure.jl
@@ -703,8 +703,8 @@ pipeline:
       duration: 0.02
       dt: 0.001
       pulse_sequence:
-        - {t: 0.0, apply: zeeman, duration: 0.01, p: {from: 0.0, to: 10.0}, q: 0.5}
-        - {t: 0.01, apply: zeeman, duration: 0.01, p: 10.0, q: 0.5}
+        - {t: 0.0, apply: B, duration: 0.01, p: {from: 0.0, to: 10.0}, q: 0.5}
+        - {t: 0.01, apply: B, duration: 0.01, p: 10.0, q: 0.5}
 """)
         result = SpinorBEC.run_config(cfg)
         @test result.dynamics_result !== nothing


### PR DESCRIPTION
**This is the last failing file in the nightly tier.** With it, `nightly.yml` can be green for the first time in its 70-run history.

## The failure

```
ArgumentError: pulse_sequence apply: zeeman is not compiled.
Use one of (:B, :raman, :interactions).
(`zeeman` became `B` with the unified B block; `trap` has never been implemented.)
```

The source is correct and its error names the fix outright. The test was simply never migrated.

## Why it survived the rename

The same file has two `P1.4` testsets:

| testset | guarded? | state |
|---|---|---|
| `Pulse sequence parse + compile` | no — runs per PR | **migrated at the rename**, with a comment explaining why |
| `Pulse sequence YAML round-trip` | `_SKIP_HEAVY_YAML_INFRA` — nightly only | **missed** |

Same file, same testset family. The visible half was updated; the env-guarded half was not, and the only job that would have said so had never been green and had no notification (#241).

That is the shape in one artifact: **gating the file is not gating its contents.** `test_infrastructure.jl` is in the `integration` tier (#226) and its file-level membership is proven by `test_tier_membership.jl` — neither says anything about a block behind an env guard.

## Verification

```
$ SPINORBEC_RUN_HEAVY_YAML=true julia --project=. -e 'using Test, SpinorBEC; include("test/workflow/test_infrastructure.jl")'
Test Summary:             | Pass  Total   Time
Infrastructure extensions |  137    137  54.3s
```

The guarded block ran — this is not a green from a skip.

## Noted, deliberately not fixed here

`validate_config!` **accepts** `apply: zeeman`. The schema does not check the target against the set the compiler accepts, so an old config passes validation and then dies at runtime. `test_infrastructure.jl:716` asserts exactly that, so it passes while encoding the gap. Fixing it means adding enum validation to `DYNAMICS_SCHEMA` — worth doing, but not in the PR whose job is to turn the nightly green.