### PR TITLE
fix(test): the history-precision gate depended on how the solve stopped

### DIFF
--- a/test/solvers/test_lbfgs_history_precision.jl
+++ b/test/solvers/test_lbfgs_history_precision.jl
@@ -61,23 +61,40 @@ using SpinorBEC:
     @testset "the run really used it" begin
         # Without this the agreement below could hold because the kwarg never
         # reached the history at all.
-        s64, _, rho = r64.lbfgs_history
+        #
+        # Asserted on the CONTAINER's element type, not on `s[1]`. The first
+        # version indexed, and it errored on main: the driver empties the
+        # history on a line-search failure and `stop_at_floor` then breaks
+        # immediately, so a run that ends at its gradient floor returns EMPTY
+        # vectors. The container type is what the kwarg actually chose and it
+        # survives that, so this gate no longer depends on how the solve
+        # happened to stop.
+        s64, y64, _ = r64.lbfgs_history
         s32, y32, _ = r32.lbfgs_history
-        @test !isempty(rho)
-        @test eltype(s64[1]) === ComplexF64
-        @test eltype(s32[1]) === ComplexF32
-        @test eltype(y32[1]) === ComplexF32
+        @test eltype(s64) === Array{ComplexF64, 4}
+        @test eltype(y64) === Array{ComplexF64, 4}
+        @test eltype(s32) === Array{ComplexF32, 4}
+        @test eltype(y32) === Array{ComplexF32, 4}
     end
 
     @testset "the direction is still a descent direction" begin
-        s32, y32, rho32 = r32.lbfgs_history
-        ws = r32.workspace
-        dV = cell_volume(ws.grid)
-        g = similar(ws.state.psi)
-        fill!(g, zero(eltype(g)))
-        SpinorBEC.energy_gradient!(g, ws.state.psi, ws; k_squared_dev=ws.grid.k_squared)
-        SpinorBEC._project_constraints!(g, ws.state.psi, ws.grid, nothing, 1)
-        d = _lbfgs_direction(g, s32, y32, rho32, dV)
+        # Built from a SYNTHETIC curvature pair rather than from whatever the
+        # solve happened to leave behind: a run that stops at its gradient
+        # floor returns an empty history, and a two-loop over an empty history
+        # is just steepest descent, which is trivially a descent direction.
+        # That would be a gate that cannot fail.
+        dV = 0.125
+        n = (4, 4, 4, 3)
+        g = ComplexF64[cis(0.3i) * (1 + 0.01i) for i in 1:prod(n)]
+        g = reshape(g, n)
+        s = ComplexF32.(reshape(ComplexF64[cis(0.7i) for i in 1:prod(n)], n))
+        # ⟨s,y⟩ > 0 is the curvature condition the driver enforces before
+        # storing a pair, so a valid history has it by construction.
+        y = ComplexF32.(0.4f0 .* s)
+        rho = [1.0 / (_realdot(s, y) * dV)]
+        @test rho[1] > 0
+        d = _lbfgs_direction(g, [s], [y], rho, dV)
+        @test eltype(d) === ComplexF64          # F32 history, F64 direction
         @test _realdot(g, d) * dV < 0
     end
 
@@ -89,6 +106,10 @@ using SpinorBEC:
         # count differing.
         @test isapprox(r32.energy, r64.energy; rtol=1.0e-6)
         @test r32.grad_norm < 1.0e-4
+        # Whichever way each run stopped, it has to have taken real steps —
+        # two solves that both did nothing would also agree.
+        @test r64.last_step > 5
+        @test r32.last_step > 5
     end
 
     @testset "refused where it has not been measured" begin


### PR DESCRIPTION
**main is red on the integration tier** — `test/solvers/test_lbfgs_history_precision.jl`, which I added in #255. That tier is not a required check, so auto-merge fired on a green required set while this was failing. Mine twice over: the gate was written against a return value that is not always populated, and I let it merge on a check set that does not cover the tier the file runs in.

```
Error During Test at test_lbfgs_history_precision.jl:68
  Expression: eltype(s32[1]) === ComplexF32
```

`s32` was **empty**. The driver empties `s_hist`/`y_hist` on a line-search failure and `stop_at_floor` then breaks immediately, so any run ending at its gradient floor returns an empty history and `s32[1]` throws. The Float64 arm happened to end differently — exactly the kind of accident a gate must not rest on.

## Fixes, all the same direction: stop depending on how the solve stopped

- Assert the **container's** element type (`eltype(s32) === Array{ComplexF32,4}`). That is what the kwarg actually chose, and it survives the history being emptied.
- Build the descent-direction check from a **synthetic** curvature pair with ⟨s,y⟩ > 0. Reading the pair out of the solve was worse than fragile: over an empty history the two-loop is just steepest descent, so on runs where it did not throw it was asserting that −g is a descent direction — **a gate that cannot fail**.
- Require both solves to have taken real steps, so "same energy" cannot be two runs that did nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)