### PR TITLE
fix(test): the last `apply: zeeman` in the pulse-sequence tests, in its YAML form

### DIFF
--- a/test/workflow/test_infrastructure.jl
+++ b/test/workflow/test_infrastructure.jl
@@ -703,8 +703,12 @@ pipeline:
       duration: 0.02
       dt: 0.001
       pulse_sequence:
-        - {t: 0.0, apply: zeeman, duration: 0.01, p: {from: 0.0, to: 10.0}, q: 0.5}
-        - {t: 0.01, apply: zeeman, duration: 0.01, p: 10.0, q: 0.5}
+        # `apply: B`, not `zeeman`: the unified B block renamed the target and
+        # `parse_pulse_sequence` now rejects the old name outright. #198 fixed
+        # the dict-form occurrence a few testsets up; this YAML one is the same
+        # rename, and it was the last red left in the `full` tier.
+        - {t: 0.0, apply: B, duration: 0.01, p: {from: 0.0, to: 10.0}, q: 0.5}
+        - {t: 0.01, apply: B, duration: 0.01, p: 10.0, q: 0.5}
 """)
         result = SpinorBEC.run_config(cfg)
         @test result.dynamics_result !== nothing
@@ -713,7 +717,7 @@ pipeline:
     @testset "P1: Schema validates dynamics pulse_sequence" begin
         d = Dict{String, Any}(
             "duration" => 1.0, "dt" => 0.001,
-            "pulse_sequence" => [Dict("t" => 0.0, "apply" => "zeeman")],
+            "pulse_sequence" => [Dict("t" => 0.0, "apply" => "B")],
         )
         SpinorBEC.validate_config!(d, SpinorBEC.DYNAMICS_SCHEMA, "test")
     end


### PR DESCRIPTION
Measured on current `main` with the nightly's own configuration
(`SPINORBEC_TEST_TIER=full SPINORBEC_RUN_HEAVY_YAML=true`, 4 workers): the tier
is down to **one** failing site, `workflow/test_infrastructure.jl:691`, and it is
the same stale name #198 fixed one testset earlier.

`parse_pulse_sequence` rejects it with the reason written out —

```
ArgumentError: pulse_sequence apply: zeeman is not compiled.
Use one of (:B, :raman, :interactions).
(`zeeman` became `B` with the unified B block; `trap` has never been implemented.)
```

— but #198 only reached the dict-form occurrence. Two more were inside YAML
strings, so the rename never touched them and the tier stayed red on a name,
not on physics.

`workflow/test_infrastructure.jl` now passes under `SPINORBEC_RUN_HEAVY_YAML=true`.

With this, the `full` tier that **has not gone green in 69 scheduled nightly
runs** (no success since at least 2026-05-08) has no known red left. The 13
failing sites in the 2026-07-30 nightly are closed by #198, #225, #238 and this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)