### PR TITLE
ci: one concurrency group per main commit, so no merge goes unverified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,29 @@ on:
   pull_request:
     branches: [main]
 
-# Cancel superseded runs on a PR — pushing a fixup should not leave the previous
-# commit's run burning a runner. Never cancel a push to `main`: that run is the
-# only verification the merged commit ever gets, and `github.ref` is
-# `refs/heads/main` for every one of them, so back-to-back merges were killing
-# each other's. Measured 2026-07-31: 13 of the last 30 `main` runs ended
-# `cancelled`, i.e. 43 % of merges landed with no completed check of the tree
-# they produced. Same group, so rapid merges queue instead of racing; each one
-# still runs.
+# One concurrency group per `main` commit, one per PR branch.
+#
+# `cancel-in-progress: false` protects the run that is already EXECUTING, but
+# GitHub keeps only the newest PENDING run in a group and cancels the older
+# ones. So dropping cancellation for pushes was not enough: measured on
+# 2026-07-31, `2206b49a` (queued 09:49:39, behind `78010e82` which was still
+# running) was cancelled at 09:54:05 — the instant `d1d10e8f` queued. The
+# middle commit of any three merged inside one CI cycle still went unverified.
+#
+# Putting the SHA in the group for pushes makes every `main` commit its own
+# group, so nothing queues behind anything and nothing is superseded. Runs go
+# wide instead of deep; at the measured merge rate (5 in 3 h) that is a few
+# concurrent runs, not a stampede.
+#
+# PRs keep the shared per-ref group and keep cancelling, which is right there:
+# pushing a fixup should not leave the previous commit's run burning a runner,
+# and only the head commit of a PR needs a verdict.
+#
+# Why this matters at all: a PR's checks run against the base it was cut from,
+# not the base it lands on, so the post-merge run on `main` is the only thing
+# that ever sees the merged tree. Cancelling it discards the only evidence.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'shared' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Opt into Node.js 24 ahead of the September 2026 forced migration so we


### PR DESCRIPTION
#234 was incomplete, and this is the measurement that shows it.

## What #234 missed

It set `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` so pushes to `main` would stop killing each other. But `false` only protects the run that is already **executing**. GitHub keeps just the newest **pending** run in a concurrency group and cancels the older ones.

Measured on `main` *after* #234 had landed:

```
78010e82  queued 09:43:39   still running
2206b49a  queued 09:49:39   cancelled 09:54:05   <- pending, superseded
d1d10e8f  queued 09:54:03   survived
```

`2206b49a` died the instant `d1d10e8f` queued. So the middle commit of any three merged inside one CI cycle still went unverified. #234 turned *"newest kills everything"* into *"oldest running and newest pending survive"* — better, and still wrong.

## Fix

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'shared' }}
```

Every `main` commit becomes its own group: nothing queues behind anything, nothing is superseded. Runs go **wide** instead of deep — at the measured merge rate (5 in 3 h) that is a few concurrent runs, not a stampede.

PRs keep the shared per-ref group and keep cancelling, which is correct there: pushing a fixup should not leave the superseded commit's run burning a runner, and only a PR's head commit needs a verdict.

## Canary

GitHub's `&&` / `||` return operands rather than booleans, so the expression was simulated with those semantics rather than assumed:

| case | group |
|---|---|
| main push A / B / C | three **distinct** groups |
| PR#9 commit 1 and 2 | **same** group (older superseded) |
| PR#9 vs PR#10 | different groups |
| PR vs main push | never collide |

## Why this is worth the runner minutes

A PR's checks run against the base it was cut from, not the base it lands on, and GitHub does not re-run them at merge time — that is how #227 and #228 were each green and still left `main` red. The post-merge run on `main` is the only thing that ever sees the merged tree. Cancelling it discards the only evidence there is.