### PR TITLE
ci: run the nightly so its result is waiting, not landing mid-morning

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,9 +10,19 @@ name: Nightly heavy YAML
 
 on:
   schedule:
-    # 02:00 UTC every day = 11:00 JST. Skips weekends to save runner
-    # minutes — failures on Mon-Fri are usually enough to catch drift.
-    - cron: "0 2 * * 1-5"
+    # 20:17 UTC = 05:17 JST the NEXT day. The run takes ~40-50 min, so the
+    # result is sitting there before the day starts. The old 02:00 UTC slot was
+    # 11:00 JST — a "nightly" that both started and finished mid-morning, after
+    # the day's work had already begun on an unverified tree.
+    #
+    # Day-of-week is `0-4` (Sun-Thu UTC), NOT `1-5`. cron's dow is evaluated in
+    # UTC, and 20:17 UTC lands on the following JST date, so keeping `1-5` here
+    # would have fired Tue-Sat JST — losing Monday and burning a Saturday.
+    # Sun-Thu UTC is Mon-Fri JST.
+    #
+    # :17 rather than :00 on purpose: GitHub delays scheduled workflows when a
+    # popular cron minute comes round, and the hour mark is the most popular.
+    - cron: "17 20 * * 0-4"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
`02:00 UTC` is **11:00 JST**, and the run takes ~40–50 min. So the "nightly" both started *and* finished mid-morning — the day's work had already begun on a tree nothing had checked, and the result arrived after it could have changed anyone's first decision.

`20:17 UTC` is **05:17 JST the next day**. The verdict is sitting there before the day starts.

## The day-of-week is not a copy-paste

cron's `dow` is evaluated in **UTC**, and 20:17 UTC lands on the *following* JST date. Keeping `1-5` while moving the hour would have fired **Tue–Sat JST** — silently dropping Monday and burning a Saturday runner.

Verified rather than reasoned:

```
cron '17 20 * * 1-5'  ->  Tue, Wed, Thu, Fri, Sat  05:17 JST   <- wrong
cron '17 20 * * 0-4'  ->  Mon, Tue, Wed, Thu, Fri  05:17 JST   <- correct
                          weekend JST runs: none
```

## Why `:17`

GitHub delays scheduled workflows when a popular cron minute comes round, and the hour mark is the most popular. Nothing depends on the exact minute here.

## Unchanged

Five runs a week, `workflow_dispatch` still available, and the `report` job still skips on manual dispatch so a hand-run cannot churn the status issue — meaning the first scheduled run under this schedule is also the first end-to-end test of the notification path from #241/#253.