### PR TITLE
fix(test): the history-precision gate asked for an accuracy below the L-BFGS floor

### DIFF
--- a/test/solvers/test_lbfgs_history_precision.jl
+++ b/test/solvers/test_lbfgs_history_precision.jl
@@ -33,9 +33,20 @@ using SpinorBEC:
         grid, atom=Na23,
         interactions=InteractionParams(Dict(0 => 20.0, 1 => -0.5)),
         potential=HarmonicTrap((1.0, 1.0, 1.0)),
-        initial_state=:polar, verbose=false, n_steps=60, tol=1.0e-8,
+        initial_state=:polar, verbose=false, n_steps=60, tol=1.0e-5,
         m_lbfgs=8,
     )
+    # `tol` ABOVE the L-BFGS energy-comparison floor, on purpose. At the 1e-8
+    # this asked for originally, both solves ended `floor_limited = true` with
+    # an EMPTY curvature history (measured: `rho` length 0, grad_norm 1.04e-8 /
+    # 1.22e-7), so "the run really used it" indexed `s64[1]` into a 0-element
+    # vector and the file was red on `main` from the moment it merged — its own
+    # `Integration gates` check was already failing when it went in.
+    # 1e-5 converges normally (history length 8, `floor_limited = false`, 15
+    # steps, both precisions), which is what this file needs to inspect. This
+    # is not a step budget tuned until green: it is asking the solver for an
+    # accuracy it can deliver, the distinction `test_lbfgs_stall_fixed_point.jl`
+    # draws in its own header.
 
     @testset "the history is actually narrowed" begin
         psi = zeros(ComplexF64, 4, 4, 4, 3)


### PR DESCRIPTION
`solvers/test_lbfgs_history_precision.jl` has been red on `main` since it merged
(#255) — its own **`Integration gates` check was already failing when it went
in**, and `Integration gates` is not a required check.

## It is not about single precision

Measured with the file's own configuration, **both** precisions end
`floor_limited = true` with an empty curvature history:

```
Float64: history=0  last_step=25  grad_norm=1.04e-8  floor_limited=true
Float32: history=0  last_step=26  grad_norm=1.22e-7  floor_limited=true
```

so `@test eltype(s64[1]) === ComplexF64` indexed a 0-element vector. `tol = 1e-8`
sits below the energy-comparison floor that `stop_at_floor` exists to detect
(#210), so the solve stops before accepting a step and there is no curvature
pair to inspect.

## The fix

`tol = 1e-5` converges normally — history length 8, `floor_limited = false`, 15
steps, both precisions, energies agreeing to 1e-15.

This is **not** a step budget tuned until green: it is asking the solver for an
accuracy it can deliver. `test_lbfgs_stall_fixed_point.jl` draws exactly that
distinction in its own header — *"a gate that legislates it is a gate that gets
its step count tuned until it goes green"* — and the two earlier versions it
describes failed for this same uninteresting reason.

## Context

With this, the `full` tier has no known red left. Measured end to end on
post-merge `main` with the nightly's own configuration
(`SPINORBEC_TEST_TIER=full SPINORBEC_RUN_HEAVY_YAML=true`, 4 workers): one
failing file, this one.

Worth noting separately: this landed red because `Integration gates` — the job
#226 added precisely to cover the half of the `ci` tier nothing else ran — is
still not in `required_status_checks.contexts`. #226's commit message flagged
that making it required is a repository setting left out of that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)