### PR TITLE
test: retire three of the five MANUAL entries — their reason had stopped being true

### DIFF
--- a/test/MANUAL_TESTS.md
+++ b/test/MANUAL_TESTS.md
@@ -1,89 +1,76 @@
 # Manual test inventory
 
-Tests under `test/` that are intentionally NOT wired into
-`test/runtests.jl` because they depend on environment conditions the
-default test runner cannot guarantee (GPU, dashboard build, opt-in
-heavy YAML, scenario directories pending schema migration).
+Two files under `test/` are not wired into any tier. Each reason was
+**measured**, not inherited (2026-07-31): every candidate was run, with and
+without `SPINORBEC_RUN_HEAVY_YAML=true`, and the three that passed were moved
+into tiers. What is left is what genuinely cannot run.
 
-Run each manually as documented below.
+The old framing — "depend on environment conditions the default test runner
+cannot guarantee (GPU, dashboard build, opt-in heavy YAML, scenario directories
+pending schema migration)" — had stopped being true for three of the five, and
+nothing had checked since 2026-05-25. Between them those three carried 35
+assertions that no tier ran.
 
-## GPU-dependent
+`MANUAL_TESTS_ALLOWLIST` in `test/_tiers.jl` is the machine-readable copy;
+`test_tier_membership.jl` asserts the two agree.
 
-### `gpu/test_cuda.jl`
+## `workflow/test_klaus_validation.jl` — cannot run as written
 
-Coarse CUDA backend smoke (Workspace creation, split_step, ground
-state on GPU vs CPU). Internally guards on `CUDA.functional()` and
-returns silently when CUDA is unavailable.
+Not an environment problem. Its `ground_state` step uses the real experimental
+field (`B: {Bz: "1.0 Gauss"}`, Dy164, `omega_ref: 314.159`) at `dt: 0.001`.
+That is `p ≈ −3.5e4`, so across `m = ±8` the ITP exponent spans
+`|p·m·dt| ≈ 278` and `exp` overflows on the first step:
 
-```bash
-LD_LIBRARY_PATH=/usr/lib/wsl/lib \
-  julia --project=. -e 'using CUDA; using SpinorBEC; include("test/gpu/test_cuda.jl")'
+```
+ArgumentError: NaN detected in ITP at step 1. Likely DDI or interaction
+overflow. Reduce dt.
 ```
 
-### `rotating_basis/test_rotating_basis_gpu.jl`
+`hamiltonian/test_b_block_builders.jl` documents the same footgun and
+deliberately uses `Bz: 1.0e-4` to avoid it:
 
-Option-γ rotating_basis on GPU. Exercises every public function with
-`CUDA.allowscalar(false)` to surface scalar-indexing bugs. **Errors**
-(not skips) if `CUDA.functional() == false`, so it cannot live in the
-default-loaded tier.
+> Tiny Bz to avoid ITP exp-V underflow at large dimensionless p. Real
+> experimental values (e.g. Klaus 2022 Bz=0.819G) give p≈3e4 which requires
+> matching small dt and physics-aware setup — not a plumbing test.
 
-```bash
-LD_LIBRARY_PATH=/usr/lib/wsl/lib \
-  julia --project=. -e 'using CUDA; using SpinorBEC; include("test/rotating_basis/test_rotating_basis_gpu.jl")'
-```
-
-## Heavy YAML (opt-in via `SPINORBEC_RUN_HEAVY_YAML=true`)
-
-These tests run full `run_yaml` / `run_config` pipelines. CLAUDE.md
-notes a trivial pipeline takes >4 min to first output due to
-`Workspace{...23 type params...}` specialisation. Nightly CI sets
-`SPINORBEC_RUN_HEAVY_YAML=true`; default `Pkg.test()` does not.
-
-### `workflow/test_active_learning_yaml.jl`
-
-Active-learning YAML wrapper end-to-end (R38). Gates on
-`_SKIP_HEAVY_YAML_AL = ENV["SPINORBEC_RUN_HEAVY_YAML"] != "true"`.
+So this is a physics-setup decision (a smaller ground-state field with a ramp,
+or a `dt` matched to `p`), not the "pending schema audit" it was filed under.
+Until that decision is made the file cannot be run at all:
 
 ```bash
-SPINORBEC_RUN_HEAVY_YAML=true \
-  julia --project=. -e 'using SpinorBEC; include("test/workflow/test_active_learning_yaml.jl")'
+SPINORBEC_RUN_HEAVY_YAML=true julia --project=. \
+  -e 'using Test; using SpinorBEC; include("test/workflow/test_klaus_validation.jl")'
 ```
 
-### `workflow/test_multi_fidelity_yaml.jl`
+It is also the only artifact behind the Klaus 2022 entry in the type-C registry
+(`test/validation/test_type_c_claims.jl`), which is why that entry is ungated.
 
-Multi-fidelity BO YAML wrapper (R34). Same gate
-`_SKIP_HEAVY_YAML_MFBO`.
+## `workflow/test_live_monitor.jl` — blocks forever
+
+`serve_dashboard` does not return until the server is closed, and this file's
+close path is never reached, so the run hangs until something kills it
+(measured: SIGTERM at a 2400 s timeout, `Press Ctrl+C to stop` in the log). Its
+own comment states the intent — *"the function blocks until the server is
+closed; we'll close it manually"* — which is exactly what does not happen.
+
+Needs restructuring (serve on a task, assert, close in a `finally`), not a tier
+entry. Run it only if you are prepared to interrupt it:
 
 ```bash
-SPINORBEC_RUN_HEAVY_YAML=true \
-  julia --project=. -e 'using SpinorBEC; include("test/workflow/test_multi_fidelity_yaml.jl")'
+julia --project=. \
+  -e 'using Test; using SpinorBEC; include("test/workflow/test_live_monitor.jl")'
 ```
 
-## Pending Step 2 schema audit (2026-05-25 priorities)
+## Moved into tiers, 2026-07-31
 
-### `workflow/test_klaus_validation.jl`
+| file | was filed as | measured | now |
+|---|---|---|---|
+| `gpu/test_cuda.jl` | "gated, but needs GPU to be useful" | guards on `CUDA.functional()` like every other `gpu/` file; 3.9 s on a GPU host, no-op without one | `FULL_EXTRA` |
+| `workflow/test_active_learning_yaml.jl` | "heavy YAML" | carries its own `_SKIP_HEAVY_YAML_AL`; 0.0 s with the flag off, 19.7 s with it on, passes both ways | `CI_EXTRA` |
+| `workflow/test_multi_fidelity_yaml.jl` | "heavy YAML" | same shape; 0.0 s / 50.2 s | `CI_EXTRA` |
 
-Klaus 2022 minimal regression — Dy164 16²×8 + 0.5 ω_ref⁻¹ stir.
-Uses `initial_state: ferromagnetic_min`, `save: {every: ...}`,
-`Bx: {sinusoidal: ...}`. Confirm each maps to current schema before
-wiring.
-
-```bash
-julia --project=. -e 'using SpinorBEC; include("test/workflow/test_klaus_validation.jl")'
-```
-
-## External-process dependent
-
-### `workflow/test_live_monitor.jl`
-
-Spawns `serve_dashboard` on a port and exercises `/api/lab/image`
-via raw `Sockets`. Requires `dashboard/dist/index.html` (the test
-auto-creates a stub if missing) and a free TCP port. Excluded from
-the default tier because TCP binding can collide on CI agents.
-
-```bash
-julia --project=. -e 'using SpinorBEC; include("test/workflow/test_live_monitor.jl")'
-```
+The heavy-YAML pair needed no guard added — they already had one. The entry in
+this file was the only thing keeping them out of a tier.
 
 ## Re-audit (2026-06-19)
 

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -283,6 +283,14 @@ const CI_EXTRA = [
     "dynamics/test_twa_N_scan.jl",
     "solvers/test_absorbing_boundary.jl",
     "workflow/test_infrastructure.jl",
+    # Heavy-YAML Bayesian-optimisation drivers. Both were in the MANUAL
+    # allowlist as "heavy YAML (SPINORBEC_RUN_HEAVY_YAML)" — but they already
+    # carry their own `_SKIP_HEAVY_YAML_*` guard, so with the flag off they cost
+    # 0.0 s and with it on (the nightly) they cost 19.7 s and 50.2 s. Measured
+    # 2026-07-31: both pass, both ways. The environment reason had stopped
+    # being true and nobody had checked.
+    "workflow/test_active_learning_yaml.jl",
+    "workflow/test_multi_fidelity_yaml.jl",
     # Spatial / B(r,t) Zeeman + TOF (#14): split_step / simulate_* (per-voxel
     # propagation, multi-frame TOF) — integration weight, not fast-tier units.
     "analysis/test_tof.jl",
@@ -489,6 +497,10 @@ const FULL_EXTRA = [
     "workflow/test_calibration_drift.jl",
     "workflow/test_dynamics_knobs.jl",
     "gpu/test_cuda_equivalence.jl",
+    # Coarse CUDA backend smoke. Was MANUAL as "gated, but needs GPU to be
+    # useful" — it guards on `CUDA.functional()` like every other gpu/ file, so
+    # on a CPU-only runner it is the same no-op they are. 3.9 s on a GPU host.
+    "gpu/test_cuda.jl",
     "gpu/test_superfluid_fraction_gpu.jl",
     # Same bug class: a public analysis entry point that scalar-indexed a
     # device array and threw. Lz is the observable the EdH/Barnett J_z ledger
@@ -596,11 +608,26 @@ const PHYSICS_TESTS = [
 # here so the tier-membership meta-test counts them as "accounted for"
 # (i.e. they are deliberately manual, not orphaned). Run them by hand.
 const MANUAL_TESTS_ALLOWLIST = [
-    "gpu/test_cuda.jl",                              # coarse CUDA smoke (gated, but needs GPU to be useful)
-    "workflow/test_active_learning_yaml.jl",         # heavy YAML (SPINORBEC_RUN_HEAVY_YAML)
-    "workflow/test_multi_fidelity_yaml.jl",          # heavy YAML (SPINORBEC_RUN_HEAVY_YAML)
-    "workflow/test_klaus_validation.jl",             # heavy YAML scenario pending schema audit
-    "workflow/test_live_monitor.jl",                 # spawns dashboard server on a TCP port
+    # Two files, each with a MEASURED reason (2026-07-31). The other three that
+    # sat here — gpu/test_cuda.jl, workflow/test_{active_learning,multi_fidelity}_yaml.jl
+    # — were run both ways and pass, so they are in tiers now.
+    #
+    # `test_klaus_validation.jl`: cannot run AS WRITTEN, and not for an
+    # environment reason. Its ground_state uses the real experimental field
+    # (`B: {Bz: "1.0 Gauss"}`, Dy164, ω_ref = 314.159) at `dt = 0.001`. That is
+    # p ≈ −3.5e4, so the ITP exponent spans |p·m·dt| ≈ 278 across m = ±8 and
+    # `exp` overflows on the first step: `ArgumentError: NaN detected in ITP at
+    # step 1`. The same footgun is documented in `test_b_block_builders.jl`
+    # ("real experimental values … require matching small dt and physics-aware
+    # setup — not a plumbing test"). Fixing it is a physics-setup decision
+    # (smaller GS field, or a dt that matches p), not a schema audit.
+    "workflow/test_klaus_validation.jl",
+    # `test_live_monitor.jl`: blocks forever. `serve_dashboard` does not return
+    # until the server is closed, and the close path is never reached, so the
+    # file hangs until it is killed (measured: SIGTERM at the 2400 s timeout,
+    # "Press Ctrl+C to stop" in the log). Its own comment says it means to close
+    # the server manually. Needs restructuring, not a tier entry.
+    "workflow/test_live_monitor.jl",
 ]
 
 # Derived view (NOT a partition list): every `oracles/` gate, regardless of which
@@ -720,6 +747,9 @@ const _COST = Dict{String, Float64}(
     "analysis/test_physics_level0.jl" => 6.1,
     "oracles/test_gpu_cpu_per_term_parity.jl" => 6.1,
     "analysis/test_imaging.jl" => 6.0,
+    # 0.0 s with SPINORBEC_RUN_HEAVY_YAML off, these with it on.
+    "workflow/test_multi_fidelity_yaml.jl" => 50.2,
+    "workflow/test_active_learning_yaml.jl" => 19.7,
     "hamiltonian/test_mixed_precision_kinetic_buffer.jl" => 9.7,
     # 4.8 s here against a warm depot; the CI runner pays a cold precompile
     # inside the subprocess, so reserve for that rather than under-book it.


### PR DESCRIPTION
`MANUAL_TESTS_ALLOWLIST` held five files that no tier runs — **53 assertions**,
untouched since 2026-05-25. The reason on file was environmental: *"depend on
environment conditions the default test runner cannot guarantee (GPU, dashboard
build, opt-in heavy YAML, …)"*. Nobody had checked it since.

Ran all five, with and without `SPINORBEC_RUN_HEAVY_YAML=true`.

## Three pass both ways → into tiers

| file | was filed as | measured | now |
|---|---|---|---|
| `gpu/test_cuda.jl` | "gated, but needs GPU to be useful" | guards on `CUDA.functional()` like every other `gpu/` file, so on a CPU-only runner it is the same no-op they are; 3.9 s on a GPU host | `FULL_EXTRA` |
| `workflow/test_active_learning_yaml.jl` | "heavy YAML" | already carries `_SKIP_HEAVY_YAML_AL`; **0.0 s** with the flag off, 19.7 s with it on | `CI_EXTRA` |
| `workflow/test_multi_fidelity_yaml.jl` | "heavy YAML" | same shape; 0.0 s / 50.2 s | `CI_EXTRA` |

The heavy-YAML pair needed no guard added — they already had one. The allowlist
entry was the only thing keeping them out of a tier.

## Two stay, with a measured reason instead of an inherited one

**`test_klaus_validation.jl` — cannot run as written, and not for an environment
reason.** Its `ground_state` uses the real experimental field
(`B: {Bz: "1.0 Gauss"}`, Dy164, `omega_ref: 314.159`) at `dt: 0.001`. That is
`p ≈ −3.5e4`, so across `m = ±8` the ITP exponent spans `|p·m·dt| ≈ 278` and
`exp` overflows on the first step:

```
ArgumentError: NaN detected in ITP at step 1. Likely DDI or interaction overflow.
```

`hamiltonian/test_b_block_builders.jl` documents the identical footgun and
deliberately uses `Bz: 1.0e-4` to dodge it. Fixing this is a physics-setup
decision — a smaller ground-state field with a ramp, or a `dt` matched to `p` —
not the "pending schema audit" it was filed under. It is also the only artifact
behind the Klaus 2022 row in the type-C registry (#248), which is why that row
is listed as ungated.

**`test_live_monitor.jl` — blocks forever.** `serve_dashboard` does not return
until the server is closed and this file's close path is never reached, so the
run hangs until something kills it (measured: SIGTERM at a 2400 s timeout, with
`Press Ctrl+C to stop` in the log). Its own comment states the intent — *"the
function blocks until the server is closed; we'll close it manually"* — which is
exactly what does not happen. Needs restructuring, not a tier entry.

## Verified

All three newly-tiered files pass with and without the heavy-YAML flag;
`test_tier_membership.jl` green (it asserts `MANUAL_TESTS.md` and the allowlist
agree). `MANUAL_TESTS.md` rewritten to match, with the 2026-05-25 and 2026-06-19
audit history kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)