### PR TITLE
fix(inventory): it read the prose, not the assertion — 22 files were labelled unprovable

### DIFF
--- a/test/_inventory.jl
+++ b/test/_inventory.jl
@@ -43,26 +43,52 @@ const _MARKERS = [
     ],
     :differential => [
         r"reference_\w+", r"dumb_\w+", r"\blegacy\b"i, r"parity"i,
+        # "bit-identity" is not "bit-identical", and the file whose whole title
+        # is "HamTerm ↔ independent statement bit-identity" was landing in :pin.
+        r"bit[-_ ]?identit"i, r"↔",
         r"registry.{0,40}(≈|isapprox)"i, r"cpu.{0,30}gpu"i, r"gpu.{0,30}cpu"i,
         r"bit[-_ ]?identical"i, r"cross[-_ ]?check"i, r"\btwin\b"i,
         r"independent(ly)?\s+(computed|stated|implement)"i,
     ],
     :metamorphic => [
+        # A round-trip is f⁻¹(f(x)) == x — the canonical metamorphic relation.
+        # It was ONLY in _API_MARKERS, so the two SI round-trips (physical
+        # quantities through unit conversion and back) read as spelling tests.
+        r"round[-_ ]?trip"i,
         r"covarian"i, r"invarian"i, r"symmetr"i, r"\bparity\b"i,
         r"translat"i, r"rotat\w*.{0,40}(≈|isapprox)"i, r"mirror"i,
         r"global[_ ]phase"i, r"time[-_ ]revers"i, r"gauge"i, r"chiral"i,
     ],
     :invariant => [
+        # Algebraic contracts stated as maths rather than as the word
+        # "conservation": Σ parts == total, and the accumulate contract.
+        r"total.{0,30}(≈|==).{0,10}(Σ|sum|parts)"i, r"Σ\s*parts"i,
+        r"accumulat"i,
         r"conserv"i, r"\bdrift\b"i, r"hermitic"i, r"unitar"i,
         r"norm\w*\s*.{0,20}(≈|isapprox)\s*1", r"sum[_ ]rule"i,
         r"positive[-_ ]?(semi)?definite"i, r"virial"i, r"trace"i,
         r"continuity"i, r"completeness"i, r"orthonormal"i,
     ],
     :exact => [
+        # The claim written as the identity itself. These files state
+        # `E = Re⟨ψ|Hψ⟩·dV`, `E = −Ω·⟨L_z⟩`, `= ψ†·F_α·ψ`, `v = k` — none of
+        # which contains the word "analytic", so all of them were :pin.
+        r"⟨ψ\s*\|", r"ψ†", r"Re⟨", r"⟨L_z⟩", r"⟨F", r"·dV\b",
         r"analytic"i, r"\bexact\b"i, r"closed[-_ ]form"i, r"theoretical"i,
         r"gauss[-_ ]hermite"i, r"manufactured"i, r"\bclosed form\b"i,
         r"known\s+(solution|answer|value)"i, r"first[-_ ]principles"i,
     ],
+]
+
+# Gates whose subject is the SUITE, not the physics: coverage meta-tests, static
+# source scans, doc-citation ratchets. They ground nothing about the simulator
+# and are not meant to — but they are not pins or spellings either, and calling
+# them :pin marks them for pruning. Checked BEFORE :pin/:api, after the five
+# grounding labels.
+const _META_MARKERS = [
+    r"meta[-_ ]?test"i, r"\bcoverage\b"i, r"every\s+\w+\s+is\s+(gated|in|listed)"i,
+    r"no\s+bare\s+`?\w+`?\s+broadcast"i, r"source[-_ ]scan"i,
+    r"cite\s+runs/"i, r"do\s+not\s+shadow"i, r"orphan"i, r"allowlist"i,
 ]
 
 const _API_MARKERS = [
@@ -120,6 +146,7 @@ struct FileInfo
     labels::Vector{Symbol}
     npin::Int
     napi::Int
+    nmeta::Int
     layer::Symbol
 end
 
@@ -159,6 +186,7 @@ function _scan(root::String, rel::String)
         labels,
         sum(p -> count(p, src), _PIN_MARKERS; init=0),
         sum(p -> count(p, src), _API_MARKERS; init=0),
+        sum(p -> count(p, src), _META_MARKERS; init=0),
         _layer_of(src),
     )
 end
@@ -169,6 +197,16 @@ function primary(fi::FileInfo)
     for (name, _) in _MARKERS
         name in fi.labels && return name
     end
+    # :meta is checked AFTER the five grounding labels, not before. Meta-first
+    # was tried and measured: it moves 18 files, and among them
+    # `test_master_oracle.jl` (:differential — the dumb-vs-production gate),
+    # `test_propagator_references.jl` (:order) and `test_term_fd_registry_
+    # coverage.jl` (:order). Those ground physics AND carry a coverage clause;
+    # calling them :meta understates them, which is the direction that turns a
+    # file into a pruning candidate. Two coverage gates therefore keep an
+    # over-credited grounding label, which is the safe direction this file
+    # declares in its header.
+    fi.nmeta > 0 && return :meta
     fi.npin > 0 && return :pin
     fi.napi > 0 && return :api
     return :unclassified
@@ -185,7 +223,7 @@ function inventory(root::String=_INV_DIR)
 end
 
 const _ORDER = [:order, :differential, :metamorphic, :invariant, :exact,
-    :pin, :api, :unclassified]
+    :meta, :pin, :api, :unclassified]
 
 _row(k, n, tot, cost) = println("  ", rpad(string(k), 16),
     lpad(string(n), 4), " files ", lpad("$(round(Int, 100n / tot))%", 5),
@@ -246,13 +284,13 @@ end
 
 function write_csv(inv::Vector{FileInfo}, path::String)
     open(path, "w") do io
-        println(io, "path,tier,loc,assertions,cost_s,primary,labels,pins,api,layer")
+        println(io, "path,tier,loc,assertions,cost_s,primary,labels,pins,api,meta,layer")
         for f in inv
             println(
                 io,
                 join(
                     (f.path, f.tier, f.loc, f.ntest, f.cost,
-                        primary(f), join(f.labels, ";"), f.npin, f.napi, f.layer), ","),
+                        primary(f), join(f.labels, ";"), f.npin, f.napi, f.nmeta, f.layer), ","),
             )
         end
     end


### PR DESCRIPTION
`test/_inventory.jl` (#198) classifies every test file by the strongest thing it
can prove, so that "the suite can be pruned on evidence rather than on taste".
Its header commits to a direction:

> Over-crediting a file is the safe direction — it lands in the "grounded"
> bucket and gets read by a human, rather than being silently proposed for
> deletion.

It was failing in the other direction. Of the 15 `oracles/` files it called
ungrounded I read all 15, and **11 carry an exact / differential / invariant /
metamorphic claim** while labelled `pin`:

| file | what it asserts | label |
|---|---|---|
| `test_energy_operator_identity.jl` | `E = Re⟨ψ\|Hψ⟩·dV` | pin |
| `test_coriolis_energy_sign.jl` | `E = −Ω·⟨L_z⟩` | pin |
| `test_meanfield_energy_half.jl` | `E = ½·Re⟨ψ\|Hψ⟩·dV` | pin |
| `test_spin_density_consistency.jl` | `= ψ†·F_α·ψ` per voxel | pin |
| `test_energy_decomposition_sum.jl` | `total = Σ parts` | pin |
| `test_apply_operator_accumulates.jl` | the accumulate contract | pin |
| `test_term_legacy_equivalence.jl` | "bit-identity" vs an independent statement | pin |

## Three mechanical causes

1. **The markers read prose, the files state maths.** `analytic` / `exact` /
   `closed-form` never appear in a file whose whole content is
   `E = Re⟨ψ|Hψ⟩·dV`. Added markers for the notation the assertions use —
   `⟨ψ|`, `ψ†`, `Re⟨`, `⟨L_z⟩`, `·dV`, `total = Σ parts`, `accumulat`.
2. `bit[-_ ]?identical` does not match **"bit-identity"**, which is the entire
   title of `test_term_legacy_equivalence.jl`.
3. `round[-_ ]?trip` lived **only in `_API_MARKERS`**, so two SI round-trips —
   physical quantities through unit conversion and back, the canonical
   metamorphic relation — read as spelling tests. Moved to `:metamorphic`.

Plus a `:meta` label for the four genuinely outside the physics taxonomy:
coverage meta-tests, static source scans, doc-citation ratchets. They ground
nothing about the simulator and are not meant to, but they are not pins or
spellings either, and `:pin` marks them for pruning.

## The ordering was measured, not assumed

`:meta` is checked **after** the five grounding labels. Meta-first moves 18
files and takes `test_master_oracle.jl` (`:differential`),
`test_propagator_references.jl` (`:order`) and
`test_term_fd_registry_coverage.jl` (`:order`) with it — files that ground
physics *and* carry a coverage clause. Understating those is the direction that
turns a file into a deletion candidate, so two coverage gates keep an
over-credited grounding label instead. That is the safe direction this file
declares in its own header.

## Result

```
grounded    276/358 (77 %)  →  298/358 (83 %)
ungrounded       82        →       60
ungrounded oracles 15      →        1
```

The one left is `oracles/test_velocity_planewave.jl` (`v = k` for a plane wave,
against a closed form built in the test). No pattern is added for it: a marker
narrow enough to catch it would be a marker fitted to one file.

Not touched: `test/mutation/run.jl --probe` errors with a `BoundsError` — on
`main`'s `_inventory.jl` too, so it is pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)