### PR TITLE
fix(ci): the cost model was measured on the wrong machine, and it killed the nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,14 @@ jobs:
       # the two long poles (BO ~161 s, triple-point ~127 s) and the cold F32
       # JIT land on separate chunks. Total serial ~14 min → makespan ~4-5 min.
       SPINORBEC_TEST_WORKERS: "4"
+      # Per-worker wall-clock cap. The default 1800 s is a hang guard sized for
+      # the per-push tiers; `full` on a 4-vCPU runner is 6317 s of measured work
+      # (run 30668378491), i.e. a perfectly-packed makespan of ~1580 s — 12 %
+      # of headroom, and any imbalance eats it. That run died with all four
+      # workers killed at the cap and ZERO assertion failures. 2700 s keeps the
+      # hang guard well inside the 90-minute job timeout while leaving the
+      # margin the arithmetic says this tier needs.
+      SPINORBEC_TEST_TIMEOUT: "2700"
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -698,7 +698,7 @@ const _COST = Dict{String, Float64}(
     "foundation/test_property_based.jl" => 16.0,
     "oracles/test_stability_indeterminate.jl" => 15.5,
     "oracles/test_term_properties.jl" => 15.5,
-    "oracles/test_term_fd_registry_coverage.jl" => 36.0,
+    "oracles/test_term_fd_registry_coverage.jl" => 125.0,  # 36 s locally, 125.4 s on the runner
     "hamiltonian/test_lhy.jl" => 15.2,
     "analysis/test_phase_classification_polyhedral.jl" => 15.1,
     "oracles/test_registry_completeness.jl" => 14.4,
@@ -748,12 +748,19 @@ const _COST = Dict{String, Float64}(
     "oracles/test_gpu_cpu_per_term_parity.jl" => 6.1,
     "analysis/test_imaging.jl" => 6.0,
     # 0.0 s with SPINORBEC_RUN_HEAVY_YAML off, these with it on.
-    "workflow/test_multi_fidelity_yaml.jl" => 50.2,
-    "workflow/test_active_learning_yaml.jl" => 19.7,
+    # MEASURED ON THE RUNNER, not on a workstation. 50.2 s was this file on a
+    # 10-core box with a warm depot; the 4-vCPU CI runner takes 776.3 s — 15x —
+    # because it is GP fitting, and `_COST` sets the HAND-OUT ORDER. Declared at
+    # 50 s it was handed out late, so a worker was still inside it at the
+    # 1800 s cap and the whole `full` tier died with "unrun files" (nightly run
+    # 30668378491, 2026-07-31: all four workers killed, zero assertion
+    # failures). Longest file in the suite; it must be handed out first.
+    "workflow/test_multi_fidelity_yaml.jl" => 776.0,
+    "workflow/test_active_learning_yaml.jl" => 21.7,
     "hamiltonian/test_mixed_precision_kinetic_buffer.jl" => 9.7,
     # 4.8 s here against a warm depot; the CI runner pays a cold precompile
     # inside the subprocess, so reserve for that rather than under-book it.
-    "gpu/test_cpu_only_runner.jl" => 60.0,
+    "gpu/test_cpu_only_runner.jl" => 9.0,   # reserved 60 for a cold subprocess precompile; measured 8.7
     # ── Heavy `ci`/`full`-tier files, not exercised by the per-push CI jobs;
     # estimates carried over from the full-tier measurement.
     "workflow/test_multi_fidelity_bo.jl" => 161.0,


### PR DESCRIPTION
The `full` tier died on 2026-07-31 (run
[30668378491](https://github.com/KozumaLaboratory/BEC-simulation/actions/runs/30668378491))
with **all four workers killed at the 1800 s cap and zero assertion failures** —
`unrun files (tier=full)`. Not a test failure. A scheduling one, and mine.

## The cost model was measured on a workstation

`workflow/test_multi_fidelity_yaml.jl` entered `CI_EXTRA` in #267 with
`_COST = 50.2`, measured on a 10-core box with a warm depot. On the 4-vCPU
runner it is **776.3 s — 15×** — because it is GP fitting, which CLAUDE.md
already calls out (*"GP fitting > 100 s wall ⇒ heavy-tier only"*).

`_COST` sets the **hand-out order** (heaviest first), so declaring the longest
file in the suite as a 50 s file handed it out late and left a worker inside it
when the cap fell.

| file | declared | runner |
|---|---|---|
| `workflow/test_multi_fidelity_yaml.jl` | 50.2 s | **776.3 s** |
| `oracles/test_term_fd_registry_coverage.jl` | 36 s | **125.4 s** |
| `workflow/test_active_learning_yaml.jl` | 19.7 s | 21.7 s ✓ |
| `gpu/test_cpu_only_runner.jl` | 60 s (guessed) | 8.7 s |

All four now carry the runner number.

## And the cap itself

`full` is **6317 s of measured work** across 4 workers: a perfectly-packed
makespan of ~1580 s against an 1800 s cap. 12 % of headroom, and any imbalance
eats it. The 1800 s default is a hang guard sized for the per-push tiers; the
nightly now sets `SPINORBEC_TEST_TIMEOUT: 2700` — still a hang guard, still well
inside the 90-minute job timeout, with the margin the arithmetic says this tier
needs.

## Why the drift guard did not catch it

`warn_cost_drift` exists for exactly this and would have flagged 776 s against a
50 s estimate — but it runs at the **end**, and this run never got there. A
cost-model error large enough to matter is large enough to prevent its own
detection.

I have my own note on this — *"OpenBLAS level-1 team overhead scales with the
MACHINE"*, *"compute the start-up cost before parallelising"* — and measured on
the wrong machine anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)