### PR TITLE
Assert the four TSUBAME requirements instead of documenting them a third time

### DIFF
--- a/docs/guides/tsubame.md
+++ b/docs/guides/tsubame.md
@@ -47,11 +47,23 @@ Throughput on H100 at 128³ × D=13:
 
 128³ × 107.6 ω⁻¹ at dt=1e-4 ≈ 2.5 h walltime. 256³ ≈ 15 h.
 
+## Pre-flight
+
+```bash
+source scripts/tsubame/preflight.sh          # or --gpu for a CUDA job
+```
+
+Four environment requirements have each cost a whole job batch, and all four were
+already documented — two of them in this file. Reading them did not prevent it, so
+they are now asserted at second zero with the fix in the message: BLAS threads
+pinned, project root off `$HOME`, group-volume headroom, `runs/` present, and (for
+`--gpu`) the `import CUDA` ordering. The script says why for each.
+
 ## Filesystem layout
 
 | path                   | type                | use                        |
 |------------------------|---------------------|----------------------------|
-| `$HOME`                | Lustre, 30 GB quota | tiny (no project dirs)     |
+| `$HOME`                | Lustre, **25 GB** quota | tiny (no project dirs) — measured 2026-08-01 with `t4-user-info disk home`; the 30 GB here was wrong and a batch died on it |
 | `$T4_GROUP`            | Lustre, TB-scale    | code + finalised results   |
 | `$T4_LOCAL`/`$T4_TMPDIR` | node-local NVMe   | depots, scratch snapshots  |
 | `/scratch`             | per-node, ephemeral | cleared at job end         |

--- a/scripts/tsubame/preflight.sh
+++ b/scripts/tsubame/preflight.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Source this at the top of any TSUBAME job that runs SpinorBEC:
+#
+#     source scripts/tsubame/preflight.sh          # asserts + exports
+#     source scripts/tsubame/preflight.sh --gpu    # also checks the CUDA path
+#
+# Why this is a script and not a paragraph in a guide. On 2026-07-31 one session
+# lost four job batches to four separate environment requirements, and every one
+# of them was already written down — two of them in files that same session had
+# just edited:
+#
+#   1. BLAS threads unpinned      → a ci tier ran 18m52s on one file against a
+#                                   51.8s estimate, hit the per-file timeout and
+#                                   aborted with 227 files never started.
+#   2. `runs/` excluded from rsync → config-scanning gates errored on ENOENT and
+#                                   reported a red that was about the transfer.
+#   3. `import CUDA` omitted      → all five GPU configs died with
+#                                   `MethodError: _to_device(::CUDABackend, ::Array)`.
+#   4. work tree under $HOME      → $HOME is a 25 GB quota; nine of twelve runs
+#                                   died mid-flight with "Disk quota exceeded".
+#
+# Reading did not prevent any of them. Failing at second zero, with the fix in the
+# message, might. Each check below costs milliseconds and names its own remedy.
+
+_pf_die() { echo "[preflight] FAIL: $*" >&2; exit 78; }
+_pf_warn() { echo "[preflight] warn: $*" >&2; }
+
+# ── 1. BLAS threads ──────────────────────────────────────────────────────
+# OpenBLAS sizes its level-1 team from the core count and a TSUBAME node reports
+# 384, so every `dot` on a few-MB ComplexF64 array becomes spawn+barrier. The
+# workers are already the parallelism; a BLAS team inside each is pure
+# contention. `${VAR:-1}` so an explicit caller choice still wins.
+export OPENBLAS_NUM_THREADS=${OPENBLAS_NUM_THREADS:-1}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
+
+# ── 2. Not under $HOME ───────────────────────────────────────────────────
+# docs/guides/tsubame.md's filesystem table: $HOME is "tiny (no project dirs)".
+# The quota is 25 GB, not the 30 the table says — `t4-user-info disk home`.
+_pf_root="${SPINORBEC_TSUBAME_PROJECT_ROOT:-$PWD}"
+case "$_pf_root" in
+    "$HOME"/*)
+        _pf_die "project root is under \$HOME ($_pf_root).
+    \$HOME has a 25 GB quota and fills silently — a run dies with
+    'SystemError: close: Disk quota exceeded' partway through, so early jobs in a
+    batch look fine. Use \$T4_GROUP (TB-scale):
+        /gs/fs/tga-kozuma-kouhi/\$USER/<name>
+    Check with: t4-user-info disk home" ;;
+esac
+
+# ── 3. Headroom on whatever volume we ARE on ─────────────────────────────
+# A quota is not free space: `df` reports the raw Lustre mount, which is why a
+# full group volume shows as terabytes available right up until EDQUOT.
+if command -v t4-user-info >/dev/null 2>&1; then
+    _pf_grp=$(t4-user-info disk group 2>/dev/null | awk 'NR==3 {print $3, $4}')
+    if [ -n "${_pf_grp:-}" ]; then
+        set -- $_pf_grp
+        _pf_used=${1%%.*}; _pf_cap=${2%%.*}
+        if [ -n "$_pf_cap" ] && [ "$_pf_cap" -gt 0 ] 2>/dev/null; then
+            _pf_pct=$(( _pf_used * 100 / _pf_cap ))
+            [ "$_pf_pct" -ge 90 ] && _pf_die \
+                "group volume ${_pf_used}/${_pf_cap} GB (${_pf_pct}%). Free space
+    before launching; a batch that fills it dies partway, and the jobs that ran
+    first still look successful."
+            [ "$_pf_pct" -ge 75 ] && _pf_warn "group volume ${_pf_pct}% full"
+        fi
+    fi
+fi
+
+# ── 4. runs/ present ─────────────────────────────────────────────────────
+# test_config_zeeman_seed_agreement.jl and test_lhy_config_validity_domain.jl
+# walk runs/. An rsync that syncs only src/ and test/ makes them ENOENT rather
+# than skip, so the suite goes red for a reason that is about the transfer.
+[ -d "$_pf_root/runs" ] || _pf_warn \
+    "no runs/ under $_pf_root — config-scanning gates will error, not skip.
+    Include it in the rsync (excluding *.jld2 keeps it small)."
+
+# ── 5. GPU path ──────────────────────────────────────────────────────────
+# `_to_device(::CUDABackend, ::Array)` lives in ext/SpinorBECCUDAExt, a weak
+# dependency: it is only active once CUDA is loaded. `import CUDA` must come
+# BEFORE `using SpinorBEC` (CLAUDE.md:141). This cannot check the caller's julia
+# one-liner, so it verifies the runtime is there and says the rest.
+if [ "${1:-}" = "--gpu" ]; then
+    module load "${SPINORBEC_TSUBAME_CUDA_MODULE:-cuda/12.8.0}" 2>/dev/null || \
+        module load cuda 2>/dev/null || _pf_warn "no cuda module loaded"
+    echo "[preflight] GPU job: every julia invocation must start with" \
+         "\`import CUDA; using SpinorBEC\` — in that order, or the extension is" \
+         "inert and backend: gpu dies with MethodError on _to_device."
+fi
+
+echo "[preflight] ok — root=$_pf_root OPENBLAS_NUM_THREADS=$OPENBLAS_NUM_THREADS"


### PR DESCRIPTION
On 2026-07-31 I lost **four job batches to four separate environment
requirements**, and every one of them was already written down — two in files I
had edited that same day.

| # | requirement | what it cost |
|---|---|---|
| 1 | BLAS threads pinned | a `ci` tier ran **18m52s** on one file against a 51.8s estimate, hit the per-file timeout, aborted with **227 files never started** — and reported FAIL while having measured almost nothing |
| 2 | `runs/` in the synced tree | config-scanning gates errored on ENOENT instead of skipping; a red that was about the transfer |
| 3 | `import CUDA` **before** `using SpinorBEC` | all five GPU configs died with `MethodError: _to_device(::CUDABackend, ::Array)` |
| 4 | work tree off `$HOME` | **nine of twelve** runs died mid-flight with `Disk quota exceeded` |

Reading did not prevent any of them. `scripts/tsubame/preflight.sh` asserts them at
second zero with the remedy in the failure message:

```bash
source scripts/tsubame/preflight.sh          # or --gpu for a CUDA job
```

Each check costs milliseconds and explains itself:

- **BLAS/OMP pinned** to 1 via `${VAR:-1}`, so an explicit caller choice still wins.
- **`$HOME` root is a hard failure**, not a warning. It fails *partway through a
  batch* — the jobs that ran first still look successful, which is the worst
  shape a resource failure can take.
- **Group-volume headroom** checked with `t4-user-info`, not `df`: a quota is not
  free space, and `df` reports the raw Lustre mount right up until EDQUOT.
- **`runs/` present** — warn, since some jobs legitimately do not need it.
- **`--gpu`** loads the cuda module and states the `import CUDA` ordering. It
  cannot inspect the caller's julia one-liner, so it says so rather than
  pretending to check.

## Also corrects this guide's own table

`$HOME` is **25 GB**, not the 30 the filesystem table claimed. Measured with
`t4-user-info disk home` after filling it.

## What this cannot do

Check the thing that actually failed in case 3 — the order of imports inside
someone's `julia -e` string. It prints the rule at the top of a GPU job instead.
A guard that names its own blind spot is worth more than one that implies
coverage it lacks.

Shell + docs. No source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)