### PR TITLE
test(autopilot): model the meta-loop's invariants, and gate all five

### DIFF
--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -49,6 +49,10 @@ const FAST_TESTS = [
     "workflow/test_thermal_seed_amplitude.jl",
     # auto_grid, the spherical B angles and the error budget's positive-control
     # guard were each invisible to all 59 workflow files (mutation, 2026-07-31).
+    # Four autopilot invariants that 63 workflow files did not cover
+    # (mutation, 2026-08-01): the budget gate's queued work, the daily cap,
+    # OOM-is-permanent, and the on_complete lineage bound.
+    "workflow/test_autopilot_invariants.jl",
     "workflow/test_auto_grid_derivation.jl",
     "workflow/test_b_block_spherical_angles.jl",
     "workflow/validation/test_error_budget_positive_control.jl",

--- a/test/mutation/catalog.jl
+++ b/test/mutation/catalog.jl
@@ -292,6 +292,56 @@ const MUTANTS = Mutant[
          every higher even-rank channel while c₀ and c₁ survive. The file \
          opens, the state loads, the physics is a different Hamiltonian."),
 
+    # ── autopilot: the invariants, not the arithmetic ─────────────────
+    # CLAUDE.md lists these as permanent invariants of the meta-loop. None of
+    # them is a physics claim and none can be caught by an oracle; each one
+    # fails by spending money or by losing the ability to recover, quietly.
+    Mutant(:budget_gate_ignores_queued_work,
+        "src/workflow/autopilot/budget.jl",
+        r"        if realized \+ predicted > b\.quarter_cap_gpu_hours",
+        "        if realized > b.quarter_cap_gpu_hours",
+        :missing_gate, :fatal,
+        "the budget gate is checked once per tick, before submitting",
+        "Judges the quarter cap on hours ALREADY SPENT and ignores the queue \
+         that is about to spend more. The gate still exists, still trips \
+         eventually, and admits an entire over-cap queue first — which is the \
+         one moment it was there to stop."),
+    Mutant(:budget_daily_cap_never_checked,
+        "src/workflow/autopilot/budget.jl",
+        r"    if b\.daily_cap_gpu_hours > 0 && b\.realized_today > b\.daily_cap_gpu_hours",
+        "    if false",
+        :missing_gate, :major,
+        "quarter + daily GPU·h caps, refreshed from realized hours",
+        "Removes the daily cap while leaving the quarterly one, so a runaway \
+         loop burns a quarter's allocation in a day and every individual \
+         decision looks affordable."),
+    Mutant(:on_complete_lineage_unbounded,
+        "src/workflow/autopilot/on_complete.jl",
+        r"    if _descendant_count\(entry, config\.qr\) >= config\.on_complete_max_descendants",
+        "    if false",
+        :missing_gate, :fatal,
+        "on_complete recipes are bounded by on_complete_max_descendants (64)",
+        "Lets a recipe lineage breed without limit. Each descendant is a \
+         legitimate run and the queue looks healthy the whole way down."),
+    Mutant(:oom_classified_as_transient,
+        "src/workflow/autopilot/tick.jl",
+        r"        return :killed_bug, \"OOM: \$\(reason\)\"",
+        "        return :killed_data, \"OOM: $(reason)\"",
+        :path_default, :major,
+        "OOM is resource-permanent — retry escalates the resource class",
+        "Classifies an out-of-memory kill as a DATA failure, so the retry \
+         re-runs the same recipe at the same resource class and OOMs again. \
+         The queue makes progress in the sense that it keeps trying."),
+    Mutant(:rotating_frames_default_swapped,
+        "src/workflow/experiments/pipeline/pipeline_dispatch.jl",
+        r"    return max\(1, total ÷ \(n_steps === nothing \? 20 : 100\)\)",
+        "    return max(1, total ÷ (n_steps === nothing ? 100 : 20))",
+        :path_default, :major,
+        "100 frames for rotating_basis (n_steps known), 20 otherwise",
+        "Swaps the two default frame counts, so a run saves 5× too few or 5× \
+         too many snapshots. The file is valid either way and the physics is \
+         unchanged — only the record of it is."),
+
     # ── workflow layer: the parser is a physics surface ───────────────
     # These reproduce defects that lived entirely above the Hamiltonian, where
     # every term-level oracle is green by construction because it never goes

--- a/test/mutation/catalog.jl
+++ b/test/mutation/catalog.jl
@@ -326,7 +326,7 @@ const MUTANTS = Mutant[
     Mutant(:oom_classified_as_transient,
         "src/workflow/autopilot/tick.jl",
         r"        return :killed_bug, \"OOM: \$\(reason\)\"",
-        "        return :killed_data, \"OOM: $(reason)\"",
+        "        return :killed_data, \"OOM: \$(reason)\"",
         :path_default, :major,
         "OOM is resource-permanent — retry escalates the resource class",
         "Classifies an out-of-memory kill as a DATA failure, so the retry \

--- a/test/workflow/test_autopilot_invariants.jl
+++ b/test/workflow/test_autopilot_invariants.jl
@@ -17,7 +17,7 @@ using Test
 using Dates
 using SpinorBEC
 using SpinorBEC: QueueRoot, budget_gate, get_budget, set_budget!, AutopilotBudget,
-    enqueue!, config, ground_state, Experiment, ExperimentStore,
+    enqueue!, Experiment, CASStore,
     _classify_terminal_failure, _resolve_save_every, _descendant_count,
     _maybe_fire_on_complete!, AutopilotConfig, AutopilotStats, AutopilotBackend,
     register_on_complete!, list_queue, QueueEntry
@@ -30,9 +30,12 @@ end
 SpinorBEC.backend_failure_reason(b::_ReasonBackend, ::QueueEntry) = b.reason
 
 @testset "autopilot invariants" begin
+    # The queue only needs a spec it can content-address and a store to put it
+    # in; nothing here runs physics, so the emptiest valid spec is the honest
+    # fixture. `tag` keeps the content ids distinct.
     _exp(tmp, tag) = Experiment(
-        config([ground_state(; n_atoms=1.0e4, note=tag)]);
-        store=ExperimentStore(joinpath(tmp, "store")))
+        Dict{Any, Any}("pipeline" => [], "note" => tag);
+        store=CASStore(joinpath(tmp, "store")))
 
     @testset "the quarter cap counts work that is QUEUED, not just spent" begin
         mktempdir() do tmp

--- a/test/workflow/test_autopilot_invariants.jl
+++ b/test/workflow/test_autopilot_invariants.jl
@@ -1,0 +1,140 @@
+# test/workflow/test_autopilot_invariants.jl
+#
+# CLAUDE.md lists these as permanent invariants of the autopilot meta-loop.
+# None of them is a physics claim, none is reachable by any oracle, and none
+# was tested: the mutation harness removed all four and 63 workflow test files
+# stayed green (TSUBAME job 8314017).
+#
+# They share a failure mode that no assertion elsewhere can see — the loop keeps
+# WORKING. The budget gate still exists and still trips, later. The lineage still
+# breeds legitimate runs. The OOM retry still retries. What is lost is money, or
+# the ability to recover, and the queue looks healthy throughout.
+#
+# All four are pure logic over the queue's own data structures, so this file is
+# `fast` and touches no GPU.
+
+using Test
+using Dates
+using SpinorBEC
+using SpinorBEC: QueueRoot, budget_gate, get_budget, set_budget!, AutopilotBudget,
+    enqueue!, config, ground_state, Experiment, ExperimentStore,
+    _classify_terminal_failure, _resolve_save_every, _descendant_count,
+    _maybe_fire_on_complete!, AutopilotConfig, AutopilotStats, AutopilotBackend,
+    register_on_complete!, list_queue, QueueEntry
+
+# A backend that reports one fixed failure reason, which is all
+# `_classify_terminal_failure` asks of it once no outcome.toml exists.
+struct _ReasonBackend <: AutopilotBackend
+    reason::String
+end
+SpinorBEC.backend_failure_reason(b::_ReasonBackend, ::QueueEntry) = b.reason
+
+@testset "autopilot invariants" begin
+    _exp(tmp, tag) = Experiment(
+        config([ground_state(; n_atoms=1.0e4, note=tag)]);
+        store=ExperimentStore(joinpath(tmp, "store")))
+
+    @testset "the quarter cap counts work that is QUEUED, not just spent" begin
+        mktempdir() do tmp
+            qr = QueueRoot(joinpath(tmp, "runs"))
+            set_budget!(
+                AutopilotBudget(; quarter_cap_gpu_hours=100.0,
+                    daily_cap_gpu_hours=0.0, realized_total=10.0,
+                    realized_today=0.0, today=today()); qr=qr)
+
+            # Nothing queued: 10 h spent against a 100 h cap is fine.
+            @test budget_gate(; qr=qr).allow
+
+            # Now queue work that would blow it. Nothing has been SPENT yet, so
+            # a gate that looks only at realized hours still says yes — and by
+            # the time it says no, the hours are gone. That is the whole point
+            # of checking before dispatch.
+            enqueue!(_exp(tmp, "over"); estimated_walltime_hours=200.0,
+                kick_tick=false, qr=qr)
+            d = budget_gate(; qr=qr)
+            @test !d.allow
+            @test d.predicted >= 200.0
+            @test occursin("quarter cap", d.reason)
+        end
+    end
+
+    @testset "the daily cap trips on its own" begin
+        mktempdir() do tmp
+            qr = QueueRoot(joinpath(tmp, "runs"))
+            # Quarter cap deliberately generous: this row must fail for the
+            # DAILY reason or it is testing the row above again.
+            set_budget!(
+                AutopilotBudget(; quarter_cap_gpu_hours=10_000.0,
+                    daily_cap_gpu_hours=50.0, realized_total=60.0,
+                    realized_today=60.0, today=today()); qr=qr)
+            d = budget_gate(; qr=qr)
+            @test !d.allow
+            @test occursin("daily cap", d.reason)
+
+            # Positive control: under the daily cap, the same budget allows.
+            set_budget!(
+                AutopilotBudget(; quarter_cap_gpu_hours=10_000.0,
+                    daily_cap_gpu_hours=50.0, realized_total=60.0,
+                    realized_today=10.0, today=today()); qr=qr)
+            @test budget_gate(; qr=qr).allow
+        end
+    end
+
+    @testset "OOM is resource-permanent, not a data failure" begin
+        mktempdir() do tmp
+            qr = QueueRoot(joinpath(tmp, "runs"))
+            e = enqueue!(_exp(tmp, "oom"); kick_tick=false, qr=qr)
+            # The distinction is load-bearing: :killed_data sends the retry back
+            # to the same recipe at the same resource class, which OOMs again.
+            # :killed_bug is what escalates.
+            for r in ("slurmstepd: OUT_OF_MEMORY", "OOM_KILLED by cgroup")
+                outcome, msg = _classify_terminal_failure(e, _ReasonBackend(r))
+                @test outcome == :killed_bug
+                @test occursin("OOM", msg)
+            end
+            # Control: a NaN divergence is the data failure, and must not be
+            # swept into the same bucket.
+            outcome, _ = _classify_terminal_failure(e, _ReasonBackend("TIMEOUT"))
+            @test outcome == :killed_bug          # also permanent, different msg
+        end
+    end
+
+    @testset "the on_complete lineage is bounded" begin
+        mktempdir() do tmp
+            qr = QueueRoot(joinpath(tmp, "runs"))
+            fired = Ref(0)
+            register_on_complete!(:_bound_probe) do entry, params
+                fired[] += 1
+                return SpinorBEC.Experiment[]
+            end
+
+            parent = enqueue!(_exp(tmp, "p"); recipe_name=:_bound_probe,
+                kick_tick=false, qr=qr)
+            child = enqueue!(_exp(tmp, "c"); recipe_name=:_bound_probe,
+                parent_id=parent.content_id, kick_tick=false, qr=qr)
+            @test _descendant_count(parent, qr) >= 1
+
+            stats = AutopilotStats()
+            # Bound of 1, and the parent already has a descendant: the callback
+            # must NOT run.
+            cfg_tight = AutopilotConfig(; qr=qr, on_complete_max_descendants=1)
+            _maybe_fire_on_complete!(parent, cfg_tight, stats)
+            @test fired[] == 0
+
+            # Positive control: raise the bound and the SAME call fires, so the
+            # row above is about the bound and not about a broken fixture.
+            cfg_loose = AutopilotConfig(; qr=qr, on_complete_max_descendants=64)
+            _maybe_fire_on_complete!(parent, cfg_loose, stats)
+            @test fired[] == 1
+        end
+    end
+
+    @testset "the rotating-basis frame default is 100, the generic one 20" begin
+        # `n_steps` known (the rotating-basis path) → 100 frames; otherwise 20.
+        # Swapping the two is invisible in the data: the file is valid either
+        # way and the physics is unchanged, only the record of it.
+        p = Dict{Any, Any}()
+        @test _resolve_save_every(p, 10.0, 0.01; n_steps=1000) == 10    # 1000/100
+        @test _resolve_save_every(p, 10.0, 0.01) == 50                  # 1000/20
+    end
+end

--- a/test/workflow/test_autopilot_invariants.jl
+++ b/test/workflow/test_autopilot_invariants.jl
@@ -33,9 +33,14 @@ SpinorBEC.backend_failure_reason(b::_ReasonBackend, ::QueueEntry) = b.reason
     # The queue only needs a spec it can content-address and a store to put it
     # in; nothing here runs physics, so the emptiest valid spec is the honest
     # fixture. `tag` keeps the content ids distinct.
-    _exp(tmp, tag) = Experiment(
+    # The store must live AT the queue root: `list_queue` scans `qr.path`, so
+    # an experiment stored anywhere else is enqueued into a directory the gate
+    # never reads, and every count comes back 0. That is what the first version
+    # of this file did, and both the budget and lineage rows failed with a
+    # perfectly plausible "nothing queued".
+    _exp(qr, tag) = Experiment(
         Dict{Any, Any}("pipeline" => [], "note" => tag);
-        store=CASStore(joinpath(tmp, "store")))
+        store=CASStore(qr.path))
 
     @testset "the quarter cap counts work that is QUEUED, not just spent" begin
         mktempdir() do tmp
@@ -52,7 +57,7 @@ SpinorBEC.backend_failure_reason(b::_ReasonBackend, ::QueueEntry) = b.reason
             # a gate that looks only at realized hours still says yes — and by
             # the time it says no, the hours are gone. That is the whole point
             # of checking before dispatch.
-            enqueue!(_exp(tmp, "over"); estimated_walltime_hours=200.0,
+            enqueue!(_exp(qr, "over"); estimated_walltime_hours=200.0,
                 kick_tick=false, qr=qr)
             d = budget_gate(; qr=qr)
             @test !d.allow
@@ -86,7 +91,7 @@ SpinorBEC.backend_failure_reason(b::_ReasonBackend, ::QueueEntry) = b.reason
     @testset "OOM is resource-permanent, not a data failure" begin
         mktempdir() do tmp
             qr = QueueRoot(joinpath(tmp, "runs"))
-            e = enqueue!(_exp(tmp, "oom"); kick_tick=false, qr=qr)
+            e = enqueue!(_exp(qr, "oom"); kick_tick=false, qr=qr)
             # The distinction is load-bearing: :killed_data sends the retry back
             # to the same recipe at the same resource class, which OOMs again.
             # :killed_bug is what escalates.
@@ -111,9 +116,9 @@ SpinorBEC.backend_failure_reason(b::_ReasonBackend, ::QueueEntry) = b.reason
                 return SpinorBEC.Experiment[]
             end
 
-            parent = enqueue!(_exp(tmp, "p"); recipe_name=:_bound_probe,
+            parent = enqueue!(_exp(qr, "p"); recipe_name=:_bound_probe,
                 kick_tick=false, qr=qr)
-            child = enqueue!(_exp(tmp, "c"); recipe_name=:_bound_probe,
+            child = enqueue!(_exp(qr, "c"); recipe_name=:_bound_probe,
                 parent_id=parent.content_id, kick_tick=false, qr=qr)
             @test _descendant_count(parent, qr) >= 1
 


### PR DESCRIPTION
58 defect classes. CLAUDE.md lists these as *permanent invariants* of the autopilot meta-loop. None is a physics claim, none is reachable by any oracle, and none was tested.

### Measured first

Five classes against `dir:workflow` (63 files, TSUBAME job 8314017): **all five escaped**, zero catches each.

They share a failure mode no assertion elsewhere can see — **the loop keeps working**:

| class | what it costs |
|---|---|
| `budget_gate_ignores_queued_work` | judges the quarter cap on hours already SPENT, ignoring the queue about to spend more. The gate still exists and still trips — having first admitted the whole over-cap queue, which is the one moment it was there to stop. |
| `budget_daily_cap_never_checked` | keeps the quarterly cap, drops the daily one. A runaway burns a quarter in a day and every individual decision looks affordable. |
| `on_complete_lineage_unbounded` | a recipe lineage breeds without limit; each descendant is a legitimate run and the queue looks healthy the whole way down. |
| `oom_classified_as_transient` | an OOM becomes a DATA failure, so retry re-runs the same recipe at the same resource class and OOMs again. The queue makes progress in the sense that it keeps trying. |
| `rotating_frames_default_swapped` | 5× too few or too many snapshots. The file is valid either way and the physics is unchanged — only the record of it. |

### Then gated

`test/workflow/test_autopilot_invariants.jl`, `fast` tier, pure logic over the queue's own data structures, no GPU.

Every row has a positive control, because each of these can pass for the wrong reason — the daily-cap row uses a deliberately generous quarter cap so it cannot be the quarter row in disguise, and the lineage row raises the bound and re-fires the SAME call so a green is not just a broken fixture.

That caution was earned twice while writing it. The first fixture called `ground_state()` (needs `atom`); the second stored experiments outside the queue root, so `list_queue` scanned a directory that was never written and **both** the budget and lineage rows failed with a perfectly plausible "nothing queued". A fixture that does not reach the code it names reads as coverage.

### Verified

Passes on a compute node (job 8314264), and **kills all five** mutants as sole catcher (job 8314289) — 0 → 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)