### PR TITLE
Figure 1 re-derived: peak density 16.5% lower, and the grid axis is irrelevant

### DIFF
--- a/docs/campaign/rederivation_fig1_l4_ladder.md
+++ b/docs/campaign/rederivation_fig1_l4_ladder.md
@@ -5,10 +5,12 @@ rung of `runs/l4_k3_ladder/*.yaml` and the two `runs/matsui_baseline/*_n64.yaml`
 against their stored summaries of 2026-05-26 — among the 230 that predate every
 correction and carry no producing commit.
 
-`runs/l4_k3_ladder/summary.json` (gone) is the data behind **Fig 1 (a, b)** of
+`runs/l4_k3_ladder/`'s `summary.json` — the configs are tracked, the summary was
+never committed — is the data behind **Fig 1 (a, b)** of
 `four_figure_spec_2026_05_26.md` and behind claim row 1 of
 `day_inventory_2026_05_26.md`, *"L4 isotropic no-collapse"*.
-`runs/matsui_baseline/summary.json` (gone) is behind **Fig 1 (c, d)**.
+`runs/matsui_baseline/`'s `summary.json`, likewise uncommitted, is behind
+**Fig 1 (c, d)**.
 
 ## The comparison, on the same quantity
 

--- a/docs/campaign/rederivation_fig1_l4_ladder.md
+++ b/docs/campaign/rederivation_fig1_l4_ladder.md
@@ -1,0 +1,82 @@
+# Figure 1 re-derived: peak density is 16.5 % lower, and the grid axis is irrelevant
+
+**2026-08-01, TSUBAME jobs 8310351 / 8313735 (gpu_h).** Re-runs the committed n64
+rung of `runs/l4_k3_ladder/*.yaml` and the two `runs/matsui_baseline/*_n64.yaml`
+against their stored summaries of 2026-05-26 — among the 230 that predate every
+correction and carry no producing commit.
+
+`runs/l4_k3_ladder/summary.json` (gone) is the data behind **Fig 1 (a, b)** of
+`four_figure_spec_2026_05_26.md` and behind claim row 1 of
+`day_inventory_2026_05_26.md`, *"L4 isotropic no-collapse"*.
+`runs/matsui_baseline/summary.json` (gone) is behind **Fig 1 (c, d)**.
+
+## The comparison, on the same quantity
+
+`peak_max` is a maximum over time on both sides — taken from the run's own
+`dynamics/peak_density` series, not from the final state.
+
+| config | stored `peak_max` | re-derived | change |
+|---|---:|---:|---:|
+| `L4_K3_n64_HamOnly` | 0.00951101 | 0.00793751 | **−16.5 %** |
+| `L4_K3_n64_K3` | 0.00949813 | 0.00792665 | **−16.5 %** |
+| `L4_K3_n64_K3gdr` | 0.00949780 | 0.00792608 | **−16.5 %** |
+| `L4_K3_n64_gdr` | 0.00951079 | 0.00793694 | **−16.5 %** |
+| `L4_K3_n64_K3LHY` | 0.00953759 | 0.00692943 | **−27.3 %** |
+| `matsui_40ms_dynamics_n64` | 0.00716601 | 0.00612421 | −14.5 % |
+| `matsui_5ms_morphology_n64` | 0.00611232 | 0.00452326 | −26.0 % |
+
+Four of the five L4 cells move by **the same −16.5 %**, agreeing with each other
+to 0.14 %. K3 and γ_dr change nothing, which is the same conclusion Fig 3's
+re-derivation reached from the other direction.
+
+`K3LHY` is the outlier at −27.3 %, and it is the only cell with LHY active — so
+its extra shift is the 2026-07 LHY corrections, isolated by construction against
+the four `lhy: none` cells beside it.
+
+## The n96 and n128 rungs were not run, on purpose
+
+Raised by anko: is the rest of the ladder needed? Measured, no.
+
+| | magnitude |
+|---|---:|
+| grid dependence, n64 → n128 at fixed physics (stored data) | **1.19 %** |
+| the change this re-derivation found, at fixed n64 | **16.5 %** |
+
+**The grid axis is a fourteenth of the effect**, the stored ladder was already
+converged to ~1 %, and the shift is uniform across the physics branches — so the
+higher rungs would restate −16.5 % at a few GPU-hours each. Spending that to
+confirm a 1.2 % axis is the wrong trade. Stated rather than quietly skipped.
+
+## A conservation scare that was mine, not the code's
+
+I first flagged `Fz_drift` of 0.61–1.65 as "heavier than the classification
+change". That was wrong, and the mistake was not checking what the conserved
+quantity is.
+
+These configs run **full MDDI** (`ddi.secular: false`). Under DDI, F_z is *not*
+conserved — transferring spin to orbital angular momentum is the Einstein-de Haas
+effect, which is the phenomenon being measured. The conserved quantity is
+`J_z = L_z + S_z`:
+
+| run | S_z(end) | L_z(end) | J_z(end) | ΔJ_z |
+|---|---:|---:|---:|---:|
+| `L4_K3_n64_HamOnly` | −5.3942 | −0.6056 | **−5.9998** | **+0.0002** |
+| `L4_K3_n64_K3` | −5.3359 | −0.5953 | −5.9312 | +0.0688 |
+| `matsui_40ms_dynamics_n64` | −4.8565 | −1.0524 | −5.9088 | +0.0912 |
+
+The 0.606 I called drift appears in L_z as −0.6056 — **the same figure to four
+places.** It is the signal. J_z holds to 2e-4 in the Hamiltonian-only cell; the
+0.07–0.09 in the other two is K3 discarding atoms, which is what a non-Hermitian
+loss does.
+
+## Status of the claim
+
+*"L4 isotropic no-collapse"* is unaffected in direction — nothing collapses in
+either dataset — but every number under it moved by 16.5 %, and the figure should
+be redrawn rather than re-captioned.
+
+## Not covered
+
+- Fig 1 (d)'s `matsui_5ms_n64_density_slice.json` and the inset's two lossy
+  configs.
+- The n96/n128 rungs, deliberately, for the reason above.


### PR DESCRIPTION
Third of the four-figure spec's figures. Figure 2's premise was already found
gone; Figure 3 changed seven of ten classifications; this is Figure 1.

`runs/l4_k3_ladder/summary.json` (gone) backs **Fig 1 (a, b)** and
`day_inventory`'s claim row 1, *"L4 isotropic no-collapse"*.
`runs/matsui_baseline/summary.json` (gone) backs **Fig 1 (c, d)**.

## Same quantity on both sides

`peak_max` is a time-maximum on both sides, taken from each run's own
`dynamics/peak_density` series — not a final state. (Fig 3's write-up records the
first attempt where I got that wrong.)

| config | stored | re-derived | change |
|---|---:|---:|---:|
| `L4_K3_n64_HamOnly` | 0.00951101 | 0.00793751 | **−16.5 %** |
| `L4_K3_n64_K3` | 0.00949813 | 0.00792665 | **−16.5 %** |
| `L4_K3_n64_K3gdr` | 0.00949780 | 0.00792608 | **−16.5 %** |
| `L4_K3_n64_gdr` | 0.00951079 | 0.00793694 | **−16.5 %** |
| `L4_K3_n64_K3LHY` | 0.00953759 | 0.00692943 | **−27.3 %** |
| `matsui_40ms_dynamics_n64` | 0.00716601 | 0.00612421 | −14.5 % |
| `matsui_5ms_morphology_n64` | 0.00611232 | 0.00452326 | −26.0 % |

Four of five L4 cells move by **the same −16.5 %**, agreeing to 0.14 %. K3 and
γ_dr change nothing — Fig 3's conclusion from the other direction. `K3LHY` is the
outlier at −27.3 % and is the only cell with LHY active, so its extra shift is the
2026-07 LHY corrections, isolated by construction against the four `lhy: none`
cells beside it.

## The n96/n128 rungs were skipped on purpose

anko asked whether they were needed. Measured:

| | magnitude |
|---|---:|
| grid dependence n64 → n128 at fixed physics (stored) | **1.19 %** |
| the change found here, at fixed n64 | **16.5 %** |

**The grid axis is a fourteenth of the effect**, the stored ladder was already
converged to ~1 %, and the shift is uniform across physics branches. The higher
rungs would restate −16.5 % at a few GPU-hours each. Stated rather than quietly
skipped.

## A conservation scare that was mine, not the code's

I first flagged `Fz_drift` of 0.61–1.65 as *"heavier than the classification
change"*. **Wrong** — I never checked what is conserved.

These configs run full MDDI (`ddi.secular: false`), where F_z is **not** conserved:
transferring spin to orbital angular momentum *is* the Einstein-de Haas effect
being measured. The conserved quantity is `J_z = L_z + S_z`:

| run | S_z(end) | L_z(end) | J_z(end) | ΔJ_z |
|---|---:|---:|---:|---:|
| `L4_K3_n64_HamOnly` | −5.3942 | −0.6056 | **−5.9998** | **+0.0002** |
| `L4_K3_n64_K3` | −5.3359 | −0.5953 | −5.9312 | +0.0688 |
| `matsui_40ms_dynamics_n64` | −4.8565 | −1.0524 | −5.9088 | +0.0912 |

The 0.606 I called drift shows up in L_z as −0.6056 — **the same figure to four
places.** It was the signal. J_z holds to 2e-4 in the Hamiltonian-only cell; the
0.07–0.09 elsewhere is K3 discarding atoms.

## Status

*"L4 isotropic no-collapse"* is unaffected in direction — nothing collapses in
either dataset — but every number under it moved 16.5 %. The figure needs
redrawing, not re-captioning.

Fig 4 (`barnett_eu_window`, 16 configs) is in flight.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)