### PR TITLE
fix(nightly): the mutation job timed out every night and produced nothing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,7 +68,7 @@ jobs:
   mutation:
     name: Mutation catalog (defect classes vs the suite)
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -83,7 +83,17 @@ jobs:
       # gap to triage from the report, not a broken build. A STALE anchor DOES
       # fail, because a catalog entry that quietly tests nothing is the exact
       # failure mode the catalog exists to prevent.
-      - run: julia --project=. --startup-file=no test/mutation/run.jl --workers 3
+      # ONE SEVENTH of the catalog per night, chosen by day-of-year, so the
+      # whole thing sweeps weekly and every night FINISHES. Asking for the
+      # full catalog cost 53 classes x every probe file x one package load
+      # each, which ran into the 180-minute timeout and produced nothing —
+      # every night, reported as `cancelled` (2026-08-01). The harness names
+      # the classes it skipped, so a shard report cannot be mistaken for a
+      # clean bill of health.
+      - run: |
+          SHARD=$(( $(date -u +%j) % 7 ))
+          julia --project=. --startup-file=no test/mutation/run.jl \
+            --workers 3 --shard "$SHARD/7"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/scripts/tsubame/submit_mutation.sh
+++ b/scripts/tsubame/submit_mutation.sh
@@ -11,7 +11,7 @@
 # this uses its own checkout (`bec-mutation`) and not the shared one.
 #
 #   qsub -g tga-kozuma-kouhi \
-#        -v MUT_PROBE=<spec+spec>,MUT_MUTANTS=<id:id:…>,MUT_TAG=<name> \
+#        -v MUT_PROBE=<spec+spec>,MUT_MUTANTS=<id:id:…>,MUT_TAG=<name>[,MUT_SHARD=k_n] \
 #        scripts/tsubame/submit_mutation.sh
 #
 # Everything it writes lands under /gs/fs (group volume), never $HOME.
@@ -72,6 +72,8 @@ $JULIA --project=. -e 'using Pkg; Pkg.instantiate()' 2>&1 | tail -3
 ARGS=(--probe "$MUT_PROBE" --workers "${MUT_WORKERS:-8}"
       --max-cost "${MUT_MAX_COST:-300}" --out "$OUT")
 [ -n "${MUT_MUTANTS:-}" ] && ARGS+=(--mutants "$MUT_MUTANTS")
+# `k/n` — the same sharding the nightly uses, so a shard can be reproduced here.
+[ -n "${MUT_SHARD:-}" ] && ARGS+=(--shard "${MUT_SHARD//_//}")
 
 $JULIA --project=. --startup-file=no test/mutation/run.jl "${ARGS[@]}" 2>&1
 echo "MUT_RC=$?"

--- a/test/mutation/run.jl
+++ b/test/mutation/run.jl
@@ -2,6 +2,7 @@
 #
 #   julia --project=. test/mutation/run.jl [options]
 #     --mutants a,b,…     subset of catalog ids            (default: all)
+#     --shard k/n         every n-th class from k         (default: no sharding)
 #     --probe NAME|list   grounded_cheap | oracles | fast  (default: grounded_cheap)
 #                         or a comma-separated list of test files
 #     --workers N         parallel test processes          (default: CPU threads − 2)
@@ -94,12 +95,39 @@ end
 
 function chosen_mutants()
     ids = _arg("--mutants", "")
-    isempty(ids) && return MUTANTS
-    want = Set(Symbol.(split(ids, ",")))
-    sel = filter(m -> m.id in want, MUTANTS)
-    length(sel) == length(want) ||
-        error("unknown mutant id(s): $(setdiff(want, Set(m.id for m in sel)))")
-    sel
+    sel = if isempty(ids)
+        MUTANTS
+    else
+        want = Set(Symbol.(split(ids, ",")))
+        got = filter(m -> m.id in want, MUTANTS)
+        length(got) == length(want) ||
+            error("unknown mutant id(s): $(setdiff(want, Set(m.id for m in got)))")
+        got
+    end
+    _shard(sel)
+end
+
+# `--shard k/n` takes every n-th class starting at k. A full pass costs
+# n_mutants × n_probe_files package loads, which on one runner is hours: the
+# nightly job asked for the whole catalog and was killed at its 180-minute
+# timeout every night, doing nothing at all (2026-08-01). Sharding turns that
+# into a sweep that completes over n nights and finishes every night.
+#
+# What is dropped is NAMED, not silently cut — a report that covers 1/7th of
+# the catalog and does not say so reads as a clean bill of health.
+function _shard(sel)
+    spec = _arg("--shard", "")
+    isempty(spec) && return sel
+    parts = split(spec, "/")
+    length(parts) == 2 || error("--shard takes k/n, got $spec")
+    k, n = parse(Int, parts[1]), parse(Int, parts[2])
+    (n >= 1 && 0 <= k < n) || error("--shard k/n needs 1 ≤ n and 0 ≤ k < n, got $spec")
+    out = [m for (i, m) in enumerate(sel) if (i - 1) % n == k]
+    isempty(out) && error("--shard $spec selected no classes out of $(length(sel))")
+    println("  shard $k/$n: $(length(out)) of $(length(sel)) classes — NOT a full \
+             catalog pass. Skipped: ", join(
+            [String(m.id) for m in sel if !(m in out)], ", "))
+    out
 end
 
 # ── running one probe pass ─────────────────────────────────────────


### PR DESCRIPTION
The nightly mutation job started 06:01:40 and was killed at 09:01:55 — exactly its 180-minute timeout, which GitHub reports as **`cancelled`**, so it did not even read as a failure. That has happened every night since it landed in #198.

A full pass is 53 classes × every probe file × one package load each. It was never going to fit on one runner, and I did not size it before shipping it.

### The fix

`--shard k/n` takes every n-th class. The nightly picks `k` from the day-of-year: **one seventh a night, the whole catalog swept weekly, and every night finishes.** Timeout down to 120 minutes, since a shard that needs more than that is itself the signal.

The harness **names** the classes a shard skipped:

```
shard 2/7: 8 of 58 classes — NOT a full catalog pass. Skipped: zeeman_b_to_p_sign,
zeeman_quadratic_sign, yoshida_w0_sign, kinetic_propagator_factor, ... (50 ids)
```

A report covering 1/7th of the catalog that does not say so reads as a clean bill of health — which is the failure mode this whole tool exists to hunt.

`scripts/tsubame/submit_mutation.sh` takes `MUT_SHARD=k_n` so a nightly shard can be reproduced on a compute node instead of by waiting a day.

Verified end to end on TSUBAME (job 8314628): 8 of 58 selected, 50 named, `MUT_RC=0`, `dirty_after=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)