### PR TITLE
fix(test): the Klaus smoke was unrunnable because its initial state fought the field

### DIFF
--- a/test/MANUAL_TESTS.md
+++ b/test/MANUAL_TESTS.md
@@ -1,49 +1,16 @@
 # Manual test inventory
 
-Two files under `test/` are not wired into any tier. Each reason was
-**measured**, not inherited (2026-07-31): every candidate was run, with and
-without `SPINORBEC_RUN_HEAVY_YAML=true`, and the three that passed were moved
-into tiers. What is left is what genuinely cannot run.
+**One** file under `test/` is not wired into any tier. Its reason was measured,
+not inherited: every candidate was run, and the four that could be made to run
+were moved into tiers (2026-07-31 / 2026-08-01).
 
 The old framing — "depend on environment conditions the default test runner
 cannot guarantee (GPU, dashboard build, opt-in heavy YAML, scenario directories
-pending schema migration)" — had stopped being true for three of the five, and
-nothing had checked since 2026-05-25. Between them those three carried 35
-assertions that no tier ran.
+pending schema migration)" — was true for none of those four. Between them they
+carried 39 assertions that no tier ran, since 2026-05-25.
 
 `MANUAL_TESTS_ALLOWLIST` in `test/_tiers.jl` is the machine-readable copy;
 `test_tier_membership.jl` asserts the two agree.
-
-## `workflow/test_klaus_validation.jl` — cannot run as written
-
-Not an environment problem. Its `ground_state` step uses the real experimental
-field (`B: {Bz: "1.0 Gauss"}`, Dy164, `omega_ref: 314.159`) at `dt: 0.001`.
-That is `p ≈ −3.5e4`, so across `m = ±8` the ITP exponent spans
-`|p·m·dt| ≈ 278` and `exp` overflows on the first step:
-
-```
-ArgumentError: NaN detected in ITP at step 1. Likely DDI or interaction
-overflow. Reduce dt.
-```
-
-`hamiltonian/test_b_block_builders.jl` documents the same footgun and
-deliberately uses `Bz: 1.0e-4` to avoid it:
-
-> Tiny Bz to avoid ITP exp-V underflow at large dimensionless p. Real
-> experimental values (e.g. Klaus 2022 Bz=0.819G) give p≈3e4 which requires
-> matching small dt and physics-aware setup — not a plumbing test.
-
-So this is a physics-setup decision (a smaller ground-state field with a ramp,
-or a `dt` matched to `p`), not the "pending schema audit" it was filed under.
-Until that decision is made the file cannot be run at all:
-
-```bash
-SPINORBEC_RUN_HEAVY_YAML=true julia --project=. \
-  -e 'using Test; using SpinorBEC; include("test/workflow/test_klaus_validation.jl")'
-```
-
-It is also the only artifact behind the Klaus 2022 entry in the type-C registry
-(`test/validation/test_type_c_claims.jl`), which is why that entry is ungated.
 
 ## `workflow/test_live_monitor.jl` — blocks forever
 
@@ -61,16 +28,16 @@ julia --project=. \
   -e 'using Test; using SpinorBEC; include("test/workflow/test_live_monitor.jl")'
 ```
 
-## Moved into tiers, 2026-07-31
+## Moved into tiers
 
 | file | was filed as | measured | now |
 |---|---|---|---|
 | `gpu/test_cuda.jl` | "gated, but needs GPU to be useful" | guards on `CUDA.functional()` like every other `gpu/` file; 3.9 s on a GPU host, no-op without one | `FULL_EXTRA` |
-| `workflow/test_active_learning_yaml.jl` | "heavy YAML" | carries its own `_SKIP_HEAVY_YAML_AL`; 0.0 s with the flag off, 19.7 s with it on, passes both ways | `CI_EXTRA` |
-| `workflow/test_multi_fidelity_yaml.jl` | "heavy YAML" | same shape; 0.0 s / 50.2 s | `CI_EXTRA` |
+| `workflow/test_active_learning_yaml.jl` | "heavy YAML" | already carried `_SKIP_HEAVY_YAML_AL`; 0.0 s with the flag off, 21.7 s on the runner | `CI_EXTRA` |
+| `workflow/test_multi_fidelity_yaml.jl` | "heavy YAML" | same shape; 0.0 s / **776 s on the runner** — see `_COST` | `CI_EXTRA` |
+| `workflow/test_klaus_validation.jl` | "heavy YAML scenario pending schema audit" | the schema was fine. `initial_state: m_plus_F` was inverted against the field sign, so ITP underflowed every surviving component and the state normalised to NaN. `m_minus_F` runs it at the real 1 Gauss field, unchanged `dt`, in 68 s | `CI_EXTRA` |
 
-The heavy-YAML pair needed no guard added — they already had one. The entry in
-this file was the only thing keeping them out of a tier.
+Three of the four needed no code change at all — only for someone to run them.
 
 ## Re-audit (2026-06-19)
 

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -300,6 +300,10 @@ const CI_EXTRA = [
     # being true and nobody had checked.
     "workflow/test_active_learning_yaml.jl",
     "workflow/test_multi_fidelity_yaml.jl",
+    # Klaus 2022 magnetostir plumbing smoke. Was MANUAL as "heavy YAML scenario
+    # pending schema audit" since 2026-05-25; the schema was fine and the
+    # `initial_state` was inverted (see the file header). Runs in ~68 s.
+    "workflow/test_klaus_validation.jl",
     # Spatial / B(r,t) Zeeman + TOF (#14): split_step / simulate_* (per-voxel
     # propagation, multi-frame TOF) — integration weight, not fast-tier units.
     "analysis/test_tof.jl",
@@ -618,26 +622,18 @@ const PHYSICS_TESTS = [
 # here so the tier-membership meta-test counts them as "accounted for"
 # (i.e. they are deliberately manual, not orphaned). Run them by hand.
 const MANUAL_TESTS_ALLOWLIST = [
-    # Two files, each with a MEASURED reason (2026-07-31). The other three that
-    # sat here — gpu/test_cuda.jl, workflow/test_{active_learning,multi_fidelity}_yaml.jl
-    # — were run both ways and pass, so they are in tiers now.
+    # One file. `test_live_monitor.jl` blocks forever: `serve_dashboard` does not
+    # return until the server is closed and this file's close path is never
+    # reached, so the run hangs until it is killed (measured: SIGTERM at a
+    # 2400 s timeout, "Press Ctrl+C to stop" in the log). Its own comment says
+    # it means to close the server manually. Needs restructuring — serve on a
+    # task, assert, close in a `finally` — not a tier entry.
     #
-    # `test_klaus_validation.jl`: cannot run AS WRITTEN, and not for an
-    # environment reason. Its ground_state uses the real experimental field
-    # (`B: {Bz: "1.0 Gauss"}`, Dy164, ω_ref = 314.159) at `dt = 0.001`. That is
-    # p ≈ −3.5e4, so the ITP exponent spans |p·m·dt| ≈ 278 across m = ±8 and
-    # `exp` overflows on the first step: `ArgumentError: NaN detected in ITP at
-    # step 1`. The same footgun is documented in `test_b_block_builders.jl`
-    # ("real experimental values … require matching small dt and physics-aware
-    # setup — not a plumbing test"). Fixing it is a physics-setup decision
-    # (smaller GS field, or a dt that matches p), not a schema audit.
-    "workflow/test_klaus_validation.jl",
-    # `test_live_monitor.jl`: blocks forever. `serve_dashboard` does not return
-    # until the server is closed, and the close path is never reached, so the
-    # file hangs until it is killed (measured: SIGTERM at the 2400 s timeout,
-    # "Press Ctrl+C to stop" in the log). Its own comment says it means to close
-    # the server manually. Needs restructuring, not a tier entry.
-    "workflow/test_live_monitor.jl",
+    # The other four that sat here are in tiers as of 2026-07-31/08-01, each
+    # after being run rather than re-inheriting its reason: gpu/test_cuda.jl,
+    # workflow/test_{active_learning,multi_fidelity}_yaml.jl and
+    # workflow/test_klaus_validation.jl.
+    "workflow/test_live_monitor.jl"
 ]
 
 # Derived view (NOT a partition list): every `oracles/` gate, regardless of which
@@ -766,6 +762,9 @@ const _COST = Dict{String, Float64}(
     # 30668378491, 2026-07-31: all four workers killed, zero assertion
     # failures). Longest file in the suite; it must be handed out first.
     "workflow/test_multi_fidelity_yaml.jl" => 776.0,
+    # 68 s here; declared high because a runner estimate is what this model
+    # needs and the nightly timing table will correct it downward if generous.
+    "workflow/test_klaus_validation.jl" => 180.0,
     "workflow/test_active_learning_yaml.jl" => 21.7,
     "hamiltonian/test_mixed_precision_kinetic_buffer.jl" => 9.7,
     # 4.8 s here against a warm depot; the CI runner pays a cold precompile

--- a/test/validation/test_type_c_claims.jl
+++ b/test/validation/test_type_c_claims.jl
@@ -78,8 +78,12 @@ const TYPE_C_CLAIMS = TypeCClaim[
         "carries a ±10 nT offset, so only the WIDTH arbitrates."),
     TypeCClaim(
         "Klaus et al. 2022", "magnetostirring vortex nucleation", "—", nothing,
-        "workflow/test_klaus_validation.jl exists but is in MANUAL_TESTS_ALLOWLIST " *
-        "('heavy YAML scenario pending schema audit') and untouched since 2026-05-25"),
+        "workflow/test_klaus_validation.jl now RUNS (2026-08-01 — it was not a " *
+        "schema problem, its `initial_state` was inverted against the field sign) " *
+        "and is in CI_EXTRA. It stays ungated here because its own header says " *
+        "what it is: a plumbing smoke for the magnetostir path, NOT a physics " *
+        "validation of the published vortex-stripe count, which needs the full " *
+        "64x64x32 + 1 s stir"),
     TypeCClaim(
         "Matsui et al. (Eu Bogoliubov cascade)", "spin-excitation cascade", "—", nothing,
         "no test"),

--- a/test/workflow/test_klaus_validation.jl
+++ b/test/workflow/test_klaus_validation.jl
@@ -14,7 +14,19 @@ using SpinorBEC
 @testset "Klaus 2022 minimal regression" begin
     # Tiny smoke version of runs/klaus2022_full
     # Schema notes: `trap:` migrated to `potential:`,
-    # `level:` removed from B-block, `ferromagnetic_min` → `m_plus_F`.
+    # `level:` removed from B-block, `ferromagnetic_min` → `m_minus_F`.
+    #
+    # `m_minus_F`, not `m_plus_F`: the rename was read the wrong way round and
+    # that is what made this file unrunnable. `H = -p·F_z + q·F_z²` with
+    # `p ≡ -g_F μ_B B` means +Bz on a g_F > 0 atom (Dy164) puts the ground state
+    # at m = -F. ITP applies `exp(-(E-min)·dt)`, so at p ≈ -3.5e4 every
+    # component except m = -F underflows to zero on the first step — and with
+    # all the weight started in m = +F the state went to zero and normalising it
+    # gave `NaN detected in ITP at step 1. Likely DDI or interaction overflow.
+    # Reduce dt.` The message is misleading: it is underflow, not overflow, and
+    # neither dt nor the field needed to change. Measured, same 8³ config:
+    #     m_plus_F  / 1.0 Gauss    → NaN at step 1
+    #     m_minus_F / 1.0 Gauss    → E = -277668.36
     yaml_str = """
     pipeline:
       - ground_state:
@@ -27,7 +39,7 @@ using SpinorBEC
           dt: 0.001
           n_steps: 500
           tol: 1.0e-5
-          initial_state: m_plus_F
+          initial_state: m_minus_F
       - dynamics:
           duration: 0.5
           dt: 0.002


### PR DESCRIPTION
`workflow/test_klaus_validation.jl` has been in `MANUAL_TESTS_ALLOWLIST` since
2026-05-25 as *"heavy YAML scenario pending schema audit"*. **The schema was
fine.**

Its own header records the rename `ferromagnetic_min` → `m_plus_F`. That is
backwards: `ferromagnetic_min` was m = −F. With `H = -p·F_z + q·F_z²` and
`p ≡ -g_F μ_B B`, +Bz on a g_F > 0 atom (Dy164) puts the ground state at
**m = −F** — so the config started every atom in the one component the field
empties.

ITP applies `exp(-(E-min)·dt)`, so at `p ≈ -3.5e4` every component except m = −F
underflows to zero on the first step. All the weight was in m = +F, the state
went to zero, and normalising it produced

```
ArgumentError: NaN detected in ITP at step 1. Likely DDI or interaction
overflow. Reduce dt.
```

The message is misleading — **underflow, not overflow** — and it sent the earlier
diagnosis (mine included, in #267's doc) at the field magnitude and `dt` instead
of at the state. Measured, same 8³ config:

| initial_state | Bz | result |
|---|---|---|
| `m_plus_F` | 1.0 Gauss | **NaN at step 1** |
| `m_minus_F` | 1.0 Gauss | E = −277668.36 |
| `m_plus_F` | 1.0e-4 Gauss | E = 38.14 — a small field hides it |

So neither the field nor `dt` needed to change; shrinking either would have
papered over an inverted state. The full test now passes **3/3 in 68 s** at the
real 1 Gauss field, and is in `CI_EXTRA`.

## The allowlist is down to one

`MANUAL_TESTS_ALLOWLIST` held five files / 53 assertions, untouched since
2026-05-25. Four are now in tiers, each after being **run** rather than
re-inheriting its reason — and three of the four needed no code change at all,
only for someone to run them. What is left is `test_live_monitor.jl`, which
blocks forever by construction.

## Type-C

The registry keeps Klaus 2022 **ungated**, with a sharper note: this file is a
plumbing smoke for the magnetostir path by its own header — *"NOT a physics
validation of the published vortex-stripe count (that needs the full
64×64×32 + 1 s stir)"*. Running is not the same as validating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)