### PR TITLE
perf(lbfgs): take the accepted line-search trial's gradient on the GPU

### DIFF
--- a/bench/probe_lbfgs_pass_costs.jl
+++ b/bench/probe_lbfgs_pass_costs.jl
@@ -83,7 +83,10 @@ for (label, ddi) in (("contact", false), ("+DDI", true))
     ws = r.workspace
     psi = copy(ws.state.psi)
     g = similar(psi)
-    k2 = ws.grid.k_squared
+    # `Grid.k_squared` is a HOST array even for a GPU workspace — the driver
+    # keeps a device copy. Timing `energy_gradient!` against the host one would
+    # measure a per-call H2D transfer that production does not pay.
+    k2 = SpinorBEC._to_device_cached(ws.backend, ws.grid.k_squared)
     dV = cell_volume(ws.grid)
 
     t_E = timed(() -> total_energy(ws))
@@ -113,14 +116,29 @@ for (label, ddi) in (("contact", false), ("+DDI", true))
         t_EG.med < t_E.med + t_G.med ? "fusing saves $(round(t_E.med + t_G.med - t_EG.med; digits=2)) ms" :
         "NO saving as built")
 
-    # Reconcile against a measured iteration. n_ls energy passes + 1 gradient
-    # + two-loop + projection, against the slope of wall vs n_steps.
-    n_lo, n_hi = 25, 125
-    t_lo = @elapsed find_ground_state_lbfgs(; cell..., n_steps=n_lo, tol=0.0, m_lbfgs=20)
+    # Reconcile against a measured iteration.
+    #
+    # NOT `tol = 0.0`. The first version used it so that `n_steps` would be
+    # exact for the slope, and on the contact cell — which converges in 36
+    # iterations — that made every one of the differenced steps a
+    # POST-CONVERGENCE one at ~5 line-search evaluations each. The breakdown
+    # came out at 207 % and the guard below correctly refused to certify it.
+    # A reachable `tol` costs an inexact step count and buys a slope over
+    # steps that are doing work; `last_step` is read back rather than assumed.
+    r_lo = find_ground_state_lbfgs(; cell..., n_steps=4000, tol=1.0e-5, m_lbfgs=20)
+    t_lo = @elapsed find_ground_state_lbfgs(; cell..., n_steps=4000, tol=1.0e-5, m_lbfgs=20)
     r_hi = nothing
-    t_hi = @elapsed (r_hi = find_ground_state_lbfgs(; cell..., n_steps=n_hi, tol=0.0, m_lbfgs=20))
+    t_hi = @elapsed (r_hi = find_ground_state_lbfgs(; cell..., n_steps=4000, tol=1.0e-7, m_lbfgs=20))
+    n_lo, n_hi = r_lo.last_step, r_hi.last_step
+    if n_hi <= n_lo + 5
+        @printf("  ---- reconcile SKIPPED: the two tolerances took %d and %d steps\n",
+            n_lo, n_hi)
+        println()
+        continue
+    end
     per_iter = 1000 * (t_hi - t_lo) / (n_hi - n_lo)
     n_ls = r_hi.n_line_search_evals / max(r_hi.last_step, 1)
+    @printf("  ---- slope over %d..%d iterations (tol 1e-5 -> 1e-7)\n", n_lo, n_hi)
     parts = n_ls * t_E.med + t_G.med + (isnan(t_2L.med) ? 0.0 : t_2L.med) + t_P.med
     @printf("  ---- reconcile: measured %.2f ms/it  vs parts %.2f ms (n_ls=%.2f) => %.0f%%\n",
         per_iter, parts, n_ls, 100 * parts / per_iter)

--- a/src/solvers/lbfgs/driver.jl
+++ b/src/solvers/lbfgs/driver.jl
@@ -7,6 +7,27 @@ export find_ground_state_lbfgs
 # preconditioning — the physical convergence certificate). Single source so the
 # initial and per-step gradient (reused across steps, not recomputed) precondition
 # identically. Mirrors the former inline block exactly ⇒ bit-identical trajectory.
+# Everything after the raw gradient: constraint projection, the projected-raw
+# residual, preconditioning. Split out so the fused line-search path — which
+# already holds `H·ψ` at the accepted iterate — can finish it without repeating
+# the pass that produced it.
+@inline function _lbfgs_grad_finish!(
+    g, psi, ws, k_squared_dev, grid, target_magnetization, F,
+    precond_alpha_v::Float64, precond_alpha_k::Float64, sobolev_alpha::Float64, dV::Float64,
+)
+    _project_constraints!(g, psi, grid, target_magnetization, F)
+    grad_norm = sqrt(sum(abs2, g) * dV)
+    if precond_alpha_v >= 0
+        sqrt_pv = build_precond_sqrt_pv(ws, psi, precond_alpha_v)
+        combined_precondition!(g, ws, sqrt_pv, k_squared_dev, precond_alpha_k)
+        _project_constraints!(g, psi, grid, target_magnetization, F)
+    elseif sobolev_alpha > 0
+        _sobolev_precondition!(g, ws, k_squared_dev, sobolev_alpha)
+        _project_constraints!(g, psi, grid, target_magnetization, F)
+    end
+    grad_norm
+end
+
 @inline function _lbfgs_grad!(
     g, psi, ws, k_squared_dev, grid, target_magnetization, F,
     precond_alpha_v::Float64, precond_alpha_k::Float64, sobolev_alpha::Float64, dV::Float64;
@@ -23,16 +44,9 @@ export find_ground_state_lbfgs
         gradient_only!(g, psi, ws)
         E_known
     end
-    _project_constraints!(g, psi, grid, target_magnetization, F)
-    grad_norm = sqrt(sum(abs2, g) * dV)
-    if precond_alpha_v >= 0
-        sqrt_pv = build_precond_sqrt_pv(ws, psi, precond_alpha_v)
-        combined_precondition!(g, ws, sqrt_pv, k_squared_dev, precond_alpha_k)
-        _project_constraints!(g, psi, grid, target_magnetization, F)
-    elseif sobolev_alpha > 0
-        _sobolev_precondition!(g, ws, k_squared_dev, sobolev_alpha)
-        _project_constraints!(g, psi, grid, target_magnetization, F)
-    end
+    grad_norm = _lbfgs_grad_finish!(
+        g, psi, ws, k_squared_dev, grid, target_magnetization, F,
+        precond_alpha_v, precond_alpha_k, sobolev_alpha, dV)
     (E, grad_norm)
 end
 
@@ -304,9 +318,21 @@ function find_ground_state_lbfgs(;
 
         # Backtracking-Armijo line search from the natural L-BFGS step α=1.
         # `expand` lets the unscaled steepest-descent step auto-find its scale.
-        α, E_trial, psi_accepted, n_ls = _line_search_energy_decrease(
+        # Fuse the first trial with the gradient where that is free. On the
+        # GPU `energy_gradient!` and `gradient_only!` are the SAME fused kernel
+        # (1.383 vs 1.382 ms at 24³ D=13) because the energy falls out of the
+        # pass that forms H·ψ, so evaluating the α=1 trial that way and reusing
+        # its gradient removes a whole `total_energy` — 1.306 ms of a measured
+        # 5.83 ms iteration, on the ~85 % of iterations where α=1 is accepted.
+        #
+        # NOT done on the CPU, and that is a measurement: there
+        # `energy_gradient!` traverses the term registry twice, 12.80 ms
+        # against 6.57 + 6.11 for the two passes separately, so fusing would
+        # cost 0.1 ms rather than save.
+        fused_grad = _is_gpu(psi) ? grad_new : nothing
+        α, E_trial, psi_accepted, n_ls, grad_ready = _line_search_energy_decrease(
             psi, direction, E, ws, grid, dV, target_magnetization, F;
-            slope=slope, expand=is_sd,
+            slope=slope, expand=is_sd, grad_out=fused_grad, k_squared_dev,
         )
         n_line_search_evals += n_ls
 
@@ -345,11 +371,24 @@ function find_ground_state_lbfgs(;
         # Gradient at the new ψ — same preconditioning as the initial gradient so
         # it can be carried to the next iteration. grad_norm_new is the projected-
         # raw residual used by the next convergence test.
-        E_new, grad_norm_new = _lbfgs_grad!(
-            grad_new, psi, ws, k_squared_dev, grid, target_magnetization, F,
-            precond_alpha_v, precond_alpha_k, sobolev_alpha, dV;
-            E_known=Float64(E_trial),
-        )
+        E_new, grad_norm_new = if grad_ready
+            # `grad_new` already holds 2·δE/δψ̄ at exactly this iterate — the
+            # line search accepted the trial it was evaluated at, and the
+            # driver adopted that trial's ψ. Only the projection and
+            # preconditioning are left.
+            (
+                Float64(E_trial),
+                _lbfgs_grad_finish!(
+                    grad_new, psi, ws, k_squared_dev, grid, target_magnetization, F,
+                    precond_alpha_v, precond_alpha_k, sobolev_alpha, dV),
+            )
+        else
+            _lbfgs_grad!(
+                grad_new, psi, ws, k_squared_dev, grid, target_magnetization, F,
+                precond_alpha_v, precond_alpha_k, sobolev_alpha, dV;
+                E_known=Float64(E_trial),
+            )
+        end
 
         # L-BFGS history update — `real(dot(s_k, y_k))` is the same
         # quantity as `real(sum(conj.(s_k) .* y_k))` without the two

--- a/src/solvers/lbfgs/helpers.jl
+++ b/src/solvers/lbfgs/helpers.jl
@@ -207,6 +207,17 @@ function _line_search_energy_decrease(
     α_init::Float64=1.0, shrink::Float64=0.5, grow::Float64=2.0,
     c1::Float64=1.0e-4, max_iter::Int=30, max_expand::Int=6,
     expand::Bool=false,
+    # When given, the FIRST trial evaluates `energy_gradient!` into this buffer
+    # instead of `total_energy`, and the returned `grad_valid` says whether the
+    # step that was accepted is the one it was evaluated at. On the GPU that
+    # gradient is free — measured at 24³ D=13, `energy_gradient!` costs 1.383 ms
+    # against `gradient_only!`'s 1.382, because both are the same fused kernel
+    # and the energy falls out of it — so the caller can skip its own gradient
+    # pass and save a whole `total_energy` (1.306 ms of a 5.83 ms iteration).
+    # On the CPU it is NOT free: `energy_gradient!` runs the term registry
+    # twice, 12.80 ms against 6.57 + 6.11 separately, so the caller does not
+    # pass this there.
+    grad_out=nothing, k_squared_dev=nothing,
 )
     D = 2F + 1
     N_dim = length(grid.config.n_points)
@@ -226,9 +237,18 @@ function _line_search_energy_decrease(
         nothing
     end
     n_eval = 0
+    fused_done = false
     eval_energy = function (α)
         retract!(α)
         n_eval += 1
+        if grad_out !== nothing && !fused_done
+            fused_done = true
+            # `retract!` has already placed `psi_trial` in `ws.state.psi`; the
+            # copy inside `energy_gradient!` repeats it. Kept rather than
+            # special-cased because it is one device copy against the 1.3 ms
+            # this saves.
+            return energy_gradient!(grad_out, psi_trial, ws; k_squared_dev)
+        end
         total_energy(ws)
     end
 
@@ -259,9 +279,11 @@ function _line_search_energy_decrease(
             # (`best_E` is already known), which is why this is `retract!` and
             # not the `eval_energy` the fix on main used.
             last_α == best_α || retract!(best_α)
-            return best_α, best_E, psi_trial, n_eval
+            # The expansion phase moved on from the point `grad_out` was taken
+            # at, so the caller must not reuse it.
+            return best_α, best_E, psi_trial, n_eval, false
         end
-        return α, E_trial, psi_trial, n_eval
+        return α, E_trial, psi_trial, n_eval, grad_out !== nothing
     end
 
     # Backtracking from α_init.
@@ -269,11 +291,12 @@ function _line_search_energy_decrease(
         α *= shrink
         E_trial = eval_energy(α)
         if accept(α, E_trial)
-            return α, E_trial, psi_trial, n_eval
+            # Backtracked: `grad_out` was evaluated at α_init, not here.
+            return α, E_trial, psi_trial, n_eval, false
         end
     end
     # No sufficient decrease found — return zero step.
-    (0.0, E0, psi, n_eval)
+    (0.0, E0, psi, n_eval, false)
 end
 
 """

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -272,6 +272,7 @@ const CI_EXTRA = [
     "solvers/test_lbfgs_line_search_and_de.jl",
     "solvers/test_lbfgs_fast_path_equivalence.jl",
     "solvers/test_lbfgs_history_precision.jl",
+    "solvers/test_lbfgs_line_search_fused_gradient.jl",
     "analysis/test_energy.jl",
     # Evaporation OPTIMIZATION/SCAN tools run the scalar model in loops
     # (optimizer, parameter scans, K3 fit) — aggregate-heavy, kept out of the
@@ -787,6 +788,7 @@ const _COST = Dict{String, Float64}(
     "solvers/test_lbfgs_sobolev_preconditioner.jl" => 6.5,
     "solvers/test_lbfgs_fast_path_equivalence.jl" => 6.0,
     "solvers/test_lbfgs_history_precision.jl" => 8.0,
+    "solvers/test_lbfgs_line_search_fused_gradient.jl" => 6.0,
     "rotating_basis/test_rotating_basis_pipeline_parsing.jl" => 6.0,
     "solvers/test_lbfgs_accuracy_floor.jl" => 6.0,
     "solvers/test_3d.jl" => 5.0,

--- a/test/solvers/test_lbfgs_line_search_fused_gradient.jl
+++ b/test/solvers/test_lbfgs_line_search_fused_gradient.jl
@@ -1,0 +1,109 @@
+using Test
+using SpinorBEC
+using SpinorBEC: _line_search_energy_decrease, gradient_only!, energy_gradient!,
+    _project_constraints!, _lbfgs_scratch
+
+# The line search can evaluate its FIRST trial with `energy_gradient!` instead
+# of `total_energy`, and hand the caller the gradient it formed on the way.
+#
+# On the GPU that gradient is free — `energy_gradient!` 1.383 ms against
+# `gradient_only!` 1.382 at 24³ D=13, because both are the same fused kernel —
+# so the driver skips its own gradient pass and saves a whole `total_energy`
+# (1.306 ms of a 5.83 ms iteration, on the ~85 % of iterations where α=1 is
+# accepted). On the CPU `energy_gradient!` traverses the term registry twice
+# (12.80 ms vs 6.57 + 6.11 separately), so the driver does NOT pass it there.
+#
+# The MECHANISM is backend-agnostic, though; only the decision to use it is
+# gated on the backend. So the contract is testable without a GPU, and that is
+# what this file does:
+#
+#   - passing `grad_out` does not change which step is accepted, or its energy;
+#   - the gradient handed back is the one `gradient_only!` would have computed
+#     at the accepted iterate — the whole point, since the driver stops
+#     computing it;
+#   - `grad_valid` is FALSE whenever the accepted point is not the point the
+#     gradient was taken at (backtracking, and the steepest-descent expansion),
+#     because reusing it there would silently descend the wrong gradient.
+
+function _ls_fixture()
+    grid = make_grid(GridConfig((8, 8, 8), (6.0, 6.0, 6.0)))
+    ws = make_workspace(;
+        grid, atom=Na23,
+        interactions=InteractionParams(Dict(0 => 20.0, 1 => -0.5)),
+        potential=HarmonicTrap((1.0, 1.0, 1.0)),
+        sim_params=SimParams(; dt=0.005, n_steps=1),
+    )
+    psi = copy(ws.state.psi)
+    dV = cell_volume(grid)
+    g = similar(psi)
+    fill!(g, zero(eltype(g)))
+    E0 = energy_gradient!(g, psi, ws; k_squared_dev=grid.k_squared)
+    _project_constraints!(g, psi, grid, nothing, 1)
+    direction = -g
+    slope = -sum(abs2, g) * dV
+    (; psi, direction, E0, ws, grid, dV, slope, k2=grid.k_squared)
+end
+
+@testset "line search: fused first-trial gradient" begin
+    f = _ls_fixture()
+    common = (f.psi, f.direction, f.E0, f.ws, f.grid, f.dV, nothing, 1)
+
+    @testset "accepted at α_init: same step, and the gradient is reusable" begin
+        # α small enough that the first trial is accepted — asserted, not
+        # assumed, since every claim below is about that branch.
+        αi = 1.0e-3
+        a0, E0_, _, n0, v0 = _line_search_energy_decrease(
+            common...; slope=f.slope, α_init=αi)
+        @test n0 == 1          # first trial accepted; positive control
+        @test v0 == false      # no `grad_out` ⇒ nothing to reuse
+
+        gbuf = similar(f.psi)
+        fill!(gbuf, zero(eltype(gbuf)))
+        a1, E1, psi_acc, n1, v1 = _line_search_energy_decrease(
+            common...; slope=f.slope, α_init=αi, grad_out=gbuf, k_squared_dev=f.k2)
+
+        # Passing the buffer must not change the search.
+        @test a1 == a0
+        @test E1 == E0_
+        @test n1 == n0
+        @test v1 == true
+
+        # And the buffer holds the gradient the driver no longer computes.
+        ref = similar(f.psi)
+        fill!(ref, zero(eltype(ref)))
+        gradient_only!(ref, psi_acc, f.ws)
+        @test maximum(abs, gbuf .- ref) == 0.0
+        @test maximum(abs, ref) > 0        # not vacuous
+    end
+
+    @testset "backtracked: the gradient is NOT offered" begin
+        # A step far too long, so the first trial is rejected and the accepted
+        # point is somewhere the gradient was never evaluated.
+        gbuf = similar(f.psi)
+        fill!(gbuf, zero(eltype(gbuf)))
+        α, _, psi_acc, n, v = _line_search_energy_decrease(
+            common...; slope=f.slope, α_init=1.0e6, grad_out=gbuf, k_squared_dev=f.k2)
+        @test n > 1            # it really backtracked; positive control
+        @test v == false
+        # The buffer was written at α_init, and that is exactly why it must not
+        # be reused: it does NOT match the accepted iterate.
+        if α > 0
+            ref = similar(f.psi)
+            fill!(ref, zero(eltype(ref)))
+            gradient_only!(ref, psi_acc, f.ws)
+            @test maximum(abs, gbuf .- ref) > 0
+        end
+    end
+
+    @testset "steepest-descent expansion: the gradient is NOT offered" begin
+        # `expand=true` walks past the point it evaluated the gradient at.
+        gbuf = similar(f.psi)
+        fill!(gbuf, zero(eltype(gbuf)))
+        α, _, _, n, v = _line_search_energy_decrease(
+            common...; slope=f.slope, α_init=1.0e-6, expand=true,
+            grad_out=gbuf, k_squared_dev=f.k2)
+        @test n > 1            # the expansion phase ran; positive control
+        @test v == false
+        @test α > 1.0e-6       # and it did move
+    end
+end


### PR DESCRIPTION
**−27 to −30 % per L-BFGS iteration on the production configuration, with the trajectory bit-identical.**

## What was being paid twice

24³ Eu-151 F=6 on an H100, each point over 3 s of repeats, breakdown closing at 87 % against a slope over working iterations:

| | ms |
|---|---|
| `total_energy` | 1.306 |
| `gradient_only!` | 1.382 |
| **`energy_gradient!`** | **1.383** |
| two-loop (m=20) | 2.098 |
| `project_constraints` | 0.065 |
| iteration | 5.83 (n_ls = 1.18) |

`energy_gradient!` and `gradient_only!` are the *same* fused GPU kernel — the energy falls out of the pass that forms `H·ψ`, which is why those two rows are indistinguishable to 1 µs. Meanwhile the driver evaluated the line search with `total_energy` and then ran a separate gradient pass: **1.306 ms paid for a number the next call produces for nothing.**

## The change

The line search evaluates its **first** trial with `energy_gradient!` into a caller-supplied buffer and reports whether the step it accepted is the one that buffer belongs to. When it is, the driver skips its own gradient pass. α=1 is accepted on ~85 % of useful iterations (n_ls measured at 1.08–1.25).

`grad_valid` is false whenever the accepted point is *not* where the gradient was taken — after any backtrack, and after the steepest-descent expansion phase, which walks past it. Reusing it there would descend a gradient belonging to a rejected iterate.

**Not done on the CPU**, and that is a measurement rather than caution: there `energy_gradient!` traverses the term registry twice (12.80 ms against 6.57 + 6.11 separately), so fusing would cost 0.1 ms instead of saving. `_is_gpu(psi)` is the switch.

## A/B, same job, both revisions back to back

| cell | main | this | iterations | energy |
|---|---|---|---|---|
| +DDI, tol 1e-5 | 6.88 ms/it | **4.81** (−30 %) | 482 = 482 | 7.8619335121 = same |
| +DDI, tol 1e-6 | 7.15 ms/it | **5.21** (−27 %) | 558 = 558 | 7.8619335120 = same |

Wall 3.32 → 2.32 s and 3.99 → 2.90 s. Iteration count, `evals/it` and `|g|` agree to every printed digit — the trajectory is unchanged, as it must be when the substituted energy comes from the same kernel.

**The contact rows are not quoted.** Those runs are 0.15–0.39 s and one of them reads 4.98 → 10.82 ms/it, an outlier with no explanation (it is the *later* run in the same process, so not JIT). 36 iterations at 5 ms is too short to measure against setup and shared-GPU clock variation; that is a fault of the measurement, not evidence about the change.

Measured 2.07 ms saved against 1.72 predicted from the pass costs. The discrepancy is in the favourable direction and both +DDI points agree, so the direction is solid, but it is not fully accounted for.

## Gate

`test/solvers/test_lbfgs_line_search_fused_gradient.jl` (CI_EXTRA). The mechanism is backend-agnostic — only the *decision* to use it is gated on the backend — so the contract is checked without a GPU: passing the buffer does not change which step is accepted or its energy; the gradient handed back is **bit-identical** to what `gradient_only!` would compute at the accepted iterate; and both not-reusable branches are really reached (asserted via `n_eval`, not assumed).

Also splits `_lbfgs_grad_finish!` out of `_lbfgs_grad!` so the fused path finishes through the same projection/preconditioning code rather than a copy of it, and fixes the pass-cost probe, which reconciled against `tol = 0.0` and so differenced post-convergence steps on the contact cell (207 %, refused by its own guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)