### PR TITLE
fix(inventory): three more claim shapes it could not see — null, preserved, agrees-with

### DIFF
--- a/test/_inventory.jl
+++ b/test/_inventory.jl
@@ -46,6 +46,15 @@ const _MARKERS = [
         # "bit-identity" is not "bit-identical", and the file whose whole title
         # is "HamTerm ↔ independent statement bit-identity" was landing in :pin.
         r"bit[-_ ]?identit"i, r"↔",
+        # "A agrees with B" is the differential claim in words. NOT a bare
+        # `match`: tried, and it promoted 41 files that were correctly
+        # :metamorphic / :invariant / :exact into :differential — a stronger
+        # claim they do not carry (`analysis/test_bogoliubov.jl` compares a
+        # dispersion to its closed form; that is exact, not differential).
+        # Re-labelling a grounded file is not the safe direction the header
+        # licenses; only moving an UNgrounded one into grounded is.
+        r"\bagree(s|ment)?\s+with\b"i, r"\b≡\b",
+        r"\bmatch(es)?\s+(the\s+)?(per[-_ ]component|reference|legacy|dumb|independent)"i,
         r"registry.{0,40}(≈|isapprox)"i, r"cpu.{0,30}gpu"i, r"gpu.{0,30}cpu"i,
         r"bit[-_ ]?identical"i, r"cross[-_ ]?check"i, r"\btwin\b"i,
         r"independent(ly)?\s+(computed|stated|implement)"i,
@@ -64,6 +73,9 @@ const _MARKERS = [
         # "conservation": Σ parts == total, and the accumulate contract.
         r"total.{0,30}(≈|==).{0,10}(Σ|sum|parts)"i, r"Σ\s*parts"i,
         r"accumulat"i,
+        # "preserved" is "conserved" said the other way. `Norm preserved by
+        # batched step` was :api.
+        r"\bpreserv"i,
         r"conserv"i, r"\bdrift\b"i, r"hermitic"i, r"unitar"i,
         r"norm\w*\s*.{0,20}(≈|isapprox)\s*1", r"sum[_ ]rule"i,
         r"positive[-_ ]?(semi)?definite"i, r"virial"i, r"trace"i,
@@ -74,6 +86,17 @@ const _MARKERS = [
         # `E = Re⟨ψ|Hψ⟩·dV`, `E = −Ω·⟨L_z⟩`, `= ψ†·F_α·ψ`, `v = k` — none of
         # which contains the word "analytic", so all of them were :pin.
         r"⟨ψ\s*\|", r"ψ†", r"Re⟨", r"⟨L_z⟩", r"⟨F", r"·dV\b",
+        # "X is zero / vanishes / is null" is a closed form — the closed form
+        # is 0. `probability_current zero for real Gaussian`, `plane wave has
+        # zero vorticity`, `Nyquist-null in FFT first-derivatives`,
+        # `orbital_angular_momentum returns 0 for 1D` were all :pin.
+        r"\b(is|are|returns?|gives?)\s+(exactly\s+)?(zero|0\b)"i,
+        r"\bzero\s+(for|at|in|when)\b"i, r"\bvanish"i, r"[-_ ]null\b"i,
+        # Closed-form shapes: a beam profile, a peak position, a limit value.
+        # NOT a bare `profile`: it is a common noun here (density profile,
+        # beam profile, "profiling") and it dragged two meta gates into :exact.
+        r"\bpeak\s+at\b"i, r"(gaussian|transverse|radial|density)\s+profile"i,
+        r"\blimit\b.{0,30}(≈|isapprox|==)"i,
         r"analytic"i, r"\bexact\b"i, r"closed[-_ ]form"i, r"theoretical"i,
         r"gauss[-_ ]hermite"i, r"manufactured"i, r"\bclosed form\b"i,
         r"known\s+(solution|answer|value)"i, r"first[-_ ]principles"i,


### PR DESCRIPTION
Second pass over #268's finding. Reading the files the inventory still calls
ungrounded, the same cause keeps producing them: the markers read **prose** and
the files state their claim as **maths**, or as plain English the marker list
does not happen to contain.

## Three shapes added, each named by the file that motivated it

| shape | file | was |
|---|---|---|
| "X **is zero** / vanishes / is null" — a closed form whose value is 0 | `analysis/test_currents.jl` — *probability_current zero for real Gaussian*<br>`analysis/test_vorticity_berry.jl` — *plane wave has zero vorticity*<br>`foundation/test_fft_nyquist_null.jl` — *Nyquist-null in FFT first-derivatives* | pin |
| "**preserved**" — "conserved" said the other way | `hamiltonian/test_batched_kinetic.jl` — *Norm preserved by batched step* | api |
| "**agrees with**" / `≡` / "matches the reference\|legacy\|dumb\|per-component" | `hamiltonian/test_batched_kinetic.jl` — *Batched matches per-component 1D* | api |

## Two markers were tried and REJECTED, on measurement

A bare **`match`** promoted **41 files** that were correctly `:metamorphic` /
`:invariant` / `:exact` into `:differential` — a stronger claim they do not
carry (`analysis/test_bogoliubov.jl` compares a dispersion to its closed form:
that is exact, not differential). **Re-labelling a grounded file is not the safe
direction this file's header licenses**; only moving an ungrounded one into
grounded is. Narrowed to its differential senses.

A bare **`profile`** is a common noun here (density profile, beam profile,
"profiling") and dragged two meta gates into `:exact`. Narrowed to
`(gaussian|transverse|radial|density) profile`.

## Result

```
grounded    298/358 (83 %)  →  312/363 (86 %)
ungrounded       60         →       46
```

7 sideways moves, all defensible ("preserved" → `:invariant`, the SpatialLHY
comparisons → `:differential`).

## What the remaining 46 are — read, not assumed

Mostly **correct**:

- `workflow/test_config.jl` (api, 52) and `foundation/test_types_validation.jl`
  (api, 41) — YAML parsing and constructor validation. There is no physics in
  the config layer; `:api` is the right label.
- `solvers/test_evaporation_tools.jl` (pin, 40) — optimiser landscapes.
- `analysis/test_sinatra_diagnostics.jl` (pin, 26) — helpers with no closed form
  written down.

**22 of the 46 are in `workflow/`, and those should stay `:api`.** The target I
first named — "23 of 346 files carry a control" — was the wrong measure. This is
the right one, and it says the work here is mostly done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)