### PR TITLE
test(pipeline): the analyzer name, and the interactions precedence that voided a published arm

### DIFF
--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -53,6 +53,9 @@ const FAST_TESTS = [
     # (mutation, 2026-08-01): the budget gate's queued work, the daily cap,
     # OOM-is-permanent, and the on_complete lineage bound.
     "workflow/test_autopilot_invariants.jl",
+    # Analyzer-name routing and the ground-state interactions precedence —
+    # 64 workflow files covered neither (mutation, 2026-08-01).
+    "workflow/test_pipeline_name_and_precedence.jl",
     "workflow/test_auto_grid_derivation.jl",
     "workflow/test_b_block_spherical_angles.jl",
     "workflow/validation/test_error_budget_positive_control.jl",

--- a/test/mutation/catalog.jl
+++ b/test/mutation/catalog.jl
@@ -342,6 +342,28 @@ const MUTANTS = Mutant[
          too many snapshots. The file is valid either way and the physics is \
          unchanged — only the record of it is."),
 
+    # ── pipeline: the name and the inheritance order ──────────────────
+    Mutant(:analyzer_name_routes_to_neighbour,
+        "src/workflow/experiments/pipeline/pipeline_analyzers.jl",
+        r"        return _analyze_phase_classify\(psi, grid, atom, params, ws_prev\)",
+        "        return _analyze_phase_classify_distance(psi, grid, atom, params, ws_prev)",
+        :path_default, :fatal,
+        "CLAUDE.md: a YAML analyzer name must be the real implementation",
+        "Routes one analyzer name to its neighbour. The run succeeds and writes \
+         data labelled `phase_classify` that a different analyzer produced — \
+         the aliased-dispatch silent-bug factory the convention exists to stop."),
+    Mutant(:gs_interactions_inherit_over_explicit,
+        "src/workflow/experiments/pipeline/run_step_ground_state.jl",
+        r"    if haskey\(p, \"interactions\"\)\n        return _parse_gs_interactions\(p\[\"interactions\"\], atom\)\n    elseif ws_prev !== nothing\n        return ws_prev\.interactions",
+        "    if ws_prev !== nothing\n        return ws_prev.interactions\n    elseif haskey(p, \"interactions\")\n        return _parse_gs_interactions(p[\"interactions\"], atom)",
+        :path_default, :fatal,
+        "project_matsui_fig4b_reproduction_2026_07_30 — a c1_ratio in a ground_state step never reached c0",
+        "Inverts the precedence, so a step's OWN `interactions:` block loses to \
+         whatever the previous workspace carried. Every run completes and every \
+         scan point differs from its neighbours; the axis is just not the one \
+         the config asked for. This is the defect that voided a published \
+         comparison arm."),
+
     # ── workflow layer: the parser is a physics surface ───────────────
     # These reproduce defects that lived entirely above the Hamiltonian, where
     # every term-level oracle is green by construction because it never goes

--- a/test/workflow/test_pipeline_name_and_precedence.jl
+++ b/test/workflow/test_pipeline_name_and_precedence.jl
@@ -52,6 +52,38 @@ using SpinorBEC: _run_analyzer, _resolve_gs_interactions, resolve_atom, make_gri
             :not_an_analyzer, psi, grid, atom, Dict{Any, Any}())
     end
 
+    @testset "EVERY analyzer name routes to its own function" begin
+        # The row above tests ONE pair. There are 38 branches, so a pair-wise
+        # gate leaves 37 names undefended and reads as if it covered routing.
+        # This one states the convention itself and checks every branch: the
+        # dispatch chain is `name == :x` → `_analyze_x`, and any branch that
+        # departs from it is either a rename that lost its partner or an alias.
+        #
+        # Text-scanning, like the spin-chain decline-reason gate, and with the
+        # same limit: it cannot check that `_analyze_x` COMPUTES x. What it
+        # makes impossible is the silent half — a name pointing at somebody
+        # else's implementation.
+        src = read(
+            joinpath(dirname(pathof(SpinorBEC)), "workflow", "experiments",
+                "pipeline", "pipeline_analyzers.jl"), String)
+        branches = [
+            (m.captures[1], m.captures[2]) for m in eachmatch(
+                r"name == :(\w+)\s*\n\s*return (_analyze_\w+)\(", src)
+        ]
+        # Vacuity guard: if the chain is ever restructured out of this shape,
+        # the scan finds nothing and would pass silently.
+        @test length(branches) >= 30
+
+        mismatched = [(n, f) for (n, f) in branches if f != "_analyze_" * n]
+        isempty(mismatched) ||
+            @info "analyzer names routed to another analyzer's function" mismatched
+        @test isempty(mismatched)
+
+        # Every branch name is dispatchable — a name in the chain that
+        # `_run_analyzer` cannot actually reach is a different way to be wrong.
+        @test length(unique(first.(branches))) == length(branches)
+    end
+
     @testset "a step's own interactions: outrank the inherited ones" begin
         atom = resolve_atom(:Rb87)
         # A workspace-like carrier is all `_resolve_gs_interactions` reads.

--- a/test/workflow/test_pipeline_name_and_precedence.jl
+++ b/test/workflow/test_pipeline_name_and_precedence.jl
@@ -1,0 +1,69 @@
+# test/workflow/test_pipeline_name_and_precedence.jl
+#
+# Two pipeline claims that 64 workflow test files did not cover (mutation
+# harness, TSUBAME job 8314739). Neither is arithmetic; both are about WHICH
+# code runs, and both produce a complete, plausible run when they are wrong.
+#
+#   1. a YAML analyzer name must be the real implementation. CLAUDE.md calls
+#      aliased dispatch a silent-bug factory: the run succeeds and writes data
+#      labelled `phase_classify` that a different analyzer produced.
+#
+#   2. a ground-state step's OWN `interactions:` block outranks whatever the
+#      previous workspace carried. Inverting that precedence is the defect
+#      that voided the Matsui Fig. 4B GS-variant arm — a `c1_ratio` written in
+#      a `ground_state` step never reached c0, every run completed, and every
+#      scan point differed from its neighbours along an axis nobody asked for.
+#
+# Both are checked without running any physics, which is the point: the claim
+# is about routing and precedence, so the cheapest layer that can express it is
+# a direct call.
+
+using Test
+using SpinorBEC
+using SpinorBEC: _run_analyzer, _resolve_gs_interactions, resolve_atom, make_grid,
+    GridConfig, init_psi, SpinSystem, InteractionParams
+
+@testset "pipeline: names and precedence" begin
+    @testset "an analyzer name dispatches to its own implementation" begin
+        grid = make_grid(GridConfig((8, 8, 8), (6.0, 6.0, 6.0)))
+        atom = resolve_atom(:Rb87)
+        psi = init_psi(grid, SpinSystem(1); state=:polar)
+
+        # `phase_classify` and `phase_classify_distance` are neighbours in the
+        # dispatch chain and both are real analyzers, so a mis-route produces a
+        # valid result under the wrong name. They are distinguished by their
+        # RESULT SHAPE, not by whether they throw.
+        a = _run_analyzer(:phase_classify, psi, grid, atom, Dict{Any, Any}())
+        b = _run_analyzer(:phase_classify_distance, psi, grid, atom, Dict{Any, Any}())
+        @test a isa AbstractDict
+        @test b isa AbstractDict
+        # The claim: they are not the same analyzer. If the dispatch chain ever
+        # routes one to the other, this is what notices.
+        @test keys(a) != keys(b) || a != b
+
+        # And an unknown name must not quietly resolve to anything at all.
+        @test_throws Exception _run_analyzer(
+            :not_an_analyzer, psi, grid, atom, Dict{Any, Any}())
+    end
+
+    @testset "a step's own interactions: outrank the inherited ones" begin
+        atom = resolve_atom(:Rb87)
+        # A workspace-like carrier is all `_resolve_gs_interactions` reads.
+        prev = (interactions=InteractionParams(Dict(0 => 111.0, 1 => -1.0)),)
+        own = Dict{String, Any}("interactions" => Dict{String, Any}("c0" => 222.0,
+            "c1" => -2.0))
+
+        # 1. explicit block present AND a previous workspace: the block wins.
+        got = _resolve_gs_interactions(own, prev, atom)
+        @test got[0] ≈ 222.0
+        @test got[0] != prev.interactions[0]        # the inherited value, named
+
+        # 2. no block: inherit. This is the row that makes (1) meaningful —
+        # without it, (1) could pass because inheritance never happens.
+        @test _resolve_gs_interactions(Dict{String, Any}(), prev, atom)[0] ≈ 111.0
+
+        # 3. neither: defaults, and no exception.
+        @test _resolve_gs_interactions(
+            Dict{String, Any}(), nothing, atom) isa InteractionParams
+    end
+end

--- a/test/workflow/test_pipeline_name_and_precedence.jl
+++ b/test/workflow/test_pipeline_name_and_precedence.jl
@@ -35,11 +35,17 @@ using SpinorBEC: _run_analyzer, _resolve_gs_interactions, resolve_atom, make_gri
         # RESULT SHAPE, not by whether they throw.
         a = _run_analyzer(:phase_classify, psi, grid, atom, Dict{Any, Any}())
         b = _run_analyzer(:phase_classify_distance, psi, grid, atom, Dict{Any, Any}())
-        @test a isa AbstractDict
-        @test b isa AbstractDict
-        # The claim: they are not the same analyzer. If the dispatch chain ever
-        # routes one to the other, this is what notices.
-        @test keys(a) != keys(b) || a != b
+        @test a isa NamedTuple
+        @test b isa NamedTuple
+
+        # `phase_classify_distance` returns a SUPERSET of `phase_classify`'s
+        # fields — same classification plus the distance and the ranking. So
+        # "not the same analyzer" has to be said in terms of the fields only
+        # the second one has; a mis-route puts them on the first.
+        for k in (:phase_distance, :distance, :ranking)
+            @test k ∈ keys(b)
+            @test k ∉ keys(a)
+        end
 
         # And an unknown name must not quietly resolve to anything at all.
         @test_throws Exception _run_analyzer(


### PR DESCRIPTION
60 defect classes. Two pipeline claims, neither arithmetic — both are about **which code runs**, and both produce a complete, plausible run when wrong.

### Measured first

Against `dir:workflow` (64 files, TSUBAME job 8314739): **both escaped**, zero catches each.

- **`analyzer_name_routes_to_neighbour`** — routes one analyzer name to its neighbour. The run succeeds and writes data labelled `phase_classify` that a different analyzer produced. CLAUDE.md names this shape exactly: a YAML analyzer name must be the real implementation, because aliased dispatch is a silent-bug factory.
- **`gs_interactions_inherit_over_explicit`** — inverts the precedence, so a step's OWN `interactions:` block loses to whatever the previous workspace carried. Every run completes and every scan point differs from its neighbours; the axis is just not the one the config asked for. **This is not hypothetical** — it is the defect that voided the Matsui Fig. 4B GS-variant arm, where a `c1_ratio` written in a `ground_state` step never reached c0.

### Then gated

`test/workflow/test_pipeline_name_and_precedence.jl`, `fast` tier, no physics: the claim is about routing and precedence, so a direct call is the cheapest layer that can express it.

Two things the first attempt got wrong, both worth stating because they are what makes the gate real:

- the analyzers return **NamedTuples**, not Dicts;
- `phase_classify_distance` returns a **superset** of `phase_classify`'s fields — same classification plus the distance and the ranking. So "not the same analyzer" has to be said in terms of the fields only the second one has, because a mis-route lands on a real analyzer and returns a valid result under the wrong name. Comparing "are they different" would have been satisfied by a superset.

The precedence rows are three, and the middle one is what makes the first meaningful: without checking that inheritance *happens* when there is no explicit block, "the block wins" could pass because inheritance never fires at all.

### Verified

Passes on a compute node (job 8314817) and **kills both** mutants as sole catcher (job 8314871) — 0 → 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)