### PR TITLE
fix(inventory): it graded the prose, not the assertion

### DIFF
--- a/scripts/tsubame/submit_script.sh
+++ b/scripts/tsubame/submit_script.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#$ -cwd
+#$ -l cpu_16=1
+#$ -l h_rt=0:30:00
+#$ -N script
+#$ -o /gs/fs/tga-kozuma-kouhi/uk07267/logs-mutation/
+#$ -e /gs/fs/tga-kozuma-kouhi/uk07267/logs-mutation/
+#
+# Run one Julia script with arguments on a compute node, in its own checkout
+# pinned by SHA. For the tools that are scripts rather than test files —
+# `test/_inventory.jl`, the audit drivers under `scripts/`.
+#
+#   qsub -g tga-kozuma-kouhi \
+#        -v SC_FILE=test/_inventory.jl,SC_ARGS=--files,SC_TAG=inv \
+#        scripts/tsubame/submit_script.sh
+#
+# `SC_ARGS` uses `+` between arguments, since UGE's `-v` splits on commas.
+set -u
+
+SC_FILE=${SC_FILE:?set SC_FILE}
+ROOT=${SC_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/bec-sc-${SC_TAG:-run}}
+REF=${SC_REF:-main}
+JULIA=${SPINORBEC_TSUBAME_JULIA:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia}
+
+export JULIA_DEPOT_PATH=${JULIA_DEPOT_PATH:-/gs/fs/tga-kozuma-kouhi/shared/.julia}
+export SPINORBEC_FFT_ESTIMATE=1
+export OPENBLAS_NUM_THREADS=1
+
+if [ ! -d "$ROOT/.git" ]; then
+    git clone -q /gs/fs/tga-kozuma-kouhi/uk07267/BEC-simulation "$ROOT" ||
+        git clone -q https://github.com/KozumaLaboratory/BEC-simulation.git "$ROOT"
+fi
+cd "$ROOT"
+git remote set-url origin https://github.com/KozumaLaboratory/BEC-simulation.git
+git fetch -q origin "$REF" || { echo "FETCH FAILED — refusing to run a stale tree"; exit 1; }
+git checkout -q -f FETCH_HEAD
+
+echo "host=$(hostname) date=$(date)"
+echo "commit=$(git rev-parse HEAD)"
+echo "file=$SC_FILE args=${SC_ARGS:-<none>}"
+
+IFS='+' read -r -a ARGV <<< "${SC_ARGS:-}"
+$JULIA --project=. --startup-file=no "$SC_FILE" "${ARGV[@]}" 2>&1
+echo "SC_RC=$?"
+echo "ALL DONE $(date)"

--- a/test/_inventory.jl
+++ b/test/_inventory.jl
@@ -100,6 +100,18 @@ const _MARKERS = [
         r"analytic"i, r"\bexact\b"i, r"closed[-_ ]form"i, r"theoretical"i,
         r"gauss[-_ ]hermite"i, r"manufactured"i, r"\bclosed form\b"i,
         r"known\s+(solution|answer|value)"i, r"first[-_ ]principles"i,
+        # The ASSERTION, not the prose. Every marker above needs the author to
+        # have said a word; this one needs only that they wrote the identity —
+        # `@test f(5.0) ≈ a_bg * (1 - Δ/(5.0 - B0))` computes the closed form
+        # right there and says nothing "analytic" anywhere. Five files in the
+        # ungrounded bucket were exactly that shape (audit, 2026-08-01),
+        # i.e. 5 of 47 deletion candidates were grounded — the direction this
+        # file's header claims cannot happen.
+        #
+        # Multiplicative structure only (`*`, `/`, `^`) on a NAMED quantity: a
+        # bare `≈ 0.5` is a pin, and `≈ x - 1` is too weak a signature to
+        # separate a formula from an offset.
+        r"@test[^\n]*(≈|isapprox\()[^\n]*[a-zA-Z_]\w*\s*[*/^]\s*[a-zA-Z_(]",
     ],
 ]
 


### PR DESCRIPTION
The deletion decision will rest on these labels, so I audited them before using them: an 18-file stratified sample read by hand, plus a mechanical screen of the entire ungrounded bucket.

### The finding

**5 of the 47 files labelled `pin`/`api`/`unclassified` assert against a closed form computed in the test.** That is `exact` — the strongest grounding there is — and they were sitting in the bucket that gets proposed for deletion:

| file | the identity it asserts |
|---|---|
| `analysis/test_larmor_adiabaticity.jl` | `larmor_frequency(B, atom) ≈ g_F μ_B B / ℏ` |
| `solvers/test_quasi_2d_api.jl` | `ws.interactions[0] ≈ c0 * factor` |
| `analysis/test_optics.jl` | `peak_intensity(beam) ≈ 2P/(π w0²)` |
| `analysis/test_sinatra_diagnostics.jl` | `E_cut ≈ 4 g_per_atom n_peak` |
| `workflow/test_feshbach.jl` | `a_s(B) ≈ a_bg (1 − Δ/(B − B0))`, plus the zero crossing at `B0+Δ` |

`_inventory.jl`'s own header says over-crediting is the safe direction, because an over-credited file "gets read by a human rather than being silently proposed for deletion". **It under-credits too — 10.6 % of that bucket — and the header did not know.**

### Cause

Every `:exact` marker was **prose**: `analytic`, `closed-form`, `theoretical`, `known solution`. A file got credit only if its author happened to use a word. None of the five does.

The new marker reads the **assertion** instead — an `≈` against multiplicative structure on a named quantity is a closed form regardless of what anyone called it. Multiplicative only (`*`, `/`, `^`): a bare `≈ 0.5` is a pin, and `≈ x - 1` is too weak a signature to separate a formula from an offset.

### Measured, not asserted

Re-ran the inventory and diffed the labels:

```
5 files changed label
  ungrounded -> grounded : 5   (the fix's target)
  grounded   -> grounded : 0   (no relabelling churn)
  grounded   -> ungrounded: 0
```

313/365 → 318/365 grounded. Exactly the five, nothing else moved.

### Also

The sample turned up mislabels *within* the grounded set too — `analysis/test_spinor_fingerprint.jl` is labelled `exact` while asserting inequalities against hand-picked thresholds, and `solvers/test_binary_simulation.jl` is labelled `differential` while asserting norm conservation. Those cost confusion, not deletion, so they are recorded here rather than chased: the binary grounded/ungrounded split is what the pruning decision reads, and that is what this PR repairs.

`scripts/tsubame/submit_script.sh` comes along because `_inventory.jl` is a script with flags and the test-file runner cannot invoke it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)