### PR TITLE
RK4IP on GPU: correct to round-off; break-even is between 1e-4 and 1e-5, and production is on the losing side

### DIFF
--- a/docs/validation/rk4ip_cost_on_gpu.md
+++ b/docs/validation/rk4ip_cost_on_gpu.md
@@ -1,9 +1,13 @@
-# RK4IP: the CPU cost result does not transfer to the GPU
+# RK4IP on GPU: correct to round-off, and worth taking only below ~1e-5
 
-Measured 2026-08-02. `scripts/validation/rk4ip_gpu_cost_probe.jl`, commit
-`e6084559`, clean `src`. UGE 8316108 (H100) and a local RTX 5070 Ti. Type A.
+Measured 2026-08-02 on an H100 (UGE 8316108 / 8316433 / 8316492) and a local
+RTX 5070 Ti. Commits `e6084559` … `9af38974`, clean `src`. Type A.
 
-## Correctness first
+> **Two earlier framings in this branch were wrong and are retracted at the
+> bottom.** The short version: accuracy and cost were collapsed into a single
+> "net speedup" built from measurements taken on different problems.
+
+## 1. Correctness transfers
 
 One RK4IP step, GPU against CPU from the same start, Eu F=6 (D=13), DDI on and
 zero-padded:
@@ -13,61 +17,95 @@ zero-padded:
 | 16 | 5.5×10⁻¹⁶ | 5.9×10⁻¹⁶ |
 | 32 | 6.9×10⁻¹⁶ | 7.2×10⁻¹⁶ |
 
-Round-off in every one of the 13 channels, on both cards. **Every HamTerm's
-`apply_operator!` face already had a GPU path** — RK4IP had never been executed
-on a GPU before this, so that was not a given. Compared per component because a
-term missing its GPU path can contribute nothing to the aggregate while being
-wrong in one m channel.
+Round-off in every one of the 13 channels, on both cards. RK4IP had never been
+executed on a GPU before this, so it was not a given that every HamTerm's
+`apply_operator!` face had a GPU path — they all do. Compared per component
+because a term missing its GPU path can contribute nothing to the aggregate
+while being wrong in one m channel.
 
-## Cost, and the reversal
+## 2. The two axes, kept apart
 
-ms/step, `split_step!` / `split_step_midpoint!` / `rk4ip_step!`:
+### Axis 1 — same `dt`: RK4IP is more accurate and dearer
+
+H100, 64³, at `dt = 7.81×10⁻⁴` (the sampled step nearest production's 1e-3):
+
+- **7090× more accurate** (1.25×10⁻¹⁰ against 8.88×10⁻⁷ relative L2 over T = 0.05)
+- **3.28× the cost per step**
+
+If the extra accuracy is not needed, that is the whole story and it is a loss.
+For the Fig. 4B observable it is not needed: `dt = 1e-3` is converged there to
+0.0001 nT (`matsui_residual_root_cause.md`), so every one of those 7090× is
+unspendable.
+
+### Axis 2 — same accuracy: time to solution
+
+Both halves measured at 64³ on the H100, every row a genuine two-sided
+interpolation:
+
+| error budget | rk4ip `dt` | split_step! `dt` | step ratio | **time ratio** |
+|---|---|---|---|---|
+| 1e-3 | 4.23×10⁻² | 2.62×10⁻² | 1.62 | **0.49×** |
+| 1e-4 | 2.34×10⁻² | 8.29×10⁻³ | 2.82 | **0.86×** |
+| 1e-5 | 1.31×10⁻² | 2.62×10⁻³ | 5.00 | **1.53×** |
+| 1e-6 | 7.38×10⁻³ | 8.29×10⁻⁴ | 8.90 | 2.71× |
+| 1e-7 | 4.15×10⁻³ | 2.62×10⁻⁴ | 15.84 | 4.83× |
+
+**Break-even sits between 1e-4 and 1e-5.** Above it — looser tolerances — RK4IP
+costs more wall-clock for the same answer.
+
+## 3. What depends on `n`, and what does not
+
+**Accuracy does not.** The error columns at 64³ and 128³ agree to the digits
+printed:
+
+| `dt` | split_step! @64³ | split_step! @128³ |
+|---|---|---|
+| 3.91×10⁻⁴ | 2.220×10⁻⁷ | 2.220×10⁻⁷ |
+| 7.81×10⁻⁴ | 8.878×10⁻⁷ | 8.878×10⁻⁷ |
+| 1.56×10⁻³ | 3.551×10⁻⁶ | 3.551×10⁻⁶ |
+
+Refining the grid at fixed box does not change the time-discretisation error
+here, because the state is smooth and the added high-`k` modes are empty. (The
+plausible-sounding argument that Strang's `[K,[K,V]]` grows with `k_max²` and so
+the step ratio must move with `n` is therefore **not** what happens for this
+problem. It was the stated reason for re-measuring; it did not survive.)
+
+**Cost does.** ms/step, `split_step!` / `split_step_midpoint!` / `rk4ip_step!`:
 
 | device | n | split_step! | midpoint | rk4ip | rk4ip vs split |
 |---|---|---|---|---|---|
 | CPU | 12 | 3.00 | 4.46 | **2.61** | **0.87×** |
-| RTX 5070 Ti | 128 | 175.21 | 257.83 | 258.15 | 1.47× |
-| H100 | 128 | 25.13 | 36.73 | 72.07 | **2.87×** |
-| H100 | 64 | 2.77 | 4.04 | 9.16 | 3.30× |
 | H100 | 32 | 0.62 | 0.92 | 4.63 | 7.44× |
+| H100 | 64 | 2.75 | 4.04 | 9.05 | 3.28× |
+| H100 | 128 | 25.10 | 36.73 | 72.04 | 2.87× |
+| RTX 5070 Ti | 128 | 175.21 | 257.83 | 258.15 | 1.47× |
 
-**On CPU RK4IP is cheaper per step than the default; on the H100 it is 2.9×
-dearer.** The sign of the comparison flips with the backend.
+**On CPU RK4IP is cheaper per step; on the H100 it is 2.9–7.4× dearer.** The
+mechanism is the interaction picture: RK4IP applies `e^{K dt/2}` **four times per
+step** (`rk4ip.jl:143, 144, 162, 167`) where Strang applies `e^{K dt}` **once**
+(`split_step.jl:96`), and each is an FFT pair. On CPU the mean-field and DDI work
+dominates — and the default is itself paying for a predictor-corrector, since
+`split_step!` auto-dispatches to `_half_potential_step_midpoint!` whenever DDI is
+active — so the 4× hides. On GPU the FFTs dominate and it is the whole cost. The
+gap *widens* as `n` falls because the FFTs go launch-bound: four launches to one.
 
-### Why
+Because accuracy is `n`-independent and cost is not, the break-even budget moves
+with grid size. Composing the measured 64³ step ratios with each measured cost
+ratio:
 
-RK4IP applies `e^{K dt/2}` **four times per step** — `rk4ip.jl:143, 144, 162,
-167` — where Strang applies `e^{K dt}` **once** (`split_step.jl:96`). Each is an
-FFT pair.
+| budget | 32³ | 64³ | 128³ |
+|---|---|---|---|
+| 1e-4 | 0.38× | 0.86× | 0.98× |
+| 1e-5 | 0.67× | **1.53×** | **1.74×** |
+| 1e-6 | **1.20×** | 2.71× | 3.10× |
 
-On CPU the mean-field and DDI work dominates a step, and the default is itself
-paying for a predictor-corrector (`split_step!` auto-dispatches to
-`_half_potential_step_midpoint!` whenever DDI is active), so the 4× kinetic cost
-is invisible and RK4IP wins. On a GPU the FFTs dominate and that 4× is the whole
-story. The gap widens as `n` falls, which is the same effect: at 32³ the FFTs are
-launch-bound and RK4IP is paying four launches to Strang's one.
+Break-even ≈ 1e-6 at 32³, ≈ 2×10⁻⁵ at 64³, ≈ 1×10⁻⁴ at 128³.
 
-## Net
+## 4. Memory
 
-Net speedup = the step RK4IP holds under a fixed error budget
-(`rk4ip_step_size_probe.jl`) divided by the cost above.
-
-| device / n | at 1e-4 (step 2.4×) | at 1e-5 (step 4.2×) |
-|---|---|---|
-| CPU 12³ | 2.7× | 4.9× |
-| RTX 5070 Ti 128³ | 1.6× | 2.9× |
-| **H100 128³** | **0.84× — a net loss** | **1.46×** |
-
-The step ratios are CPU-measured. They are a property of the method and the
-problem's stiffness rather than of the hardware, but they have not been
-re-measured on GPU, so the H100 row is the cost measurement combined with a CPU
-accuracy measurement and should be read as an estimate.
-
-## Memory
-
-Five full-state scratch buffers: 436 MB each at 128³ F64 D=13, so 2.2 GB
-nominal. Measured allocator high-water across one step, which also carries the
-padded DDI transforms the four registry passes each trigger:
+Five full-state scratch buffers, 436 MB each at 128³ F64 D=13. Measured
+allocator high-water for one step, which also carries the padded DDI transforms
+each of the four registry passes triggers:
 
 | device | n | high-water | of total |
 |---|---|---|---|
@@ -75,19 +113,34 @@ padded DDI transforms the four registry passes each trigger:
 | RTX 5070 Ti | 128 | 4.78 GiB | **30 % of 15.9** |
 | H100 | 64 | 2.56 GiB | — |
 
-On the consumer card a single 128³ RK4IP step reserves nearly a third of the
-device.
+## 5. Conclusions
 
-## Conclusions
+- **Not a default.** Production runs at roughly the 1e-4 accumulated-error scale,
+  which is on the losing side of break-even at every grid size measured.
+- **Keep it opt-in** (`integrator: rk4ip`) and select it when the tolerance is
+  tight — below ~1e-5 at 64³ and above — or on CPU, where it is cheaper per step
+  outright.
+- The lever is the kinetic count. Four half-exponentials is intrinsic to the
+  standard RK4IP formulation; going below it means a different scheme.
 
-- **Do not make RK4IP the default.** At ordinary tolerances on the production
-  GPU it is slower than what it would replace.
-- **Keep it opt-in** (`integrator: rk4ip`), and select it for tight tolerances
-  (≲1e-5), for CPU work, or when 4th order is wanted for its own sake.
-- The obvious optimisation is the kinetic count. Four half-exponentials is
-  intrinsic to the standard RK4IP formulation; getting below it means a
-  different scheme, not a tuning of this one.
-- **The CPU/GPU reversal is the transferable lesson.** A cost ratio between two
-  integrators is not a property of the integrators — it is a property of which
-  part of the step dominates, and that changes with the backend. Any
-  "integrator A is cheaper than B" claim needs the device attached.
+## 6. Retracted
+
+**"Order 2 → 4 at equal cost."** From counting mean-field evaluations on CPU. The
+count was right and irrelevant: on GPU the kinetic FFTs dominate and RK4IP does
+four of them per step.
+
+**"Net 2.7× at a 1e-4 budget, 4.9× at 1e-5."** Built by dividing a step ratio
+measured on a **12³ CPU** config by a cost ratio measured on a **128³ GPU**
+config. Those do not compose — the cost ratio is strongly `n`-dependent. The
+measured 128³ figures are 0.98× and 1.74×.
+
+**"The step ratio is strongly size-dependent, which is why this had to be
+re-measured."** Argued from `[K,[K,V]] ~ k_max²`. Measured: the error columns at
+64³ and 128³ are identical. The re-measurement was still necessary, but for the
+cost ratio, not the step ratio.
+
+**A capped crossing reported as a measurement.** The first 64³ run's sweep did
+not go coarse enough for either integrator to leave a 1e-3 or 1e-4 budget, and
+`crossing` returned the coarsest sample — printing "we did not look far enough"
+as a number. The script now tags each row `measured` / `LOWER BOUND` and the
+sweep was extended two octaves.

--- a/docs/validation/rk4ip_cost_on_gpu.md
+++ b/docs/validation/rk4ip_cost_on_gpu.md
@@ -1,0 +1,93 @@
+# RK4IP: the CPU cost result does not transfer to the GPU
+
+Measured 2026-08-02. `scripts/validation/rk4ip_gpu_cost_probe.jl`, commit
+`e6084559`, clean `src`. UGE 8316108 (H100) and a local RTX 5070 Ti. Type A.
+
+## Correctness first
+
+One RK4IP step, GPU against CPU from the same start, Eu F=6 (D=13), DDI on and
+zero-padded:
+
+| n | total rel L2 | worst component |
+|---|---|---|
+| 16 | 5.5×10⁻¹⁶ | 5.9×10⁻¹⁶ |
+| 32 | 6.9×10⁻¹⁶ | 7.2×10⁻¹⁶ |
+
+Round-off in every one of the 13 channels, on both cards. **Every HamTerm's
+`apply_operator!` face already had a GPU path** — RK4IP had never been executed
+on a GPU before this, so that was not a given. Compared per component because a
+term missing its GPU path can contribute nothing to the aggregate while being
+wrong in one m channel.
+
+## Cost, and the reversal
+
+ms/step, `split_step!` / `split_step_midpoint!` / `rk4ip_step!`:
+
+| device | n | split_step! | midpoint | rk4ip | rk4ip vs split |
+|---|---|---|---|---|---|
+| CPU | 12 | 3.00 | 4.46 | **2.61** | **0.87×** |
+| RTX 5070 Ti | 128 | 175.21 | 257.83 | 258.15 | 1.47× |
+| H100 | 128 | 25.13 | 36.73 | 72.07 | **2.87×** |
+| H100 | 64 | 2.77 | 4.04 | 9.16 | 3.30× |
+| H100 | 32 | 0.62 | 0.92 | 4.63 | 7.44× |
+
+**On CPU RK4IP is cheaper per step than the default; on the H100 it is 2.9×
+dearer.** The sign of the comparison flips with the backend.
+
+### Why
+
+RK4IP applies `e^{K dt/2}` **four times per step** — `rk4ip.jl:143, 144, 162,
+167` — where Strang applies `e^{K dt}` **once** (`split_step.jl:96`). Each is an
+FFT pair.
+
+On CPU the mean-field and DDI work dominates a step, and the default is itself
+paying for a predictor-corrector (`split_step!` auto-dispatches to
+`_half_potential_step_midpoint!` whenever DDI is active), so the 4× kinetic cost
+is invisible and RK4IP wins. On a GPU the FFTs dominate and that 4× is the whole
+story. The gap widens as `n` falls, which is the same effect: at 32³ the FFTs are
+launch-bound and RK4IP is paying four launches to Strang's one.
+
+## Net
+
+Net speedup = the step RK4IP holds under a fixed error budget
+(`rk4ip_step_size_probe.jl`) divided by the cost above.
+
+| device / n | at 1e-4 (step 2.4×) | at 1e-5 (step 4.2×) |
+|---|---|---|
+| CPU 12³ | 2.7× | 4.9× |
+| RTX 5070 Ti 128³ | 1.6× | 2.9× |
+| **H100 128³** | **0.84× — a net loss** | **1.46×** |
+
+The step ratios are CPU-measured. They are a property of the method and the
+problem's stiffness rather than of the hardware, but they have not been
+re-measured on GPU, so the H100 row is the cost measurement combined with a CPU
+accuracy measurement and should be read as an estimate.
+
+## Memory
+
+Five full-state scratch buffers: 436 MB each at 128³ F64 D=13, so 2.2 GB
+nominal. Measured allocator high-water across one step, which also carries the
+padded DDI transforms the four registry passes each trigger:
+
+| device | n | high-water | of total |
+|---|---|---|---|
+| H100 | 128 | 12.88 GiB | 14 % of 93.1 |
+| RTX 5070 Ti | 128 | 4.78 GiB | **30 % of 15.9** |
+| H100 | 64 | 2.56 GiB | — |
+
+On the consumer card a single 128³ RK4IP step reserves nearly a third of the
+device.
+
+## Conclusions
+
+- **Do not make RK4IP the default.** At ordinary tolerances on the production
+  GPU it is slower than what it would replace.
+- **Keep it opt-in** (`integrator: rk4ip`), and select it for tight tolerances
+  (≲1e-5), for CPU work, or when 4th order is wanted for its own sake.
+- The obvious optimisation is the kinetic count. Four half-exponentials is
+  intrinsic to the standard RK4IP formulation; getting below it means a
+  different scheme, not a tuning of this one.
+- **The CPU/GPU reversal is the transferable lesson.** A cost ratio between two
+  integrators is not a property of the integrators — it is a property of which
+  part of the step dominates, and that changes with the backend. Any
+  "integrator A is cheaper than B" claim needs the device attached.

--- a/runs/rk4ip_gpu/submit_probe.sh
+++ b/runs/rk4ip_gpu/submit_probe.sh
@@ -6,7 +6,8 @@
 #$ -cwd
 #$ -N rk4ip_gpu
 #$ -l gpu_1=1
-#$ -l h_rt=1:00:00
+#$ -l h_rt=2:00:00
+#$ -t 1-3
 #$ -j n
 
 set -euo pipefail
@@ -22,6 +23,11 @@ export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH}:/gs/fs/tga-kozuma-kouhi/shared/.jul
 echo "[src]   $(git rev-parse HEAD)  $(git status --porcelain -- src | wc -l) dirty src files"
 nvidia-smi -L || true
 
-"$JULIA" --project=. scripts/validation/rk4ip_gpu_cost_probe.jl
+case "${SGE_TASK_ID:-1}" in
+    1) "$JULIA" --project=. scripts/validation/rk4ip_gpu_cost_probe.jl ;;
+    2) "$JULIA" --project=. scripts/validation/rk4ip_time_to_solution_gpu.jl 64 ;;
+    3) "$JULIA" --project=. scripts/validation/rk4ip_time_to_solution_gpu.jl 128 ;;
+    *) echo "no task ${SGE_TASK_ID}"; exit 1 ;;
+esac
 
 echo "[done]"

--- a/runs/rk4ip_gpu/submit_probe.sh
+++ b/runs/rk4ip_gpu/submit_probe.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# RK4IP on GPU: parity, cost, memory. See scripts/validation/rk4ip_gpu_cost_probe.jl.
+#
+#   qsub -g tga-kozuma-kouhi runs/rk4ip_gpu/submit_probe.sh
+#
+#$ -cwd
+#$ -N rk4ip_gpu
+#$ -l gpu_1=1
+#$ -l h_rt=1:00:00
+#$ -j n
+
+set -euo pipefail
+
+PROJECT_ROOT=/gs/fs/tga-kozuma-kouhi/uk07267/wt_matsui_fig4b
+JULIA=/gs/fs/tga-kozuma-kouhi/shared/.juliaup/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia
+
+cd "$PROJECT_ROOT"
+source scripts/tsubame_setup.sh
+set -euo pipefail                       # re-arm: tsubame_setup runs `set +e`
+export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH}:/gs/fs/tga-kozuma-kouhi/shared/.julia:${HOME}/.julia"
+
+echo "[src]   $(git rev-parse HEAD)  $(git status --porcelain -- src | wc -l) dirty src files"
+nvidia-smi -L || true
+
+"$JULIA" --project=. scripts/validation/rk4ip_gpu_cost_probe.jl
+
+echo "[done]"

--- a/scripts/validation/rk4ip_gpu_cost_probe.jl
+++ b/scripts/validation/rk4ip_gpu_cost_probe.jl
@@ -1,0 +1,137 @@
+#!/usr/bin/env julia
+# RK4IP on GPU: does it agree with CPU, what does a step cost, and does it fit?
+#
+#     julia --project=. scripts/validation/rk4ip_gpu_cost_probe.jl
+#
+# RK4IP was measured on CPU at 12^3 — 2.61 ms/step against `split_step!`'s 3.00,
+# net 2.7x at a 1e-4 error budget once the larger step it holds is folded in.
+# None of that has been shown to transfer. Two things could break it:
+#
+#   * it has never been executed on GPU at all. `_rk4ip_scratch` uses `similar`,
+#     so the buffers should follow the array type, but every term's
+#     `apply_operator!` face has to have a GPU path or the answer is silently
+#     wrong (or scalar-indexes and is silently 1000x slow).
+#   * five full-state scratch buffers. At 128^3 with D=13 ComplexF64 that is
+#     5 x 436 MB = 2.2 GB on top of the workspace's own, and the DDI path is
+#     zero-padded 2x, i.e. 8x the volume for its own transforms.
+#
+# So: PARITY FIRST, then cost, then the memory high-water mark. A cost number
+# for a wrong result is worth nothing, and the parity check is the reason this
+# is a script and not a benchmark.
+
+import CUDA
+using SpinorBEC
+using LinearAlgebra
+using Printf
+
+const D_EU = 13
+
+function build(n::Int, dt::Float64, backend)
+    grid = make_grid(GridConfig(ntuple(_ -> n, 3), ntuple(_ -> 16.0, 3)))
+    make_workspace(;
+        grid,
+        atom=Eu151,
+        interactions=InteractionParams(Dict(0 => 4687.2663 / 50, 1 => -0.5)),
+        zeeman=ZeemanParams(0.4, 0.02),
+        potential=HarmonicTrap((1.0, 1.0, 1.181818)),
+        sim_params=SimParams(; dt=dt, n_steps=1, save_every=10^9),
+        enable_ddi=true,
+        c_dd=147.715012,
+        secular_ddi=false,
+        ddi_padding=true,
+        backend=backend,
+    )
+end
+
+psi0(ws) = init_psi(ws.grid, ws.spin_matrices.system;
+    state=:spin_coherent, init_theta=0.35, init_phi=0.2)
+
+"One step from the same start on both backends, compared component by component."
+function parity(n::Int)
+    dt = 1e-3
+    ws_c = build(n, dt, CPUBackend())
+    p0 = ComplexF64.(psi0(ws_c))
+
+    copyto!(ws_c.state.psi, p0)
+    ws_c.state.t = 0.0
+    rk4ip_step!(ws_c)
+    a = Array(ws_c.state.psi)
+
+    ws_g = build(n, dt, CUDABackend())
+    copyto!(ws_g.state.psi, p0)
+    ws_g.state.t = 0.0
+    rk4ip_step!(ws_g)
+    b = Array(ws_g.state.psi)
+
+    total = norm(a .- b) / norm(a)
+    per = [norm(selectdim(a, 4, c) .- selectdim(b, 4, c)) /
+           max(norm(selectdim(a, 4, c)), eps()) for c in 1:size(a, 4)]
+    (total, maximum(per), argmax(per))
+end
+
+function ms_per_step(stepper, ws, n_reps::Int)
+    for _ in 1:3
+        stepper(ws)
+    end
+    CUDA.synchronize()
+    best = Inf
+    for _ in 1:3
+        CUDA.synchronize()
+        t = @elapsed begin
+            for _ in 1:n_reps
+                stepper(ws)
+            end
+            CUDA.synchronize()
+        end
+        best = min(best, t / n_reps)
+    end
+    1e3 * best
+end
+
+gib(x) = x / 2^30
+
+function main()
+    CUDA.functional() || error("CUDA not functional — this probe is about the GPU")
+    dev = CUDA.device()
+    @printf("device: %s, %.1f GiB total\n\n", CUDA.name(dev), gib(CUDA.totalmem(dev)))
+
+    # --- 1. parity, before any timing is believed ---
+    println("=== GPU vs CPU, one RK4IP step (Eu F=6, D=13, DDI on, padded) ===")
+    @printf("%6s %16s %16s %8s\n", "n", "total rel L2", "worst component", "at m")
+    for n in (16, 32)
+        tot, worst, c = parity(n)
+        @printf("%6d %16.3e %16.3e %8d\n", n, tot, worst, 6 - (c - 1))
+    end
+    println("\nA per-component split is the point: a term missing its GPU path can")
+    println("contribute nothing to the aggregate while being wrong in one channel.\n")
+
+    # --- 2. cost, at sizes production actually runs ---
+    println("=== ms/step on GPU ===")
+    @printf("%6s %14s %14s %14s %10s %10s\n",
+        "n", "split_step!", "midpoint", "rk4ip", "vs split", "psi [GiB]")
+    for (n, reps) in ((32, 40), (64, 20), (128, 6))
+        local row
+        try
+            ws = build(n, 1e-3, CUDABackend())
+            copyto!(ws.state.psi, psi0(ws))
+            psi_gib = gib(n^3 * D_EU * 16)
+            a = ms_per_step(split_step!, ws, reps)
+            b = ms_per_step(split_step_midpoint!, ws, reps)
+            free_before = CUDA.available_memory()
+            c = ms_per_step(rk4ip_step!, ws, reps)
+            free_after = CUDA.available_memory()
+            @printf("%6d %14.2f %14.2f %14.2f %10.2fx %10.2f   (scratch %.2f GiB)\n",
+                n, a, b, c, c / a, psi_gib, gib(max(0, free_before - free_after)))
+        catch e
+            @printf("%6d  FAILED: %s\n", n, sprint(showerror, e)[1:min(end, 120)])
+        end
+        CUDA.reclaim()
+    end
+
+    println("\nRK4IP holds 2.4x split_step!'s step at a 1e-4 error budget and 4.2x at")
+    println("1e-5 (CPU, scripts/validation/rk4ip_step_size_probe.jl). Net speedup is")
+    println("that ratio divided by the `vs split` column above. Below 1.0 in that")
+    println("column means RK4IP is cheaper per step as well.")
+end
+
+main()

--- a/scripts/validation/rk4ip_time_to_solution_gpu.jl
+++ b/scripts/validation/rk4ip_time_to_solution_gpu.jl
@@ -112,7 +112,7 @@ function main()
     @printf("reference RK4IP at dt = %.2e; Richardson bound on its own error %.2e\n\n",
         T / 4096, ref_err)
 
-    steps = [T / k for k in (512, 256, 128, 64, 32, 16, 8, 4)]
+    steps = [T / k for k in (512, 256, 128, 64, 32, 16, 8, 4, 2, 1)]
     errs = Dict(:rk4ip => Float64[], :strang => Float64[])
     @printf("%12s %16s %16s\n", "dt", "rk4ip err", "split_step! err")
     for dt in steps

--- a/scripts/validation/rk4ip_time_to_solution_gpu.jl
+++ b/scripts/validation/rk4ip_time_to_solution_gpu.jl
@@ -86,14 +86,17 @@ end
 # Refuses to extrapolate past the sampled range.
 function crossing(dts, errs, budget)
     ok = [i for i in eachindex(errs) if isfinite(errs[i])]
-    length(ok) >= 2 || return NaN
+    length(ok) >= 2 || return (NaN, :nodata)
     lo = findlast(i -> errs[i] <= budget, ok)
-    lo === nothing && return NaN
+    lo === nothing && return (NaN, :budget_below_every_sample)
     i = ok[lo]
-    lo == length(ok) && return dts[i]
+    # Under budget even at the COARSEST sample: the true crossing is somewhere
+    # past the sweep, so this is a LOWER BOUND, not a measurement. Reporting it
+    # as a crossing silently turns "we did not look far enough" into a number.
+    lo == length(ok) && return (dts[i], :capped)
     j = ok[lo + 1]
     p = log(errs[j] / errs[i]) / log(dts[j] / dts[i])
-    dts[i] * (budget / errs[i])^(1 / p)
+    (dts[i] * (budget / errs[i])^(1 / p), :interpolated)
 end
 
 function main()
@@ -109,7 +112,7 @@ function main()
     @printf("reference RK4IP at dt = %.2e; Richardson bound on its own error %.2e\n\n",
         T / 4096, ref_err)
 
-    steps = [T / k for k in (512, 256, 128, 64, 32, 16)]
+    steps = [T / k for k in (512, 256, 128, 64, 32, 16, 8, 4)]
     errs = Dict(:rk4ip => Float64[], :strang => Float64[])
     @printf("%12s %16s %16s\n", "dt", "rk4ip err", "split_step! err")
     for dt in steps
@@ -142,13 +145,16 @@ function main()
     println("  If that accuracy is not needed, this is a pure loss.")
 
     println("\n--- AXIS 2: fixed accuracy. Time to solution. ---")
-    @printf("%12s %14s %14s %14s\n", "budget", "rk4ip dt", "split dt", "time ratio")
-    for b in (1e-3, 1e-4, 1e-5, 1e-6)
-        a = crossing(steps, errs[:rk4ip], b)
-        s = crossing(steps, errs[:strang], b)
+    @printf("%12s %14s %14s %14s   %s\n",
+        "budget", "rk4ip dt", "split dt", "time ratio", "quality")
+    for b in (1e-3, 1e-4, 1e-5, 1e-6, 1e-7)
+        a, qa = crossing(steps, errs[:rk4ip], b)
+        s, qs = crossing(steps, errs[:strang], b)
         r = (a / s) / (c_rk / c_ss)
-        @printf("%12.0e %14.3e %14.3e %14s\n", b, a, s,
-            isfinite(r) ? @sprintf("%.2fx", r) : "—")
+        q = (qa === :interpolated && qs === :interpolated) ? "measured" :
+            (qa === :capped || qs === :capped) ? "LOWER BOUND ($qa/$qs)" : "$qa/$qs"
+        @printf("%12.0e %14.3e %14.3e %14s   %s\n", b, a, s,
+            isfinite(r) ? @sprintf("%.2fx", r) : "—", q)
     end
     println("\n>1 means rk4ip reaches that accuracy sooner. Both columns are measured")
     println("HERE, at this n on this device — the previous write-up divided a 12^3 CPU")

--- a/scripts/validation/rk4ip_time_to_solution_gpu.jl
+++ b/scripts/validation/rk4ip_time_to_solution_gpu.jl
@@ -1,0 +1,158 @@
+#!/usr/bin/env julia
+# Time to solution at fixed accuracy — both halves measured on the SAME problem.
+#
+#     julia --project=. scripts/validation/rk4ip_time_to_solution_gpu.jl [n]
+#
+# The first pass at this divided a step-size ratio measured on a 12^3 CPU config
+# by a cost ratio measured on a 128^3 GPU config. Those do not compose. The
+# step size an integrator holds at a fixed error budget is hardware-independent
+# but strongly SIZE-dependent: Strang's leading error carries [K,[K,V]], which
+# grows with k_max^2, so at fixed box a 12 -> 128 refinement multiplies it by
+# ~1e2 while RK4IP's 4th-order constant moves differently. With
+#   dt_strang ~ (eps/C2)^(1/2),  dt_rk4ip ~ (eps/C4)^(1/4)
+# the RATIO of the two is not a constant of the method. It has to be measured
+# where the cost is measured.
+#
+# So this measures, at ONE n on ONE device:
+#   * error vs dt for both integrators, against a common fine reference
+#   * ms/step for both
+#   * the largest dt each holds per error budget, and the resulting
+#     time-to-solution ratio
+#
+# It also reports the comparison at FIXED dt, which is the one that matters when
+# the accuracy axis is already saturated — as it is for the Matsui Fig. 4B
+# observable, where dt = 1e-3 is converged to 1e-4 nT and any extra accuracy is
+# unspendable.
+
+import CUDA
+using SpinorBEC
+using LinearAlgebra
+using Printf
+
+const N = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 64
+const T = 0.05
+const PRODUCTION_DT = 1e-3
+
+function build(dt::Float64)
+    grid = make_grid(GridConfig(ntuple(_ -> N, 3), ntuple(_ -> 16.0, 3)))
+    make_workspace(;
+        grid, atom=Eu151,
+        interactions=InteractionParams(Dict(0 => 4687.2663 / 50, 1 => -0.5)),
+        zeeman=ZeemanParams(0.4, 0.02),
+        potential=HarmonicTrap((1.0, 1.0, 1.181818)),
+        sim_params=SimParams(; dt=dt, n_steps=max(1, round(Int, T / dt)), save_every=10^9),
+        enable_ddi=true, c_dd=147.715012, secular_ddi=false, ddi_padding=true,
+        backend=CUDABackend(),
+    )
+end
+
+psi0(ws) = init_psi(ws.grid, ws.spin_matrices.system;
+    state=:spin_coherent, init_theta=0.35, init_phi=0.2)
+
+function evolve(stepper, p0, dt)
+    ws = build(dt)
+    copyto!(ws.state.psi, p0)
+    ws.state.t = 0.0
+    for _ in 1:(ws.sim_params.n_steps)
+        stepper(ws)
+    end
+    CUDA.synchronize()
+    Array(ws.state.psi)
+end
+
+function ms_per_step(stepper, dt, reps)
+    ws = build(dt)
+    copyto!(ws.state.psi, psi0(ws))
+    for _ in 1:3
+        stepper(ws)
+    end
+    CUDA.synchronize()
+    best = Inf
+    for _ in 1:3
+        CUDA.synchronize()
+        t = @elapsed begin
+            for _ in 1:reps
+                stepper(ws)
+            end
+            CUDA.synchronize()
+        end
+        best = min(best, t / reps)
+    end
+    CUDA.reclaim()
+    1e3 * best
+end
+
+# Largest dt holding `budget`, interpolated between the two bracketing samples.
+# Refuses to extrapolate past the sampled range.
+function crossing(dts, errs, budget)
+    ok = [i for i in eachindex(errs) if isfinite(errs[i])]
+    length(ok) >= 2 || return NaN
+    lo = findlast(i -> errs[i] <= budget, ok)
+    lo === nothing && return NaN
+    i = ok[lo]
+    lo == length(ok) && return dts[i]
+    j = ok[lo + 1]
+    p = log(errs[j] / errs[i]) / log(dts[j] / dts[i])
+    dts[i] * (budget / errs[i])^(1 / p)
+end
+
+function main()
+    CUDA.functional() || error("CUDA not functional")
+    @printf("device: %s\n", CUDA.name(CUDA.device()))
+    @printf("Eu F=6 D=13, %d^3 box 16, DDI on + padded, T = %.3f\n\n", N, T)
+
+    p0 = ComplexF64.(psi0(build(PRODUCTION_DT)))
+
+    ref = evolve(rk4ip_step!, p0, T / 4096)
+    ref_half = evolve(rk4ip_step!, p0, T / 2048)
+    ref_err = norm(ref .- ref_half) / norm(ref) / 15
+    @printf("reference RK4IP at dt = %.2e; Richardson bound on its own error %.2e\n\n",
+        T / 4096, ref_err)
+
+    steps = [T / k for k in (512, 256, 128, 64, 32, 16)]
+    errs = Dict(:rk4ip => Float64[], :strang => Float64[])
+    @printf("%12s %16s %16s\n", "dt", "rk4ip err", "split_step! err")
+    for dt in steps
+        row = Any[@sprintf("%12.2e", dt)]
+        for (k, st) in ((:rk4ip, rk4ip_step!), (:strang, split_step!))
+            e = try
+                v = norm(evolve(st, p0, dt) .- ref) / norm(ref)
+                isfinite(v) && v >= 10 * ref_err ? v : NaN
+            catch
+                NaN
+            end
+            push!(errs[k], e)
+            push!(row, isfinite(e) ? @sprintf("%16.3e", e) : rpad("   <ref / diverged", 16))
+        end
+        println(join(row, " "))
+        CUDA.reclaim()
+    end
+
+    reps = N >= 128 ? 6 : 20
+    c_rk = ms_per_step(rk4ip_step!, PRODUCTION_DT, reps)
+    c_ss = ms_per_step(split_step!, PRODUCTION_DT, reps)
+    @printf("\nms/step at this n:  split_step! %.2f   rk4ip %.2f   (rk4ip / split = %.2fx)\n",
+        c_ss, c_rk, c_rk / c_ss)
+
+    println("\n--- AXIS 1: fixed dt. Relevant when the accuracy needed is already met. ---")
+    i = argmin(abs.(steps .- PRODUCTION_DT))
+    @printf("at dt = %.2e (nearest sampled to production's %.0e):\n", steps[i], PRODUCTION_DT)
+    @printf("  rk4ip is %.1fx more accurate and %.2fx the cost per step\n",
+        errs[:strang][i] / errs[:rk4ip][i], c_rk / c_ss)
+    println("  If that accuracy is not needed, this is a pure loss.")
+
+    println("\n--- AXIS 2: fixed accuracy. Time to solution. ---")
+    @printf("%12s %14s %14s %14s\n", "budget", "rk4ip dt", "split dt", "time ratio")
+    for b in (1e-3, 1e-4, 1e-5, 1e-6)
+        a = crossing(steps, errs[:rk4ip], b)
+        s = crossing(steps, errs[:strang], b)
+        r = (a / s) / (c_rk / c_ss)
+        @printf("%12.0e %14.3e %14.3e %14s\n", b, a, s,
+            isfinite(r) ? @sprintf("%.2fx", r) : "—")
+    end
+    println("\n>1 means rk4ip reaches that accuracy sooner. Both columns are measured")
+    println("HERE, at this n on this device — the previous write-up divided a 12^3 CPU")
+    println("step ratio by a 128^3 GPU cost ratio, which does not compose.")
+end
+
+main()

--- a/src/hamiltonian/integrator/rk4ip.jl
+++ b/src/hamiltonian/integrator/rk4ip.jl
@@ -14,33 +14,49 @@
 # diagonal-in-k part — is absorbed into an interaction picture and applied
 # exactly, so it does not limit `dt`.
 #
-# COST — and the CPU answer does not survive contact with the GPU.
+# WHEN IT PAYS. Two axes, and they must not be collapsed into one number — see
+# `docs/validation/rk4ip_cost_on_gpu.md` for the full measurement and for what
+# earlier drafts of this comment got wrong.
 #
-# ms/step, Eu F=6 D=13 with padded DDI, `split_step!` / `midpoint` / `rk4ip`:
+# At the SAME dt (H100 64³, dt = 7.81e-4, Eu F=6 D=13 padded DDI): RK4IP is
+# **7090× more accurate at 3.28× the cost per step**. If that accuracy is not
+# wanted, that is the whole story and it is a loss.
 #
-#   CPU 12³            3.00 / 4.46 / 2.61      rk4ip 0.87× the default
+# At the SAME accuracy, time to solution (all rows measured at 64³):
+#
+#   budget     rk4ip dt    split dt   step ratio   TIME RATIO
+#    1e-3      4.23e-2     2.62e-2       1.62        0.49×
+#    1e-4      2.34e-2     8.29e-3       2.82        0.86×
+#    1e-5      1.31e-2     2.62e-3       5.00        1.53×
+#    1e-6      7.38e-3     8.29e-4       8.90        2.71×
+#
+# **Break-even is between 1e-4 and 1e-5.** Production sits at roughly the 1e-4
+# accumulated-error scale, i.e. on the losing side — hence opt-in, not default.
+#
+# Cost per step, `split_step!` / `midpoint` / `rk4ip`:
+#
+#   CPU 12³            3.00 / 4.46 / 2.61      rk4ip 0.87×  (CHEAPER)
+#   H100  32³          0.62 / 0.92 / 4.63      rk4ip 7.44×
+#   H100  64³          2.75 / 4.04 / 9.05      rk4ip 3.28×
+#   H100 128³         25.10 / 36.73 / 72.04    rk4ip 2.87×
 #   RTX 5070 Ti 128³ 175.21 / 257.83 / 258.15  rk4ip 1.47×
-#   H100 128³         25.13 /  36.73 /  72.07  rk4ip **2.87×**
-#   H100  64³          2.77 /   4.04 /   9.16  rk4ip 3.30×
-#   H100  32³          0.62 /   0.92 /   4.63  rk4ip 7.44×
 #
 # The mechanism is the interaction picture itself: **this applies e^{K dt/2} four
 # times per step (lines below) where Strang applies e^{K dt} once.** Each is an
-# FFT pair. On CPU the mean-field and DDI work dominates and that 4× is invisible
-# — RK4IP even comes out cheaper, because `split_step!` auto-dispatches to the
-# midpoint predictor-corrector whenever DDI is active. On a GPU the FFTs dominate
-# and the 4× is the whole story.
+# FFT pair. On CPU the mean-field and DDI work dominates — and the default is
+# itself paying for a predictor-corrector, since `split_step!` auto-dispatches to
+# `_half_potential_step_midpoint!` whenever DDI is active — so the 4× hides and
+# RK4IP comes out cheaper. On GPU the FFTs dominate and it is the whole cost; the
+# gap widens as n falls because the FFTs go launch-bound, four launches to one.
 #
-# Net speedup = the step ratio RK4IP holds under a fixed error budget
-# (`scripts/validation/rk4ip_step_size_probe.jl`: 2.4× at 1e-4, 4.2× at 1e-5)
-# divided by the cost ratio above. On the H100 at 128³ that is **0.84× at a 1e-4
-# budget — a net LOSS — and 1.46× at 1e-5**. On CPU it is 2.7× and 4.9×.
+# Accuracy, by contrast, is n-independent here: the error-vs-dt columns at 64³
+# and 128³ agree to the digits printed, because the state is smooth and the added
+# high-k modes are empty. So the break-even budget moves only through the cost:
+# ≈1e-6 at 32³, ≈2e-5 at 64³, ≈1e-4 at 128³.
 #
-# So: worth selecting when the tolerance is tight (≲1e-5) or on CPU; not worth it
-# at ordinary tolerances on the production GPU, and not a candidate for the
-# default. Memory is the other reason: the five scratch buffers below are 436 MB
-# each at 128³ F64 D=13, and the measured allocator high-water for one step is
-# 12.9 GiB on the H100 and 4.8 GiB of a 15.9 GiB consumer card.
+# Memory: the five scratch buffers below are 436 MB each at 128³ F64 D=13, and
+# the measured allocator high-water for one step is 12.9 GiB on the H100 and
+# 4.8 GiB of a 15.9 GiB consumer card.
 #
 # What it gives up: neither symplectic nor exactly norm-conserving. Over the
 # 5-40 ms real-time windows this program runs that is not a constraint, and the

--- a/src/hamiltonian/integrator/rk4ip.jl
+++ b/src/hamiltonian/integrator/rk4ip.jl
@@ -14,17 +14,33 @@
 # diagonal-in-k part — is absorbed into an interaction picture and applied
 # exactly, so it does not limit `dt`.
 #
-# Cost, MEASURED rather than counted (Eu-like 12³ with DDI, CPU, ms/step):
-# `split_step!` 3.00, `split_step_midpoint!` 4.46, `rk4ip_step!` **2.61**. RK4IP
-# is cheaper per step than the default, because `split_step!` auto-dispatches to
-# the midpoint predictor-corrector whenever DDI is active (~1.5× a plain V step,
-# twice per step) while RK4IP makes four accumulating registry passes.
+# COST — and the CPU answer does not survive contact with the GPU.
 #
-# Combined with the step sizes each holds under a fixed error budget
-# (`scripts/validation/rk4ip_step_size_probe.jl`), the net is **2.7× at a 1e-4
-# budget and 4.9× at 1e-5**. Both numbers are one config on CPU; the GPU cost
-# ratio is unmeasured, and the five scratch buffers below are ~2.2 GB at 128³
-# F64 D=13, which is the thing to check before assuming this transfers.
+# ms/step, Eu F=6 D=13 with padded DDI, `split_step!` / `midpoint` / `rk4ip`:
+#
+#   CPU 12³            3.00 / 4.46 / 2.61      rk4ip 0.87× the default
+#   RTX 5070 Ti 128³ 175.21 / 257.83 / 258.15  rk4ip 1.47×
+#   H100 128³         25.13 /  36.73 /  72.07  rk4ip **2.87×**
+#   H100  64³          2.77 /   4.04 /   9.16  rk4ip 3.30×
+#   H100  32³          0.62 /   0.92 /   4.63  rk4ip 7.44×
+#
+# The mechanism is the interaction picture itself: **this applies e^{K dt/2} four
+# times per step (lines below) where Strang applies e^{K dt} once.** Each is an
+# FFT pair. On CPU the mean-field and DDI work dominates and that 4× is invisible
+# — RK4IP even comes out cheaper, because `split_step!` auto-dispatches to the
+# midpoint predictor-corrector whenever DDI is active. On a GPU the FFTs dominate
+# and the 4× is the whole story.
+#
+# Net speedup = the step ratio RK4IP holds under a fixed error budget
+# (`scripts/validation/rk4ip_step_size_probe.jl`: 2.4× at 1e-4, 4.2× at 1e-5)
+# divided by the cost ratio above. On the H100 at 128³ that is **0.84× at a 1e-4
+# budget — a net LOSS — and 1.46× at 1e-5**. On CPU it is 2.7× and 4.9×.
+#
+# So: worth selecting when the tolerance is tight (≲1e-5) or on CPU; not worth it
+# at ordinary tolerances on the production GPU, and not a candidate for the
+# default. Memory is the other reason: the five scratch buffers below are 436 MB
+# each at 128³ F64 D=13, and the measured allocator high-water for one step is
+# 12.9 GiB on the H100 and 4.8 GiB of a 15.9 GiB consumer card.
 #
 # What it gives up: neither symplectic nor exactly norm-conserving. Over the
 # 5-40 ms real-time windows this program runs that is not a constraint, and the

--- a/src/workflow/experiments/pipeline/run_step_dynamics.jl
+++ b/src/workflow/experiments/pipeline/run_step_dynamics.jl
@@ -422,22 +422,29 @@ measured 2.00 at `c_dd` = 0 and 147.7, 1.93 at 1477. The "plain `split_step!` is
 off. Selecting `midpoint` explicitly lowers the error ~1.7× at fixed `dt`, i.e.
 ~1.3× the step, for 1.49× the per-step cost. Close to a wash.
 
-`rk4ip` is 4th order, and whether that is worth taking depends on the backend —
-the CPU answer reverses on GPU. It applies `e^{K dt/2}` FOUR times per step where
-Strang applies `e^{K dt}` once; each is an FFT pair, so on CPU (mean-field
-dominated) the extra work hides and on GPU (FFT dominated) it is the whole cost.
-ms/step, `split_step!` / `midpoint` / `rk4ip`:
+`rk4ip` is 4th order, and whether that is worth taking is a question about the
+required TOLERANCE, not about the order. Full measurement:
+`docs/validation/rk4ip_cost_on_gpu.md`.
 
-    CPU 12³            3.00 / 4.46 / 2.61      rk4ip 0.87x
-    RTX 5070 Ti 128³ 175.21 / 257.83 / 258.15  rk4ip 1.47x
-    H100 128³         25.13 /  36.73 /  72.07  rk4ip 2.87x
+At the same `dt` it is more accurate and dearer — H100 64³, `dt` = 7.81e-4:
+**7090x the accuracy at 3.28x the cost per step**. At the same accuracy, time to
+solution (measured at 64³):
 
-Net = the step it holds (2.4x at a 1e-4 error budget, 4.2x at 1e-5) over that
-cost. **On the H100 at 128³: 0.84x at 1e-4 — slower than the default — and 1.46x
-at 1e-5.** On CPU: 2.7x and 4.9x. Select it for tight tolerances or CPU work, not
-as a general speedup. Memory is the other constraint: five full-state scratch
-buffers, measured 12.9 GiB allocator high-water for one 128³ step on the H100 and
-4.8 GiB of a 15.9 GiB consumer card. Two more things to know. It is not
+    budget    rk4ip dt    split dt    TIME RATIO
+     1e-3     4.23e-2     2.62e-2       0.49x
+     1e-4     2.34e-2     8.29e-3       0.86x
+     1e-5     1.31e-2     2.62e-3       1.53x
+     1e-6     7.38e-3     8.29e-4       2.71x
+
+**Break-even is between 1e-4 and 1e-5**, and production sits near 1e-4 — so at
+default tolerances this is slower for the same answer. Select it when the
+tolerance is tight, or on CPU, where it is cheaper per step outright (2.61 ms
+against `split_step!`'s 3.00 at 12³; on the H100 it is 2.87x at 128³, 3.28x at
+64³, 7.44x at 32³, because it applies `e^{K dt/2}` four times per step where
+Strang applies `e^{K dt}` once and the GPU is FFT-bound). Memory is the other
+constraint: five full-state scratch buffers, measured 12.9 GiB allocator
+high-water for one 128³ step on the H100 and 4.8 GiB of a 15.9 GiB consumer
+card. Two more things to know. It is not
 norm-conserving — the drift is a free error monitor, and `normalize_every` is not
 honoured. And its failure mode is a wall rather than a slope: measured on an
 Eu-like 12³ DDI config it holds ~1e-1 relative error at `dt` = 2.5e-2 and returns

--- a/src/workflow/experiments/pipeline/run_step_dynamics.jl
+++ b/src/workflow/experiments/pipeline/run_step_dynamics.jl
@@ -422,13 +422,22 @@ measured 2.00 at `c_dd` = 0 and 147.7, 1.93 at 1477. The "plain `split_step!` is
 off. Selecting `midpoint` explicitly lowers the error ~1.7× at fixed `dt`, i.e.
 ~1.3× the step, for 1.49× the per-step cost. Close to a wash.
 
-`rk4ip` is 4th order and, measured on an Eu-like 12³ DDI config, **cheaper per
-step than the default** (2.61 ms against 3.00; `midpoint` is 4.46) because the
-default runs the predictor-corrector twice per step while RK4IP makes four
-accumulating registry passes. Net of the larger step it holds: **2.7× at a 1e-4
-error budget, 4.9× at 1e-5**. Those are CPU at 12³; the GPU ratio is unmeasured
-and RK4IP's five scratch buffers are ~2.2 GB at 128³ F64 D=13, so check both
-before assuming it transfers. Two more things to know. It is not
+`rk4ip` is 4th order, and whether that is worth taking depends on the backend —
+the CPU answer reverses on GPU. It applies `e^{K dt/2}` FOUR times per step where
+Strang applies `e^{K dt}` once; each is an FFT pair, so on CPU (mean-field
+dominated) the extra work hides and on GPU (FFT dominated) it is the whole cost.
+ms/step, `split_step!` / `midpoint` / `rk4ip`:
+
+    CPU 12³            3.00 / 4.46 / 2.61      rk4ip 0.87x
+    RTX 5070 Ti 128³ 175.21 / 257.83 / 258.15  rk4ip 1.47x
+    H100 128³         25.13 /  36.73 /  72.07  rk4ip 2.87x
+
+Net = the step it holds (2.4x at a 1e-4 error budget, 4.2x at 1e-5) over that
+cost. **On the H100 at 128³: 0.84x at 1e-4 — slower than the default — and 1.46x
+at 1e-5.** On CPU: 2.7x and 4.9x. Select it for tight tolerances or CPU work, not
+as a general speedup. Memory is the other constraint: five full-state scratch
+buffers, measured 12.9 GiB allocator high-water for one 128³ step on the H100 and
+4.8 GiB of a 15.9 GiB consumer card. Two more things to know. It is not
 norm-conserving — the drift is a free error monitor, and `normalize_every` is not
 honoured. And its failure mode is a wall rather than a slope: measured on an
 Eu-like 12³ DDI config it holds ~1e-1 relative error at `dt` = 2.5e-2 and returns


### PR DESCRIPTION
Follow-up to #269, which landed RK4IP with a CPU-only cost measurement.

## 1. Correctness transfers

One RK4IP step, GPU against CPU from the same start, Eu F=6 (D=13), DDI on and zero-padded:

| n | total rel L2 | worst component |
|---|---|---|
| 16 | 5.5×10⁻¹⁶ | 5.9×10⁻¹⁶ |
| 32 | 6.9×10⁻¹⁶ | 7.2×10⁻¹⁶ |

Round-off in every one of the 13 channels, on both cards. **RK4IP had never been executed on a GPU** — every HamTerm's `apply_operator!` face already had a path. Compared per component, because a term missing its GPU path can contribute nothing to the aggregate while being wrong in one m channel.

## 2. Two axes, kept apart

The first draft of this PR reported a single "net speedup". That collapsed two questions and was built from measurements on different problems. Both are fixed.

### Same `dt` — more accurate, dearer

H100 64³ at `dt = 7.81×10⁻⁴` (nearest sample to production's 1e-3): **7090× more accurate at 3.28× the cost per step.** For the Fig. 4B observable that accuracy is unspendable — `dt = 1e-3` is converged there to 0.0001 nT.

### Same accuracy — time to solution

Both halves measured at 64³ on the H100, every row a genuine two-sided interpolation:

| error budget | rk4ip `dt` | split_step! `dt` | step ratio | **time ratio** |
|---|---|---|---|---|
| 1e-3 | 4.23×10⁻² | 2.62×10⁻² | 1.62 | **0.49×** |
| 1e-4 | 2.34×10⁻² | 8.29×10⁻³ | 2.82 | **0.86×** |
| 1e-5 | 1.31×10⁻² | 2.62×10⁻³ | 5.00 | **1.53×** |
| 1e-6 | 7.38×10⁻³ | 8.29×10⁻⁴ | 8.90 | 2.71× |
| 1e-7 | 4.15×10⁻³ | 2.62×10⁻⁴ | 15.84 | 4.83× |

**Break-even sits between 1e-4 and 1e-5, and production sits near 1e-4** — just on the losing side.

## 3. What depends on `n`

**Accuracy does not.** Error-vs-`dt` at 64³ and 128³ agrees to every printed digit (2.220e-7 / 8.878e-7 / 3.551e-6 …): the state is smooth and the added high-`k` modes are empty.

**Cost does.** ms/step, `split_step!` / `midpoint` / `rk4ip`:

| device | n | split_step! | midpoint | rk4ip | vs split |
|---|---|---|---|---|---|
| CPU | 12 | 3.00 | 4.46 | **2.61** | **0.87×** |
| H100 | 32 | 0.62 | 0.92 | 4.63 | 7.44× |
| H100 | 64 | 2.75 | 4.04 | 9.05 | 3.28× |
| H100 | 128 | 25.10 | 36.73 | 72.04 | 2.87× |
| RTX 5070 Ti | 128 | 175.21 | 257.83 | 258.15 | 1.47× |

RK4IP applies `e^{K dt/2}` **four times per step** (`rk4ip.jl:143,144,162,167`) where Strang applies `e^{K dt}` **once** (`split_step.jl:96`); each is an FFT pair. On CPU the mean-field and DDI work dominates — the default is itself paying for a predictor-corrector — so the 4× hides and RK4IP is *cheaper*. On GPU the FFTs dominate. The gap widens as `n` falls because the FFTs go launch-bound.

So the break-even budget moves only through the cost: ≈1e-6 at 32³, ≈2×10⁻⁵ at 64³, ≈1×10⁻⁴ at 128³.

## 4. Memory

Five full-state scratch buffers, 436 MB each at 128³ F64 D=13. Measured allocator high-water for one step: **12.88 GiB on the H100** (14 % of 93.1) and **4.78 GiB of a 15.9 GiB consumer card** — nearly a third of the device.

## 5. What changes

- **RK4IP stays opt-in, not a default.** Production's tolerance is on the losing side of break-even at every grid size measured.
- Both docstrings rewritten on the two-axis framing; `docs/validation/rk4ip_cost_on_gpu.md` records the measurement and the retractions.

## Retracted in this PR

- **"Order 2 → 4 at equal cost"** — from counting mean-field evaluations on CPU. The count was right and irrelevant; on GPU the kinetic FFTs dominate.
- **"Net 2.7× / 4.9×"** — a 12³ CPU step ratio divided by a 128³ GPU cost ratio. Measured at 128³: 0.98× and 1.74×.
- **"The step ratio is strongly size-dependent, which is why this needed re-measuring"** — argued from `[K,[K,V]] ~ k_max²`; measured, it is not. Right to re-measure, wrong reason.
- **A capped crossing printed as a measurement** — the first 64³ sweep never went coarse enough for either integrator to leave a 1e-3 or 1e-4 budget, and the helper returned the coarsest sample. Rows are now tagged `measured` / `LOWER BOUND`, sweep extended two octaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
