### PR TITLE
fix(dashboard,test): make the server stoppable, and empty the manual allowlist

### DIFF
--- a/src/workflow/io/dashboard/server/router.jl
+++ b/src/workflow/io/dashboard/server/router.jl
@@ -36,6 +36,7 @@ React app consumes.
 """
 function serve_dashboard(port::Int=8080; base_dir::String="runs",
     bind::AbstractString=get(ENV, "SPINORBEC_DASHBOARD_BIND", "0.0.0.0"),
+    server_ref::Union{Nothing, Ref}=nothing,
 )
     if !isfile(_WEB_DIST_INDEX)
         throw(
@@ -77,6 +78,13 @@ function serve_dashboard(port::Int=8080; base_dir::String="runs",
         )
     end
     server = Sockets.listen(Sockets.InetAddr(bind_addr, port))
+    # A caller that spawned this on a task has no other way to stop it: the
+    # loop below only exits on an InterruptException, and `Base.throwto` on a
+    # task parked in `accept` switches to that task and does not reliably come
+    # back — which is why `test_live_monitor.jl` hung forever and sat in
+    # MANUAL_TESTS_ALLOWLIST rather than in a tier. Hand the listen socket out
+    # and `close(ref[])` makes `accept` throw, the `finally` runs, the task ends.
+    server_ref === nothing || (server_ref[] = server)
     println("Dashboard server running at http://$(bind_addr):$port")
     println("  Serving runs from: $(abspath(base_dir))")
     println("  React app:         $(_WEB_DIST_INDEX)")
@@ -92,7 +100,9 @@ function serve_dashboard(port::Int=8080; base_dir::String="runs",
             )
         end
     catch e
-        e isa InterruptException || rethrow(e)
+        # A closed listen socket surfaces as IOError/EOFError from `accept`;
+        # that is the programmatic stop, not a fault.
+        e isa InterruptException || e isa Base.IOError || e isa EOFError || rethrow(e)
         println("\nDashboard server stopped.")
     finally
         close(server)

--- a/test/MANUAL_TESTS.md
+++ b/test/MANUAL_TESTS.md
@@ -1,43 +1,51 @@
-# Manual test inventory
+# Manual test inventory — empty
 
-**One** file under `test/` is not wired into any tier. Its reason was measured,
-not inherited: every candidate was run, and the four that could be made to run
-were moved into tiers (2026-07-31 / 2026-08-01).
+**No file under `test/` is outside a tier.** `MANUAL_TESTS_ALLOWLIST` in
+`test/_tiers.jl` is `String[]`, and `test_tier_membership.jl` asserts this file
+and that list agree.
 
-The old framing — "depend on environment conditions the default test runner
-cannot guarantee (GPU, dashboard build, opt-in heavy YAML, scenario directories
-pending schema migration)" — was true for none of those four. Between them they
-carried 39 assertions that no tier ran, since 2026-05-25.
+It held five files / 53 assertions that no tier ran, untouched since
+2026-05-25, each with an environment reason nobody had rechecked since. Every
+one was run, 2026-07-31 / 08-02:
 
-`MANUAL_TESTS_ALLOWLIST` in `test/_tiers.jl` is the machine-readable copy;
-`test_tier_membership.jl` asserts the two agree.
-
-## `workflow/test_live_monitor.jl` — blocks forever
-
-`serve_dashboard` does not return until the server is closed, and this file's
-close path is never reached, so the run hangs until something kills it
-(measured: SIGTERM at a 2400 s timeout, `Press Ctrl+C to stop` in the log). Its
-own comment states the intent — *"the function blocks until the server is
-closed; we'll close it manually"* — which is exactly what does not happen.
-
-Needs restructuring (serve on a task, assert, close in a `finally`), not a tier
-entry. Run it only if you are prepared to interrupt it:
-
-```bash
-julia --project=. \
-  -e 'using Test; using SpinorBEC; include("test/workflow/test_live_monitor.jl")'
-```
-
-## Moved into tiers
-
-| file | was filed as | measured | now |
+| file | was filed as | what was actually true | now |
 |---|---|---|---|
-| `gpu/test_cuda.jl` | "gated, but needs GPU to be useful" | guards on `CUDA.functional()` like every other `gpu/` file; 3.9 s on a GPU host, no-op without one | `FULL_EXTRA` |
-| `workflow/test_active_learning_yaml.jl` | "heavy YAML" | already carried `_SKIP_HEAVY_YAML_AL`; 0.0 s with the flag off, 21.7 s on the runner | `CI_EXTRA` |
+| `gpu/test_cuda.jl` | "needs GPU to be useful" | guards on `CUDA.functional()` like every other `gpu/` file — on a CPU-only runner it is the same no-op they are. 3.9 s on a GPU host | `FULL_EXTRA` |
+| `workflow/test_active_learning_yaml.jl` | "heavy YAML" | already carried `_SKIP_HEAVY_YAML_AL`: 0.0 s with the flag off, 21.7 s with it on | `CI_EXTRA` |
 | `workflow/test_multi_fidelity_yaml.jl` | "heavy YAML" | same shape; 0.0 s / **776 s on the runner** — see `_COST` | `CI_EXTRA` |
-| `workflow/test_klaus_validation.jl` | "heavy YAML scenario pending schema audit" | the schema was fine. `initial_state: m_plus_F` was inverted against the field sign, so ITP underflowed every surviving component and the state normalised to NaN. `m_minus_F` runs it at the real 1 Gauss field, unchanged `dt`, in 68 s | `CI_EXTRA` |
+| `workflow/test_klaus_validation.jl` | "pending schema audit" | the schema was fine. `initial_state: m_plus_F` was inverted against the field sign, so ITP underflowed every surviving component and the state normalised to NaN. 68 s at the real 1 Gauss field | `CI_EXTRA` |
+| `workflow/test_live_monitor.jl` | "spawns a server on a TCP port" | the port was never the problem. Two independent defects, the first hiding the second — see below. 10 s | `CI_EXTRA` |
 
-Three of the four needed no code change at all — only for someone to run them.
+**Three of the five needed no code change at all** — only for someone to run
+them.
+
+## What was wrong with `test_live_monitor.jl`
+
+1. The POST sent no `Connection: close`, and the test then did
+   `read(sock, String)`, which reads to EOF. HTTP/1.1 keeps the connection
+   alive by default, so the read never returned.
+2. Teardown was `Base.throwto(srv_task, InterruptException())` on a task parked
+   in `accept`. `throwto` switches to the target task and does not reliably
+   come back, so the server stayed up and the process hung until something
+   killed it (measured: SIGTERM at a 2400 s timeout, `Press Ctrl+C to stop` in
+   the log).
+
+`serve_dashboard` had no way to be stopped programmatically — it creates its
+listen socket internally and loops on `accept`, exiting only on an
+`InterruptException`. It now takes `server_ref::Ref`, so a caller that spawned
+it on a task can `close(ref[])`; `accept` throws, the `finally` runs, and
+`wait(srv_task)` is deterministic. That is useful beyond the test.
+
+Fixing the hang exposed a third defect that had never executed:
+`Base.Filesystem.touch(path; times=…)` is not a Julia method. The endpoint ages
+a run by its **mtime** (`routes/lab_live.jl`), so the back-dating is real and is
+now done with `touch -d @epoch`, with an assertion that it took.
+
+## Keep this empty
+
+A file that cannot run is a file to fix or delete. Parking one here is how 53
+assertions stopped being tests for ten weeks. If something genuinely must be
+manual it needs an entry here with a reason that was **measured**.
 
 ## Re-audit (2026-06-19)
 

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -311,6 +311,11 @@ const CI_EXTRA = [
     # pending schema audit" since 2026-05-25; the schema was fine and the
     # `initial_state` was inverted (see the file header). Runs in ~68 s.
     "workflow/test_klaus_validation.jl",
+    # Dashboard HTTP round-trip. Was the last MANUAL entry ("spawns dashboard
+    # server on a TCP port"); it hung forever for two reasons, both fixed
+    # 2026-08-02 — a keep-alive read with no `Connection: close`, and a
+    # teardown by `Base.throwto` on a task parked in `accept`. 10 s.
+    "workflow/test_live_monitor.jl",
     # Spatial / B(r,t) Zeeman + TOF (#14): split_step / simulate_* (per-voxel
     # propagation, multi-frame TOF) — integration weight, not fast-tier units.
     "analysis/test_tof.jl",
@@ -628,20 +633,20 @@ const PHYSICS_TESTS = [
 # documented in test/MANUAL_TESTS.md with the exact invocation. Listed
 # here so the tier-membership meta-test counts them as "accounted for"
 # (i.e. they are deliberately manual, not orphaned). Run them by hand.
-const MANUAL_TESTS_ALLOWLIST = [
-    # One file. `test_live_monitor.jl` blocks forever: `serve_dashboard` does not
-    # return until the server is closed and this file's close path is never
-    # reached, so the run hangs until it is killed (measured: SIGTERM at a
-    # 2400 s timeout, "Press Ctrl+C to stop" in the log). Its own comment says
-    # it means to close the server manually. Needs restructuring — serve on a
-    # task, assert, close in a `finally` — not a tier entry.
-    #
-    # The other four that sat here are in tiers as of 2026-07-31/08-01, each
-    # after being run rather than re-inheriting its reason: gpu/test_cuda.jl,
-    # workflow/test_{active_learning,multi_fidelity}_yaml.jl and
-    # workflow/test_klaus_validation.jl.
-    "workflow/test_live_monitor.jl"
-]
+# EMPTY, 2026-08-02. Every `test_*.jl` under test/ is now in a tier.
+#
+# This held five files / 53 assertions that no tier ran, untouched since
+# 2026-05-25, each with an environment reason nobody had rechecked. Run one by
+# one, three needed no code change at all; the two that did were broken for
+# reasons that had nothing to do with the environment they were filed under
+# (an inverted `initial_state`, and an HTTP read that never saw EOF).
+#
+# Keep it empty. A file that cannot run is a file to fix or delete — parking it
+# here is how 53 assertions stopped being tests for ten weeks. If something
+# genuinely must be manual, it needs an entry in test/MANUAL_TESTS.md stating a
+# reason that was MEASURED, and the tier-membership meta-test asserts the two
+# lists agree.
+const MANUAL_TESTS_ALLOWLIST = String[]
 
 # Derived view (NOT a partition list): every `oracles/` gate, regardless of which
 # tier list it lives in. The `oracles` pseudo-tier runs JUST these so the per-PR
@@ -772,6 +777,7 @@ const _COST = Dict{String, Float64}(
     # 68 s here; declared high because a runner estimate is what this model
     # needs and the nightly timing table will correct it downward if generous.
     "workflow/test_klaus_validation.jl" => 180.0,
+    "workflow/test_live_monitor.jl" => 30.0,   # 10 s here; a runner is slower
     "workflow/test_active_learning_yaml.jl" => 21.7,
     "hamiltonian/test_mixed_precision_kinetic_buffer.jl" => 9.7,
     # 4.8 s here against a warm depot; the CI runner pays a cold precompile

--- a/test/workflow/test_live_monitor.jl
+++ b/test/workflow/test_live_monitor.jl
@@ -17,13 +17,14 @@ using SpinorBEC
 
         # Spawn the dashboard server in an async task
         # (the function blocks until the server is closed; we'll close it manually)
+        srv_ref = Ref{Any}(nothing)
         srv_task = @async begin
             try
                 # Build minimal HTML so serve_dashboard doesn't error on missing dist
                 webdir = joinpath(@__DIR__, "..", "..", "dashboard", "dist")
                 indexhtml = joinpath(webdir, "index.html")
                 isfile(indexhtml) || (mkpath(webdir); write(indexhtml, "<html></html>"))
-                serve_dashboard(port; base_dir=tmp)
+                serve_dashboard(port; base_dir=tmp, server_ref=srv_ref)
             catch e
                 e isa Base.IOError || rethrow(e)
             end
@@ -37,6 +38,9 @@ using SpinorBEC
         write(sock, "Host: localhost:$(port)\r\n")
         write(sock, "Content-Length: $(length(body))\r\n")
         write(sock, "Content-Type: image/png\r\n")
+        # `read(sock, String)` reads to EOF; HTTP/1.1 keeps the connection
+        # alive by default, so without this the read never returns.
+        write(sock, "Connection: close\r\n")
         write(sock, "\r\n")
         write(sock, body)
         flush(sock)
@@ -55,12 +59,13 @@ using SpinorBEC
         first_file = joinpath(out_dir, sort(files)[1])
         @test read(first_file) == body
 
-        # Tear down — interrupt the server task
-        try
-            Base.throwto(srv_task, InterruptException())
-        catch e
-            # ignore
-        end
+        # Tear down by closing the listen socket. The task is parked in
+        # `accept`, and `Base.throwto` switches to it without reliably coming
+        # back — that is why this file used to leave the server running and
+        # hang until something killed the process. `wait` makes it
+        # deterministic.
+        srv_ref[] === nothing || close(srv_ref[])
+        wait(srv_task)
     end
 end
 
@@ -80,16 +85,25 @@ end
             stale_path,
             """{"step":1,"t":0.0,"energy":0.0,"norm":1.0,"populations":[1.0],"updated_ms":1}""",
         )
-        old_t = time() - 600  # 10 minutes ago
-        Base.Filesystem.touch(stale_path; times=(old_t, old_t))
+        # Back-date the file, because `/api/live/list` ages a run by its
+        # mtime (`routes/lab_live.jl`), not by the `updated_ms` in the JSON.
+        # `touch(path; times=…)` is not a Julia method — this errored with
+        # `MethodError: no method matching touch(::String; times=…)` the first
+        # time anything ran the file, which was 2026-08-02, because the hang
+        # above had kept it from ever getting here. `Base.Filesystem.futime`
+        # is not usable either (checked). coreutils `touch -d @epoch` is.
+        old_t = round(Int, time()) - 600  # 10 minutes ago
+        run(pipeline(`touch -d @$(old_t) $(stale_path)`; stdout=devnull, stderr=devnull))
+        @test time() - mtime(stale_path) > 500   # the back-dating really took
 
         port = 8900 + (getpid() % 100)
+        srv_ref = Ref{Any}(nothing)
         srv_task = @async begin
             try
                 webdir = joinpath(@__DIR__, "..", "..", "dashboard", "dist")
                 indexhtml = joinpath(webdir, "index.html")
                 isfile(indexhtml) || (mkpath(webdir); write(indexhtml, "<html></html>"))
-                serve_dashboard(port; base_dir=tmp)
+                serve_dashboard(port; base_dir=tmp, server_ref=srv_ref)
             catch e
                 e isa Base.IOError || rethrow(e)
             end
@@ -130,9 +144,12 @@ end
         close(sock)
         @test occursin("HTTP/1.1 404", miss_resp)
 
-        try
-            Base.throwto(srv_task, InterruptException())
-        catch e
-        end
+        # Tear down by closing the listen socket. The task is parked in
+        # `accept`, and `Base.throwto` switches to it without reliably coming
+        # back — that is why this file used to leave the server running and
+        # hang until something killed the process. `wait` makes it
+        # deterministic.
+        srv_ref[] === nothing || close(srv_ref[])
+        wait(srv_task)
     end
 end


### PR DESCRIPTION
`test_live_monitor.jl` was the last file no tier ran. It was filed under
*"spawns dashboard server on a TCP port"*. **The port was never the problem.**

## Two defects, the first hiding the second

1. The POST sent no `Connection: close`, and the test then did
   `read(sock, String)` — which reads to **EOF**. HTTP/1.1 keeps the connection
   alive by default, so the read never returned.
2. Teardown was `Base.throwto(srv_task, InterruptException())` on a task parked
   in `accept`. `throwto` switches to the target task and does not reliably come
   back, so the server stayed up and the process hung until something killed it
   (measured: SIGTERM at a 2400 s timeout, `Press Ctrl+C to stop` in the log).

## `serve_dashboard` had no programmatic stop

It creates its listen socket internally and loops on `accept`, exiting only on
an `InterruptException` — so a caller that spawned it on a task had no way to
shut it down. It now takes `server_ref::Ref`: `close(ref[])` makes `accept`
throw, the existing `finally` closes the server, and `wait(srv_task)` is
deterministic. That is useful beyond this test.

## And a third defect that had never executed

Because nothing ever got past the hang:

```
MethodError: no method matching touch(::String; times::Tuple{Float64, Float64})
```

`Base.Filesystem.touch(path; times=…)` is not a Julia method (and `futime` is
not usable either — checked). `/api/live/list` ages a run by its **mtime**
(`routes/lab_live.jl`), not by the `updated_ms` in the JSON, so the back-dating
is real and is now done with `touch -d @epoch`, with an assertion that it took.

**Both testsets pass in 10 s.**

## The allowlist is now empty

`MANUAL_TESTS_ALLOWLIST = String[]`. It held five files / **53 assertions** that
no tier ran, untouched since 2026-05-25, each with an environment reason nobody
had rechecked.

| file | was filed as | what was actually true |
|---|---|---|
| `gpu/test_cuda.jl` | "needs GPU to be useful" | guards on `CUDA.functional()` like every other `gpu/` file |
| `workflow/test_active_learning_yaml.jl` | "heavy YAML" | already carried its own guard: 0.0 s with the flag off |
| `workflow/test_multi_fidelity_yaml.jl` | "heavy YAML" | same — and 776 s on the runner, which is its own story (#270) |
| `workflow/test_klaus_validation.jl` | "pending schema audit" | the schema was fine; `initial_state` was inverted against the field sign (#277) |
| `workflow/test_live_monitor.jl` | "spawns a server on a TCP port" | the two defects above |

**Three of the five needed no code change at all** — only for someone to run
them.

`MANUAL_TESTS.md` rewritten to match, with a note to keep the list empty: a file
that cannot run is a file to fix or delete, and parking one there is how 53
assertions stopped being tests for ten weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)