### PR TITLE
The disposal count was measuring the regex: a citation gate that stopped at the first path segment

### DIFF
--- a/docs/campaign/rederivation_fig1_l4_ladder.md
+++ b/docs/campaign/rederivation_fig1_l4_ladder.md
@@ -113,6 +113,31 @@ a single `N_trajectory` block (`Fz_per_N`, `DeltaFz`, `N_final_ratio`, …);
   summaries contain `N_trajectory` and nothing else, so there is no like-for-like
   density number to put beside the panel's table.
 
+## The inset survives where the main panel does not
+
+The inset's two lossy arms were re-run on TSUBAME. Its quantity is the surviving
+fraction N(T)/N(0), which the stored summaries record as
+`N_trajectory.N_final_ratio` and the v3 extractor as `1 − norm_rel_drift` — the
+same number by construction, unlike ΔF_z below.
+
+| config | stored | re-derived | change |
+|---|---:|---:|---:|
+| `matsui_40ms_lossy_medium` | 0.516038 | 0.516901 | **+0.17 %** |
+| `matsui_40ms_lossy_strong` | 0.244302 | 0.243647 | **−0.27 %** |
+
+**Two to three tenths of a percent, against −16.5 % on the same figure's main
+panel.** The inset does not need redrawing.
+
+That is a discrimination rather than a reassurance: both panels went through the
+same pipeline on the same day and only one moved. Peak density is a local maximum
+of the field and rides on the corrected LHY and dealias paths; the surviving
+fraction is a volume integral of a K3 decay and does not. A campaign that had
+re-derived only the inset would have concluded the figure was fine.
+
+The re-derived runs also classify — `stable_arrest` (medium),
+`sacrificial_arrest` (strong) — where the stored summaries classify nothing. New
+information, not a comparison.
+
 ## Not covered
 
 - Fig 1 (d)'s density slice is an analysis of `matsui_5ms_morphology_n64`, which

--- a/docs/campaign/rederivation_fig1_l4_ladder.md
+++ b/docs/campaign/rederivation_fig1_l4_ladder.md
@@ -77,8 +77,47 @@ loss does.
 either dataset — but every number under it moved by 16.5 %, and the figure should
 be redrawn rather than re-captioned.
 
+## Fig 1's inset: the two lossy arms
+
+Re-run on TSUBAME (`gpu_h`, 64³, `import CUDA` first). The inset plots
+N(t)/N(0), so the comparable quantity is the surviving fraction at 40 ms.
+
+| config | stored `N_final_ratio` | re-derived `1 − norm_rel_drift` | change |
+|---|---:|---:|---:|
+| `matsui_40ms_lossy_medium` | 0.516038 | 0.516901 | **+0.17 %** |
+| `matsui_40ms_lossy_strong` | 0.244302 | 0.243647 | **−0.27 %** |
+
+**The inset survives the corrections.** Both arms move by less than a third of a
+percent, against the −16.5 % that moved every peak-density number in the panel
+above. That is not a contradiction: `peak_max` is a density, sensitive to the
+DDI-padding and LHY corrections, while N(t)/N(0) is set by K₃ acting on a decay
+that the corrections barely touch — the same insensitivity Fig 3's re-derivation
+found from the other direction.
+
+The re-derivation also classifies the two arms, which the stored summaries do
+not: `stable_arrest` (medium) and `sacrificial_arrest` (strong).
+
+### What could not be compared, and why
+
+The extractor schema changed between the two epochs. The stored summaries carry
+a single `N_trajectory` block (`Fz_per_N`, `DeltaFz`, `N_final_ratio`, …);
+`_extractor_version: 3` emits `Fz_drift`, `Mz` and `norm_rel_drift` instead.
+
+- **ΔF_z is NOT reported here.** Stored `DeltaFz` is 3.478276 (medium) and
+  re-derived `Fz_drift` is 3.328342, which looks like a −4.3 % shift — but
+  `DeltaFz` is a per-atom difference over the `Fz_per_N` series and `Fz_drift`
+  comes from a different extractor, and I did not confirm the two definitions
+  agree. Quoting the ratio would repeat the Fig 3 error of comparing a
+  time-maximum against a final-state value because both were called "peak".
+- **`peak_max` has no stored counterpart** for these two configs. Their stored
+  summaries contain `N_trajectory` and nothing else, so there is no like-for-like
+  density number to put beside the panel's table.
+
 ## Not covered
 
-- Fig 1 (d)'s `matsui_5ms_n64_density_slice.json` and the inset's two lossy
-  configs.
+- Fig 1 (d)'s density slice is an analysis of `matsui_5ms_morphology_n64`, which
+  is re-derived in the table above (−26.0 %), not a separate run — so the slice
+  moves with it and does not need its own cell.
 - The n96/n128 rungs, deliberately, for the reason above.
+- ΔF_z on the lossy arms, pending a check that the two extractors define it the
+  same way.

--- a/docs/campaign/rederivation_fig1_l4_ladder.md
+++ b/docs/campaign/rederivation_fig1_l4_ladder.md
@@ -77,42 +77,6 @@ loss does.
 either dataset — but every number under it moved by 16.5 %, and the figure should
 be redrawn rather than re-captioned.
 
-## Fig 1's inset: the two lossy arms
-
-Re-run on TSUBAME (`gpu_h`, 64³, `import CUDA` first). The inset plots
-N(t)/N(0), so the comparable quantity is the surviving fraction at 40 ms.
-
-| config | stored `N_final_ratio` | re-derived `1 − norm_rel_drift` | change |
-|---|---:|---:|---:|
-| `matsui_40ms_lossy_medium` | 0.516038 | 0.516901 | **+0.17 %** |
-| `matsui_40ms_lossy_strong` | 0.244302 | 0.243647 | **−0.27 %** |
-
-**The inset survives the corrections.** Both arms move by less than a third of a
-percent, against the −16.5 % that moved every peak-density number in the panel
-above. That is not a contradiction: `peak_max` is a density, sensitive to the
-DDI-padding and LHY corrections, while N(t)/N(0) is set by K₃ acting on a decay
-that the corrections barely touch — the same insensitivity Fig 3's re-derivation
-found from the other direction.
-
-The re-derivation also classifies the two arms, which the stored summaries do
-not: `stable_arrest` (medium) and `sacrificial_arrest` (strong).
-
-### What could not be compared, and why
-
-The extractor schema changed between the two epochs. The stored summaries carry
-a single `N_trajectory` block (`Fz_per_N`, `DeltaFz`, `N_final_ratio`, …);
-`_extractor_version: 3` emits `Fz_drift`, `Mz` and `norm_rel_drift` instead.
-
-- **ΔF_z is NOT reported here.** Stored `DeltaFz` is 3.478276 (medium) and
-  re-derived `Fz_drift` is 3.328342, which looks like a −4.3 % shift — but
-  `DeltaFz` is a per-atom difference over the `Fz_per_N` series and `Fz_drift`
-  comes from a different extractor, and I did not confirm the two definitions
-  agree. Quoting the ratio would repeat the Fig 3 error of comparing a
-  time-maximum against a final-state value because both were called "peak".
-- **`peak_max` has no stored counterpart** for these two configs. Their stored
-  summaries contain `N_trajectory` and nothing else, so there is no like-for-like
-  density number to put beside the panel's table.
-
 ## The inset survives where the main panel does not
 
 The inset's two lossy arms were re-run on TSUBAME. Its quantity is the surviving
@@ -137,6 +101,22 @@ re-derived only the inset would have concluded the figure was fine.
 The re-derived runs also classify — `stable_arrest` (medium),
 `sacrificial_arrest` (strong) — where the stored summaries classify nothing. New
 information, not a comparison.
+
+### What could not be compared, and why
+
+The extractor schema changed between the two epochs. The stored summaries carry
+a single `N_trajectory` block (`Fz_per_N`, `DeltaFz`, `N_final_ratio`, …);
+`_extractor_version: 3` emits `Fz_drift`, `Mz` and `norm_rel_drift` instead.
+
+- **ΔF_z is NOT reported here.** Stored `DeltaFz` is 3.478276 (medium) and
+  re-derived `Fz_drift` is 3.328342, which looks like a −4.3 % shift — but
+  `DeltaFz` is a per-atom difference over the `Fz_per_N` series while `Fz_drift`
+  comes from a different extractor, and I did not confirm the two definitions
+  agree. Quoting the ratio would repeat the Fig 3 error of comparing a
+  time-maximum against a final-state value because both were called "peak".
+- **`peak_max` has no stored counterpart** for these two configs. Their stored
+  summaries contain `N_trajectory` and nothing else, so there is no like-for-like
+  density number to put beside the main panel's table.
 
 ## Not covered
 

--- a/docs/campaign/stored_run_disposal.md
+++ b/docs/campaign/stored_run_disposal.md
@@ -90,27 +90,78 @@ Two facts, measured:
 Disposal therefore needs *all* of: uncited, untracked, unstamped, superseded by a
 correction — **and not a scan family.**
 
-## The disposable set: 280 directories
+## Second correction: the count was a property of the matcher
 
-392 uncited, minus 7 tracked, minus 105 scan families.
+Raised by anko — *"that's still a lot."* It was, and chasing that produced the
+finding that matters more than any of the numbers below.
 
-Every one satisfies all of:
+**The size of the disposable set moved every time the citation matcher was fixed:
+385 → 280 → 259 → 207.** Three separate defects, each found only because the
+previous number was questioned:
 
-1. no live document cites it, by name or by family glob;
+1. **Nested citations were read at their first segment only.** The matcher keyed
+   on the top-level directory, so `runs/verification_suite/L4_eu_matsui_hamiltonian_only_*` (gone)
+   resolved to `verification_suite` and the 13 directories it names were
+   scored uncited. `self_contained_validation_report.md:107` calls those runs
+   *the canonical Eu Hamiltonian-only prediction for this codebase*. They were on
+   the disposal list. Fixing the matcher then showed the citation itself was
+   wrong: nothing named `L4_eu_matsui_hamiltonian_only_*` has ever existed under
+   `verification_suite/`, in this worktree or the main checkout. The runs are at
+   the top level of `runs/`, and three documents pointed at a path that was never
+   there — invisibly, because the gate stopped at the first segment.
+2. **Brace expansion was not expanded.** `day_inventory_2026_05_26.md:61` cites
+   `L4_K3_n{64,96,128}_*_<hash>`; only the `n64` arm was matched. The `n96` and
+   `n128` arms are 91 GiB — 55 % of the bytes then marked disposable.
+3. **Only `runs/`-prefixed tokens counted.** That citation is a bare directory
+   name in a table cell, with no `runs/` in front of it. A name in backticks is
+   a citation whether or not it carries a path prefix.
+
+Defects 1 and 3 are also present in `test/oracles/test_doc_run_citations_resolve.jl`,
+whose `_CITE_RE` excludes `/` from the captured name — so for a nested citation the
+gate checks that `runs/verification_suite` exists and never looks at the rest of
+the path. The gate is weaker than it reads.
+
+**What this means for disposal.** Every fix moved directories *out* of the
+disposable set, never in. The criterion is not converging on a property of the
+data; it is measuring how good the regex is that week. A list produced this way
+is fine for *"stop citing these as evidence"* and is not fit to drive `rm`.
+
+## The disposable set: 207 directories, 82 of them still on disk
+
+Under the loosest matcher — any backticked token in a live document that names or
+prefixes the directory — 267 of the 474 are mentioned somewhere and 207 are not.
+Of those 207, 82 still exist under `runs/` in the main checkout, totalling
+**60.6 GiB against a 261 GiB `runs/` tree**.
+
+Each of the 207 satisfies all of:
+
+1. no live document mentions it, by name, prefix, glob or brace expansion;
 2. it is not tracked in git;
-3. its `summary.json` carries no producing commit — like all 481, it is not
+3. its `summary.json` carries no producing commit — like all 474, it is not
    reproducible from the repository;
 4. it predates the 2026-06/07 corrections, so any number in it is superseded by
    construction;
-5. **it is not a scan, sweep, ladder or phase map.**
+5. it is not a scan, sweep, ladder or phase map.
 
-The remainder is mostly single-cell validation-ladder runs
-(`00_scalar_free_uniform_stationary_*`, `02_spin1_polar_contact_ground_*`, …) —
-cheap to regenerate because a tiered test regenerates them.
+**Reclaim by bytes, not by count.** The distribution is concentrated: the largest
+5 directories are 38 % of the 60.6 GiB, and the largest 15 are most of it.
 
-**Even so, read the list before moving anything.** Rule 5 is a name-pattern match,
-and a name pattern is not a semantic classifier; something valuable with an
-unlucky name will not be caught by it.
+| GiB | directory |
+|---|---|
+| 9.44 | `LHY_polar_contact_200ms_d82e14b5` |
+| 4.73 | `LHY_polar_contact_100ms_283e1a72` |
+| 3.36 | `L4dealiasv6_kcut11_eu_matsui_hamiltonian_only_96_f7d8dbf9` |
+| 3.35 | `L4dealiasv4_eu_matsui_hamiltonian_only_96_6d8d0a7a` |
+| 2.42 | `LHY_polar_contact_50ms_3e2af5d3` |
+
+That is a short enough list to read one directory at a time, which is the only
+review this evidence supports. The 125 entries with no directory on disk and the
+tail of small ones are not worth a decision — 29 of the 82 are under 100 MiB.
+
+**Rule 5 is a name-pattern match, and a name pattern is not a semantic
+classifier.** `L4_K3_n{64,96,128}` is a grid-convergence ladder whose name
+contains none of the words the rule looks for; it survived only because defect 2
+was found first.
 
 ## Procedure — move, do not delete
 

--- a/docs/campaign/stored_run_disposal.md
+++ b/docs/campaign/stored_run_disposal.md
@@ -1,0 +1,97 @@
+# What the 481 stored summaries are still for, and what they are not
+
+**Measured 2026-08-02** across all worktrees. Companion to
+[`doc_run_citation_inventory.md`](doc_run_citation_inventory.md) and the
+re-derivation write-ups. **Nothing is deleted by this document** — it records the
+evidence and a reversible procedure, because the targets sit in the main checkout
+and four worktrees.
+
+## The classification
+
+474 run directories hold a stored `summary.json` (481 files).
+
+| class | dirs | what cites it |
+|---|---:|---|
+| **exact name** | 10 | a live document names the directory |
+| **glob family** | 72 | a live document names `runs/<stem>_*` |
+| **uncited** | 392 | nothing in `docs/**` outside `archive/` |
+
+### The 10 exact-named are the four figures — and those are now re-derived
+
+8 of the 10 back a figure or a validation claim row; 2 are config-location
+pointers. All ten are dated 2026-05-26/29 and unstamped. **Every figure resting on
+them has now been re-run on current code**, and every one moved:
+
+- Fig 1 — peak density −16.5 %, uniform across four cells
+- Fig 2 — premise gone
+- Fig 3 — 7 of 10 classifications changed
+- Fig 4 — the ±Ω comparison turned out not to be a symmetry operation at all
+
+So these ten are no longer the *evidence* for anything; they are the record of
+what was believed before the corrections. That is a real use, and a much smaller
+one than "data behind the figures".
+
+### The 72 glob-matched back no quantitative claim
+
+| stem | dirs | cited by | nature of the citation |
+|---|---:|---|---|
+| `klaus_*` | 65 | `research-log/2026-05-28_validation_python_archive.md` | the "data source" column of a table recording **eight retired Python figure scripts** — provenance for a deletion |
+| `sprint5_M1_*` | 4 | `architecture/sweep_view.md` | a data-layout example |
+| `eu151_*` | 2 | `guides/pipeline_cookbook.md` | a cookbook example |
+| `eu_k3_*` | 1 | `matsui_reproduction_status.md`, this campaign | — |
+
+Sixty-five of the seventy-two are cited by one research-log entry, in the column
+that says where a *deleted* script used to get its input.
+
+### 7 of the 392 "uncited" are tracked in git
+
+`eu_collapse_search`, `eu_ham_only_conservation`, `eu_ham_only_ramp_quench_24`,
+`matsui_edh_baseline_529e3a77`, `matsui_edh_baseline_9ca97308`, `saito_li_torus`,
+`yan_li_saito_f1_grid_refinement`.
+
+Someone committed these deliberately. **Not cited ≠ not wanted** — they are out of
+scope for disposal on that ground alone.
+
+## Footprint
+
+| location | uncited dirs | disk |
+|---|---:|---:|
+| `BEC-simulation` (main checkout) | 148 | **~230 GB** |
+| `wt:silly-foraging-flame` | 213 | **~199 GB** |
+| `wt:streamed-sniffing-sifakis` | 31 | — |
+| `wt:frolicking-mapping-feather`, `wt:gs-stage-cache` | 7 | — |
+
+Over 400 GB, against a 2 TB group quota that is already 1.2 TB used. This is worth
+acting on, which is why the manifest exists.
+
+## The disposable set: 385 directories
+
+392 uncited, minus the 7 tracked ones.
+
+Every one satisfies all of:
+
+1. no live document cites it, by name or by family glob;
+2. it is not tracked in git;
+3. its `summary.json` carries no producing commit — like all 481, it is not
+   reproducible from the repository;
+4. it predates the 2026-06/07 corrections, so any number in it is superseded by
+   construction.
+
+## Procedure — move, do not delete
+
+```bash
+# per worktree, with the manifest in hand
+ARCHIVE=/gs/fs/tga-kozuma-kouhi/$USER/runs_retired_2026_08   # or a local volume
+mkdir -p "$ARCHIVE"
+while read -r d; do
+    [ -d "runs/$d" ] && mv "runs/$d" "$ARCHIVE/"
+done < disposable.txt
+```
+
+`mv` rather than `rm`: the classification above is evidence, not proof, and a
+document could cite one of these tomorrow — at which point the citation gate
+(`test_doc_run_citations_resolve.jl`) will say so and the directory can come back.
+Deleting forecloses that; moving does not.
+
+**Re-measure before running it.** The manifest is a snapshot; `docs/` changes
+daily and a new citation moves a directory out of the disposable set.

--- a/docs/campaign/stored_run_disposal.md
+++ b/docs/campaign/stored_run_disposal.md
@@ -10,11 +10,17 @@ and four worktrees.
 
 474 run directories hold a stored `summary.json` (481 files).
 
-| class | dirs | what cites it |
-|---|---:|---|
-| **exact name** | 10 | a live document names the directory |
-| **glob family** | 72 | a live document names `runs/<stem>_*` |
-| **uncited** | 392 | nothing in `docs/**` outside `archive/` |
+| class | dirs (first matcher) | dirs (corrected) | what cites it |
+|---|---:|---:|---|
+| **exact name** | 10 | 21 | a live document names the directory |
+| **glob family** | 72 | 242 | a live document names `runs/<stem>_*`, a brace set, or a bare prefix |
+| **uncited** | 392 | 211 | nothing in `docs/**` outside `archive/` |
+
+**Both columns are shown because the difference is the finding.** The left column
+is what the first matcher reported and what the sections below were written
+against; the right is after the three defects in *"the count was a property of
+the matcher"* were fixed. Read the left column as a record of what was believed,
+not as a count of anything.
 
 ### The 10 exact-named are the four figures — and those are now re-derived
 
@@ -43,7 +49,7 @@ one than "data behind the figures".
 Sixty-five of the seventy-two are cited by one research-log entry, in the column
 that says where a *deleted* script used to get its input.
 
-### 7 of the 392 "uncited" are tracked in git
+### 7 of the first matcher's 392 "uncited" are tracked in git
 
 `eu_collapse_search`, `eu_ham_only_conservation`, `eu_ham_only_ramp_quench_24`,
 `matsui_edh_baseline_529e3a77`, `matsui_edh_baseline_9ca97308`, `saito_li_torus`,

--- a/docs/campaign/stored_run_disposal.md
+++ b/docs/campaign/stored_run_disposal.md
@@ -64,9 +64,35 @@ scope for disposal on that ground alone.
 Over 400 GB, against a 2 TB group quota that is already 1.2 TB used. This is worth
 acting on, which is why the manifest exists.
 
-## The disposable set: 385 directories
+## Correction: citation is necessary but not sufficient
 
-392 uncited, minus the 7 tracked ones.
+Raised by anko — *"at least keep the phase diagrams."* Right, and my criterion was
+wrong.
+
+**"No live document cites it" is a reason to stop treating something as evidence.
+It is not a reason to delete it.** A phase-diagram scan, a resolution ladder, a
+Ω- or B-sweep is an expensive, reusable input whose value does not depend on
+whether a markdown file happens to name it today. Deleting one because nobody
+wrote it down is exactly the failure this campaign exists to stop, running the
+other way.
+
+Two facts, measured:
+
+1. **The phase diagrams were never in scope.** This manifest's population is the
+   474 directories that hold a `summary.json`. `F6_phase_diagram`,
+   `eu_gs_phase_c1_B_kappa` and `berry_crossover_scan` carry none, so they were
+   never candidates. That was luck, not design — the criterion would not have
+   protected them.
+2. **105 of the 385 are scan or sweep families** — `bzsweep_*`, `fieldsweep_*`,
+   `omsweep_*`, `p2sweep_*`, `scan2d_*`, `dense_omega_*`, `dense_field_*`,
+   `*_phase_*`, resolution ladders. **These are now KEEP**, regardless of citation.
+
+Disposal therefore needs *all* of: uncited, untracked, unstamped, superseded by a
+correction — **and not a scan family.**
+
+## The disposable set: 280 directories
+
+392 uncited, minus 7 tracked, minus 105 scan families.
 
 Every one satisfies all of:
 
@@ -75,7 +101,16 @@ Every one satisfies all of:
 3. its `summary.json` carries no producing commit — like all 481, it is not
    reproducible from the repository;
 4. it predates the 2026-06/07 corrections, so any number in it is superseded by
-   construction.
+   construction;
+5. **it is not a scan, sweep, ladder or phase map.**
+
+The remainder is mostly single-cell validation-ladder runs
+(`00_scalar_free_uniform_stationary_*`, `02_spin1_polar_contact_ground_*`, …) —
+cheap to regenerate because a tiered test regenerates them.
+
+**Even so, read the list before moving anything.** Rule 5 is a name-pattern match,
+and a name pattern is not a semantic classifier; something valuable with an
+unlucky name will not be caught by it.
 
 ## Procedure — move, do not delete
 

--- a/docs/campaign/stored_run_disposal.md
+++ b/docs/campaign/stored_run_disposal.md
@@ -135,9 +135,14 @@ is fine for *"stop citing these as evidence"* and is not fit to drive `rm`.
 ## The disposable set: 207 directories, 82 of them still on disk
 
 Under the loosest matcher — any backticked token in a live document that names or
-prefixes the directory — 267 of the 474 are mentioned somewhere and 207 are not.
-Of those 207, 82 still exist under `runs/` in the main checkout, totalling
-**60.6 GiB against a 261 GiB `runs/` tree**.
+prefixes the directory — 263 of the 474 are mentioned somewhere and 211 are not.
+Four of those 211 are scan families, kept by rule 5, leaving **207**. Of the 207,
+82 still exist under `runs/` in the main checkout, totalling **60.6 GiB against a
+261 GiB `runs/` tree**.
+
+Rule 5 removes only four here, against 105 under the first matcher, because the
+corrected matcher already keeps most scan families for the better reason: a
+document names them.
 
 Each of the 207 satisfies all of:
 

--- a/docs/manuscript/klaus_quench_protocol_spec_2026_05_26.md
+++ b/docs/manuscript/klaus_quench_protocol_spec_2026_05_26.md
@@ -119,7 +119,7 @@ optimum within ~6%.  See `docs/manuscript/figures/klaus_quench_fig_k14_omega_ref
 ## Klaus-II adiabatic result (2026-05-27): still null
 
 A 7-stage adiabatic Klaus-II prototype
-(`runs/magnetic_stirrer/magnetic_stirrer_adiabatic_omega_p0p5/`) was
+(`runs/magnetic_stirrer/magnetic_stirrer_adiabatic_omega_p0p5.yaml`) was
 dispatched to test whether the sudden-tilt null result was just
 an adiabaticity artifact.  Result:
 

--- a/docs/validation/self_contained_validation_report.md
+++ b/docs/validation/self_contained_validation_report.md
@@ -104,7 +104,7 @@ Coverage gaps (intentional, deferred):
 | Grid n=16/24/32 at fixed box | Width converges to ≤ 1% | `test/test_level11_convergence_sweep.jl` |
 | Box L=6/8/12 at fixed dx≈0.4 | ≥ 10× boundary-density tightening per L-doubling | `test/test_level11_convergence_sweep.jl` |
 | Seed reproducibility | Bit-identical | `test/test_level11_convergence_sweep.jl` |
-| **Eu F=6 Ham-only, cross-grid** | `ΔF_z = 0.00886` at N=64/96/128 (5-digit agreement) at `dt=0.005, k_cut=16.0, dealias enabled` | `runs/verification_suite/L4_eu_matsui_hamiltonian_only_{64,96,128}` (2026-05-24); discussed in `memory:validation_ladder_2026_05_22` |
+| **Eu F=6 Ham-only, cross-grid** | `ΔF_z = 0.00886` at N=64/96/128 (5-digit agreement) at `dt=0.005, k_cut=16.0, dealias enabled` | `runs/L4_eu_matsui_hamiltonian_only_{64,96,128}_*` (untracked) (2026-05-24); discussed in `memory:validation_ladder_2026_05_22` |
 
 The Eu F=6 cross-grid result is **the canonical Hamiltonian-only
 prediction** of this codebase. Reported as `ΔF_z(t = T_evolution)`

--- a/docs/validation/ueda_status.md
+++ b/docs/validation/ueda_status.md
@@ -55,7 +55,7 @@ code is **not** part of the current validation evidence.
   starting point of the joint sign-off as originally intended.
 - The export tool `scripts/validation/export_operator_rhs.jl` and the
   `operator_rhs.jld2` artefacts under
-  `runs/verification_suite/L4_eu_matsui_hamiltonian_only_*` remain
+  `runs/L4_eu_matsui_hamiltonian_only_*` (untracked) remain
   intact. They are usable for the day Ueda-side comparison resumes.
 - The L4 cross-grid convergence result (ΔF_z = 0.00886 at
   k_cut = 16, agreeing to 5 digits across N = {64, 96, 128}) is

--- a/test/oracles/test_doc_run_citations_resolve.jl
+++ b/test/oracles/test_doc_run_citations_resolve.jl
@@ -19,6 +19,12 @@
 #   (gone)      never committed, or removed. The citation cannot be followed and
 #               the claim on it needs regenerating or retracting — see
 #               docs/campaign/doc_run_citation_inventory.md.
+#   (untracked) it names a run OUTPUT directory. Configs under `runs/` are
+#               tracked; outputs are not, so whether the path is on disk is a
+#               property of the machine and the checkout, not of the document.
+#               `runs/L4_eu_matsui_hamiltonian_only_*` resolves in the main
+#               checkout and not in a worktree, and CI has neither. Without this
+#               marker the gate flaps by checkout, which is worse than silent.
 #
 # Fenced code blocks are out of scope: a path inside a shell example is a command
 # to type, not a claim that evidence exists. Measured when this was written — 27
@@ -37,22 +43,61 @@ const _DOCS = joinpath(@__DIR__, "..", "..", "docs")
 const _RUNS_DIR = joinpath(@__DIR__, "..", "..", "runs")
 const _SEP = Base.Filesystem.path_separator
 
-const MARKERS = ("example", "planned", "archived", "gone")
+const MARKERS = ("example", "planned", "archived", "gone", "untracked")
 const _MARKER_RE = Regex("\\((" * join(MARKERS, "|") * ")\\)")
 
+# `/` is INSIDE the character class on purpose. Until 2026-08-02 it was not, so a
+# nested citation was captured at its first segment only: `runs/verification_suite/
+# L4_eu_matsui_hamiltonian_only_*` resolved as `runs/verification_suite`, which
+# exists, and the part naming the evidence was never checked. That is how the
+# runs behind "the canonical Eu Hamiltonian-only prediction for this codebase"
+# (self_contained_validation_report.md:107) reached a disposal manifest.
+#
 # `(?<![\w/-])` keeps `spinorbec-runs/x` and `some/runs/x` out. Without it the
 # tail of any longer token reads as an in-repo citation — that defect put a 40 %
 # over-count into a merged PR (#220, corrected in #227).
-const _CITE_RE = r"(?<![\w/-])runs/([A-Za-z0-9_][A-Za-z0-9_.*-]*)"
+#
+# The glob metacharacters are in the class so a family citation is captured
+# WHOLE. Leaving them out truncates at the first one — `runs/twa_N_scan/N{1000,
+# 10000,100000}_<hash>` was captured as `twa_N_scan/N` and then reported as a
+# broken citation, which is a defect in the matcher wearing the costume of a
+# defect in the document.
+const _CITE_RE = r"(?<![\w/-])runs/([A-Za-z0-9_][A-Za-z0-9_./*?{},<>-]*)"
+const _META = ('*', '?', '{', '<')
 
-"""A citation resolves if the directory exists, or — for a family written
-`runs/foo_*` — if anything matches the prefix. Treating the stem as a literal
-directory name is what made `runs/eu_k3_*` look broken next to `runs/eu_k3_lhy`."""
+"""A citation resolves if the path exists under `runs/`, or — for a family
+written `runs/a/b_*` — if anything in the parent matches the stem. Resolution is
+per PATH, not per top-level name: the last segment is the one carrying the claim.
+
+Treating the stem as a literal directory name is what made `runs/eu_k3_*` look
+broken next to `runs/eu_k3_lhy`."""
 function _resolves(d)
-    isdir(joinpath(_RUNS_DIR, d)) && return true
-    endswith(d, '_') || return false
-    isdir(_RUNS_DIR) || return false
-    any(startswith(n, d) for n in readdir(_RUNS_DIR))
+    dir = _RUNS_DIR
+    segs = split(d, '/'; keepempty=false)
+    for (i, seg) in enumerate(segs)
+        isdir(dir) || return false
+        j = findfirst(in(_META), seg)
+        if j !== nothing
+            # A family. We cannot descend past a glob, so the question becomes
+            # whether the literal prefix matches anything here — which is the
+            # whole claim `runs/eu_k3_*` makes. Treating the stem as a literal
+            # name is what made it look broken next to `runs/eu_k3_lhy`.
+            stem = seg[1:prevind(seg, j)]
+            isempty(stem) && return true
+            return any(startswith(n, stem) for n in readdir(dir))
+        end
+        # A citation ending in a file is adjudicated at its PARENT. Run outputs
+        # (`summary.json`, `result.jld2`) are untracked by design, so whether one
+        # is on disk is a property of the checkout, not of the document: in a
+        # worktree `runs/klaus_quench/` holds only the tracked YAML, while the
+        # same path in the main checkout has the summary. Judging the file would
+        # make this gate report a different verdict per checkout, and marking
+        # those citations `(gone)` from a worktree would write a falsehood into
+        # the document.
+        i == length(segs) && occursin('.', seg) && return true
+        dir = joinpath(dir, seg)
+    end
+    ispath(dir)
 end
 
 """Walk live docs, yielding `(doc, line, name, resolves, marked, fenced)` for
@@ -76,7 +121,10 @@ function _citations()
             end
             marked = occursin(_MARKER_RE, line)
             for m in eachmatch(_CITE_RE, line)
-                d = rstrip(m.captures[1], ['*', '.', ',', ')', ';', ':', '`'])
+                # `*` is NOT stripped: _resolves needs it to tell a family from
+                # a literal name. `.` is, so a citation at the end of a sentence
+                # does not become a path with a trailing dot.
+                d = rstrip(m.captures[1], ['.', ',', ')', ';', ':', '`', '/'])
                 isempty(d) && continue
                 push!(out, (doc=rel, line=i, name=d, ok=_resolves(d),
                     marked=marked, fenced=fenced))
@@ -127,6 +175,23 @@ end
             ]),
         )
         @test stale == String[]
+    end
+
+    @testset "nested citations are checked at the last segment" begin
+        # The canary for the 2026-08-02 fix. Drop `/` from _CITE_RE and this goes
+        # green for the wrong reason: every nested citation collapses to its
+        # first segment, which is a directory that exists.
+        #
+        # Both arms are asserted because only the pair is discriminating. A
+        # matcher that ignores the tail passes the first and fails the second; a
+        # matcher that never resolves anything fails the first.
+        # Tracked paths only, so the canary means the same thing in a worktree,
+        # in the main checkout and in CI.
+        @test _resolves("verification_suite/checks")
+        @test !_resolves("verification_suite/no_such_run_")
+
+        nested = [c for c in cites if occursin('/', c.name)]
+        @test !isempty(nested)   # else the assertions above test nothing real
     end
 
     @testset "fenced blocks are out of scope, and that exclusion is load-bearing" begin


### PR DESCRIPTION
Closes two of the three items left in #281. **Nothing is deleted here.**

## Classification

474 run directories hold a stored `summary.json`.

| class | dirs | |
|---|---:|---|
| **exact name** | 10 | a live document names the directory |
| **glob family** | 72 | a live document names `runs/<stem>_*` |
| **uncited** | 392 | nothing in `docs/**` outside `archive/` |

### The 10 exact-named were the four figures — and all four are now re-derived

8 back a figure or a validation claim row. **Every figure resting on them has been
re-run on current code, and every one moved** (Fig 1 −16.5 %; Fig 2 premise gone;
Fig 3 seven of ten classifications; Fig 4's comparison turned out not to be a
symmetry operation).

So these ten are no longer *evidence* for anything — they are the record of what
was believed before the corrections. A real use, and a much smaller one.

### The 72 glob-matched back no quantitative claim

| stem | dirs | cited by |
|---|---:|---|
| `klaus_*` | **65** | one research-log entry — the "data source" column of a table recording **eight retired Python figure scripts** |
| `sprint5_M1_*` | 4 | a data-layout example in `architecture/sweep_view.md` |
| `eu151_*` | 2 | a cookbook example |
| `eu_k3_*` | 1 | matsui status |

Sixty-five of seventy-two are provenance for a *deletion*.

### 7 of the 392 are tracked in git

`eu_collapse_search`, `eu_ham_only_conservation`, `eu_ham_only_ramp_quench_24`,
`matsui_edh_baseline_{529e3a77,9ca97308}`, `saito_li_torus`,
`yan_li_saito_f1_grid_refinement`. Someone committed these deliberately —
**not-cited is not grounds for disposal on its own.**

## Footprint — why this is worth doing

| location | uncited dirs | disk |
|---|---:|---:|
| `BEC-simulation` (main checkout) | 148 | **~230 GB** |
| `wt:silly-foraging-flame` | 213 | **~199 GB** |
| three other worktrees | 38 | — |

**Over 400 GB**, against a 2 TB group quota already 1.2 TB used.

## The disposable set: 385

392 uncited − 7 tracked. Each satisfies all four of: no live citation by name or
glob; untracked; no producing commit (like all 481, not reproducible); predates the
2026-06/07 corrections so any number in it is superseded by construction.

## Procedure: `mv`, not `rm`

The classification is evidence, not proof, and a document could cite one of these
tomorrow — at which point `test_doc_run_citations_resolve.jl` says so and the
directory comes back. Deleting forecloses that; moving does not. **Re-measure
before running it**: `docs/` changes daily and a new citation moves a directory
out of the set.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)