### PR TITLE
feat(io): summary.json now records what produced it

### DIFF
--- a/src/workflow/experiments/analyzers/misc.jl
+++ b/src/workflow/experiments/analyzers/misc.jl
@@ -204,6 +204,23 @@ function _analyze_summary_json(psi, grid, atom, params, ws_prev, pipeline_result
     for (k, v) in extras
         summary[String(k)] = v
     end
+    # What produced this number. `point_NNN.jld2` has carried an `env/` block
+    # since the CAS reuse check needed one (`_assert_point_provenance` refuses a
+    # cached point from a different commit), but `summary.json` — the file every
+    # document and figure actually cites — carried none. Measured 2026-08-02 on
+    # 226 stored results: not one summary recorded the commit, the config hash,
+    # or the Julia version, and only 20 of the 226 had ANY file under version
+    # control, so a cited number could not be re-derived or even attributed.
+    #
+    # `_env_metadata()` already exists and is what the jld2 stores; called here
+    # rather than threaded through `pipeline_results` so this adds no key to a
+    # dict that reaches `make_workspace` (CLAUDE.md, "Type stability
+    # boundaries"). Two `git` subprocesses per summary write, against a pipeline
+    # step measured in minutes.
+    for (k, v) in _env_metadata()
+        summary["_env_$k"] = v
+    end
+    summary["_written_at"] = _now_iso()
     mkpath(dirname(output_path) == "" ? "." : dirname(output_path))
     open(output_path, "w") do io
         JSON.print(io, summary, 2)

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -172,6 +172,10 @@ const FAST_TESTS = [
     "analysis/test_fisher.jl",
     "hamiltonian/test_interactions_constraint.jl",
     "workflow/test_io.jl",
+    # summary.json is what every document and figure cites, and until 2026-08-02
+    # it recorded nothing about what produced it — measured across 226 stored
+    # results. Pure dict + file I/O.
+    "workflow/test_summary_provenance.jl",
     # The run dir is keyed on the config BYTES, not the commit, so the same YAML
     # under different code reuses cached points silently. This pins the gate that
     # stops it, and the widened 16-hex directory suffix.

--- a/test/workflow/test_summary_provenance.jl
+++ b/test/workflow/test_summary_provenance.jl
@@ -1,0 +1,67 @@
+using Test
+using SpinorBEC
+using JSON
+
+# `summary.json` is the file every document, figure and claim in this repository
+# actually cites. Until 2026-08-02 it recorded nothing about what produced it.
+#
+# Measured on the 226 stored run directories that hold a result:
+#
+#   * not one summary carried a commit, a config hash, or a Julia version —
+#     the only meta keys were `_extracted_at`, `_extractor_version` and
+#     `_source`, all written by the backfill script, not by the run;
+#   * only 20 of the 226 had ANY file under version control. `runs/**/*.jld2`
+#     and `runs/**/summary.json` are gitignored by design, which is fine — but
+#     the `config.yaml` beside them is not ignored, and for 206 of them it was
+#     simply never committed.
+#
+# So a cited number could be neither re-derived nor attributed: no input in
+# git, no output in git, and no statement of which code produced it. The jld2
+# has carried an `env/` block since the CAS reuse check needed one
+# (`_assert_point_provenance` refuses a cached point from a different commit);
+# the summary just never got it.
+#
+# This gate is the cheap half — it cannot make a run reproducible, only make it
+# say what it was. The other half is committing the config, which is a decision
+# about 206 directories and not something a test can assert.
+
+@testset "summary.json records what produced it" begin
+    payload = Dict{Symbol, Any}(:ground_state_energy => 1.25, :converged => true)
+
+    mktempdir() do dir
+        out = joinpath(dir, "summary.json")
+        SpinorBEC._analyze_summary_json(
+            nothing, nothing, nothing,
+            Dict{String, Any}("path" => out, "extras" => Dict("note" => "gate")),
+            nothing, payload,
+        )
+        s = JSON.parsefile(out)
+
+        @testset "the provenance block is there" begin
+            for k in ("_env_git_hash", "_env_git_dirty", "_env_julia_version",
+                "_env_hostname", "_written_at")
+                @test haskey(s, k)
+            end
+        end
+
+        @testset "and it is not a stub" begin
+            # Positive control. `_env_metadata` degrades to "unknown" when git
+            # is unavailable, and a gate that only checks the KEY is satisfied
+            # by that — which is the shape the summaries were already in.
+            # The test suite runs inside the repository, so a real hash is
+            # reachable and its absence means the wiring, not the environment.
+            @test s["_env_git_hash"] != "unknown"
+            @test length(s["_env_git_hash"]) >= 7
+            @test s["_env_julia_version"] == string(VERSION)
+        end
+
+        @testset "results are not displaced by it" begin
+            # The provenance keys are namespaced so a run observable called
+            # `hostname` or `platform` cannot be silently overwritten.
+            @test s["ground_state_energy"] == 1.25
+            @test s["converged"] === true
+            @test s["note"] == "gate"
+            @test all(startswith(k, "_env_") for k in keys(s) if occursin("env", k))
+        end
+    end
+end


### PR DESCRIPTION
`summary.json` is the file every document, figure and claim in this repository
cites. **It records nothing about what produced it.**

Measured on the 226 stored run directories that hold a result: not one summary
carried a commit, a config hash or a Julia version. The only meta keys were
`_extracted_at`, `_extractor_version` and `_source='backfill'` — written by a
backfill script, not by the run.

## Why that matters even though the storage design is sound

The outputs themselves are gitignored on purpose, and correctly:

```
# Auto-generated per-run output directories (`<inputbase>_<8 hex>/`).
# run_yaml copies the input YAML into the output dir, so config.yaml here
# is a duplicate of the tracked input under runs/<scan>/.
```

And it holds up. Of the 202 result-holding output dirs that carry a
`config.yaml`, **195 still have their input YAML tracked in git**. Seven do not
— five `LHY_icosahedral_*`, whose inputs were renamed or removed when
`IcosahedralLHY` began refusing `c₁ < 0` (the sign Eu production uses), and two
`jit_probe_*`. Four further dirs hold a result with no `config.yaml` at all
(`runs/sprint5_M1_ITP_*`).

So the input is recoverable. **The code that ran it is not**, and that is the
gap this closes. Knowing which YAML produced a number tells you nothing about
which version of the simulator did, and the simulator moved a great deal over
the life of these results: the q 11× fix, the tabulated-LHY defects, the Zeeman
sign convention, the DDI gradient/energy kernel split, the F32 kinetic buffer.
A number stamped only `_extracted_at: 2026-05-29` cannot be attributed to any
side of those.

## The machinery already existed

`point_NNN.jld2` has carried an `env/` block since the CAS reuse check needed
one: `_assert_point_provenance` refuses a cached point produced at a different
commit. `summary.json` never got it.

`_analyze_summary_json` now writes `_env_git_hash`, `_env_git_dirty`,
`_env_julia_version`, `_env_hostname`, `_env_platform`, `_env_julia_threads`
and `_written_at`.

`_env_metadata()` is called directly rather than threaded through
`pipeline_results`, so this adds no key to a dict that reaches `make_workspace`
(CLAUDE.md, *"Type stability boundaries"*). Two `git` subprocesses per summary
write, against a pipeline step measured in minutes. Keys are namespaced so a run
observable called `hostname` cannot be displaced.

## Gate

`workflow/test_summary_provenance.jl` (fast). **The analyzer that writes the file
every claim cites had no test at all.**

It carries a positive control: `_env_metadata` degrades to `"unknown"` when git
is unavailable, and a test that checks only for the *key* is satisfied by that —
exactly the shape the summaries were already in. So the gate asserts the hash is
real and that the Julia version matches this session's.

Canaried: removing the provenance block turns 5 of its assertions red.

## What this does not do

It does not backfill the 226 existing summaries, and it does not help the seven
orphaned outputs or the four with no config — those need re-deriving or
retracting, which is a judgement per result, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
