### PR TITLE
Two claims were struck through over data that is sitting on disk

### DIFF
--- a/docs/campaign/doc_run_citation_inventory.md
+++ b/docs/campaign/doc_run_citation_inventory.md
@@ -78,7 +78,29 @@ lost; the citation points at the pre-move path. Repointing it is a doc fix.
 `12174e883326ecac`). These describe a tree the reader does not have. They mislead,
 but they assert no result.
 
-### Live claims with a stated result — 4
+### Live claims with a stated result — 4, of which 2 were false alarms
+
+> **Correction (2026-08-02): two of these four are on disk.** This list was built
+> with the matcher whose three defects are documented in
+> [`stored_run_disposal.md`](stored_run_disposal.md). Re-adjudicated with the
+> fixed resolver against the main checkout:
+>
+> | run | verdict | what is actually there |
+> |---|---|---|
+> | `lhy_mode_ablation` | absent | — |
+> | `twa_sinatra` | absent | — |
+> | `sprint5_M1_multistart_groundstate` | **on disk** | 30 `cell_B*_Om*.jld2` + `groundstate_audit.jld2`, 83 MB |
+> | `ddi_convention_factorial` | **on disk** | `results.jld2`, 10 885 bytes, 2026-05-26 |
+>
+> Both are **untracked**, so they are invisible from a clone, from CI and from a
+> worktree — but the numbers they back can be re-checked in the main checkout.
+> The two documents that had struck their claims through on the strength of this
+> list have been corrected (`m1_groundstate_audit_2026-06-08.md`,
+> `self_contained_validation_report.md` Layer F). Reading "untracked" as "gone" is
+> the same conflation that put the canonical Eu Hamiltonian-only runs on a
+> disposal list.
+>
+> **The regenerate-or-retract list is therefore 2, not 4.**
 
 **This is the regenerate-or-retract list.**
 

--- a/docs/campaign/doc_run_citation_inventory.md
+++ b/docs/campaign/doc_run_citation_inventory.md
@@ -94,6 +94,9 @@ but they assert no result.
 >
 > Both are **untracked**, so they are invisible from a clone, from CI and from a
 > worktree — but the numbers they back can be re-checked in the main checkout.
+> Both also have a **producer committed** — `scripts/m1_b1_multistart_newton.jl`
+> and `scripts/validation/run_validation_matrix.jl` — so they are regenerable
+> too, not merely re-readable. Neither retraction was warranted on any reading.
 > The two documents that had struck their claims through on the strength of this
 > list have been corrected (`m1_groundstate_audit_2026-06-08.md`,
 > `self_contained_validation_report.md` Layer F). Reading "untracked" as "gone" is

--- a/docs/campaign/stored_run_disposal.md
+++ b/docs/campaign/stored_run_disposal.md
@@ -181,6 +181,40 @@ classifier.** `L4_K3_n{64,96,128}` is a grid-convergence ladder whose name
 contains none of the words the rule looks for; it survived only because defect 2
 was found first.
 
+## Third correction: 249 of 251 are regenerable, not 32
+
+The campaign's alarm was that stored results are unattributable. Measured
+directly — for each run directory holding data, is there **any** committed
+artifact that names it?
+
+| | dirs |
+|---|---:|
+| a recipe is reachable in git (tracked YAML, or a script/test that names it) | **249** |
+| nothing in git names it | **2** — `dipole_field_demo`, `yan_li_saito_f1_torus_gs_disc`, 0.1 GiB total, cited by no document |
+
+**That measurement moved 219 → 166 → 62 → 2**, and every step was a defect in the
+question, not a change in the tree:
+
+1. **"Recipe" was assumed to mean a YAML in the run directory.** Most of this work
+   was driven by committed *scripts* — `scripts/m1_b1_multistart_newton.jl`,
+   `scripts/validation/run_validation_matrix.jl` — which are recipes.
+2. **Directory names were matched whole**, so every CAS name lost to its
+   `_<hash>` suffix. Matching the stem too recovered 104.
+3. **Only file *contents* were searched**, not tracked *filenames*. The factorial
+   arms live at `runs/eu_robust_factorial/K0_gdr0_LHY1.yaml` — the config is
+   committed, under a name no content grep would surface. That recovered 60.
+
+This is the same failure as the citation matcher two sections up, a fourth time
+in one session: **a single assumed form for the thing being looked for, and
+everything outside that form reported as absent.** Each fix moved the count one
+way. When that happens, stop and measure what the question is excluding.
+
+**What this does not soften.** A committed script that names a directory is not
+the same as a reproducible run: it does not pin the commit, the parameters, or
+the Julia version, which is precisely the gap #290 closes for `summary.json` going
+forward. The claim here is narrow and worth having anyway — the stored tree is not
+an orphanage. It is 2 directories and 0.1 GiB of orphans.
+
 ## Procedure — move, do not delete
 
 ```bash

--- a/docs/research_notes/m1_groundstate_audit_2026-06-08.md
+++ b/docs/research_notes/m1_groundstate_audit_2026-06-08.md
@@ -1,17 +1,23 @@
 # M1 sweep — gate (1) ground-state-ness audit (2026-06-08)
 
-> **その sweep は git に無い (2026-07-31)。** `runs/sprint5_M1_multistart_groundstate/` (gone)
-> はどの commit にも存在せず、下記の数値は再チェックできない。解析側
-> (`scripts/m1_groundstate_audit.jl`) はコミットされているので手順は再現できるが、
-> 入力の 30 セル (B × Ω, Eu F=6, 24³, 50k) が無い。
+> **訂正 (2026-08-02): sweep は在る。** 2026-07-31 の版はここに「どの commit にも
+> 存在せず、下記の数値は再チェックできない」「入力の 30 セルが無い」と書いていた。
+> **誤り。** `runs/sprint5_M1_multistart_groundstate/` (untracked) は 30 セル
+> (`cell_B*_Om*.jld2`) と `groundstate_audit.jld2`、計 31 ファイル 83 MB が
+> main checkout に揃っている。
 >
-> 再生成は可能だが安くはなく、本監査は自ら **gate (1) のみ**（saddle 除去と
-> vortex 解像度は pending）と述べているので、暫定結果のために sweep を回すのは
-> 優先度が低い。**現状は「証拠を辿れない暫定監査」として読むこと。**
-> 全体像: [`doc_run_citation_inventory.md`](../../campaign/doc_run_citation_inventory.md)。
+> 正しい制約は **untracked であること** — git に無いので clone からは再現できず、
+> CI にも worktree にも見えない。しかし手元では**数値を辿り直せる**。
+> 「追跡外」を「消失」と読み替えたのが元の誤りで、これは廃棄 manifest が
+> 474 件で犯したのと同じ取り違えである
+> ([`stored_run_disposal.md`](../campaign/stored_run_disposal.md))。
+>
+> 監査自体の限界は変わらない: 自ら **gate (1) のみ**（saddle 除去と vortex 解像度は
+> pending）と述べている。
+> 全体像: [`doc_run_citation_inventory.md`](../campaign/doc_run_citation_inventory.md)。
 
 First physics-gated extraction from the on-disk 30-cell rotating-frame
-sweep (`runs/sprint5_M1_multistart_groundstate/` (gone), B × Ω, Eu F=6, 24³,
+sweep (`runs/sprint5_M1_multistart_groundstate/` (untracked), B × Ω, Eu F=6, 24³,
 50k atoms). Produced by `scripts/m1_groundstate_audit.jl`.
 
 Gate (1) of the phase verdict: the gradients are gated (master oracle)

--- a/docs/validation/self_contained_validation_report.md
+++ b/docs/validation/self_contained_validation_report.md
@@ -114,20 +114,26 @@ production runs.
 ### Layer F — DDI convention factorial
 
 Script: `test/hamiltonian/test_ddi_convention_factorial.jl` — **in `FAST_TESTS`,
-so it runs on every PR.** ~~Output: `runs/ddi_convention_factorial/results.jld2` (gone).~~
+so it runs on every PR.** Output: `runs/ddi_convention_factorial/results.jld2` (untracked).
 
-> **The authority here is the test, not the table (2026-07-31).**
-> `runs/ddi_convention_factorial/` (gone) has never existed in any commit, so the numeric
-> rows below cannot be re-checked. That matters less than it does elsewhere,
-> because what the test asserts is the *relations* — spherical → 0 (traceless Q),
-> prolate along B → E_DDI < 0 (head-to-tail attractive), oblate ⊥ B → E_DDI > 0,
-> and invariance under the axis flip — and those are gated on every push. The
-> vintage audit's own carve-out applies: "everything gated by a test in a tier"
-> is unaffected.
+> **Correction (2026-08-02): the output is on disk.** The 2026-07-31 version of
+> this box said `runs/ddi_convention_factorial/` (untracked) "has never existed in any commit,
+> so the numeric rows below cannot be re-checked", and struck the output line
+> through. Half right and wrongly concluded: **no commit contains it — and
+> `results.jld2` is 10 885 bytes in the main checkout, dated 2026-05-26.** It is
+> untracked, not gone, so it is invisible from a clone, from CI and from a
+> worktree, and the rows below *can* be re-checked here.
 >
-> So: **the physics stands, the printed numbers are illustration.** They were
-> produced by a run that is not in the repository and are not asserted anywhere.
-> Quote the relations, or re-run the test and quote its output.
+> The mistake was reading "untracked" as "absent" — the same conflation the
+> disposal manifest made across 474 directories, and the reason the citation gate
+> now carries an `(untracked)` marker
+> ([`stored_run_disposal.md`](../campaign/stored_run_disposal.md)).
+>
+> **The authority here is still the test, not the table.** What the test asserts
+> is the *relations* — spherical → 0 (traceless Q), prolate along B → E_DDI < 0
+> (head-to-tail attractive), oblate ⊥ B → E_DDI > 0, and invariance under the axis
+> flip — and those are gated on every push, which no stored number is. Quote the
+> relations, or re-run the test and quote its output.
 
 Factors: cloud shape ∈ {spherical, prolate, oblate}; B-axis ∈ {z, x};
 secular ∈ {false, true}; grid n ∈ {16, 24}. 24 rows total.


### PR DESCRIPTION
Follow-on to #288. The citation inventory's **regenerate-or-retract list** was built with the matcher whose three defects that PR documents. Re-adjudicated with the fixed resolver against the main checkout, **two of its four entries resolve**:

| run | verdict | what is actually there |
|---|---|---|
| `lhy_mode_ablation` | absent | — |
| `twa_sinatra` | absent | — |
| `sprint5_M1_multistart_groundstate` | **on disk** | 30 `cell_B*_Om*.jld2` + `groundstate_audit.jld2`, 83 MB |
| `ddi_convention_factorial` | **on disk** | `results.jld2`, 10 885 bytes, 2026-05-26 |

Both are untracked — invisible from a clone, from CI and from a worktree, present where the numbers were produced.

Acting on the old list, two documents retracted claims they did not need to retract:

- `m1_groundstate_audit_2026-06-08.md` — *"どの commit にも存在せず、下記の数値は再チェックできない … 入力の 30 セルが無い"*, of a sweep that is **entirely there**.
- `self_contained_validation_report.md` Layer F — struck through the output line and told the reader the numeric rows *"cannot be re-checked"*.

Reading **untracked as gone** is the same conflation that put the canonical Eu Hamiltonian-only runs on a disposal list, and it is why the gate now carries an `(untracked)` marker.

Layer F's substantive point is unchanged and restated rather than dropped: the authority is the test, which runs on every push — not any stored number. The correction is about what the reader is told is *available*, not about what is *asserted*.

Regenerate-or-retract is **2, not 4**.