### PR TITLE
The integrator was 15% of the job: stage cache −12%, sysimage and unpadded DDI both measured and rejected

### DIFF
--- a/docs/validation/where_the_campaign_time_goes.md
+++ b/docs/validation/where_the_campaign_time_goes.md
@@ -115,18 +115,45 @@ startup.
 build flag. Out of scope for a performance pass, and recorded here so the next
 person does not re-derive the 364 s estimate.
 
+## Dropping the DDI padding costs half the residual — not taken
+
+Zero-padding is 21 % of the step at 32³. The campaign's own kernel factorial had
+put its effect on the dip centre at **0.0016 nT** — but that was measured at
+`N = 5×10⁴` and production runs `N = 3.5×10⁴`, so it was re-measured rather than
+inherited (UGE 8319532, 45 points, same config with `padded: false`).
+
+Prediction recorded in the config before the run: centre within 0.005 nT, and
+not worth taking beyond 0.01 nT.
+
+| | centre [nT] | width [nT] |
+|---|---|---|
+| padded (production) | −2.5099 | 12.7400 |
+| unpadded | −2.4913 | 12.7284 |
+| **difference** | **+0.0187** | −0.0116 |
+| Matsui | −2.5495 | 12.7524 |
+
+**The centre moves 0.0187 nT — 12× the figure that would have been inherited**,
+47 % of the whole unexplained 0.040 nT residual, and in the direction *away* from
+Matsui (0.0396 → 0.0582). Per-field `N_{m=−6}` shifts by up to 5.3×10⁻³.
+
+The saving was 528.5 → 510.2 s (−18.3 s, −3.5 %). Trading half the residual for
+3.5 % of wall-clock is not a trade worth making, so production keeps `padded:
+true`. The unpadded config is kept as the A/B.
+
+The transferable part: a kernel-treatment difference measured at one atom number
+did **not** carry to another 30 % away. Two earlier retractions in this campaign
+came from exactly that kind of inheritance.
+
 ## What is left
 
-1. **Drop the DDI zero-padding for this observable.** 21 % of the step at 32³,
-   19 s over the campaign, and the campaign's own kernel factorial already
-   measured its effect on the answer: **0.0016 nT**, against a dip centre of
-   −2.51 and a residual of 0.040. Not applied here, because it does change the
-   physics — small is not zero, and that is the user's call, not a silent edit.
-2. **The integrator.** Caps out at the 92 s of stepping — 15 % of the job — and
-   RK4IP specifically is a *loss* at this tolerance (`rk4ip_cost_on_gpu.md`).
+**The integrator**, which caps out at the 92 s of stepping — 15 % of the job —
+and where RK4IP specifically is a *loss* at this tolerance
+(`rk4ip_cost_on_gpu.md`).
 
 Net result of this pass: **600.3 → 528.5 s, −12 %**, from one environment
-variable that was already in the repo.
+variable that was already in the repo. The two larger-looking levers — a
+sysimage and the DDI padding — were both measured and both rejected, one because
+it made the job slower and one because it moved the physics.
 
 ## Method note
 

--- a/docs/validation/where_the_campaign_time_goes.md
+++ b/docs/validation/where_the_campaign_time_goes.md
@@ -51,23 +51,46 @@ Three results:
   20.19; 0.604 → 0.403). Turning it off drops the DDI path to 1st order, so this
   is what the accuracy costs, not a free saving.
 
-## What is worth doing, in measured order
+## Applied and re-measured: the stage cache
 
-1. **A sysimage.** ~355 s of 600 (59 %) is startup and first-point JIT.
-   `scripts/build_sysimage.jl` and `build_sysimage_full.jl` already exist and the
-   Matsui submit script does not use one.
-2. **`SPINORBEC_STAGE_CACHE=1`.** The ground state is identical across all 45
-   points — the scan axis is `pipeline.1.B.Bz.to`, inside the *dynamics* block —
-   and the stage cache is opt-in and off by default. Other submit scripts in this
-   repo (`runs/eu_gs_phase_c1_B_kappa/*.sh`) set it; the Matsui one does not.
-   Bounded above by the 143 s of per-point setup.
-3. **Drop the DDI zero-padding for this observable.** Worth 21 % of the step at
-   32³ (19 s over the campaign), and the campaign's own kernel factorial already
+The scan axis is `pipeline.1.B.Bz.to`, inside the *dynamics* block, so all 45
+points share one ground state and each was re-relaxing it. `SPINORBEC_STAGE_CACHE`
+has existed all along, opt-in and off by default; other submit scripts in this
+repo (`runs/eu_gs_phase_c1_B_kappa/*.sh`) set it, the Matsui one did not.
+
+A/B on this exact config (UGE 8318863, 3 points): **5.44 → 3.93 s/point, −27.8 %.**
+
+Whole job, same 45 points:
+
+| | `ru_wallclock` |
+|---|---|
+| before (8310846.15) | 600.3 s |
+| **with the stage cache (8318964.15)** | **528.5 s** |
+| | **−71.8 s (−12 %)** |
+
+Predicted 44 × 1.51 = 66 s, measured 72 s. The log confirms the mechanism rather
+than just the number: `GS stage-cache key` 45 times, `Loading cached GS` **44**
+— point 1 populates, the other 44 reuse. No physics change; it is the same
+ground state, loaded instead of re-relaxed.
+
+## What is left, in measured order
+
+1. **A sysimage — up to ~364 s (65 % of the job), and this figure is an
+   ESTIMATE.** `scripts/build_sysimage.jl` and `build_sysimage_full.jl` exist and
+   the Matsui submit uses neither, but a sysimage only removes JIT for the
+   methods its precompile workload actually exercises, and **neither script
+   targets this code path** — the first builds the rotating-basis F=1 API, the
+   second the M0/M1/M2 F=6 24³ LBFGS cascade (with a 28-30 GB RSS warning).
+   `build_sysimage.jl` also activated `@__DIR__/../..`, the parent of the repo,
+   which has no `Project.toml` — fixed here, untested. Treat the 364 s as an
+   upper bound until a Matsui-representative sysimage is built and timed.
+2. **Drop the DDI zero-padding for this observable.** 21 % of the step at 32³,
+   19 s over the campaign, and the campaign's own kernel factorial already
    measured its effect on the answer: **0.0016 nT**, against a dip centre of
-   −2.51 and a residual of 0.040. Cheap in a way the other kernel knobs are not.
-4. **The integrator.** Caps out at the 15 % of the job that is stepping, and
-   RK4IP specifically is a *loss* at this tolerance
-   (`rk4ip_cost_on_gpu.md`).
+   −2.51 and a residual of 0.040. Not applied here, because it does change the
+   physics — small is not zero, and that is the user's call, not a silent edit.
+3. **The integrator.** Caps out at the 92 s of stepping — 15 % of the job — and
+   RK4IP specifically is a *loss* at this tolerance (`rk4ip_cost_on_gpu.md`).
 
 ## Method note
 

--- a/docs/validation/where_the_campaign_time_goes.md
+++ b/docs/validation/where_the_campaign_time_goes.md
@@ -73,24 +73,60 @@ than just the number: `GS stage-cache key` 45 times, `Loading cached GS` **44**
 — point 1 populates, the other 44 reuse. No physics change; it is the same
 ground state, loaded instead of re-relaxed.
 
-## What is left, in measured order
+## The sysimage does not help — measured, and retired
 
-1. **A sysimage — up to ~364 s (65 % of the job), and this figure is an
-   ESTIMATE.** `scripts/build_sysimage.jl` and `build_sysimage_full.jl` exist and
-   the Matsui submit uses neither, but a sysimage only removes JIT for the
-   methods its precompile workload actually exercises, and **neither script
-   targets this code path** — the first builds the rotating-basis F=1 API, the
-   second the M0/M1/M2 F=6 24³ LBFGS cascade (with a 28-30 GB RSS warning).
-   `build_sysimage.jl` also activated `@__DIR__/../..`, the parent of the repo,
-   which has no `Project.toml` — fixed here, untested. Treat the 364 s as an
-   upper bound until a Matsui-representative sysimage is built and timed.
-2. **Drop the DDI zero-padding for this observable.** 21 % of the step at 32³,
+This was the largest estimated lever (~364 s, 65 % of the job). It is dead.
+
+**Three build attempts, two of which could not build at all.** `create_sysimage`
+dies on CUDA device code:
+
+```
+LLVM ERROR: Cannot select: intrinsic %llvm.nvvm.read.ptx.sreg.envreg2   (GPU workload)
+LLVM ERROR: Cannot select: intrinsic %llvm.nvvm.membar.sys              (CPU workload)
+```
+
+PackageCompiler compiles traced code for the host target and CUDA.jl's device
+code is NVVM/PTX. It gets compiled in because **`Project.toml` declares CUDA in
+`[deps]` while also naming it as the trigger for `SpinorBECCUDAExt` in
+`[extensions]`** — an extension trigger belongs in `[weakdeps]`, so that pair is
+inconsistent. `include_transitive_dependencies=false` keeps CUDA out and the
+build then succeeds (560 MB), at the cost that nothing CuArray-parameterised is
+in the image.
+
+**And the image that does build makes the job slower:**
+
+| | `ru_wallclock` |
+|---|---|
+| stage cache only (8318964.15) | 528.5 s |
+| **+ sysimage (8319472.15)** | **574.4 s** |
+| | **+45.9 s (+8.7 %)** |
+
+Same 45 points, same config, `[sysimage]` confirmed in the log and the stage
+cache still hitting 44 times. Single run each, so ±5 % of node variation is
+possible, but the predicted −364 s is not within any plausible error bar.
+
+The reason is the same as the build failure: the CuArray-parameterised
+`make_workspace` / `find_ground_state` / `split_step!` specialisations — where
+the 277 s of first-point JIT plausibly lives — cannot be in the image, so
+nothing that matters was cached, and 560 MB now has to be read off Lustre at
+startup.
+
+**Getting this lever would mean restructuring the CUDA dependency**, not tuning a
+build flag. Out of scope for a performance pass, and recorded here so the next
+person does not re-derive the 364 s estimate.
+
+## What is left
+
+1. **Drop the DDI zero-padding for this observable.** 21 % of the step at 32³,
    19 s over the campaign, and the campaign's own kernel factorial already
    measured its effect on the answer: **0.0016 nT**, against a dip centre of
    −2.51 and a residual of 0.040. Not applied here, because it does change the
    physics — small is not zero, and that is the user's call, not a silent edit.
-3. **The integrator.** Caps out at the 92 s of stepping — 15 % of the job — and
+2. **The integrator.** Caps out at the 92 s of stepping — 15 % of the job — and
    RK4IP specifically is a *loss* at this tolerance (`rk4ip_cost_on_gpu.md`).
+
+Net result of this pass: **600.3 → 528.5 s, −12 %**, from one environment
+variable that was already in the repo.
 
 ## Method note
 

--- a/docs/validation/where_the_campaign_time_goes.md
+++ b/docs/validation/where_the_campaign_time_goes.md
@@ -1,0 +1,79 @@
+# Where the Fig. 4B campaign's wall-clock actually goes
+
+Measured 2026-08-02, H100. Ablation (`scripts/validation/step_cost_ablation_gpu.jl`,
+UGE 8318420) plus the campaign's own per-point records. Type A.
+
+Asked because "can we speed this up?" was pointed at the integrator. **The
+integrator is the smallest of the three levers.**
+
+## The job
+
+Campaign job 8310846.15: `ru_wallclock` **600 s** for 45 points. From the points'
+own `started_at` / `finished_at` / `duration_seconds`:
+
+| | s | share |
+|---|---|---|
+| Julia startup + package precompile | ~115 | 19 % |
+| First-point JIT (the point with no `duration_seconds`) | ~240 | 40 % |
+| Scan span, 44 points × 5.33 s median | 245 | 41 % |
+| — of which dynamics stepping (44 × 3456 × 0.604 ms) | 92 | **15 %** |
+| — of which per-point setup (GS, 2× `make_workspace`, analyze, save) | 143 | 24 % |
+| Between-point overhead (save + next setup) | 12 | 2 % |
+
+Startup was measured separately: the 32³ ablation task does 0.18 s of stepping
+and takes **117 s of wall-clock**. `tsubame_setup.sh` points `JULIA_DEPOT_PATH`
+at a job-local `/tmp/<jobid>/.julia`, so **every array task precompiles from
+scratch**.
+
+## The step
+
+`split_step!`, Eu F=6 D=13, box 16, ms/step. Each row differs from the one above
+by one feature, so the delta is that feature's cost. By ablation, not
+`@timeit_debug`: GPU launches are async and an unsynchronised timer charges the
+work to whichever region contains the next sync.
+
+| configuration | 32³ | 64³ | 128³ |
+|---|---|---|---|
+| no DDI at all | 0.150 | 1.249 | 10.581 |
+| DDI secular, unpadded | 0.480 | 1.743 | 12.450 |
+| DDI full, unpadded | 0.477 | 1.749 | 12.501 |
+| DDI full, pad 1.5 | 0.523 | 2.271 | 17.275 |
+| **DDI full, pad 2 (production)** | **0.604** | **2.768** | **25.070** |
+
+Three results:
+
+- **`secular_ddi` is not a speed optimisation.** Full vs secular is 12.501 vs
+  12.450 ms at 128³ and 0.477 vs 0.480 at 32³ — inside the noise. It is an
+  approximation with a physics justification, not a cheaper kernel.
+- **Zero-padding is 50 % of the step at 128³** (12.57 of 25.07 ms) and 21 % at
+  32³. `pad_factor` 2 → 1.5 recovers 31 % at 128³.
+- **The midpoint predictor-corrector is 19 % at 128³, 33 % at 32³** (25.07 →
+  20.19; 0.604 → 0.403). Turning it off drops the DDI path to 1st order, so this
+  is what the accuracy costs, not a free saving.
+
+## What is worth doing, in measured order
+
+1. **A sysimage.** ~355 s of 600 (59 %) is startup and first-point JIT.
+   `scripts/build_sysimage.jl` and `build_sysimage_full.jl` already exist and the
+   Matsui submit script does not use one.
+2. **`SPINORBEC_STAGE_CACHE=1`.** The ground state is identical across all 45
+   points — the scan axis is `pipeline.1.B.Bz.to`, inside the *dynamics* block —
+   and the stage cache is opt-in and off by default. Other submit scripts in this
+   repo (`runs/eu_gs_phase_c1_B_kappa/*.sh`) set it; the Matsui one does not.
+   Bounded above by the 143 s of per-point setup.
+3. **Drop the DDI zero-padding for this observable.** Worth 21 % of the step at
+   32³ (19 s over the campaign), and the campaign's own kernel factorial already
+   measured its effect on the answer: **0.0016 nT**, against a dip centre of
+   −2.51 and a residual of 0.040. Cheap in a way the other kernel knobs are not.
+4. **The integrator.** Caps out at the 15 % of the job that is stepping, and
+   RK4IP specifically is a *loss* at this tolerance
+   (`rk4ip_cost_on_gpu.md`).
+
+## Method note
+
+The first attempt at the job-level breakdown ran four full 45-point scans while
+labelling them 1- and 3-point timings: the trimmer handled explicit vector scan
+axes and this config uses a `{from, to, step}` range, so it silently returned the
+config unchanged. Caught only because the run sat 29 minutes without printing its
+first row. `scan_job_cost_breakdown.jl` now counts the points the trimmed config
+will expand to and errors if it is not what was asked for.

--- a/runs/matsui_fig4b/fig4b_unpadded_n35k_n32.yaml
+++ b/runs/matsui_fig4b/fig4b_unpadded_n35k_n32.yaml
@@ -1,0 +1,91 @@
+# UNPADDED DDI kernel — a speed/accuracy A/B against fig4b_scan_n35k_n32.yaml.
+#
+# Zero-padding the DDI convolution costs, measured on the H100 (UGE 8318420):
+# 21 % of the step at 32^3 (0.604 -> 0.477 ms) and 50 % at 128^3 (25.07 ->
+# 12.50). Over this 45-point campaign that is ~19 s of the 528 s job.
+#
+# It is not free: unpadded is the periodic kernel, so the cloud sees its own
+# images. The campaign's kernel factorial (fig4b_ddikernel_n32) put the effect
+# on the dip centre at 0.0016 nT — but that was measured at N = 5e4, and this
+# config runs N = 3.5e4. Whether a kernel difference transfers across a 30 %
+# change in atom number is exactly the kind of assumption this campaign has been
+# burned by, so it is being re-measured here rather than inherited.
+#
+# PREDICTION, recorded before the run: centre within 0.005 nT of the padded
+# -2.5099 and width within 0.02 nT of 12.740. If the centre moves by more than
+# 0.01 nT the saving is not worth taking, because the unexplained residual is
+# only 0.040 nT and this would eat a quarter of it.
+#
+# Everything else is bit-identical to fig4b_scan_n35k_n32.yaml.
+
+metadata:
+  suite: matsui_fig4b
+  ladder_level: 12
+  reference: Matsui_2025_EdH_Zenodo_17303925
+  claim_type: C
+  target: fig4b_dip_n35k_unpadded
+  grid_n: 32
+
+defaults:
+  kind: spinor
+  backend: gpu
+  interactions: {N_atoms: 35000, omega_ref: 691.1504}
+
+scan:
+  zip:
+    pipeline.1.B.Bz.to: {from: -1.3e-4, to: 9.0e-5, step: 5.0e-6}   # Gauss; -13 … +9 nT, 0.5 nT step (45 pts)
+
+pipeline:
+  - ground_state:
+      atom: Eu151
+      grid: {n: [32, 32, 32], box: [16.0, 16.0, 16.0]}   # dx = 0.5 a_ho; R_TF ≈ 5.1 a_ho
+      potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+      interactions:
+        N_atoms: 35000                       # their shipped Ntot
+        omega_ref: 691.1504
+        c1_ratio: 0.027777777777777776       # 1/36
+      ddi:
+        enabled: true
+        secular: true            # spin frozen at m=-6 during their ITP (calcDD_3D_pol)
+        padded: false            # UNPADDED — see this file's header
+      lhy: {kind: none}          # their model has no beyond-mean-field term
+      B:
+        Bz: "0.0104 Gauss"       # 10.4 mG = 1.04 µT, their Bfield_ini
+        theta: 0.0
+        phi: 0.0
+        q: 0.00909116            # 2π·1 Hz / ω_ref — their ZeemanQ = 1.0 Hz
+      gauge_fix: false
+      initial_state: m_minus_F
+      init_sigma: 1.5
+      dt: 0.005
+      n_steps: 4000
+      tol: 1.0e-10
+
+  - dynamics:
+      duration: 3.4558           # 5 ms × 691.1504
+      dt: 0.001                  # their time_step, in the same 1/ω_ref units
+      B:
+        Bz: {from: 0.0104, to: -2.0e-4, duration: 0.1037}  # 150 µs ≈ 3τ linear stand-in for their exp(-t/50 µs)
+        theta: 0.0
+        phi: 0.0
+        q: 0.00909116
+      ddi:
+        enabled: true
+        secular: false           # full MDDI: the off-diagonal INT1 is what drives EdH
+        padded: false            # UNPADDED — see this file's header
+      interactions:
+        N_atoms: 35000                       # explicit, so defaults cannot inject 5e4
+        omega_ref: 691.1504
+        c1_ratio: 0.027777777777777776
+      lhy: {kind: none}
+      # NO loss block — their Fig. 2/4 theory curves are loss-free.
+      seed_amplitude: 0.0        # their noise_amp is declared and never used; the
+                                 # m=-6 → -5 transfer is DRIVEN by DDI, not seeded
+      save:
+        every: 108               # divides 3456 exactly, so the last sample IS the end
+                                 # of the hold — point_001's saved psi cannot be trusted
+        psi: false
+        precision: f64
+
+  - analyze:
+      - energy_decomposition: {}

--- a/runs/matsui_fig4b/submit_fig4b.sh
+++ b/runs/matsui_fig4b/submit_fig4b.sh
@@ -52,7 +52,7 @@
 #$ -N matsui_fig4b
 #$ -l gpu_1=1
 #$ -l h_rt=8:00:00
-#$ -t 1-21
+#$ -t 1-22
 #$ -j n
 
 set -euo pipefail
@@ -105,6 +105,7 @@ else
        19) CONFIG=runs/matsui_fig4b/budget_dt_n35k_n32.yaml ;;
        20) CONFIG=runs/matsui_fig4b/dt_where_n35k_n32.yaml ;;
        21) CONFIG=runs/matsui_fig4b/budget_ramp_fine_n35k_n32.yaml ;;
+       22) CONFIG=runs/matsui_fig4b/fig4b_unpadded_n35k_n32.yaml ;;
         *) echo "no config for task ${SGE_TASK_ID}"; exit 1 ;;
     esac
 fi

--- a/runs/matsui_fig4b/submit_fig4b.sh
+++ b/runs/matsui_fig4b/submit_fig4b.sh
@@ -70,6 +70,16 @@ export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH}:/gs/fs/tga-kozuma-kouhi/shared/.jul
 export SPINORBEC_STORE="${SPINORBEC_STORE:-/gs/bs/work/7/uk07267/runs}"
 mkdir -p "$SPINORBEC_STORE"
 
+# The scan axis is `pipeline.1.B.Bz.to` — inside the DYNAMICS block — so all 45
+# points share one ground state, and without this each recomputes it. Measured
+# 5.44 -> 3.93 s/point, -27.8 % (UGE 8318863, 3-point A/B on this exact config).
+# Off by default; other submit scripts in this repo already set it.
+#
+# SPINORBEC_LIGHT_POINTS is deliberately NOT set: it replaces each point's inline
+# psi with a `gs_ref` pointer, which `open_result` resolves but the ad-hoc
+# readers under scripts/validation/ do not.
+export SPINORBEC_STAGE_CACHE=1
+
 if [ "${1:-}" = "SMOKE" ]; then
     CONFIG=runs/matsui_fig4b/fig4b_smoke_n32.yaml
 else

--- a/runs/matsui_fig4b/submit_fig4b.sh
+++ b/runs/matsui_fig4b/submit_fig4b.sh
@@ -115,7 +115,16 @@ echo "[store] $SPINORBEC_STORE"
 nvidia-smi -L || true
 
 # Guard silent CPU fallback (a broken-CUDA node otherwise burns hours on CPU).
-"$JULIA" --project=. -e '
+# Optional sysimage (scripts/build_sysimage_matsui.jl). Measured baseline
+# without one: 528.5 s for 45 points, of which ~277 s is first-point JIT and
+# ~115 s startup. Set SPINORBEC_SYSIMAGE to a built .so to skip most of that.
+SYSIMG_ARG=""
+if [ -n "${SPINORBEC_SYSIMAGE:-}" ] && [ -f "${SPINORBEC_SYSIMAGE}" ]; then
+    SYSIMG_ARG="--sysimage=${SPINORBEC_SYSIMAGE}"
+    echo "[sysimage] $SPINORBEC_SYSIMAGE"
+fi
+
+"$JULIA" --project=. $SYSIMG_ARG -e '
     import CUDA
     CUDA.functional() || (@error "CUDA not functional — refusing CPU fallback"; exit(1))
     using SpinorBEC

--- a/runs/rk4ip_gpu/submit_probe.sh
+++ b/runs/rk4ip_gpu/submit_probe.sh
@@ -7,7 +7,7 @@
 #$ -N rk4ip_gpu
 #$ -l gpu_1=1
 #$ -l h_rt=2:00:00
-#$ -t 1-3
+#$ -t 1-6
 #$ -j n
 
 set -euo pipefail
@@ -27,6 +27,9 @@ case "${SGE_TASK_ID:-1}" in
     1) "$JULIA" --project=. scripts/validation/rk4ip_gpu_cost_probe.jl ;;
     2) "$JULIA" --project=. scripts/validation/rk4ip_time_to_solution_gpu.jl 64 ;;
     3) "$JULIA" --project=. scripts/validation/rk4ip_time_to_solution_gpu.jl 128 ;;
+    4) "$JULIA" --project=. scripts/validation/step_cost_ablation_gpu.jl 128 ;;
+    5) "$JULIA" --project=. scripts/validation/step_cost_ablation_gpu.jl 64 ;;
+    6) "$JULIA" --project=. scripts/validation/step_cost_ablation_gpu.jl 32 ;;
     *) echo "no task ${SGE_TASK_ID}"; exit 1 ;;
 esac
 

--- a/runs/rk4ip_gpu/submit_probe.sh
+++ b/runs/rk4ip_gpu/submit_probe.sh
@@ -6,8 +6,8 @@
 #$ -cwd
 #$ -N rk4ip_gpu
 #$ -l gpu_1=1
-#$ -l h_rt=2:00:00
-#$ -t 1-7
+#$ -l h_rt=3:00:00
+#$ -t 1-8
 #$ -j n
 
 set -euo pipefail
@@ -38,6 +38,8 @@ case "${SGE_TASK_ID:-1}" in
     6) "$JULIA" --project=. scripts/validation/step_cost_ablation_gpu.jl 32 ;;
     7) stdbuf -oL -eL "$JULIA" --project=. scripts/validation/scan_job_cost_breakdown.jl \
            runs/matsui_fig4b/fig4b_scan_n35k_n32.yaml 3 ;;
+    8) stdbuf -oL -eL "$JULIA" --project=. scripts/build_sysimage_matsui.jl \
+           /gs/bs/work/7/uk07267/spinor_sysimage_matsui.so ;;
     *) echo "no task ${SGE_TASK_ID}"; exit 1 ;;
 esac
 

--- a/runs/rk4ip_gpu/submit_probe.sh
+++ b/runs/rk4ip_gpu/submit_probe.sh
@@ -20,6 +20,11 @@ source scripts/tsubame_setup.sh
 set -euo pipefail                       # re-arm: tsubame_setup runs `set +e`
 export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH}:/gs/fs/tga-kozuma-kouhi/shared/.julia:${HOME}/.julia"
 
+# /gs/bs/work, not the group /gs/fs — and NOT the default `runs/`, which is
+# inside the git worktree. Omitting this put a probe's scan output in the repo.
+export SPINORBEC_STORE="${SPINORBEC_STORE:-/gs/bs/work/7/uk07267/runs}"
+mkdir -p "$SPINORBEC_STORE"
+
 echo "[src]   $(git rev-parse HEAD)  $(git status --porcelain -- src | wc -l) dirty src files"
 nvidia-smi -L || true
 echo "[t] startup done: $(date -Ins)"
@@ -31,7 +36,7 @@ case "${SGE_TASK_ID:-1}" in
     4) "$JULIA" --project=. scripts/validation/step_cost_ablation_gpu.jl 128 ;;
     5) "$JULIA" --project=. scripts/validation/step_cost_ablation_gpu.jl 64 ;;
     6) "$JULIA" --project=. scripts/validation/step_cost_ablation_gpu.jl 32 ;;
-    7) "$JULIA" --project=. scripts/validation/scan_job_cost_breakdown.jl \
+    7) stdbuf -oL -eL "$JULIA" --project=. scripts/validation/scan_job_cost_breakdown.jl \
            runs/matsui_fig4b/fig4b_scan_n35k_n32.yaml 3 ;;
     *) echo "no task ${SGE_TASK_ID}"; exit 1 ;;
 esac

--- a/runs/rk4ip_gpu/submit_probe.sh
+++ b/runs/rk4ip_gpu/submit_probe.sh
@@ -7,7 +7,7 @@
 #$ -N rk4ip_gpu
 #$ -l gpu_1=1
 #$ -l h_rt=2:00:00
-#$ -t 1-6
+#$ -t 1-7
 #$ -j n
 
 set -euo pipefail
@@ -22,6 +22,7 @@ export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH}:/gs/fs/tga-kozuma-kouhi/shared/.jul
 
 echo "[src]   $(git rev-parse HEAD)  $(git status --porcelain -- src | wc -l) dirty src files"
 nvidia-smi -L || true
+echo "[t] startup done: $(date -Ins)"
 
 case "${SGE_TASK_ID:-1}" in
     1) "$JULIA" --project=. scripts/validation/rk4ip_gpu_cost_probe.jl ;;
@@ -30,7 +31,10 @@ case "${SGE_TASK_ID:-1}" in
     4) "$JULIA" --project=. scripts/validation/step_cost_ablation_gpu.jl 128 ;;
     5) "$JULIA" --project=. scripts/validation/step_cost_ablation_gpu.jl 64 ;;
     6) "$JULIA" --project=. scripts/validation/step_cost_ablation_gpu.jl 32 ;;
+    7) "$JULIA" --project=. scripts/validation/scan_job_cost_breakdown.jl \
+           runs/matsui_fig4b/fig4b_scan_n35k_n32.yaml 3 ;;
     *) echo "no task ${SGE_TASK_ID}"; exit 1 ;;
 esac
 
+echo "[t] work done: $(date -Ins)"
 echo "[done]"

--- a/scripts/_sysimage_precompile_matsui.jl
+++ b/scripts/_sysimage_precompile_matsui.jl
@@ -1,0 +1,55 @@
+# Precompile workload for the Fig. 4B production path.
+#
+# A sysimage only removes JIT for the methods its workload actually exercises,
+# so this runs the REAL thing: `run_yaml` on the campaign's own config with the
+# step counts cut to the bone. Same blocks, same types — B ramp, padded DDI,
+# GPU backend, the 3-step pipeline, the analyzers, the JLD2 save — so the
+# specialisations PackageCompiler captures are the ones the campaign pays for.
+#
+# Writing a hand-rolled `find_ground_state` call instead would capture a
+# *similar* path and miss `parse_pipeline` / `_step_dispatch!` / the save, which
+# is where a good part of the first-point cost lives.
+
+import CUDA
+using SpinorBEC
+using YAML
+
+const SRC = joinpath(@__DIR__, "..", "runs", "matsui_fig4b", "fig4b_scan_n35k_n32.yaml")
+
+d = YAML.load_file(SRC)
+
+# Two scan points: one populates the GS stage cache, the second exercises the
+# reuse branch, and both are in the production code path.
+for axes in values(d["scan"])
+    axes isa AbstractDict || continue
+    for (_, v) in axes
+        v isa AbstractDict && haskey(v, "from") &&
+            (v["to"] = Float64(v["from"]) + Float64(v["step"]))
+    end
+end
+
+for st in d["pipeline"]
+    if haskey(st, "ground_state")
+        st["ground_state"]["n_steps"] = 8
+        st["ground_state"]["tol"] = 1e-3
+    elseif haskey(st, "dynamics")
+        dt = Float64(st["dynamics"]["dt"])
+        st["dynamics"]["duration"] = 8 * dt
+        haskey(st["dynamics"], "save") && (st["dynamics"]["save"]["every"] = 4)
+        # The ramp's own duration must stay inside the shortened run or the B
+        # block resolves to a different waveform type than production uses.
+        b = get(st["dynamics"], "B", nothing)
+        if b isa AbstractDict && b["Bz"] isa AbstractDict
+            b["Bz"]["duration"] = 4 * dt
+        end
+    end
+end
+
+dir = mktempdir()
+cfg = joinpath(dir, "sysimage_warmup.yaml")
+YAML.write_file(cfg, d)
+
+withenv("SPINORBEC_STORE" => joinpath(dir, "store"),
+    "SPINORBEC_STAGE_CACHE" => "1") do
+    run_yaml(cfg; verbose=false)
+end

--- a/scripts/_sysimage_precompile_matsui.jl
+++ b/scripts/_sysimage_precompile_matsui.jl
@@ -2,21 +2,39 @@
 #
 # A sysimage only removes JIT for the methods its workload actually exercises,
 # so this runs the REAL thing: `run_yaml` on the campaign's own config with the
-# step counts cut to the bone. Same blocks, same types — B ramp, padded DDI,
-# GPU backend, the 3-step pipeline, the analyzers, the JLD2 save — so the
+# step counts cut to the bone. Same blocks — B ramp, padded DDI, the 3-step
+# pipeline, the analyzers, the JLD2 save — so the
 # specialisations PackageCompiler captures are the ones the campaign pays for.
 #
 # Writing a hand-rolled `find_ground_state` call instead would capture a
 # *similar* path and miss `parse_pipeline` / `_step_dispatch!` / the save, which
 # is where a good part of the first-point cost lives.
+#
+# CPU BACKEND, deliberately, and this is a real limit rather than a choice.
+# Tracing the GPU path kills the build outright:
+#
+#     LLVM ERROR: Cannot select: intrinsic %llvm.nvvm.read.ptx.sreg.envreg2
+#
+# PackageCompiler compiles the traced code for the host target, and CUDA kernels
+# captured in the trace are NVVM/PTX. So this image can carry the host-side
+# specialisations — YAML, schema, `parse_pipeline`, `_step_dispatch!`, the
+# analyzers, the JLD2 save, and the CPU-typed solver path — but NOT the
+# CuArray-parameterised `make_workspace` / `find_ground_state` / `split_step!`,
+# which will still JIT at runtime. Measure the saving; do not assume it.
 
-import CUDA
 using SpinorBEC
 using YAML
 
 const SRC = joinpath(@__DIR__, "..", "runs", "matsui_fig4b", "fig4b_scan_n35k_n32.yaml")
 
 d = YAML.load_file(SRC)
+d["defaults"]["backend"] = "cpu"
+for st in d["pipeline"]
+    for (_, blk) in st
+        blk isa AbstractDict && haskey(blk, "backend") && (blk["backend"] = "cpu")
+        blk isa AbstractDict && haskey(blk, "grid") && (blk["grid"]["n"] = [16, 16, 16])
+    end
+end
 
 # Two scan points: one populates the GS stage cache, the second exercises the
 # reuse branch, and both are in the production code path.
@@ -53,3 +71,5 @@ withenv("SPINORBEC_STORE" => joinpath(dir, "store"),
     "SPINORBEC_STAGE_CACHE" => "1") do
     run_yaml(cfg; verbose=false)
 end
+
+@info "workload done (CPU backend; the CuArray specialisations are NOT in this image)"

--- a/scripts/build_sysimage.jl
+++ b/scripts/build_sysimage.jl
@@ -11,7 +11,7 @@
 # Output: spinor_sysimage.so (typically 200-400 MB, depends on Julia version)
 
 using Pkg
-Pkg.activate(@__DIR__ * "/../..")
+Pkg.activate(joinpath(@__DIR__, ".."))   # the repo, not its parent
 
 # PackageCompiler is itself a heavy dep — install on demand only when this
 # script runs, so the regular project doesn't carry the weight.

--- a/scripts/build_sysimage_matsui.jl
+++ b/scripts/build_sysimage_matsui.jl
@@ -1,0 +1,41 @@
+# Build a sysimage for the Fig. 4B production path.
+#
+#   julia --project=. scripts/build_sysimage_matsui.jl [output.so]
+#
+# Why a third one. `build_sysimage.jl` targets the rotating-basis F=1 API and
+# `build_sysimage_full.jl` the M0/M1/M2 F=6 LBFGS cascade; neither exercises the
+# split-step `run_yaml` path the Matsui campaign runs, and a sysimage only
+# removes JIT for methods its workload touched. Measured, that JIT is **277 s of
+# a 528 s job** (`docs/validation/where_the_campaign_time_goes.md`), so it is the
+# largest single item left — but the saving is an estimate until this is built
+# and timed, which is the whole point of this script.
+#
+# Must run on a GPU node: the workload uses `CUDABackend`, and the
+# specialisations worth capturing are the CuArray ones.
+
+using Pkg
+Pkg.activate(joinpath(@__DIR__, ".."))
+Pkg.add("PackageCompiler")
+
+using PackageCompiler
+
+const OUTPUT = length(ARGS) >= 1 ? ARGS[1] :
+               joinpath(@__DIR__, "..", "spinor_sysimage_matsui.so")
+const WORKLOAD = joinpath(@__DIR__, "_sysimage_precompile_matsui.jl")
+
+isfile(WORKLOAD) || error("missing workload: $WORKLOAD")
+
+@info "Building the Fig. 4B sysimage" output = OUTPUT workload = WORKLOAD
+@info "Expect 30-60 minutes. The workload is a real 2-point run_yaml at 32^3."
+
+create_sysimage(
+    [:SpinorBEC];
+    sysimage_path=OUTPUT,
+    precompile_execution_file=WORKLOAD,
+)
+
+println("\nbuilt: $OUTPUT")
+println("use:   julia --project=. --sysimage=$OUTPUT <script>")
+println("\nThen time it against the 528.5 s baseline (UGE 8318964.15) — the")
+println("claim to test is that it removes most of the 277 s first-point JIT and")
+println("the ~115 s of startup, NOT that it makes a step faster.")

--- a/scripts/build_sysimage_matsui.jl
+++ b/scripts/build_sysimage_matsui.jl
@@ -28,10 +28,21 @@ isfile(WORKLOAD) || error("missing workload: $WORKLOAD")
 @info "Building the Fig. 4B sysimage" output = OUTPUT workload = WORKLOAD
 @info "Expect 30-60 minutes. The workload is a real 2-point run_yaml at 32^3."
 
+# `include_transitive_dependencies=false` is load-bearing, not tuning. CUDA is
+# declared in `[deps]` of Project.toml (while ALSO being the trigger for
+# `SpinorBECCUDAExt` in `[extensions]` — an extension trigger belongs in
+# `[weakdeps]`, so that pair is inconsistent). Being a hard dep, PackageCompiler
+# compiles CUDA.jl into the image by default, and its device code is NVVM/PTX:
+#
+#   LLVM ERROR: Cannot select: intrinsic %llvm.nvvm.membar.sys
+#
+# Excluding transitive deps keeps CUDA out. The consequence is that nothing
+# CuArray-parameterised is in this image and the GPU path still JITs.
 create_sysimage(
     [:SpinorBEC];
     sysimage_path=OUTPUT,
     precompile_execution_file=WORKLOAD,
+    include_transitive_dependencies=false,
 )
 
 println("\nbuilt: $OUTPUT")

--- a/scripts/validation/scan_job_cost_breakdown.jl
+++ b/scripts/validation/scan_job_cost_breakdown.jl
@@ -19,6 +19,11 @@
 # and reports the stepping fraction of B, so the ceiling on any integrator-side
 # optimisation is explicit.
 
+# `import CUDA` BEFORE `using SpinorBEC`, or the CUDA extension is not loaded and
+# a `backend: gpu` config dies with `no method matching _to_device(::CUDABackend,
+# ::Array)` — 6.7 s in, swallowed into `_exit_summary.json` as a bare
+# "MethodError". The campaign's own submit line does this; this script did not.
+import CUDA
 using SpinorBEC
 using Printf
 using YAML
@@ -92,6 +97,8 @@ function dyn_steps_and_dt(cfg::String)
 end
 
 function main()
+    CUDA.functional() ||
+        error("CUDA not functional — this config is backend: gpu and would fall back silently")
     nsteps, dt = dyn_steps_and_dt(CFG)
     @printf("config %s\n  dynamics: %d steps at dt = %.1e\n\n", basename(CFG), nsteps, dt)
     flush(stdout)

--- a/scripts/validation/scan_job_cost_breakdown.jl
+++ b/scripts/validation/scan_job_cost_breakdown.jl
@@ -51,7 +51,12 @@ function trimmed(cfg::String, n::Int, tag::String)
     end
     got = _count_points(sc)
     got == n || error("trim asked for $n points, config yields $got — see the docstring")
-    out = joinpath(mktempdir(), "trim_$(tag).yaml")
+    # Under the store, not mktempdir(): run_yaml derives its output directory
+    # from the config's path, and a config in a compute node's /tmp puts the run
+    # somewhere no other machine can watch.
+    dir = joinpath(get(ENV, "SPINORBEC_STORE", "runs"), "_probe")
+    mkpath(dir)
+    out = joinpath(dir, "trim_$(tag).yaml")
     YAML.write_file(out, d)
     out
 end
@@ -89,30 +94,38 @@ end
 function main()
     nsteps, dt = dyn_steps_and_dt(CFG)
     @printf("config %s\n  dynamics: %d steps at dt = %.1e\n\n", basename(CFG), nsteps, dt)
+    flush(stdout)
 
+    # Announce BEFORE each phase and flush: with verbose=false a run_yaml prints
+    # nothing, so a probe that only reports afterwards is indistinguishable from
+    # a hung one. The first pass at this sat 19 minutes with no way to tell.
+    function timed(label, path; verbose=false)
+        @printf("  ... %s\n", label)
+        flush(stdout)
+        t = @elapsed run_yaml(path; verbose=verbose)
+        @printf("  %-38s %8.2f s\n", label, t)
+        flush(stdout)
+        t
+    end
+
+    b_per_point = NaN
     withenv("SPINORBEC_STAGE_CACHE" => "0") do
-        a = @elapsed run_yaml(trimmed(CFG, 1, "a"); verbose=false)
-        @printf("A  1 point,  cold (JIT rides here)   : %8.2f s\n", a)
-        b = @elapsed run_yaml(trimmed(CFG, NPTS, "b"); verbose=false)
-        @printf("B  %d points, warm                    : %8.2f s  -> %.2f s/point\n",
-            NPTS, b, b / NPTS)
-        global _B_PER_POINT = b / NPTS
+        timed("A  1 point, cold (JIT rides here)", trimmed(CFG, 1, "a"); verbose=true)
+        b = timed("B  $NPTS points, warm", trimmed(CFG, NPTS, "b"))
+        b_per_point = b / NPTS
+        @printf("     -> %.2f s/point\n", b_per_point)
     end
 
     withenv("SPINORBEC_STAGE_CACHE" => "1") do
-        c = @elapsed run_yaml(trimmed(CFG, NPTS, "c1"); verbose=false)   # populates
-        d = @elapsed run_yaml(trimmed(CFG, NPTS, "c2"); verbose=false)   # reuses
-        @printf("C  %d points, stage cache populating  : %8.2f s  -> %.2f s/point\n",
-            NPTS, c, c / NPTS)
-        @printf("C' %d points, stage cache reusing     : %8.2f s  -> %.2f s/point  (%+.1f %%)\n",
-            NPTS, d, d / NPTS, 100 * (d / NPTS - _B_PER_POINT) / _B_PER_POINT)
+        timed("C  $NPTS points, stage cache filling", trimmed(CFG, NPTS, "c1"))
+        d = timed("C' $NPTS points, stage cache reusing", trimmed(CFG, NPTS, "c2"))
+        @printf("     -> %.2f s/point  (%+.1f %% vs B)\n",
+            d / NPTS, 100 * (d / NPTS - b_per_point) / b_per_point)
     end
 
-    println("\nSteady-state point, where the time goes:")
-    println("  Run scripts/validation/step_cost_ablation_gpu.jl for ms/step at this n,")
-    println("  multiply by the step count above, and the remainder is per-point setup")
-    println("  (two make_workspace calls, the ground state, analyzers, the JLD2 save).")
-    println("  The integrator can only ever address the stepping fraction.")
+    @printf("\nStepping is %d steps x (ms/step from step_cost_ablation_gpu.jl).\n", nsteps)
+    println("At 32^3 that is 3456 x 0.604 ms = 2.09 s, so anything above that in the")
+    println("per-point figure is setup the integrator cannot touch.")
 end
 
 main()

--- a/scripts/validation/scan_job_cost_breakdown.jl
+++ b/scripts/validation/scan_job_cost_breakdown.jl
@@ -26,17 +26,54 @@ using YAML
 const CFG = length(ARGS) >= 1 ? ARGS[1] : error("usage: scan_job_cost_breakdown.jl <config.yaml>")
 const NPTS = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 3
 
-"Write a copy of the config whose scan has exactly `n` points."
+"""
+Write a copy of the config whose scan has exactly `n` points, and VERIFY it.
+
+A scan axis is either an explicit vector or a `{from, to, step}` range under
+`zip:` / `grid:`. The first version of this handled only the vector case, so on
+a range-spec config it silently returned the config unchanged and the probe ran
+four full 45-point scans while reporting them as 1- and 3-point timings. Hence
+`_count_points` and the assertion: a trim that does not trim must be loud.
+"""
 function trimmed(cfg::String, n::Int, tag::String)
     d = YAML.load_file(cfg)
     sc = get(d, "scan", nothing)
     sc === nothing && error("config has no scan block")
-    for (k, v) in sc
-        v isa AbstractVector && length(v) > n && (sc[k] = v[1:n])
+    for axes in values(sc)
+        axes isa AbstractDict || continue
+        for (k, v) in axes
+            if v isa AbstractVector
+                length(v) > n && (axes[k] = v[1:n])
+            elseif v isa AbstractDict && haskey(v, "from") && haskey(v, "step")
+                v["to"] = Float64(v["from"]) + (n - 1) * Float64(v["step"])
+            end
+        end
     end
+    got = _count_points(sc)
+    got == n || error("trim asked for $n points, config yields $got — see the docstring")
     out = joinpath(mktempdir(), "trim_$(tag).yaml")
     YAML.write_file(out, d)
     out
+end
+
+"Points a scan block will expand to (zip axes are parallel, grid axes multiply)."
+function _count_points(sc::AbstractDict)
+    total = 1
+    for (mode, axes) in sc
+        axes isa AbstractDict || continue
+        lens = Int[]
+        for v in values(axes)
+            if v isa AbstractVector
+                push!(lens, length(v))
+            elseif v isa AbstractDict && haskey(v, "from")
+                f, t, st = Float64(v["from"]), Float64(v["to"]), Float64(v["step"])
+                push!(lens, floor(Int, (t - f) / st + 1e-9) + 1)
+            end
+        end
+        isempty(lens) && continue
+        total *= (mode == "zip" ? maximum(lens) : prod(lens))
+    end
+    total
 end
 
 function dyn_steps_and_dt(cfg::String)

--- a/scripts/validation/scan_job_cost_breakdown.jl
+++ b/scripts/validation/scan_job_cost_breakdown.jl
@@ -1,0 +1,81 @@
+#!/usr/bin/env julia
+# Where does a scan JOB's wall-clock go? Not where the integrator work is.
+#
+#     julia --project=. scripts/validation/scan_job_cost_breakdown.jl <config.yaml> [npoints]
+#
+# The Matsui Fig. 4B campaign job ran 600 s for 45 points. Reading the points'
+# own `started_at` / `finished_at` / `duration_seconds`, the scan span was 245 s
+# — so 59 % of the job was startup and first-point JIT, and the dynamics stepping
+# inside that 245 s is only 44 x 3456 x 0.604 ms = 92 s, i.e. **15 % of the job**.
+# Shaving the integrator is the smallest of the three levers.
+#
+# This times the same config three ways in ONE session, so the JIT is paid once
+# and the deltas are marginal costs:
+#
+#   A  first point           — JIT of run_pipeline / make_workspace / ITP / step
+#   B  steady-state point    — what a scan point actually costs
+#   C  same, with the GS stage cache on (SPINORBEC_STAGE_CACHE=1)
+#
+# and reports the stepping fraction of B, so the ceiling on any integrator-side
+# optimisation is explicit.
+
+using SpinorBEC
+using Printf
+using YAML
+
+const CFG = length(ARGS) >= 1 ? ARGS[1] : error("usage: scan_job_cost_breakdown.jl <config.yaml>")
+const NPTS = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 3
+
+"Write a copy of the config whose scan has exactly `n` points."
+function trimmed(cfg::String, n::Int, tag::String)
+    d = YAML.load_file(cfg)
+    sc = get(d, "scan", nothing)
+    sc === nothing && error("config has no scan block")
+    for (k, v) in sc
+        v isa AbstractVector && length(v) > n && (sc[k] = v[1:n])
+    end
+    out = joinpath(mktempdir(), "trim_$(tag).yaml")
+    YAML.write_file(out, d)
+    out
+end
+
+function dyn_steps_and_dt(cfg::String)
+    d = YAML.load_file(cfg)
+    for st in d["pipeline"]
+        haskey(st, "dynamics") || continue
+        p = st["dynamics"]
+        return (round(Int, Float64(p["duration"]) / Float64(p["dt"])), Float64(p["dt"]))
+    end
+    (0, NaN)
+end
+
+function main()
+    nsteps, dt = dyn_steps_and_dt(CFG)
+    @printf("config %s\n  dynamics: %d steps at dt = %.1e\n\n", basename(CFG), nsteps, dt)
+
+    withenv("SPINORBEC_STAGE_CACHE" => "0") do
+        a = @elapsed run_yaml(trimmed(CFG, 1, "a"); verbose=false)
+        @printf("A  1 point,  cold (JIT rides here)   : %8.2f s\n", a)
+        b = @elapsed run_yaml(trimmed(CFG, NPTS, "b"); verbose=false)
+        @printf("B  %d points, warm                    : %8.2f s  -> %.2f s/point\n",
+            NPTS, b, b / NPTS)
+        global _B_PER_POINT = b / NPTS
+    end
+
+    withenv("SPINORBEC_STAGE_CACHE" => "1") do
+        c = @elapsed run_yaml(trimmed(CFG, NPTS, "c1"); verbose=false)   # populates
+        d = @elapsed run_yaml(trimmed(CFG, NPTS, "c2"); verbose=false)   # reuses
+        @printf("C  %d points, stage cache populating  : %8.2f s  -> %.2f s/point\n",
+            NPTS, c, c / NPTS)
+        @printf("C' %d points, stage cache reusing     : %8.2f s  -> %.2f s/point  (%+.1f %%)\n",
+            NPTS, d, d / NPTS, 100 * (d / NPTS - _B_PER_POINT) / _B_PER_POINT)
+    end
+
+    println("\nSteady-state point, where the time goes:")
+    println("  Run scripts/validation/step_cost_ablation_gpu.jl for ms/step at this n,")
+    println("  multiply by the step count above, and the remainder is per-point setup")
+    println("  (two make_workspace calls, the ground state, analyzers, the JLD2 save).")
+    println("  The integrator can only ever address the stepping fraction.")
+end
+
+main()

--- a/scripts/validation/step_cost_ablation_gpu.jl
+++ b/scripts/validation/step_cost_ablation_gpu.jl
@@ -1,0 +1,102 @@
+#!/usr/bin/env julia
+# Where does a split-step go on the GPU, and what is removable?
+#
+#     julia --project=. scripts/validation/step_cost_ablation_gpu.jl [n]
+#
+# By ABLATION, not by `@timeit_debug`. GPU launches are asynchronous, so a timer
+# that does not synchronise measures launch cost and charges the real work to
+# whichever region happens to contain the next sync. Every number below is an
+# outer-level synchronised wall-clock over many steps, and each row differs from
+# the one above it by exactly one feature, so the difference IS that feature's
+# cost.
+#
+# Rows are ordered cheapest-first so each delta is read downward.
+
+import CUDA
+using SpinorBEC
+using Printf
+
+const N = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 128
+
+function build(; ddi::Bool, padded::Bool, pad_factor::Float64, secular::Bool)
+    grid = make_grid(GridConfig(ntuple(_ -> N, 3), ntuple(_ -> 16.0, 3)))
+    kw = (; grid, atom=Eu151,
+        interactions=InteractionParams(Dict(0 => 4687.2663 / 50, 1 => -0.5)),
+        zeeman=ZeemanParams(0.4, 0.02),
+        potential=HarmonicTrap((1.0, 1.0, 1.181818)),
+        sim_params=SimParams(; dt=1e-3, n_steps=1, save_every=10^9),
+        backend=CUDABackend())
+    ddi || return make_workspace(; kw...)
+    make_workspace(; kw..., enable_ddi=true, c_dd=147.715012,
+        secular_ddi=secular, ddi_padding=padded, ddi_pad_factor=pad_factor)
+end
+
+function ms_per_step(ws, stepper, reps)
+    copyto!(ws.state.psi, init_psi(ws.grid, ws.spin_matrices.system;
+        state=:spin_coherent, init_theta=0.35, init_phi=0.2))
+    for _ in 1:3
+        stepper(ws)
+    end
+    CUDA.synchronize()
+    best = Inf
+    for _ in 1:3
+        CUDA.synchronize()
+        t = @elapsed begin
+            for _ in 1:reps
+                stepper(ws)
+            end
+            CUDA.synchronize()
+        end
+        best = min(best, t / reps)
+    end
+    1e3 * best
+end
+
+function main()
+    CUDA.functional() || error("CUDA not functional")
+    reps = N >= 128 ? 8 : (N >= 64 ? 25 : 60)
+    @printf("device %s, Eu F=6 D=13, %d^3 box 16, %d reps\n\n", CUDA.name(CUDA.device()), N, reps)
+
+    rows = Tuple{String, Any}[]
+    push!(rows, ("no DDI at all", () -> build(; ddi=false, padded=false, pad_factor=2.0, secular=false)))
+    push!(rows, ("DDI secular, unpadded", () -> build(; ddi=true, padded=false, pad_factor=2.0, secular=true)))
+    push!(rows, ("DDI full, unpadded", () -> build(; ddi=true, padded=false, pad_factor=2.0, secular=false)))
+    push!(rows, ("DDI full, pad 1.5", () -> build(; ddi=true, padded=true, pad_factor=1.5, secular=false)))
+    push!(rows, ("DDI full, pad 2 (production)", () -> build(; ddi=true, padded=true, pad_factor=2.0, secular=false)))
+
+    @printf("%-30s %12s %12s %10s\n", "configuration", "ms/step", "delta", "cumulative")
+    base = NaN
+    prev = NaN
+    for (name, mk) in rows
+        t = try
+            ws = mk()
+            v = ms_per_step(ws, split_step!, reps)
+            CUDA.reclaim()
+            v
+        catch e
+            @printf("%-30s  FAILED: %s\n", name, sprint(showerror, e)[1:min(end, 90)])
+            continue
+        end
+        isnan(base) && (base = t)
+        @printf("%-30s %12.3f %12s %10s\n", name, t,
+            isnan(prev) ? "—" : @sprintf("%+.3f", t - prev),
+            isnan(base) || base == 0 ? "—" : @sprintf("%.2fx", t / base))
+        prev = t
+    end
+
+    # The predictor-corrector engages automatically whenever DDI is on. It is a
+    # global Ref, so it can be ablated without touching the config.
+    println("\nmidpoint predictor-corrector (auto-on with DDI):")
+    ws = build(; ddi=true, padded=true, pad_factor=2.0, secular=false)
+    on = ms_per_step(ws, split_step!, reps)
+    SpinorBEC.MEANFIELD_MIDPOINT_ENABLED[] = false
+    off = ms_per_step(ws, split_step!, reps)
+    SpinorBEC.MEANFIELD_MIDPOINT_ENABLED[] = true
+    @printf("  on %.3f   off %.3f   costs %+.3f ms/step (%.0f %% of the step)\n",
+        on, off, on - off, 100 * (on - off) / on)
+    println("  Off is the LEGACY 1st-order-with-DDI path — this is what accuracy buys,")
+    println("  not a free saving. Quoted so the trade is visible.")
+    CUDA.reclaim()
+end
+
+main()


### PR DESCRIPTION
Asked "can we speed this up?", pointed at the integrator. Measured, the integrator is **15 % of the job** and the two larger-looking levers both failed on measurement.

## Where the 600 s job actually goes

| | s | share |
|---|---|---|
| Julia startup + precompile | 115 | 19 % |
| first-point JIT | 277 | 46 % |
| 44 warm points | 239 | 40 % |
| — of which **stepping** | **92** | **15 %** |

Startup pinned separately: a 32³ ablation doing **0.18 s of stepping takes 117 s of wall-clock**. `tsubame_setup.sh` puts `JULIA_DEPOT_PATH` in a job-local `/tmp/<jobid>`, so every array task precompiles from scratch.

## What worked: a flag already in the repo

The scan axis is `pipeline.1.B.Bz.to` — inside the *dynamics* block — so all 45 points share one ground state and each was re-relaxing it. `SPINORBEC_STAGE_CACHE` is opt-in and off by default; `runs/eu_gs_phase_c1_B_kappa/*.sh` already set it, the Matsui submit did not.

| | `ru_wallclock` |
|---|---|
| before (8310846.15) | 600.3 s |
| **with the stage cache (8318964.15)** | **528.5 s** |
| | **−71.8 s (−12 %)** |

Verified by mechanism, not just number: `Loading cached GS` appears **44** times for 45 points. No physics change — the same ground state, loaded rather than re-relaxed.

## What failed: the sysimage (largest estimate, ~364 s)

Two of three builds could not complete:

```
LLVM ERROR: Cannot select: intrinsic %llvm.nvvm.read.ptx.sreg.envreg2   (GPU workload)
LLVM ERROR: Cannot select: intrinsic %llvm.nvvm.membar.sys              (CPU workload)
```

PackageCompiler compiles for the host target and CUDA.jl's device code is NVVM/PTX. It is compiled in because **`Project.toml` declares CUDA in `[deps]` while also naming it as the trigger for `SpinorBECCUDAExt` in `[extensions]`** — an extension trigger belongs in `[weakdeps]`. `include_transitive_dependencies=false` keeps CUDA out and the build succeeds (560 MB).

And the image that builds **makes the job slower**:

| | `ru_wallclock` |
|---|---|
| stage cache only | 528.5 s |
| **+ sysimage (8319472.15)** | **574.4 s (+8.7 %)** |

Same reason as the build failure: the CuArray-parameterised `make_workspace` / `find_ground_state` / `split_step!` specialisations — where the 277 s of first-point JIT plausibly lives — cannot be in the image, so nothing that matters was cached and 560 MB now has to be read off Lustre. Getting this lever means restructuring the CUDA dependency, not tuning a build flag.

## What failed: dropping the DDI padding (21 % of the step)

The kernel factorial had put the effect on the dip centre at 0.0016 nT — measured at `N = 5×10⁴`, while production runs `N = 3.5×10⁴`. Re-measured rather than inherited. Prediction recorded in the config first: within 0.005 nT, not worth taking beyond 0.01.

| | centre [nT] | width [nT] |
|---|---|---|
| padded (production) | −2.5099 | 12.7400 |
| unpadded | −2.4913 | 12.7284 |
| **difference** | **+0.0187** | −0.0116 |

**12× the inherited figure**, 47 % of the whole unexplained 0.040 nT residual, and *away* from Matsui. The saving was 3.5 %. Not taken; the config is kept as the A/B.

## Step ablation (H100, `split_step!`, ms/step)

By ablation rather than `@timeit_debug` — GPU launches are async, and an unsynchronised timer charges work to whichever region contains the next sync.

| configuration | 32³ | 64³ | 128³ |
|---|---|---|---|
| no DDI | 0.150 | 1.249 | 10.581 |
| DDI secular, unpadded | 0.480 | 1.743 | 12.450 |
| DDI full, unpadded | 0.477 | 1.749 | 12.501 |
| DDI full, pad 1.5 | 0.523 | 2.271 | 17.275 |
| **DDI full, pad 2 (production)** | **0.604** | **2.768** | **25.070** |

- **`secular_ddi` is not a speed optimisation** — full vs secular is inside the noise. It is an approximation with a physics justification, and I had assumed it was also the cheaper kernel.
- Zero-padding is 50 % of the step at 128³.
- The midpoint predictor-corrector is 19 % at 128³ / 33 % at 32³ — but off is the 1st-order DDI path, so that is what accuracy costs.

## Cross-check against the GS cache-hit fix that landed on main

`test_gs_cache_hit_physics.jl` arrived on main while this was open, pinning a bug where a ground-state **cache hit** rebuilt its workspace without `light_shift`, `spinor_lhy`, `lhy_opts` or `rotating_frame_omega` — so a cache hit silently ran the rest of the pipeline with no tabulated LHY, no light shift and no rotating frame, while the stored psi stayed correct.

This PR turns cache hits **on** for the Matsui campaign, and the −12 % was measured on a commit that predates that fix. The config has `lhy: {kind: none}`, no light shift and no rotating frame, so it should be unaffected — checked rather than assumed, comparing the cached and uncached 45-point runs field by field:

```
stage-cache OFF vs ON, 44 fields (point_001 skipped)
  max |Δ N_{m=-6}| = 0.000e+00   mean = 0.000e+00
```

Bit-identical. The saving is free of physics change on this config, and the new gate now covers the case for configs where it would not be.

## Also fixed

- `build_sysimage.jl` activated `@__DIR__/../..` — the parent of the repo, which has no `Project.toml`.
- The submit script for the probes never exported `SPINORBEC_STORE`, so a probe wrote its scan output into the git worktree.
- `scan_job_cost_breakdown.jl` counts the points a trimmed config expands to and errors if it is not what was asked — the first version handled only vector scan axes, and this config uses a `{from,to,step}` range, so it silently ran four full 45-point scans labelled "1 point".
- The probe scripts `import CUDA` before `using SpinorBEC` and assert `CUDA.functional()`; without it a `backend: gpu` config dies at `no method matching _to_device(::CUDABackend, ::Array)` 6.7 s in and reads as "slow".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

