### PR TITLE
Production rotation angle is 1e-3..5e-2, not 1e-5 — and the Taylor tolerance binds there

### DIFF
--- a/src/foundation/spinor_utils/spin_rotation_taylor.jl
+++ b/src/foundation/spinor_utils/spin_rotation_taylor.jl
@@ -61,14 +61,35 @@ the same conclusion measured on that device.
 The relationship, not this number, is what is gated:
 `test_cpu_spin_rotation_taylor_parity.jl` fails if the truncation error stops
 being negligible against the splitting error."""
-# 1e-15, not 1e-13. The tighter value is FREE — the degree is floored at 2 and at
-# production `R ≈ 1e-5` the schedule returns 2 for every tolerance over ten
-# decades — so shipping the loose one offered a choice that could only ever be
-# equal or worse. A setting that gives accuracy away without buying speed is not a
-# trade, and the way to remove one is to stop shipping it.
+# 1e-15, not 1e-13. The tighter value costs ONE Horner degree and buys two
+# decades of backward error, which is why it is now the default rather than a
+# "reference" sitting beside a looser shipped value.
 #
-# The knob stays registered because it CAN bind at large rotation angles, where it
-# is a real control; it is simply not one at any angle this code runs at.
+# The knob stays registered because it BINDS AT PRODUCTION ANGLES. That is a
+# correction: this comment used to say "the degree is floored at 2 and at
+# production `R ≈ 1e-5` the schedule returns 2 for every tolerance over ten
+# decades", and `RSAFE` below said production R is 0.01–0.2. The two disagreed by
+# three orders and the second one is right. Measured (Eu F=6, 16³,
+# spin-coherent, `theta_max = |c₁·dt|·fmax·F` — the quantity spin_mixing.jl:90
+# already computes):
+#
+#     c₁      dt      R_max      degree@1e-13   degree@1e-15
+#     -0.05   0.005   0.00134    5              5
+#     -0.05   0.01    0.00268    5              6
+#     -0.2    0.005   0.00536    5              6
+#     -0.2    0.01    0.0107     6              7
+#     1.0     0.005   0.0268     7              8
+#     1.0     0.01    0.0536     8              9
+#
+# It binds across the band except at its very bottom, where both give 5 — and 5
+# is the point: the degree is nowhere near the floor of 2 at any production
+# angle. Sweeping R over eleven decades the two tolerances differ at 16 of 23
+# sampled angles, and the degree returns 2 only for R ≲ 3e-8, four to five
+# orders below the weakest cell here.
+#
+# So the tolerance is a real control here, not a formality, and it must not be
+# frozen into a `const` on the grounds that production cannot feel it.
+# `test/hamiltonian/test_taylor_tolerance_binds.jl` pins that.
 const SPIN_TAYLOR_TOL = Ref(1.0e-15)
 
 """Angle above which a voxel halves its rotation and applies it twice (repeated
@@ -83,11 +104,10 @@ const SPIN_TAYLOR_RK_MAX = 40
 """Upper clamp on the Horner degree. Defaults to no clamp.
 
 Exists because the accuracy criterion needs a positive control and nothing else
-could provide one. `SPIN_TAYLOR_TOL` cannot degrade the rotation — the degree is
-floored at 2 and at production `R = |scale|·|v|·F ≈ 1e-5` the schedule returns 2
-for every tolerance over ten decades. Neither can the floor: measured, an
-order-1 rotation is still ~1e-8 relative, four orders inside the splitting
-error. The rotation is simply nowhere near binding, and the only way to make the
+could provide one. `SPIN_TAYLOR_TOL` changes the DEGREE at production angles
+(`R = |scale|·|v|·F ≈ 1e-3…5e-2`, measured — see the note on `SPIN_TAYLOR_TOL`)
+but not the observable: an order-1 rotation is still ~1e-8 relative, four orders
+inside the splitting error. The rotation is simply nowhere near binding, and the only way to make the
 observable notice it is to REMOVE it — `cap = 0` skips the Horner loop entirely,
 leaving ψ untouched.
 

--- a/src/workflow/validation/accuracy_knobs.jl
+++ b/src/workflow/validation/accuracy_knobs.jl
@@ -132,13 +132,16 @@ only. Gated by test_taylor_tolerance_criterion.jl, which therefore licenses an \
 energy claim and not a phase-classification one.";
         getter=() -> SPIN_TAYLOR_ENABLED[], setter=v -> (SPIN_TAYLOR_ENABLED[] = v)),
     AccuracyKnob(:spin_taylor_tol, :global, 1.0e-15, 1.0e-15,
-        "Backward-error target for the Taylor degree. INERT at production angles: \
-the degree is floored at 2 and at R ≈ 1e-5 the schedule returns 2 for every \
-tolerance across ten decades, so this cannot change the answer OR the cost here. \
-It shipped at 1e-13 with 1e-15 as the 'reference' — a choice that could only be \
-equal or worse, offered for nothing — so the tighter value is now simply the \
-default and the choice is gone. Still registered because it CAN bind at large \
-rotation angles.";
+        "Backward-error target for the Taylor degree. It BINDS at production \
+angles: measured R_max = 1.3e-3…5.4e-2 for Eu F=6 (theta_max = |c1*dt|*fmax*F), \
+where 1e-13 and 1e-15 give degrees 4 vs 5 through 8 vs 9. This entry used to say \
+'INERT at production angles: the degree is floored at 2 and at R ~ 1e-5 the \
+schedule returns 2' — the 1e-5 was three orders low, and the degree returns 2 \
+only for R below ~3e-8. It shipped at 1e-13 with 1e-15 as the 'reference'; the \
+tighter value is now the default, which costs one Horner degree and buys two \
+decades of backward error. Changing the degree is not the same as changing the \
+observable: the rotation stays ~1e-8 relative, four orders inside the splitting \
+error, so this is a real control on the COST and a negligible one on the ANSWER.";
         getter=() -> SPIN_TAYLOR_TOL[], setter=v -> (SPIN_TAYLOR_TOL[] = v)),
     AccuracyKnob(:dealias_2_3, :global, true, false,
         "Orszag 2/3 filter on ψ and on the bilinear DDI field. NOTE the \

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -6,6 +6,10 @@
 
 # ── Fast tier: pure unit tests, no find_ground_state / run_simulation ──
 const FAST_TESTS = [
+    # Pins that SPIN_TAYLOR_TOL is a control at the angles production runs
+    # at. Three src comments said it was inert there, from an R three orders
+    # too small; nothing checked them.
+    "hamiltonian/test_taylor_tolerance_binds.jl",
     "test_quality.jl",
     # Meta-test: every test_*.jl under test/ is in exactly one tier or the
     # MANUAL allowlist (enforces CLAUDE.md commitment #7 structurally).

--- a/test/hamiltonian/test_taylor_tolerance_binds.jl
+++ b/test/hamiltonian/test_taylor_tolerance_binds.jl
@@ -1,0 +1,93 @@
+# Gate: `SPIN_TAYLOR_TOL` is a control at the angles this code actually runs at.
+#
+# Three places in src said the opposite — "the degree is floored at 2 and at
+# production `R ≈ 1e-5` the schedule returns 2 for every tolerance over ten
+# decades" — while `SPIN_TAYLOR_RSAFE`'s own docstring, four lines below one of
+# them, said production R is 0.01–0.2. They disagreed by three orders and nothing
+# checked either, so a proposal to freeze the knob into a `const` was argued from
+# the wrong one.
+#
+# Measured: R_max for Eu F=6 is 1.3e-3 … 5.4e-2, and across that range 1e-13 and
+# 1e-15 pick different degrees. The degree returns 2 only below ~3e-8.
+#
+# What this pins is the RELATIONSHIP, not the numbers: that the tolerance moves
+# the degree where production lives, and that it does not move the observable.
+# Those are separate claims and the second is why the tolerance is safe to
+# tighten, not why it is safe to delete.
+
+using Test
+using SpinorBEC
+using SpinorBEC: SPIN_TAYLOR_TOL, _taylor_rot_schedule, _spin_field_scratch, _compute_spin_density!,
+    SPIN_TAYLOR_RK_MAX, ATOM_REGISTRY
+
+# `rk[k] = scale/k` with scale = 1, so `g = R²` makes the schedule see exactly R.
+const _RK = [1.0 / k for k in 1:SPIN_TAYLOR_RK_MAX]
+_degree(R, tol) = _taylor_rot_schedule(R^2, _RK, SPIN_TAYLOR_RK_MAX, tol^2, 1.0,
+    SPIN_TAYLOR_RK_MAX)[3]
+
+@testset "SPIN_TAYLOR_TOL binds at production rotation angles" begin
+    @testset "it is still a knob, and the schedule still reads it" begin
+        # Without this the file below only exercises `_taylor_rot_schedule` with
+        # explicit tolerances, so freezing `SPIN_TAYLOR_TOL` into a `const` —
+        # the change this evidence argues against — would leave it green. It has
+        # to fail on the actual edit, not on a proxy for it.
+        @test SPIN_TAYLOR_TOL isa Ref
+        old = SPIN_TAYLOR_TOL[]
+        try
+            SPIN_TAYLOR_TOL[] = 1.0e-13
+            @test SPIN_TAYLOR_TOL[] == 1.0e-13
+        finally
+            SPIN_TAYLOR_TOL[] = old
+        end
+        @test SPIN_TAYLOR_TOL[] == 1.0e-15      # the shipped default
+    end
+
+    @testset "production R is 1e-3..1e-1, not 1e-5" begin
+        # theta_max = |c1*dt|*fmax*F is what spin_mixing.jl computes before
+        # dispatching, i.e. the largest R any voxel will see this substep.
+        grid = make_grid(GridConfig((16, 16, 16), (8.0, 8.0, 8.0)))
+        atom = ATOM_REGISTRY[:Eu151]
+        F = Int(atom.F)
+        D = 2F + 1
+        psi = init_psi_spin_coherent(grid, SpinSystem(F); theta=π / 2, phi=0.0)
+        sm = spin_matrices(F)
+        n_pts = grid.config.n_points
+        fx, fy, fz = _spin_field_scratch(Float64, n_pts)
+        _compute_spin_density!(fx, fy, fz, psi, sm, Val(D), 3, n_pts)
+        fmax = max(maximum(abs, fx), maximum(abs, fy), maximum(abs, fz))
+
+        R_max(c1, dt) = abs(c1 * dt) * fmax * Float64(F)
+        # Weakest production cell (c1 = -0.05, dt = 0.005) through a strong one.
+        @test 1.0e-3 < R_max(-0.05, 0.005) < 1.0e-2
+        @test 1.0e-2 < R_max(1.0, 0.01) < 1.0e-1
+        # The claim that was in src for three releases. Kept as a negative
+        # assertion so it cannot come back quietly.
+        @test R_max(-0.05, 0.005) > 100 * 1.0e-5
+    end
+
+    @testset "the two tolerances pick different degrees over the band" begin
+        # Measured R_max for the six (c1, dt) production cells. The tolerance
+        # binds at five of them; at the weakest (0.00134) both give 5. Written
+        # per-cell rather than as a blanket `for` because the blanket version is
+        # what I wrote first and it was false at exactly that cell.
+        @test _degree(0.00134, 1.0e-13) == _degree(0.00134, 1.0e-15) == 5
+        for R in (0.00268, 0.00536, 0.0107, 0.0268, 0.0536)
+            @test _degree(R, 1.0e-15) - _degree(R, 1.0e-13) == 1
+        end
+    end
+
+    @testset "degree 2 needs R below ~3e-8, far under production" begin
+        @test _degree(1.0e-8, 1.0e-15) == 2
+        @test _degree(1.0e-6, 1.0e-15) > 2
+        @test _degree(0.00134, 1.0e-15) == 5    # weakest production cell
+    end
+
+    @testset "the sweep is discriminating, not uniformly true" begin
+        # If the tolerance changed the degree at EVERY angle the test above would
+        # be vacuous. It does not: there are angles where both agree, and the
+        # gate has to be able to see that.
+        agree = count(R -> _degree(R, 1.0e-13) == _degree(R, 1.0e-15),
+            (1.0e-8, 1.0e-6, 3.16e-6, 1.0e-5, 1.0e-4, 3.16e-4))
+        @test agree ≥ 4
+    end
+end


### PR DESCRIPTION
## A file that contradicted itself, and nothing checked either side

`src/foundation/spinor_utils/spin_rotation_taylor.jl` said both of these:

- lines 65 / 87, and `accuracy_knobs.jl:136` — *"the degree is floored at 2 and at production `R ≈ 1e-5` the schedule returns 2 for every tolerance over ten decades"*
- line 75, four lines below the first — *"Production `R` is 0.01–0.2 so no voxel ever halves"*

Three orders apart. Found while checking whether #271 should be allowed to freeze `SPIN_TAYLOR_TOL` into a `const`, since that argument rests on which of the two is true.

## Measured

`theta_max = |c1*dt|*fmax*F` is the largest `R` any voxel sees in a substep, and `spin_mixing.jl:90` already computes it. Eu F=6, 16³, spin-coherent:

| c₁ | dt | R_max | deg @1e-13 | deg @1e-15 |
|---:|---:|---:|---:|---:|
| −0.05 | 0.005 | 0.00134 | 5 | 5 |
| −0.05 | 0.01 | 0.00268 | 5 | **6** |
| −0.2 | 0.005 | 0.00536 | 5 | **6** |
| −0.2 | 0.01 | 0.0107 | 6 | **7** |
| 1.0 | 0.005 | 0.0268 | 7 | **8** |
| 1.0 | 0.01 | 0.0536 | 8 | **9** |

**The docstring was right; the comment was wrong.** The tolerance binds at five of the six cells, and the degree sits at 5–9 — nowhere near the floor of 2. Across an eleven-decade sweep the two tolerances differ at 16 of 23 angles; degree 2 needs `R` below about 3e-8.

## What this does and does not say about #271

#271's measurement — `rel|Δψ| = 6.46e-16`, 100× under the cost of flipping the realization — is real and not in dispute. But it establishes that the tolerance does not move the **observable**, not that it does not move the **degree**. Only the second licenses deleting a knob, and the degree moves at production.

`1e-13 → 1e-15` was the right change: one Horner degree for two decades of backward error. The claim attached to it was not.

## The gate

`test/hamiltonian/test_taylor_tolerance_binds.jl` — FAST_TESTS, 3.6 s, 16 assertions. Pins the relationship rather than the numbers: production `R` is `1e-3..1e-1`, the tolerances differ over the band, both agree at the weakest cell, and degree 2 needs `R` four orders lower.

It also asserts `SPIN_TAYLOR_TOL isa Ref` and round-trips a write. Without that arm the file only calls `_taylor_rot_schedule` with explicit tolerances and would stay green through exactly the edit it argues against — my first canary attempt missed this and the file passed with the knob's default reverted.

## Two things I got wrong on the way

- The table first went in with degrees from a **decade sweep** (1e-3, 3.16e-3, …) instead of the six measured cells. Wrong by one at the low end.
- The test first asserted the tolerance binds at **all** production cells. It does not — 0.00134 gives 5 either way. Now written per cell, for that reason.