### PR TITLE
Four gates that never crossed the producer/consumer boundary, and the three defects behind them

### DIFF
--- a/scripts/mcp/tsubame_server.py
+++ b/scripts/mcp/tsubame_server.py
@@ -399,7 +399,7 @@ async def tsubame_pull_results(params: PullInput) -> str:
     argv = [
         "rsync", "-az", "--prune-empty-dirs",
         "--include=*/",
-        "--include=*.jld2", "--include=outcome.toml",
+        "--include=*.jld2", "--include=_exit_summary.json",
         "--include=_exit_summary.json", "--include=_live_status.json",
         "--include=config.yaml",
         "--exclude=*",

--- a/src/workflow/autopilot/archive.jl
+++ b/src/workflow/autopilot/archive.jl
@@ -4,7 +4,7 @@
 # dir scan that backs `list_queue` stays in millisecond territory at
 # O(10³) entries but past that the per-tick walk hurts. This module
 # moves terminal entries older than a threshold into `<qr.path>/_archive/`,
-# preserving state.toml + outcome.toml + any small summary blobs and
+# preserving state.toml + _exit_summary.json + any small summary blobs and
 # optionally compressing or dropping large psi.jld2 artefacts.
 #
 # Run periodically (monthly cron, or as part of the daily tick when

--- a/src/workflow/autopilot/backends.jl
+++ b/src/workflow/autopilot/backends.jl
@@ -76,7 +76,7 @@ SpinorBEC.run_yaml(ARGS[1])
 
 Run jobs in a **detached subprocess** via
 `julia --project=<project_root> -e 'using SpinorBEC; run_yaml(ARGS[1])'
-<spec_path>`. The spawned process writes `summary.json` / `outcome.toml`
+<spec_path>`. The spawned process writes `summary.json` / `_exit_summary.json`
 / `_live_status.json` / `*.jld2` into `entry.run_dir` — the same layout
 the UGE submit script produces — so the dashboard and
 `run_catalog_index` never need to branch on local-vs-remote.

--- a/src/workflow/autopilot/backends_uge.jl
+++ b/src/workflow/autopilot/backends_uge.jl
@@ -453,24 +453,30 @@ function job_status(b::UGEBackend, entry::QueueEntry;
         return :failed
     elseif state == "absent"
         # Not in the active listing → scheduler considers it terminal.
-        # Outcome.toml landed by `collect!` is the authoritative
-        # done/failed signal (qacct can lag minutes on TSUBAME and
-        # often returns "not found" for short jobs).
+        # `_exit_summary.json`, collected from the node, is the authoritative
+        # done/failed signal (qacct can lag minutes on TSUBAME and often returns
+        # "not found" for short jobs).
+        #
+        # This read `outcome.toml` and its comment called it "landed by
+        # `collect!`". `collect!` does not write that file and nothing else does
+        # either — the only writer was the dry-run synthetic in `tick.jl`. Since
+        # `run_dir` is content-addressed and the rsync collect carries no
+        # `--delete`, a dry run left `terminal = "done"` where a LATER LIVE run
+        # of the same spec would find it, and any live job that vanished from
+        # `qstat` — crash, OOM, node failure — was returned `:done`. A crashed
+        # job reported as successfully completed, then credited to its recipe's
+        # trust store.
         collect!(b, entry)
-        outcome_path = joinpath(entry.run_dir, OUTCOME_FILENAME)
-        if isfile(outcome_path)
-            d = try
-                TOML.parsefile(outcome_path)
-            catch
-                nothing
-            end
-            if d isa AbstractDict
-                term = String(get(get(d, "outcome", Dict()), "terminal", ""))
-                term == "done" && return :done
-                term in ("killed_data", "killed_bug") && return :failed
+        let d = _read_exit_summary(entry)
+            if d !== nothing
+                get(d, "completed", false) === true && return :done
+                # A summary that exists and says otherwise is a real failure;
+                # its CAUSE is `_classify_terminal_failure`'s job, not this
+                # function's.
+                return :failed
             end
         end
-        # No outcome.toml yet — last resort, try qacct. If still no
+        # No `_exit_summary.json` yet — last resort, try qacct. If still no
         # record, return :unknown (next tick retries).
         return _uge_terminal_state(b, job_id)
     end
@@ -499,7 +505,7 @@ function _uge_extract_job_state_from_listing(listing::AbstractString,
 end
 
 # Last-resort terminal classification via qacct. Used only when the
-# job is no longer in qstat AND outcome.toml hasn't landed yet. qacct
+# job is no longer in qstat AND `_exit_summary.json` has not landed yet. qacct
 # on TSUBAME can lag minutes after job exit and may return
 # "error: job id N not found" for short jobs that didn't make it into
 # accounting (e.g. early script failure with bad directives).

--- a/src/workflow/autopilot/failure_analysis.jl
+++ b/src/workflow/autopilot/failure_analysis.jl
@@ -3,7 +3,7 @@
 # When a job lands in :killed_data / :killed_bug the operator wants
 # "what broke?" in one sentence — not 5000 lines of Julia stacktrace.
 # `analyze_failure` walks the per-run artefacts in order of authority
-# (outcome.toml > _exit_summary.json > stderr.log tail > backend reason
+# (_exit_summary.json > stderr.log tail > backend reason
 # > kill_reason) and returns a structured summary the dashboard can
 # render as a compact badge with a hover-title for the full trail.
 #
@@ -41,32 +41,20 @@ end
     analyze_failure(entry::QueueEntry) -> FailureAnalysis
 
 Classify a terminal-failed entry. Walks artefacts under
-`entry.run_dir` (outcome.toml / _exit_summary.json / stderr.log) plus
+`entry.run_dir` (_exit_summary.json / stderr.log) plus
 `entry.kill_reason`, returns the most informative categorisation.
 
 Cheap (≤ 1 stderr file read, bounded to last 8 KB). Safe to call
 from the dashboard `/api/queue/why` route on demand.
 """
 function analyze_failure(entry::QueueEntry)
-    # 1. outcome.toml — `run_yaml` writes a structured terminal record.
-    outcome_path = joinpath(entry.run_dir, OUTCOME_FILENAME)
-    if isfile(outcome_path)
-        d = try
-            TOML.parsefile(outcome_path)
-        catch
-            nothing
-        end
-        if d isa AbstractDict
-            outcome = get(d, "outcome", Dict())
-            reason = strip(String(get(outcome, "reason", "")))
-            if !isempty(reason) && reason != "no reason"
-                cat = _category_from_reason(reason)
-                return FailureAnalysis(cat, reason, "outcome.toml: $(reason)")
-            end
-        end
-    end
+    # The `outcome.toml` block that stood here until 2026-08-04 is DELETED, not
+    # repointed. It looked for a nested `outcome.reason` table that only that
+    # file ever had, and that file has no producer — so this branch never fired
+    # and step 2 below, which opens `_exit_summary.json` correctly, was doing
+    # all the work already.
 
-    # 2. _exit_summary.json — `run_yaml`'s atexit hook stamps this with
+    # `_exit_summary.json` — `run_yaml`'s atexit hook stamps this with
     #    exception_type / nan_encountered / oom_killed flags.
     exit_path = joinpath(entry.run_dir, "_exit_summary.json")
     if isfile(exit_path)
@@ -118,7 +106,7 @@ function analyze_failure(entry::QueueEntry)
 
     return FailureAnalysis(:unknown,
         "No recognisable failure signal in artefacts",
-        "checked outcome.toml / _exit_summary.json / stderr.log / kill_reason")
+        "checked _exit_summary.json / stderr.log / kill_reason")
 end
 
 # ── classifier rules ────────────────────────────────────────────────

--- a/src/workflow/autopilot/queue.jl
+++ b/src/workflow/autopilot/queue.jl
@@ -10,7 +10,7 @@
 #     <content_id>/
 #       config.yaml        ← user spec
 #       state.toml         ← queue entry (this file's responsibility)
-#       outcome.toml       ← structured terminal status (written by run_yaml)
+#       _exit_summary.json ← structured terminal status (written by run_pipeline)
 #       ... run artefacts (point_NNN.jld2, _live_status.json, ...)
 #     .autopilot.lock      ← process-level lockfile
 #     .autopilot.paused    ← drain / pause sentinel (touched by operator CLI)
@@ -31,7 +31,7 @@ import TOML
 import Base.Filesystem: mkpath, mv
 
 export QueueEntry, QueueRoot,
-    QUEUE_STATES, RUN_STATE_FILENAME, OUTCOME_FILENAME,
+    QUEUE_STATES, RUN_STATE_FILENAME, EXIT_SUMMARY_FILENAME,
     STATE_TOML_SCHEMA_VERSION,
     enqueue!, list_queue, get_entry, save_entry!,
     backfill_group_ids!,
@@ -39,7 +39,53 @@ export QueueEntry, QueueRoot,
     set_status!, with_autopilot_lock, with_entry_lock
 
 const RUN_STATE_FILENAME = "state.toml"
-const OUTCOME_FILENAME = "outcome.toml"
+# `outcome.toml` was the name here until 2026-08-04. It had five readers and no
+# producer: the only writer in `src/` was the dry-run synthetic in `tick.jl`,
+# whose comment "Real runs overwrite this file at process exit" was false —
+# `run_pipeline` writes `_exit_summary.json` (`pipeline/runner.jl:157-166`) and
+# nothing writes an outcome.
+#
+# It was not merely inert. `run_dir` is content-addressed, the dry-run wrote
+# `terminal = "done"` into it, `collect!` does not write the file and the rsync
+# collect carries no `--delete` — so a later LIVE run of the same spec whose job
+# left `qstat` for any reason found the stale file and was reported `:done`
+# (`backends_uge.jl`). A crashed job read as successfully completed.
+#
+# `_exit_summary.json` is the same information from a writer that exists, and it
+# is strictly better: `nan_encountered` and `oom_killed` are BOOLEANS set from
+# the actual exception (`runner.jl:237-238`), so the classifiers stop matching
+# free text. `failure_analysis.jl` already read this file and was the only
+# reader that worked.
+const EXIT_SUMMARY_FILENAME = "_exit_summary.json"
+
+"""
+    _read_exit_summary(entry) -> Union{Nothing, Dict{String,Any}}
+
+The terminal record `run_pipeline` actually writes
+(`pipeline/runner.jl:157-166`), parsed, or `nothing` when it is absent or
+unreadable.
+
+ONE reader for five call sites. Until 2026-08-04 each of them opened
+`outcome.toml` — a name with no producer — and three of them parsed it as TOML
+while naming keys that only exist in this JSON file. `failure_analysis.jl` was
+the sharpest: it read `nan_encountered` / `oom_killed` correctly and reported
+them as `"_exit_summary.json: nan_encountered=true"`, a file it never opened.
+
+`nothing` is returned for absence, never an empty Dict. An empty Dict is how a
+missing record becomes a healthy verdict at the call site, which is the class of
+bug this replacement exists to end.
+"""
+function _read_exit_summary(entry)
+    p = joinpath(entry.run_dir, EXIT_SUMMARY_FILENAME)
+    isfile(p) || return nothing
+    d = try
+        JSON.parsefile(p)
+    catch
+        return nothing
+    end
+    d isa AbstractDict ? Dict{String, Any}(d) : nothing
+end
+
 const QUEUE_STATES = (:pending, :running, :done, :killed_data, :killed_bug)
 
 """

--- a/src/workflow/autopilot/recipes.jl
+++ b/src/workflow/autopilot/recipes.jl
@@ -66,7 +66,7 @@ end
 """
     recipe_refine_around_best(entry, params) -> Vector{Experiment}
 
-Compare every completed sibling's metric (read from outcome.toml) and
+Compare every completed sibling's metric (read from summary.json) and
 propose a new run at `(best_param ± shrink * range)` halfway toward
 the best. Pure greedy exploitation — wrap in a trust gate before any
 unattended dispatch.
@@ -86,7 +86,7 @@ function recipe_refine_around_best(entry, params::AbstractDict)
     shrink = Float64(get(params, "shrink", 0.5))
 
     # Walk every :done entry in this queue and find the one whose
-    # outcome.toml metric is best (we minimise by default; flip with
+    # summary.json metric is best (we minimise by default; flip with
     # `lower_is_better = false`).
     lower_is_better = Bool(get(params, "lower_is_better", true))
     best_val = nothing
@@ -207,14 +207,20 @@ function _load_spec(entry)
 end
 
 function _outcome_metric(entry, metric_path)
-    p = joinpath(entry.run_dir, OUTCOME_FILENAME)
+    # `summary.json`, not the producerless `outcome.toml` this read until
+    # 2026-08-04. Scalars a recipe would rank on are what `write_run_summary`
+    # emits (`workflow/validation/scalar_summary.jl`); `outcome.toml`'s
+    # `[metrics]` table was written empty even by the one writer it had, so
+    # every `refine`-family recipe that ranks on a metric got `nothing` here and
+    # returned no descendants at all.
+    p = joinpath(entry.run_dir, "summary.json")
     isfile(p) || return nothing
     d = try
-        TOML.parsefile(p)
+        JSON.parsefile(p)
     catch
-        ;
         return nothing
     end
+    d isa AbstractDict || return nothing
     return _get_path(d, _split_path(metric_path))
 end
 

--- a/src/workflow/autopilot/retry.jl
+++ b/src/workflow/autopilot/retry.jl
@@ -1,6 +1,6 @@
 # ── Retry classification ──────────────────────────────────────────────
 #
-# When a job lands in killed_bug, the retry pass consults outcome.toml
+# When a job lands in killed_bug, the retry pass consults _exit_summary.json
 # (or the backend's post-mortem reason) and decides:
 #
 #   TRANSIENT             → re-enqueue with attempt+1, same profile
@@ -21,7 +21,7 @@ export retry_failed!, RetryClassification, classify_failure
     classify_failure(outcome::AbstractDict, backend_reason::AbstractString="")
         -> RetryClassification
 
-Pure predicate. `outcome` is the parsed outcome.toml's `[outcome]` table
+Pure predicate. `outcome` is the parsed `_exit_summary.json`
 (or empty). `backend_reason` is the scheduler post-mortem string.
 """
 function classify_failure(outcome::AbstractDict, backend_reason::AbstractString="")
@@ -37,8 +37,20 @@ function classify_failure(outcome::AbstractDict, backend_reason::AbstractString=
         return PERMANENT
     end
 
-    # Free-text `reason` field — OOM/TIMEOUT may be reported by run_yaml
-    # itself when it catches a sigkill / wall-time event.
+    # `oom_killed` FIRST, and as a Bool. `run_pipeline` sets it from the actual
+    # exception (`runner.jl:238`, `_is_oom_error`), so this arm needs no string
+    # matching at all — which is what made the free-text arm below unreachable
+    # on the production backend. `backend_failure_reason(::UGEBackend)` emits
+    # qacct's vocabulary (`failed=… exit_status=…`) while the regexes below are
+    # SLURM's (`OUT_OF_MEMORY` / `TIMEOUT`); the two sets do not intersect and
+    # nothing normalises between them, so RESOURCE_PERMANENT was unreachable on
+    # TSUBAME and an OOM'd job re-queued at the same memory class until its
+    # retry budget ran out.
+    get(outcome, "oom_killed", false) === true && return RESOURCE_PERMANENT
+
+    # Free-text `reason` field — kept for LocalBackend and for any backend whose
+    # reason string does speak this vocabulary. It is now a fallback behind a
+    # Boolean rather than the only route.
     outcome_reason = get(outcome, "reason", "")
     combined = String(outcome_reason) * " | " * String(backend_reason)
     if occursin(r"OUT_OF_MEMORY|OOM_KILLED|OOM\b"i, combined)
@@ -107,16 +119,8 @@ function retry_failed!(;
 end
 
 function _load_outcome(entry::QueueEntry)
-    p = joinpath(entry.run_dir, OUTCOME_FILENAME)
-    isfile(p) || return Dict{String, Any}()
-    d = try
-        TOML.parsefile(p)
-    catch
-        ;
-        nothing
-    end
-    d isa AbstractDict || return Dict{String, Any}()
-    return Dict{String, Any}(get(d, "outcome", Dict()))
+    d = _read_exit_summary(entry)
+    d === nothing ? Dict{String, Any}() : d
 end
 
 function _backend_reason(entry::QueueEntry, backend::AutopilotBackend)

--- a/src/workflow/autopilot/tick.jl
+++ b/src/workflow/autopilot/tick.jl
@@ -267,10 +267,10 @@ function _autopilot_tick_body!(config::AutopilotConfig, stats::AutopilotStats)
             _collect_safe!(backend, entry)
             _maybe_fire_on_complete!(entry, config, stats)
         elseif status === :failed
-            # Backend said failed. Look at outcome.toml + backend-side reason to decide
+            # Backend said failed. Look at _exit_summary.json + backend-side reason to decide
             # killed_data vs killed_bug (OOM is resource-permanent and
             # classified as killed_bug; divergence is killed_data).
-            # Collect first so the classifier can read outcome.toml even
+            # Collect first so the classifier can read _exit_summary.json even
             # when the producer was a remote backend.
             _collect_safe!(backend, entry)
             terminal, reason = _classify_terminal_failure(entry, backend)
@@ -538,22 +538,20 @@ end
 # Classify backend "failed" → killed_bug (resource-permanent / NaN) or
 # killed_data (divergence detected post-run by the runtime itself).
 function _classify_terminal_failure(entry::QueueEntry, backend::AutopilotBackend)
-    # First: outcome.toml (written by run_yaml at exit) — most informative.
-    outcome_path = joinpath(entry.run_dir, OUTCOME_FILENAME)
-    if isfile(outcome_path)
-        d = try
-            TOML.parsefile(outcome_path)
-        catch
-            ;
-            nothing
-        end
-        if d isa AbstractDict
-            term = String(get(get(d, "outcome", Dict()), "terminal", ""))
-            reason = String(get(get(d, "outcome", Dict()), "reason", "no reason"))
-            if term == "killed_data"
-                return :killed_data, reason
-            elseif term == "killed_bug"
-                return :killed_bug, reason
+    # First: `_exit_summary.json`, the record `run_pipeline` actually writes.
+    # The `terminal` string this used to read lived only in `outcome.toml`,
+    # which had no producer — so neither branch below has ever been taken.
+    # The two Booleans here are set from the real exception (`runner.jl:237-238`)
+    # and carry the same distinction: a NaN cascade is the run's own physics
+    # going bad (`:killed_data`), an OOM is the job being wrong for its
+    # resources (`:killed_bug`).
+    let d = _read_exit_summary(entry)
+        if d !== nothing
+            step = get(d, "last_step", "?")
+            if get(d, "nan_encountered", false) === true
+                return :killed_data, "NaN encountered at step $(step)"
+            elseif get(d, "oom_killed", false) === true
+                return :killed_bug, "OOM-killed at step $(step)"
             end
         end
     end
@@ -580,7 +578,7 @@ end
 _divergence_metric(entry::QueueEntry) = "norm/Fz drift"
 
 # Dry-run: simulate one full dispatch cycle on a single entry. Logs the
-# command we WOULD have run, writes a synthetic outcome.toml, advances
+# command we WOULD have run, writes NO run artefact at all, advances
 # state to :done, AND fires the on_complete chain so recipe-driven
 # fan-out is exercised end-to-end during the observation lap. Without
 # the explicit on_complete call here, dry-run silently masks recipe
@@ -604,27 +602,13 @@ function _dry_run_dispatch!(entry::QueueEntry,
     entry.cluster_started_at = t
     entry.cluster_state = :running
     save_entry!(entry)
-    # Synthetic outcome.toml — marks the run as "completed by dry-run"
-    # so retry / on_complete / archival downstream can see something
-    # structured. Real runs overwrite this file at process exit.
-    outcome_path = joinpath(entry.run_dir, OUTCOME_FILENAME)
-    try
-        open(outcome_path, "w") do io
-            TOML.print(
-                io,
-                Dict{String, Any}(
-                    "outcome" => Dict{String, Any}(
-                        "terminal" => "done",
-                        "reason" => "dry-run synthetic",
-                        "completed" => true,
-                    ),
-                    "metrics" => Dict{String, Any}(),
-                ),
-            )
-        end
-    catch err
-        @warn "_dry_run_dispatch! failed to write outcome.toml" exception=err
-    end
+    # The synthetic `outcome.toml` written here until 2026-08-04 is deleted, not
+    # repointed. It claimed "Real runs overwrite this file at process exit",
+    # which was false, and `run_dir` is content-addressed — so the file it left
+    # behind was read by a LATER live run of the same spec and reported that
+    # run `:done`. A dry run must leave no artefact a live run can mistake for
+    # its own. `_terminal_classify!` below already stamps everything the
+    # dashboard and the journal need.
     # Route through _terminal_classify! so dry-run entries get
     # terminal_at stamped + the same @info "terminal" line that real
     # runs produce. Without this, dashboard ETA / journal-replay

--- a/src/workflow/experiments/pipeline/pipeline_callbacks.jl
+++ b/src/workflow/experiments/pipeline/pipeline_callbacks.jl
@@ -83,6 +83,22 @@ function _build_live_callback(node, status_path::Union{Nothing, String})
     every >= 1 || throw(ArgumentError("live_monitor.every must be >= 1"))
     status_dir = dirname(status_path)
     isempty(status_dir) || mkpath(status_dir)
+    # The two quantities the DIVERGENCE KILL reads, held across calls because
+    # both are differences. Until 2026-08-04 this callback wrote none of them,
+    # and `is_divergent_status` (`autopilot/monitor.jl:56-68`) defaults every one
+    # of its three inputs to a healthy value when the key is absent — `0.0` for
+    # `norm_drift`, `nothing` for `classify`, `0.0` for `fz_jump`. The writer's
+    # keys and the reader's keys had an EMPTY intersection, so the predicate
+    # returned `false` for every run that has ever been monitored, however far
+    # it had diverged.
+    #
+    # Both suites were green throughout, because each drives its own side with
+    # synthetic input: `test_autopilot.jl:75-79` hands the reader a dict
+    # containing the reader's own keys. A gate that builds its input from the
+    # thing under test never crosses the producer/consumer boundary, which is
+    # the only place this defect lives.
+    norm_0 = Ref(NaN)
+    fz_prev = Ref(NaN)
     function (ws, step, times, energies)
         step % every == 0 || return nothing
         psi = ws.state.psi
@@ -95,13 +111,32 @@ function _build_live_callback(node, status_path::Union{Nothing, String})
         end
         e_now = isempty(energies) ? NaN : Float64(energies[end])
         t_now = isempty(times) ? Float64(ws.state.t) : Float64(times[end])
+        norm_now = Float64(n_total) * Float64(cell_volume(ws.grid))
+        isnan(norm_0[]) && (norm_0[] = norm_now)
+        # Relative to this run's FIRST observed norm, not to 1.0: a run may be
+        # normalised to something else, and the kill is about drift, not about
+        # the absolute value.
+        norm_drift = norm_0[] == 0 ? 0.0 : abs(norm_now / norm_0[] - 1)
+        # <F_z> from the populations already computed above — m runs F, F-1, …,
+        # -F over c = 1..D (CLAUDE.md: `c=1 -> m=F`), so no spin matrices and no
+        # second pass over psi.
+        F = (D - 1) / 2
+        fz_now = sum((F - (c - 1)) * pops[c] for c in 1:D)
+        fz_jump = isnan(fz_prev[]) ? 0.0 : abs(fz_now - fz_prev[])
+        fz_prev[] = fz_now
         data = Dict{String, Any}(
             "step" => step,
             "t" => t_now,
             "energy" => e_now,
-            "norm" => Float64(n_total) * Float64(cell_volume(ws.grid)),
+            "norm" => norm_now,
             "populations" => pops,
             "updated_ms" => round(Int, time() * 1000),
+            # Read by `is_divergent_status`. `classify` is deliberately NOT
+            # written: the predicate already skips a `nothing` classification,
+            # and inventing one here would be a second classifier competing with
+            # `analysis/phases/`.
+            "norm_drift" => norm_drift,
+            "fz_jump" => fz_jump,
         )
         # Atomic write: tmp file + rename so HTTP readers never see partial JSON
         tmp_path = status_path * ".tmp"

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -89,6 +89,8 @@ const FAST_TESTS = [
     # drives `is_divergent_status` with dicts it builds itself, so it passed
     # while the writer and the reader shared no keys at all.
     "workflow/test_live_status_reaches_the_detector.jl",
+    # A name the autopilot reads must be a name something writes.
+    "workflow/test_terminal_record_has_a_producer.jl",
     # Model / Stage layer + the provenance cutover's steps 1, 1b and 2.
     "model/test_model_shape.jl",
     "model/test_model_toml_roundtrip.jl",

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -85,6 +85,10 @@ const FAST_TESTS = [
     "workflow/test_checkpoint.jl",
     "workflow/test_checkpointed_sweep.jl",
     "workflow/test_gs_stage_cache.jl",
+    # Does what a run WRITES reach what the reaper READS? The autopilot suite
+    # drives `is_divergent_status` with dicts it builds itself, so it passed
+    # while the writer and the reader shared no keys at all.
+    "workflow/test_live_status_reaches_the_detector.jl",
     # Model / Stage layer + the provenance cutover's steps 1, 1b and 2.
     "model/test_model_shape.jl",
     "model/test_model_toml_roundtrip.jl",

--- a/test/workflow/test_autopilot.jl
+++ b/test/workflow/test_autopilot.jl
@@ -4,7 +4,7 @@ using JSON
 using TOML
 using SpinorBEC
 using SpinorBEC: QueueEntry, _entry_to_toml_dict, _entry_from_toml_dict,
-    _is_divergent, _maybe_fire_on_complete!, OUTCOME_FILENAME,
+    _is_divergent, _maybe_fire_on_complete!, EXIT_SUMMARY_FILENAME,
     RUN_STATE_FILENAME,
     AutopilotConfig, AutopilotBackend, LocalBackend, UGEBackend,
     resolve_backend, stage_in, pull_live, collect!, prepare_status_snapshot,
@@ -733,23 +733,19 @@ using SpinorBEC: QueueEntry, _entry_to_toml_dict, _entry_from_toml_dict,
                     rd, e
                 end
 
-                # 1. outcome.toml wins.
-                rd, e = _mkentry("ana_outcome_aaaaaa", :oom)
-                open(joinpath(rd, "outcome.toml"), "w") do io
-                    TOML.print(
-                        io,
-                        Dict(
-                            "outcome" => Dict(
-                                "terminal" => "killed_bug",
-                                "reason" => "OOM_KILLED at step 1500"),
-                        ),
-                    )
-                end
-                a = SpinorBEC.analyze_failure(e)
-                @test a.category === :oom
-                @test occursin("OOM_KILLED", a.summary)
+                # The `outcome.toml` arm that stood here until 2026-08-04 is
+                # deleted with the file. It wrote the artefact itself and then
+                # asserted the reader consumed it — so it stayed green while
+                # nothing in production ever produced one. Building the input a
+                # reader wants, without asking who writes it, is the same shape
+                # as `is_divergent_status(Dict("norm_drift" => 0.5))`: a gate
+                # that never crosses the producer/consumer boundary.
+                #
+                # `_exit_summary.json` has a producer (`pipeline/runner.jl`),
+                # and the OOM case it used to cover is now the `oom_killed`
+                # Boolean arm in `test_terminal_record_has_a_producer.jl`.
 
-                # 2. _exit_summary.json with NaN flag.
+                # _exit_summary.json with NaN flag.
                 rd2, e2 = _mkentry("ana_nan_aaaaaaa", :nan)
                 open(joinpath(rd2, "_exit_summary.json"), "w") do io
                     write(io, "{\"nan_encountered\":true,\"last_step\":2700}")

--- a/test/workflow/test_live_status_reaches_the_detector.jl
+++ b/test/workflow/test_live_status_reaches_the_detector.jl
@@ -1,0 +1,134 @@
+using Test
+using SpinorBEC
+using JSON
+using SpinorBEC: _build_live_callback, is_divergent_status, divergence_thresholds
+
+# Does what the run WRITES reach what the reaper READS?
+#
+# This is the one question neither existing suite asks. `test_autopilot.jl:74-80`
+# drives `is_divergent_status` with dicts it builds itself —
+# `Dict("norm_drift" => 0.5)` — so it tests the predicate against its own
+# vocabulary and passes whether or not any producer ever emits that key.
+#
+# It did not. Measured 2026-08-04, before the fix:
+#
+#     writer (`pipeline_callbacks.jl`)  step, t, energy, norm, populations, updated_ms
+#     reader (`autopilot/monitor.jl`)   norm_drift, classify, fz_jump
+#     intersection                      EMPTY
+#
+# and every one of the reader's three lookups defaults to a HEALTHY value when
+# the key is absent (`0.0`, `nothing`, `0.0`). So `is_divergent_status` returned
+# `false` for every monitored run in the project's history, however far it had
+# diverged — and CLAUDE.md lists the divergence kill as a standing autopilot
+# guarantee ("reap loop watches `_live_status.json`, cancels divergent runs,
+# classifies `:killed_data`"). A diverging run was filed `:done`, credited to its
+# recipe's trust store, and counted as a non-kill by the circuit breakers.
+#
+# A gate that constructs its input from the thing under test cannot see this.
+# This file runs the REAL callback, reads the file it ACTUALLY wrote, and hands
+# that to the REAL predicate. Nothing in between is synthetic.
+
+# 8^3, no solver: the callback is invoked directly with a workspace and a psi.
+# The defect is about JSON keys, not about physics, and it reproduces at any size.
+function probe_ws(; n=(8, 8, 8))
+    grid = make_grid(GridConfig{3}(n, (6.0, 6.0, 6.0)))
+    atom = resolve_atom(:Na23)
+    make_workspace(; grid, atom,
+        interactions=InteractionParams(Dict(0 => 1.0, 1 => 0.03)),
+        potential=HarmonicTrap((1.0, 1.0, 1.0)),
+        sim_params=SimParams(; dt=1.0e-3, n_steps=1, save_every=1))
+end
+
+"Run the real callback `n` times, scaling psi by `scale` before the last call."
+function emit(dir, ws; every=1, scale=1.0, calls=2)
+    path = joinpath(dir, "_live_status.json")
+    cb = _build_live_callback(Dict("every" => every), path)
+    @assert cb !== nothing
+    psi0 = copy(Array(ws.state.psi))
+    for k in 1:calls
+        if k == calls && scale != 1.0
+            ws.state.psi .= psi0 .* scale
+        end
+        cb(ws, k * every, Float64[], Float64[])
+    end
+    JSON.parsefile(path)
+end
+
+@testset "what the run writes reaches what the reaper reads" begin
+    ws = probe_ws()
+
+    @testset "the writer emits every key the detector reads" begin
+        st = mktempdir(d -> emit(d, probe_ws()))
+        # Named individually so a future omission says WHICH key went missing
+        # rather than failing as one opaque set comparison.
+        @test haskey(st, "norm_drift")
+        @test haskey(st, "fz_jump")
+        # `classify` is deliberately absent — `is_divergent_status` skips a
+        # `nothing` classification, and inventing one here would be a second
+        # classifier competing with `analysis/phases/`. Asserted so that its
+        # absence is a decision on record rather than another empty intersection.
+        @test !haskey(st, "classify")
+    end
+
+    @testset "a healthy run is not killed" begin
+        st = mktempdir(d -> emit(d, probe_ws()))
+        @test !is_divergent_status(st)
+    end
+
+    # THE ARM THE PROJECT DID NOT HAVE. A run that blows up must be seen as
+    # divergent BY THE PREDICATE, THROUGH THE FILE. Both halves matter: reading
+    # the dict the callback returned in memory would not catch a JSON round-trip
+    # that drops or renames a key.
+    @testset "a blown-up run IS killed, through the file" begin
+        thr = divergence_thresholds()
+        st = mktempdir(d -> emit(d, probe_ws(); scale=1.0e3))
+        @test st["norm_drift"] > thr.norm_drift
+        @test is_divergent_status(st)
+    end
+
+    # POSITIVE CONTROL ON THE THRESHOLD. If `norm_drift` were emitted but always
+    # zero — the shape a careless fix would produce — the arm above would fail,
+    # but an arm asserting only `haskey` would not. Pin that the quantity
+    # actually tracks the state.
+    @testset "norm_drift tracks the state rather than being a constant" begin
+        quiet = mktempdir(d -> emit(d, probe_ws()))
+        loud = mktempdir(d -> emit(d, probe_ws(); scale=2.0))
+        @test quiet["norm_drift"] < 1.0e-12
+        @test loud["norm_drift"] > 1.0
+        @test loud["norm_drift"] != quiet["norm_drift"]
+    end
+
+    # And the same for fz_jump, which is a DIFFERENCE and so has its own way of
+    # being trivially zero: a first call has no predecessor.
+    @testset "fz_jump is zero on the first sample and measured after" begin
+        mktempdir() do d
+            path = joinpath(d, "_live_status.json")
+            cb = _build_live_callback(Dict("every" => 1), path)
+            w = probe_ws()
+            cb(w, 1, Float64[], Float64[])
+            first_sample = JSON.parsefile(path)
+            @test first_sample["fz_jump"] == 0.0     # no predecessor to differ from
+
+            # Move population between components, which is what <F_z> measures.
+            #
+            # ADD, do not scale. The seed puts its population in one component,
+            # and `pops` is normalised by the total — so multiplying an EMPTY
+            # component by any factor leaves every population exactly where it
+            # was and `fz_jump` stays 0. The first version of this arm did that
+            # and failed, which is the same degenerate-knob trap recorded in
+            # [[mistake_null_from_a_degenerate_knob]]: a perturbation the
+            # observable cannot see is not a perturbation.
+            psi = w.state.psi
+            D = size(psi, ndims(psi))
+            @test D >= 3
+            fz_before = JSON.parsefile(path)
+            amp = maximum(abs.(Array(psi)))
+            psi[:, :, :, 1] .+= amp
+            cb(w, 2, Float64[], Float64[])
+            second = JSON.parsefile(path)
+            # the populations really moved, or the assertion below is vacuous
+            @test second["populations"] != fz_before["populations"]
+            @test second["fz_jump"] > 0.0
+        end
+    end
+end

--- a/test/workflow/test_terminal_record_has_a_producer.jl
+++ b/test/workflow/test_terminal_record_has_a_producer.jl
@@ -1,0 +1,121 @@
+using Test
+using SpinorBEC
+using SpinorBEC: EXIT_SUMMARY_FILENAME, _read_exit_summary
+
+# Every file the autopilot READS must be a file something WRITES.
+#
+# `outcome.toml` had five readers and no producer. The only writer in `src/` was
+# a dry-run synthetic whose own comment — "Real runs overwrite this file at
+# process exit" — was false: `run_pipeline` writes `_exit_summary.json`.
+#
+# It was not inert. `run_dir` is content-addressed, the dry run wrote
+# `terminal = "done"` into it, `collect!` does not write the file and the rsync
+# collect carries no `--delete`. So a LIVE run of the same spec whose job left
+# `qstat` for any reason found the stale file and was reported `:done` — a
+# crashed job read as successfully completed, then credited to its recipe's
+# trust store.
+#
+# This gate is at the level of the NAME, not of any one call site, because the
+# defect was a name outliving its writer.
+
+const _AUTOPILOT_SRC =
+    let root = normpath(joinpath(@__DIR__, "..", "..")),
+        dir = joinpath(root, "src", "workflow", "autopilot")
+
+        [joinpath(dir, f) for f in readdir(dir) if endswith(f, ".jl")]
+    end
+
+@testset "the terminal record has a producer" begin
+    @testset "the phantom name is gone from code" begin
+        # Comments may narrate the history — that is how the reason survives —
+        # but no CODE may name it. Strip comments before looking.
+        # Strip BOTH `#` comments and `"""` docstrings. The first version of
+        # this arm stripped only `#` and then flagged the docstring that
+        # explains the removal — the gate's own instrument reading prose as
+        # code.
+        function code_lines(path)
+            out = Tuple{Int, String}[]
+            in_doc = false
+            for (i, line) in enumerate(eachline(path))
+                n = count(!isnothing, eachmatch(r"\"\"\"", line))
+                if in_doc
+                    isodd(n) && (in_doc = false)
+                    continue
+                elseif n > 0
+                    in_doc = isodd(n)
+                    continue
+                end
+                push!(out, (i, split(line, '#')[1]))
+            end
+            out
+        end
+        offenders = String[]
+        for f in _AUTOPILOT_SRC, (i, code) in code_lines(f)
+            (occursin("outcome.toml", code) || occursin("OUTCOME_FILENAME", code)) &&
+                push!(offenders, "$(basename(f)):$i  $(strip(code))")
+        end
+        isempty(offenders) || println("  still naming the phantom in CODE:\n    ",
+            join(offenders, "\n    "))
+        @test offenders == String[]
+
+        # POSITIVE CONTROL on the scanner: it must still SEE a real occurrence,
+        # or "no offenders" means "the scanner is blind".
+        mktempdir() do d
+            probe = joinpath(d, "probe.jl")
+            write(probe, "x = 1\np = joinpath(dir, OUTCOME_FILENAME)\n")
+            @test any(occursin("OUTCOME_FILENAME", c) for (_, c) in code_lines(probe))
+        end
+    end
+
+    @testset "the name it was replaced by IS written by the pipeline" begin
+        # The whole point: this one has a producer. Assert it at the writer.
+        runner = normpath(
+            joinpath(@__DIR__, "..", "..",
+                "src", "workflow", "experiments", "pipeline", "runner.jl"),
+        )
+        src = read(runner, String)
+        @test EXIT_SUMMARY_FILENAME == "_exit_summary.json"
+        @test occursin(EXIT_SUMMARY_FILENAME, src)
+        # …and the two Booleans the classifiers now depend on are set there from
+        # the real exception, not defaulted.
+        @test occursin("nan_encountered=_is_nan_error", replace(src, " " => ""))
+        @test occursin("oom_killed=_is_oom_error", replace(src, " " => ""))
+    end
+
+    @testset "absence returns nothing, never an empty verdict" begin
+        # An empty Dict is how a missing record becomes a healthy answer at the
+        # call site. `_read_exit_summary` must distinguish absent from empty.
+        mktempdir() do d
+            e = (run_dir=d,)
+            @test _read_exit_summary(e) === nothing
+            write(joinpath(d, EXIT_SUMMARY_FILENAME), "{ not json")
+            @test _read_exit_summary(e) === nothing        # unreadable is absent
+            write(joinpath(d, EXIT_SUMMARY_FILENAME),
+                """{"completed": true, "oom_killed": false, "nan_encountered": false}""")
+            got = _read_exit_summary(e)
+            @test got isa AbstractDict
+            @test got["completed"] === true
+        end
+    end
+
+    @testset "the OOM route needs no string matching" begin
+        # This is what made the escalation reachable. `classify_failure` had only
+        # a free-text arm matching SLURM's vocabulary, while
+        # `backend_failure_reason(::UGEBackend)` emits qacct's — two sets that do
+        # not intersect, with nothing normalising between them, so an OOM'd
+        # TSUBAME job re-queued at the same memory class until its retry budget
+        # ran out.
+        @test classify_failure(Dict{String, Any}("oom_killed" => true), "") ===
+            SpinorBEC.RESOURCE_PERMANENT
+        # POSITIVE CONTROL: the Boolean must be what decides it, not the empty
+        # backend string, which on its own means UNKNOWN.
+        @test classify_failure(Dict{String, Any}("oom_killed" => false), "") ===
+            SpinorBEC.UNKNOWN_CLASS
+        # …and a REAL UGE reason string still classifies, through the Boolean,
+        # where the regex alone never could.
+        uge = "failed=37 : qmaster enforced h_rt, h_cpu, or h_vmem limit exit_status=137"
+        @test classify_failure(Dict{String, Any}(), uge) === SpinorBEC.UNKNOWN_CLASS
+        @test classify_failure(Dict{String, Any}("oom_killed" => true), uge) ===
+            SpinorBEC.RESOURCE_PERMANENT
+    end
+end


### PR DESCRIPTION
Three defects in the autopilot, each found because a gate never crossed the
boundary between the thing that WRITES and the thing that READS.

## 1. The divergence kill has never fired

`is_divergent_status` (`autopilot/monitor.jl:56-68`) is the predicate the reap
loop uses to cancel a diverging run. The callback that writes the file it reads
wrote none of its keys:

| | keys |
|---|---|
| writer (`pipeline/pipeline_callbacks.jl`) | `step`, `t`, `energy`, `norm`, `populations`, `updated_ms` |
| reader (`autopilot/monitor.jl`) | `norm_drift`, `classify`, `fz_jump` |
| **∩** | **empty** |

Every reader lookup defaults to a *healthy* value on absence — `0.0`, `nothing`,
`0.0` — so the predicate returned `false` for every monitored run in the
project's history, however far it had diverged.

Worse than a lost capability: a diverging run was filed `:done`, credited to its
recipe's trust store, counted as a non-kill by the circuit breakers, and served
downstream as good data.

**Fix.** The writer emits `norm_drift` (against this run's *first observed*
norm, not against 1.0 — the kill is about drift, and a run may be normalised to
something else) and `fz_jump`, computed from the populations the callback
already builds (`c=1 -> m=F`, so no spin matrices and no second pass over psi).
`classify` stays absent on purpose: the predicate already skips a `nothing`
classification, and inventing one here would be a second classifier competing
with `analysis/phases/`.

## 2. `outcome.toml` had five readers, no writer — and reported crashed jobs as done

The only writer was the dry-run synthetic in `tick.jl`, whose own comment "Real
runs overwrite this file at process exit" was false: `run_pipeline` writes
`_exit_summary.json`. Three call sites also parsed it as TOML while naming keys
that exist only in that JSON file.

It was not inert. `run_dir` is content-addressed, the dry run wrote
`terminal = "done"` into it, `collect!` does not write the file and the rsync
collect carries no `--delete`. So a later **live** run of the same spec whose job
left `qstat` for any reason — crash, OOM, node failure — found the stale file and
`backends_uge.jl` returned `:done`.

**Fix, by deletion and repointing rather than by adding a producer.** The
synthetic write is deleted; `OUTCOME_FILENAME` becomes `EXIT_SUMMARY_FILENAME`
behind **one** reader replacing five hand-rolled ones, returning `nothing` for
absence and never an empty Dict; `failure_analysis.jl`'s phantom block is deleted
(the block below it was already reading the right file and doing all the work);
`recipes.jl` reads `summary.json`, whose absence was why every refine-family
recipe returned no descendants.

## 3. The resource-permanent retry escalation was unreachable on TSUBAME

`classify_failure` matched the SLURM spellings `OUT_OF_MEMORY` / `TIMEOUT` in
free text; `backend_failure_reason(::UGEBackend)` emits qacct's vocabulary
(`failed=… exit_status=…`). Disjoint sets, and `combined` is a raw string
concatenation — no normalisation between them. An OOM'd job re-queued at the same
memory class until its retry budget ran out.

**Fix.** `_exit_summary.json` carries `oom_killed` as a **Boolean**, set from the
actual exception (`runner.jl:238`). The new arm needs no string matching, so the
vocabulary problem is deleted rather than patched with a second dialect.

---

## Why nothing caught any of it

Four gates, one shape. Each builds its input out of the vocabulary of the thing
it is testing:

```julia
@test is_divergent_status(Dict("norm_drift" => 0.5))    # the reader's own key
@test classify_failure(Dict(), "OUT_OF_MEMORY|...")     # the matcher's own literal
write(joinpath(rd, "outcome.toml"), …); analyze_failure(e)   # the artefact, self-produced
```

and, from yesterday, a canary that perturbed `c1` on a **polar** state where
⟨F⟩ = 0 makes the c₁ term contribute nothing — so it passed against the very
defect it was written for.

**A gate that constructs its input from the thing under test never crosses the
producer/consumer boundary, and that boundary is the only place this class of
defect lives.**

## The gates

`test/workflow/test_live_status_reaches_the_detector.jl` — the real callback
writes a file, the file is read back off disk, the real predicate judges it.
Nothing in between is synthetic. Healthy → not killed; blown up → killed, through
the file, above the configured threshold.

`test/workflow/test_terminal_record_has_a_producer.jl` — at the level of the
NAME rather than any call site, because the defect was a name outliving its
writer. No **code** under `src/workflow/autopilot/` may name the phantom
(comments may narrate the history — that is how the reason survives); the
replacement name IS written by `runner.jl`; absence returns `nothing`; the OOM
route classifies through the Boolean, including on a real UGE reason string the
regexes can never match.

Canaried in **both** directions, because a boundary has two sides:

| edit | result |
|---|---|
| delete `"norm_drift"` from the writer | `haskey` **and** `is_divergent_status` red |
| rename the key in the reader | `is_divergent_status` red |
| reintroduce `const OUTCOME_FILENAME` | the name arm red |
| delete the Boolean OOM arm | two assertions in the escalation arm red |

Plus the positive controls the equalities need. `norm_drift` must differ between
a quiet and a loud run — a fix emitting a constant `0.0` satisfies `haskey`
alone. The name scanner must still SEE a planted occurrence, or "no offenders"
means "the scanner is blind"; its first version stripped `#` comments but not
`"""` docstrings and flagged the docstring explaining the removal, which is the
same instrument-reads-prose-as-code error one level up.

The `fz_jump` arm's first version *scaled* an empty spinor component — a
perturbation the normalised populations cannot see — and failed. It now asserts
the populations actually moved before asserting the jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)