### PR TITLE
The TWA ensemble discarded itself on one bad member — plus two design rows closed by measurement

### DIFF
--- a/docs/audit/memory_ledger_2026-08-04.md
+++ b/docs/audit/memory_ledger_2026-08-04.md
@@ -1,0 +1,186 @@
+# Memory-store ledger
+
+> **FROZEN 2026-08-04.** Describes the tree as of that date and is **not maintained** against the code — do not cite it as current.
+> Live sources: `CLAUDE.md`, `docs/index.md`, and the code itself. Audit: `docs/audit/docs_inventory_2026-08-04.md`.
+
+This is the seventh source the measurement ledger declared missing: the agent
+memory store (281 files, 2.3 MB), harvested in six type-slices after a single
+agent hit the 64000-token output limit. Machine output, fenced.
+
+```markdown
+{
+  "summary": "Harvest the agent memory store into the measurement ledger, split by type so no agent hits the output limit",
+  "agentCount": 7,
+  "logs": [
+    "150 records from the memory store — {\"holds\":93,\"retracted\":30,\"superseded\":22,\"unsettled\":5}"
+  ],
+  "result": {
+    "section": "bx` with an inline \"2026-06-04 sign fix\" comment; `src/hamiltonian/integrator/split_step.jl:221ff` `_apply_transverse_zeeman_step!` now builds a registry `ZeemanTerm`. The stored-data blast radius still applies. |\n| `gotcha_lhy_block_ignored_without_N_atoms_2026_07_31` | \"STATUS: NOT FIXED\" | `src/workflow/experiments/schema/parsing_blocks.jl:259` now calls `_resolve_lhy_block!` inside the early-return branch; the file's own comment records 0 of 360 lhy-bearing configs were ever affected. |\n| `gotcha_gate_built_from_the_thing_under_test_2026_08_04` | Divergence kill has never fired; reader/writer key intersection 0 | Closed by #313. `pipeline_callbacks.jl:119/125/138-139` write `norm_drift` and `fz_jump`; `monitor.jl:56/64` read them. Historical mis-classification of past runs stands. |\n| `gotcha_a_ci_fail_that_is_a_timeout_2026_08_03` | `test_spgpe_equilibrium_number.jl` unregistered in the 15-minute fast tier | `test/_tiers.jl:851` registers `_COST 1266.0`; line 648 moves it to `FULL_EXTRA`. |\n| `gotcha_ddi_padding_default_flip_defused_fast_paths_2026_07_29` | Item #4 (RTP fused half-step) \"biggest one, not fixed\" | `src/hamiltonian/integrator/spin_chain.jl:60` — the zero-padded convolution \"gets a branch in the realization instead\"; `_spin_chain_reason` no longer lists padding as a disqualifier. |\n| `gotcha_tabulated_lhy_missed_fused_diagonal_2026_07_30` | \"Still open\" — Tabulated declined by the fused chain | `src/hamiltonian/integrator/spin_chain.jl:88-100` admits `TabulatedLHY` (\"Tabulated was declined outright until 2026-08-01\"). |\n| `gotcha_split_step_first_order_with_ddi_2026_06_22` | \"Production RTP is 1st order in time for dipolar dynamics\" | Order measurement stands; the blast-radius sentence does not. `MEANFIELD_MIDPOINT_ENABLED` defaults on — `run_step_dynamics.jl:429`, `combined_spin_step.jl:245`. |\n| `reference_code_internals.md` | \"`find_ground_state` does NOT accept `verbose`\"; \"`pipeline_runner.jl:227-235` does NOT forward `verbose` to ITP — so ITP always prints\" | Both false. `src/solvers/ground_state.jl:159` declares `verbose::Bool=_default_solver_verbose()`; `src/workflow/experiments/pipeline/run_step_ground_state.jl:697` passes `verbose=verbose` into the ITP call. `pipeline_runner.jl` no longer exists. **CLAUDE.md's Quick Facts repeats the stale claim and should be corrected with it.** |\n| `archive/lhy_refactor_2026_05_12`, `archive/project_track_a_nematic_channel_scoping_2026_06_09` | `FullBdGLHY` has a \"~3000× spurious offset at F=6 polar\" and warns on it | Retracted 2026-07-27 (UV counterterm, divergent at every F). `src/hamiltonian/terms/lhy/full_bdg.jl:120` warns only on dynamical instability. `docs/validation/self_contained_validation_report.md:224` still repeats the retracted figure. |\n| `archive/lhy_refactor_2026_05_12` | Type is `TwoChannelLHY`, \"F-generic, no runtime guard\" | `PolarTwoChannelLHY` at `src/foundation/types/potentials.jl:196`; polar-only, ~1 % off at F=2, 30–70 % at F=6. |\n| `archive/klaus_bch_leak_verification_2026_05_18` | Load-bearing path `src/rotating_basis/propagators.jl:146-231` | Path does not exist; propagators are at `src/hamiltonian/integrator/propagators.jl`. Same class of drift: `test/test_itp_ddi_strang_save_every.jl` → `test/solvers/…`; `src/hamiltonian/interactions/` merged into `src/hamiltonian/terms/` on 2026-06-06. |\n| `archive/barnett_spin_pumping_observed_2026_05_16` | Reads as a current in-hand signal (\"highest-leverage target right now\", 5 open questions) | Retracted 2026-07-05, superseded 2026-07-31. The live index annotates it; **the file itself carries no retraction marker.** |\n| `archive/option_gamma_gpu_optimization` | `klaus_eu151_spin_excitation` \"m=+F evolved 0.768→0.827\", no ε stated | That run was ε=1e-3 at p·F·dt=2884, inside the catastrophic regime of `archive/eps_threshold_finding`. |\n| `archive/project_eu_phase_diagram_gate2_strong_coupling` | Escalation plan to the combined preconditioner `P_C` | Unnecessary at Ω=0 and later measured to **lose** ~40× on the weak-field Eu+DDI manifold. Do not revive as written. |\n| `pitfall_pipeline_inference` vs CLAUDE.md | Memory: `@noinline` measured as not required, \"don't cargo-cult\". CLAUDE.md: \"the load-bearing inference firewall … do NOT remove\" | The tree keeps it at `src/workflow/experiments/pipeline/runner.jl:280`. One of the two statements is wrong and a 7 s delta is the only evidence either way. Flagged, not resolved. |\n\n**Confirmed against the tree — the memory still describes the code.** `gpu_energy.jl:122-124,173,184-185` (E_light_shift + E_coriolis in total and returned tuple); `coefficients.jl:409` (`c_lhy_2d = c0_2d^2 / (8.0 * Float64(π))`); `spin_atom.jl:30` + `:223` (`quadratic_zeeman_geometry(F,I,J)`, derived in-constructor); `lhy/dispatch.jl:299` (`energy_fn(n) / n_atoms`); `lhy/icosahedral.jl:138` (`lambda_spin < -1e-12 * c0 && return NaN`); `ddi/ddi_term.jl:123-141` (operator/gradient face branching on `ws.ddi_padded`); `make_workspace.jl:519` (`_shift_zeeman_for_rotating_frame`); `accuracy_knobs.jl:242` (dt registered, with the 2.4e-2 / 8.4e-3 ladder in the comment at :219-242); `itp_loop.jl:160` (convergence check inside the `save_every` branch); `run_step_dynamics.jl:63,180` (`_resolve_dyn_lhy!`); `parsing_blocks.jl:428-429` (`DDI_PADDED_DEFAULT = true`, `DDI_TRUNC_RADIUS_DEFAULT = -1.0`, read at :480/:499 and `run_step_dynamics.jl:141-145`); `lbfgs/driver.jl:111-112,188,240` (`spinor_lhy` / `lhy_opts` kwargs) and `:160` (`stop_at_floor::Bool=true`, `floor_limited` at :545-563) and `:78` (`m_lbfgs=20`); `potentials.jl:162` (`SpatialLHY <: AbstractLHY` directly, not `<: TabulatedLHY` — the sibling dispatch warning stands); `workspace.jl:95/100/106` (`SimState{N,A,B,T}`, `SM`, `Grid{N,T}`); `propagators.jl:359/395` (`_diagonal_step_svec_real!` / `_imag!`); `resonance_dip.jl:29-49` (endpoint_baseline caveat and the −12.5/−12 incident, pinned by `test/validation/test_matsui_fig4_dip.jl`); `test/validation/test_matsui_fig4_dip.jl:51-54` and `test_matsui2025_ref.jl:52-53` (THEO −2.5495 / 15.0224, EXP −3.2048 / 14.5414); `test_level4_general_F_phase_emergence.jl:126` (rtol=1e-3, replacing the fitted 0.15); `scripts/submit_test_tier.sh:45/:75` (`WORKERS=12`, `OPENBLAS_NUM_THREADS=1`); gates present on disk for `test_full_bdg_n_atoms_branches.jl`, `test_mixed_precision_kinetic_buffer.jl`, `test_taylor_tolerance_binds.jl`, `test_doc_run_citations_resolve.jl`, `test/solvers/test_{itp,rtp}_ddi_strang_save_every.jl`.\n\n**Confirmed still present, and still a live defect.** `src/analysis/tof.jl:109` documents `V_m(r) = m · g_F · gradient · r[axis]` per spin component while `:161` constructs the spin-**independent** `MagneticGradient`. Flagged 2026-06-10, verified unchanged. Any claim of Stern-Gerlach separation from `simulate_tof_with_gradient` is false; `SpatialZeemanTerm` is the real m-dependent gradient.\n\n**One header contradicting its own file.** `src/hamiltonian/terms/contact/contact.jl:7` still reads `TensorTerm : … (rank->=2 channels; KNOWN-LIMIT op=0)` and `:12` forwards to a memo about lifting that limit, while `:357-367` implements the anomalous gradient for c2 singlet-pair + `tensor_cache`, gated by `test_term_consistency` at ratio 1.000000 for F=2/3/6. A reader who greps the header concludes the opposite of the code 350 lines below.\n\n**Unresolved by this pass.** `archive/project_ci_tier_red_at_head_2026_07_29` records the `ci` tier red on clean `origin/main` at `9159486d` in two places. The level-4 general-F red is closed (see rtol=1e-3 above). The spatial-Zeeman red — a bit-identity claim failing by 0.08289 against 1e-12 — is at `test/analysis/test_spatial_zeeman.jl:34`, and that line is unchanged since the feature commit `b27a4fc5`. Whether it is green now cannot be determined without running it.\n\n---\n\n## 5. Coverage and known gaps in this source\n\n- Files read or triaged: 55 `mistake_*`, 100 `gotcha_*`, 34 `project_*`, 84 `feedback_*`/`reference_*`/`pitfall_*`, 30 of 75 `archive/*` in full with the remainder triaged by size and keyword. Omitted from `archive/` are loop-process records (`loop_architecture`, `loop_scheduler`, `audit_class_scan_t61/t87/t103`, `design_backlog`, `next_session_priorities`, `handoff_*`, `phd_paper_pipeline`, `four_figure_spec`, `state_zoo_yaml_integration_wip`, `dashboard_pivot_inspector`, `catalog_layer_over_cas`, `inspector_structural_lift`, `autopilot_honest/pre_dispatch`) — decisions, no measured quantity.\n- **Precision is the weakest field in this source.** Most records quote digits as printed with no repeats and no spread; treat any single figure here as one observation unless the row says otherwise. The records that *do* state a spread are the ones to trust: three bit-identical repeats per side in the Coriolis parity job; the LHY N_atoms ratio exactly integer at three decades of N; the full_bdg k_max exponent 5.054 fitted across a ladder; two independent pins agreeing to 5 digits on the Eu ground-state energy; four TSUBAME hosts agreeing to 3 % on the GPU ratchet; the L-BFGS gradient floor explicitly reported as having *no* reproducible digits.\n- **Two instrument-level caveats that invalidate other numbers.** (1) `--check-bounds=yes`, which the test runner passes, disables `@inbounds` and changes SIMD reduction order, so bit-exactness gates fail under it and pass standalone — a stash A/B under it is invalid because both sides pass standalone. (2) `init_psi`'s default state is not a physical cloud: peak density ~37× a converged Eu cloud, and since ε_LHY ∝ n^(5/2) an \"is LHY small?\" check measured on it reads 90 % even with a correct LHY.\n- **Recurrence counts the store tracks itself**, useful for ranking prevention work: \"observable read from an unconverged state\" reached instance #3 explicitly; \"stability verdict from a non-stationary point\" reached #3 within one arc and was re-committed after being retracted once; \"measurement read against code that did not produce it\" hit 4 instances in one session (2026-08-04), including three \"different\" initial conditions agreeing to 13 digits because the change had not reached the running code; \"a search that assumed one form for its target\" hit 4 in one session (2026-08-02) — disposal candidates 385→280→259→207 and orphan data 219→166→62→2, with monotonicity as the tell.",
+    "counts": {
+      "holds": 93,
+      "retracted": 30,
+      "superseded": 22,
+      "unsettled": 5
+    },
+    "total": 150
+  },
+  "workflowProgress": [
+    {
+      "type": "workflow_phase",
+      "index": 1,
+      "title": "Harvest"
+    },
+    {
+      "type": "workflow_phase",
+      "index": 2,
+      "title": "Check"
+    },
+    {
+      "type": "workflow_phase",
+      "index": 3,
+      "title": "Merge"
+    },
+    {
+      "type": "workflow_agent",
+      "index": 1,
+      "label": "mem:mistake",
+      "phaseIndex": 1,
+      "phaseTitle": "Harvest",
+      "agentId": "aa510e239712e8fab",
+      "model": "claude-opus-5[1m]",
+      "state": "done",
+      "startedAt": 1785828668953,
+      "queuedAt": 1785828668940,
+      "attempt": 1,
+      "lastToolName": "StructuredOutput",
+      "promptPreview": "Repository: /home/suzume/workspace/BEC-simulation/.claude/worktrees/purring-chasing-phoenix. Memory store: /home/suzume/.claude/projects/-home-suzume-workspace-BEC-simulation/memory (OUTSIDE the repo — read it, never\nmodify it). Run repo commands from the repo root; do NOT cd to the parent repo.\n\nREAD-ONLY. No simulations. Cheap greps and `git log` are expected.\n\nWHY THIS RUN EXISTS. On 2026-08-04…",
+      "lastProgressAt": 1785829395478,
+      "tokens": 192732,
+      "toolCalls": 19,
+      "durationMs": 726525,
+      "resultPreview": "{\"records\":[{\"topic\":\"rotating frame / GPU energy\",\"what\":\"GPU `_energy_decomposition_gpu` omitted E_coriolis (−Ω⟨L_z⟩) and E_light_shift while `_grad_coriolis!` ran on both backends, so ∇E and E were derivatives of different functionals\",\"number\":\"per-term FD-vs-gradient ratio: kinetic 1.0000, trap 0.99998, zeeman 0.99999, density 1.0000, spin 0.99988, ddi 0.99999; TOTAL 0.00456 (220x off) → post…"
+    },
+    {
+      "type": "workflow_agent",
+      "index": 2,
+      "label": "mem:gotcha-a",
+      "phaseIndex": 1,
+      "phaseTitle": "Harvest",
+      "agentId": "af97ceb8a7c87a483",
+      "model": "claude-opus-5[1m]",
+      "state": "done",
+      "startedAt": 1785828668955,
+      "queuedAt": 1785828668941,
+      "attempt": 1,
+      "lastToolName": "StructuredOutput",
+      "promptPreview": "Repository: /home/suzume/workspace/BEC-simulation/.claude/worktrees/purring-chasing-phoenix. Memory store: /home/suzume/.claude/projects/-home-suzume-workspace-BEC-simulation/memory (OUTSIDE the repo — read it, never\nmodify it). Run repo commands from the repo root; do NOT cd to the parent repo.\n\nREAD-ONLY. No simulations. Cheap greps and `git log` are expected.\n\nWHY THIS RUN EXISTS. On 2026-08-04…",
+      "lastProgressAt": 1785829072560,
+      "tokens": 151316,
+      "toolCalls": 56,
+      "durationMs": 403604,
+      "resultPreview": "{\"records\":[{\"topic\":\"LHY / wiring\",\"what\":\"full_bdg LHY reached through the YAML pipeline reported E_LHY as essentially the whole energy, while the direct-call parity oracle was green 97/97\",\"number\":\"E_LHY = 5849.32 of E_tot 5860.74 = 99.8 %; polar_contact on the same cell = 0.1548 / 11.5760 = 1.34 %; ratio full_bdg/polar_contact 14,744 (unrelaxed) → 37,786 (converged); after fix 1.259 % vs 1.33…"
+    },
+    {
+      "type": "workflow_agent",
+      "index": 3,
+      "label": "mem:gotcha-b",
+      "phaseIndex": 1,
+      "phaseTitle": "Harvest",
+      "agentId": "ab590fe7455ccbb37",
+      "model": "claude-opus-5[1m]",
+      "state": "done",
+      "startedAt": 1785828668956,
+      "queuedAt": 1785828668941,
+      "attempt": 1,
+      "lastToolName": "StructuredOutput",
+      "promptPreview": "Repository: /home/suzume/workspace/BEC-simulation/.claude/worktrees/purring-chasing-phoenix. Memory store: /home/suzume/.claude/projects/-home-suzume-workspace-BEC-simulation/memory (OUTSIDE the repo — read it, never\nmodify it). Run repo commands from the repo root; do NOT cd to the parent repo.\n\nREAD-ONLY. No simulations. Cheap greps and `git log` are expected.\n\nWHY THIS RUN EXISTS. On 2026-08-04…",
+      "lastProgressAt": 1785829024383,
+      "tokens": 179968,
+      "toolCalls": 17,
+      "durationMs": 355427,
+      "resultPreview": "{\"records\":[{\"topic\":\"GPU fused/unfused spin-chain bit-identity\",\"what\":\"Difference between fused and unfused V half-step, GPU, after re-measuring the operands of a failing `@test a == b`\",\"number\":\"|fused−unfused| = 5.26e-16 (bare DDI), 6.52e-16 (padded DDI); |fused−CPUref| 1.90e-15 / 2.00e-15; ψ scale 1.345e-01\",\"conditions\":\"test/oracles/test_spin_chain_fusion_parity.jl, GPU node (TSUBAME job 8…"
+    },
+    {
+      "type": "workflow_agent",
+      "index": 4,
+      "label": "mem:project",
+      "phaseIndex": 1,
+      "phaseTitle": "Harvest",
+      "agentId": "aa5e5cf9103d3b58e",
+      "model": "claude-opus-5[1m]",
+      "state": "done",
+      "startedAt": 1785828668956,
+      "queuedAt": 1785828668941,
+      "attempt": 1,
+      "lastToolName": "StructuredOutput",
+      "promptPreview": "Repository: /home/suzume/workspace/BEC-simulation/.claude/worktrees/purring-chasing-phoenix. Memory store: /home/suzume/.claude/projects/-home-suzume-workspace-BEC-simulation/memory (OUTSIDE the repo — read it, never\nmodify it). Run repo commands from the repo root; do NOT cd to the parent repo.\n\nREAD-ONLY. No simulations. Cheap greps and `git log` are expected.\n\nWHY THIS RUN EXISTS. On 2026-08-04…",
+      "lastProgressAt": 1785829081147,
+      "tokens": 194725,
+      "toolCalls": 19,
+      "durationMs": 412191,
+      "resultPreview": "{\"records\":[{\"topic\":\"Eu F=6 texture phase diagram / LHY\",\"what\":\"Beyond-mean-field cross-check of the texture phase diagram declared NOT ANSWERABLE with current machinery: full_bdg reports the mean field dynamically unstable at EVERY (Bz, c1, seed) cell, seed and converged, so ε_LHY is scheme-dependent and the closed forms are no better\",\"number\":\"q = 3.2e-16 … 8.3e-16 dimensionless at 50–80 µG; …"
+    },
+    {
+      "type": "workflow_agent",
+      "index": 5,
+      "label": "mem:feedback-ref",
+      "phaseIndex": 1,
+      "phaseTitle": "Harvest",
+      "agentId": "aa114b08686b1cb56",
+      "model": "claude-opus-5[1m]",
+      "state": "done",
+      "startedAt": 1785828668957,
+      "queuedAt": 1785828668941,
+      "attempt": 1,
+      "lastToolName": "StructuredOutput",
+      "promptPreview": "Repository: /home/suzume/workspace/BEC-simulation/.claude/worktrees/purring-chasing-phoenix. Memory store: /home/suzume/.claude/projects/-home-suzume-workspace-BEC-simulation/memory (OUTSIDE the repo — read it, never\nmodify it). Run repo commands from the repo root; do NOT cd to the parent repo.\n\nREAD-ONLY. No simulations. Cheap greps and `git log` are expected.\n\nWHY THIS RUN EXISTS. On 2026-08-04…",
+      "lastProgressAt": 1785829054620,
+      "tokens": 151615,
+      "toolCalls": 21,
+      "durationMs": 385663,
+      "resultPreview": "{\"records\":[{\"topic\":\"TSUBAME billing\",\"what\":\"Exact TSUBAME 4 on-demand point charge formula, validated against a real job\",\"number\":\"points = nodes × typeCoef × prioCoef × (0.7·max(actual_s, 300) + 0.1·h_rt_s) / 3600; empirical check node_q, actual 142 s, h_rt 1800 s → 0.250×(0.7×300+0.1×1800)/3600 = 0.0271 pt\",\"conclusion\":\"Formula reproduces the charge; actual wall time is floored at 300 s so …"
+    },
+    {
+      "type": "workflow_agent",
+      "index": 6,
+      "label": "mem:archive",
+      "phaseIndex": 1,
+      "phaseTitle": "Harvest",
+      "agentId": "af1ce5c7fa566da86",
+      "model": "claude-opus-5[1m]",
+      "state": "done",
+      "startedAt": 1785828668957,
+      "queuedAt": 1785828668941,
+      "attempt": 1,
+      "lastToolName": "StructuredOutput",
+      "promptPreview": "Repository: /home/suzume/workspace/BEC-simulation/.claude/worktrees/purring-chasing-phoenix. Memory store: /home/suzume/.claude/projects/-home-suzume-workspace-BEC-simulation/memory (OUTSIDE the repo — read it, never\nmodify it). Run repo commands from the repo root; do NOT cd to the parent repo.\n\nREAD-ONLY. No simulations. Cheap greps and `git log` are expected.\n\nWHY THIS RUN EXISTS. On 2026-08-04…",
+      "lastProgressAt": 1785829332339,
+      "tokens": 220910,
+      "toolCalls": 55,
+      "durationMs": 663381,
+      "resultPreview": "{\"records\":[{\"topic\":\"M1 ground-state sweep / LBFGS save integrity\",\"what\":\"Re-evaluated ‖∇E‖ via fresh energy_gradient! on ψ saved in every M1 cell_*.jld2, compared to the grad_norm stored beside it\",\"number\":\"13/22 cells demoted ✓✓→✗; drift |saved−reeval| max 9.1e-4, median 3.2e-4, mean 2.5e-4; E drift max 2.7e-2, median 1.2e-3; disk 9.9e-6 vs true 2.5e-4–5.0e-4 = 30–50× above the 1e-5 gate\",\"pr…"
+    },
+    {
+      "type": "workflow_agent",
+      "index": 7,
+      "label": "section",
+      "phaseIndex": 3,
+      "phaseTitle": "Merge",
+      "agentId": "a743cc8e0418abe8f",
+      "model": "claude-opus-5[1m]",
+      "state": "done",
+      "startedAt": 1785829395483,
+      "queuedAt": 1785829395480,
+      "attempt": 1,
+      "promptPreview": "Repository: /home/suzume/workspace/BEC-simulation/.claude/worktrees/purring-chasing-phoenix. Memory store: /home/suzume/.claude/projects/-home-suzume-workspace-BEC-simulation/memory (OUTSIDE the repo — read it, never\nmodify it). Run repo commands from the repo root; do NOT cd to the parent repo.\n\nREAD-ONLY. No simulations. Cheap greps and `git log` are expected.\n\nWHY THIS RUN EXISTS. On 2026-08-04…",
+      "lastProgressAt": 1785830133724,
+      "tokens": 236667,
+      "toolCalls": 0,
+      "durationMs": 738241,
+      "resultPreview": "bx` with an inline \"2026-06-04 sign fix\" comment; `src/hamiltonian/integrator/split_step.jl:221ff` `_apply_transverse_zeeman_step!` now builds a registry `ZeemanTerm`. The stored-data blast radius still applies. |\n| `gotcha_lhy_block_ignored_without_N_atoms_2026_07_31` | \"STATUS: NOT FIXED\" | `src/workflow/experiments/schema/parsing_blocks.jl:259` now calls `_resolve_lhy_block!` inside the early-r…"
+    }
+  ],
+  "totalTokens": 1327933,
+  "totalToolCalls": 187
+}
+```

--- a/docs/design/unified_spec_architecture.md
+++ b/docs/design/unified_spec_architecture.md
@@ -614,14 +614,15 @@ Seven tags, each with configs behind it and a gate in `test_corpus_resolves.jl`
 Fourteen requirement ids, across twelve items. Each is stated with the reason,
 because a hidden gap is worse than a stated one.
 
-**Status, 2026-08-04. Seven of the fourteen ids are resolved, across five of the
-twelve items; seven ids remain.**
+**Status, 2026-08-04. Eight of the fourteen ids are resolved, across six of the
+twelve items; six ids remain.**
 
 | item | ids | how |
 |---|---|---|
 | 1 | A2:R-OPEN-03, A5:R-NIX-03B | measured — the document's own "largest single unknown" |
 | 2 | A2:R-OPEN-01 | measured |
 | 3 | A2:R-OPEN-05 | measured — mean 1.24 against a threshold of 3 |
+| 5 | A2:R-ENS-01 | **fixed in code** — plus a second defect found while fixing it |
 | 6 | A2:R-CLASS-01/02 | **fixed in code** (#313), not registered as the row proposed |
 | 7 | A2:R-MIG-01 | withdrawn — it describes a partition cut before the row was written |
 
@@ -740,12 +741,35 @@ this is what promotion looks like.
    way, but S1's severity is still unmeasured. `kill -INT` is verified
    uncatchable in Julia script mode; whether UGE delivers something catchable at
    the `h_rt` boundary is not.
-5. **A2:R-ENS-01 — the TWA ensemble.** `grep -n isfinite src/solvers/twa.jl`
-   returns nothing, and `_welford_update!` is in-place and cumulative, so one
-   diverging member NaNs the mean for every later member. The ledger gives each
-   member a name and the diverging member a refusal — but that requires a change
-   inside `twa.jl` that this document specifies only in shape, not in detail.
-   33 configs under `runs/` use `twa:`.
+5. **A2:R-ENS-01 — the TWA ensemble. FIXED 2026-08-04.** The row said the
+   repair "requires a change inside `twa.jl` that this document specifies only
+   in shape, not in detail". The detail turned out to be small, and the row was
+   right about the defect: `grep isfinite src/solvers/twa.jl` returned nothing,
+   `_welford_update!` is cumulative and in place (`mean[I] += delta / i`), so
+   one diverging member NaNed the mean and the variance for every member after
+   it, with no recovery and no record — a 200-member ensemble returning an
+   all-NaN answer with `n_trajectories` still reading 200. 33 configs use
+   `twa:`.
+
+   `_all_finite(traj_obs)` now refuses a member before it is folded in, and the
+   refusal is recorded: `EnsembleResult.rejected::Vector{Int}`, a vector rather
+   than a count so that "none rejected" and "rejections not tracked" cannot look
+   alike, and so a caller can name the member. Checked at the OBSERVABLE, not at
+   ψ — an ensemble is a statement about its observables, and a trajectory can be
+   finite in ψ while producing a non-finite observable.
+
+   **A second defect, found while fixing the first and quieter than it.** The
+   variance divided M2 by `n_traj`, the number of trajectories REQUESTED. Adding
+   a rejection path without touching that denominator would have inflated the
+   sample count and biased the variance low — a wrong number in place of an
+   obvious NaN. Both the Welford weighting and the denominator now use the
+   contributing count.
+
+   Gated by `test/solvers/test_twa_rejects_diverged_members.jl`. Worth recording
+   about the gate itself: its first version tested the predicate, the weighting
+   and the record, and **stayed green when the rejection branch was disabled
+   outright** — every piece was covered and nothing checked that the loop
+   CONSULTS them. It now asserts that too.
 
 **Two the row proposed to register rather than repair — and neither survived
 that disposition.** One was repaired because a register entry for it would have

--- a/docs/design/unified_spec_architecture.md
+++ b/docs/design/unified_spec_architecture.md
@@ -806,11 +806,28 @@ read as a known-wrong answer rather than a caveat; the other had no subject.
 
 **Three where the mechanism is weaker than the requirement asks.**
 
-8. **A2:R-CHAIN-03 — the fork-resolution policy.** The policy (replay from the
-   nearest held ancestor) is stated, but the per-method materialisation costs
-   that would make it real — 54 MB for psi against roughly 2.1 GB of L-BFGS
-   two-loop memory at 64^3 x 13 — are quoted from issue #250, not measured under
-   this design.
+8. **A2:R-CHAIN-03 — the fork-resolution policy. The quoted costs are now
+   DERIVED rather than cited (2026-08-04); the policy question they were
+   supposed to settle is still open.** The row's complaint was that 54 MB for
+   psi against ~2.1 GB of L-BFGS two-loop memory at 64³ × 13 came from issue
+   #250 and had never been checked under this design. Recomputed from the
+   shapes and the shipped defaults:
+
+   | | |
+   |---|---|
+   | ψ at 64³ × 13, `ComplexF64` | 64³·13·16 B = **54.5 MB** (52.0 MiB) |
+   | L-BFGS history, `m_lbfgs = 20` (`lbfgs/driver.jl:78`) | 2·m·\|ψ\| = **2.18 GB** (2.03 GiB) |
+   | ratio | **40×** |
+
+   Both figures reproduce, so #250 is not the authority for them any more — the
+   arithmetic is, and it is one line from the grid shape and one default. The
+   40× is what makes the policy's shape obvious: replaying from an ancestor is
+   cheap in ψ and ruinous in solver state, so the ancestor must be a ψ.
+
+   **What remains open is not a number.** Whether "replay from the nearest held
+   ancestor" is right depends on how often a fork actually lands mid-solve
+   rather than between stages, and nothing measures that. The cost table no
+   longer blocks it; the frequency does.
 9. **A5:R-NIX-07 — trusted producers.** `require` is verdict-shaped, not
    host-shaped. The capability is not designed out, but it is not built, and the
    day a stale-sysimage TSUBAME artifact enters a shared store is when it is

--- a/docs/design/unified_spec_architecture.md
+++ b/docs/design/unified_spec_architecture.md
@@ -614,13 +614,14 @@ Seven tags, each with configs behind it and a gate in `test_corpus_resolves.jl`
 Fourteen requirement ids, across twelve items. Each is stated with the reason,
 because a hidden gap is worse than a stated one.
 
-**Status, 2026-08-04. Six of the fourteen ids are resolved, across four of the
-twelve items; eight ids remain.**
+**Status, 2026-08-04. Seven of the fourteen ids are resolved, across five of the
+twelve items; seven ids remain.**
 
 | item | ids | how |
 |---|---|---|
 | 1 | A2:R-OPEN-03, A5:R-NIX-03B | measured — the document's own "largest single unknown" |
 | 2 | A2:R-OPEN-01 | measured |
+| 3 | A2:R-OPEN-05 | measured — mean 1.24 against a threshold of 3 |
 | 6 | A2:R-CLASS-01/02 | **fixed in code** (#313), not registered as the row proposed |
 | 7 | A2:R-MIG-01 | withdrawn — it describes a partition cut before the row was written |
 
@@ -700,11 +701,37 @@ this is what promotion looks like.
    sharing is real: those 59 runs genuinely want one ground state, which is the
    stage cache's entire purpose. So the concurrent-write path is hot *because
    the design is working*, not because the id is blind to something.
-3. **A2:R-OPEN-05 — write amplification of per-attempt records.** This design
-   commits to an append-only `attempts/` shape without the
-   executions-per-artifact measurement the requirement says must come first. If
-   the mean is 3 or more, the index needs sharding and "rebuildable and safe to
-   delete" has to go.
+3. **A2:R-OPEN-05 — write amplification of per-attempt records. MEASURED
+   2026-08-04: mean 1.24, so the append-only shape stands.** The requirement
+   said the executions-per-artifact mean must be measured first, and that at
+   3 or more the index needs sharding and "rebuildable and safe to delete" has
+   to go.
+
+   | | |
+   |---|---|
+   | run directories under `runs/` | 294 |
+   | content-addressed (`<basename>_<sha>`) | 219 |
+   | distinct config basenames | 176 |
+   | **mean directories per config** | **1.24** |
+   | configs with more than one | 34 |
+   | most re-run | 4 (`L4_eu_matsui_hamiltonian_only_{32,64}`) |
+
+   Well under the threshold. No sharding; the index stays rebuildable and safe
+   to delete.
+
+   **What this measurement is NOT, stated because the difference matters.** It
+   counts DIRECTORIES per config, not executions per artifact. The direct
+   quantity is unmeasurable in this tree: there are **0 completion markers and
+   0 `_exit_summary.json`** anywhere under `runs/`, so every one of those 294
+   directories predates the record-keeping that would have counted executions.
+   A re-run that overwrote its directory in place leaves no trace at all, and
+   the stage cache — the one thing keyed on `artifact_id` rather than on config
+   bytes — is opt-in (`SPINORBEC_STAGE_CACHE`) and has never been populated
+   here. So 1.24 is a LOWER BOUND on write amplification, and the true figure
+   would need the markers this design introduces. It is quoted as a lower bound
+   because the decision it feeds is one-sided: a lower bound of 1.24 against a
+   threshold of 3 is already decisive, and no amount of undercounting reverses
+   that unless the true mean is more than double.
 
 **Two things the register names but does not build.**
 

--- a/src/analysis/tof.jl
+++ b/src/analysis/tof.jl
@@ -106,9 +106,25 @@ Real-time TOF propagator with a magnetic-gradient-driven Stern-Gerlach
 separation. Takes the wavefunction from `ws_source` (a `Workspace`), clones
 it into a temporary TOF workspace with the trap disabled (default) and the
 contact interactions zeroed (default), then adds a linear gradient potential
-`V_m(r) = m · g_F · gradient · r[axis]` per spin component via the existing
-`MagneticGradient` struct, and integrates for `t_tof` using `n_steps`
-split-step ticks.
+`V(r) = g_F · gradient · r[axis]` via the existing `MagneticGradient` struct,
+and integrates for `t_tof` using `n_steps` split-step ticks.
+
+!!! warning "This does NOT separate spin components"
+    `MagneticGradient` is **spin-INDEPENDENT**. Its own implementation says so
+    (`hamiltonian/terms/magnetic_gradient.jl:15-18`: "This is NOT a true
+    Stern-Gerlach gradient (which would carry an F_z factor) … users who need
+    m-dependence must use a different mechanism"), and CLAUDE.md lists it as
+    "spin-independent tilt, NOT a Zeeman".
+
+    This docstring and the comment at the call site carried `V_m(r) = m · g_F ·
+    …` — an `m` the term does not have — until 2026-08-04. Every component gets
+    the SAME tilt, so the cloud translates and does not split. **A
+    Stern-Gerlach separation claimed from this function is false.**
+
+    For genuine m-dependence use `SpatialZeemanTerm` (an arbitrary B(r) whose
+    Zeeman coupling is per-m by construction). The name
+    `simulate_tof_with_gradient` is kept because the gradient is real; only the
+    spin dependence was never there.
 
 Returns a `Dict(m => density_2d)` column-integrated along `imaging_axis`
 (or `density_1d` for N=1).
@@ -156,8 +172,10 @@ function simulate_tof_with_gradient(
         normalize_every=0,
         save_every=max(1, n_steps ÷ 4))
 
-    # Use existing MagneticGradient — the hot-path split_step already
-    # integrates V_mg(r, m) = m · g_F · gradient · r[axis] per component.
+    # Use existing MagneticGradient — the hot-path split_step integrates
+    # V_mg(r) = g_F · gradient · r[axis], the SAME for every component. This
+    # comment read `V_mg(r, m) = m · g_F · …` until 2026-08-04; there is no `m`
+    # (`terms/magnetic_gradient.jl:15-18`). See the warning in the docstring.
     mg = MagneticGradient{N}(gradient, gradient_axis, atom.g_F)
 
     ws_tof = make_workspace(;

--- a/src/foundation/types/integrator.jl
+++ b/src/foundation/types/integrator.jl
@@ -93,7 +93,14 @@ struct EnsembleResult
     times::Vector{Float64}
     mean::Dict{Symbol, Vector{<:AbstractArray}}
     var::Dict{Symbol, Vector{<:AbstractArray}}
+    # Trajectories that CONTRIBUTED, i.e. `n_traj - length(rejected)`. The mean
+    # and variance are over this many samples, not over the number requested.
     n_trajectories::Int
+    # Indices of trajectories excluded for producing a non-finite observable.
+    # Empty in the overwhelmingly common case. Recorded rather than counted so
+    # a caller can say WHICH member diverged, and so that "none rejected" and
+    # "rejections not tracked" cannot look alike.
+    rejected::Vector{Int}
     trajectory_results::Union{Nothing, Vector{SimulationResult}}
     # Last trajectory's full SimulationResult (with psi_snapshots). Always
     # retained so the dashboard auto-save can stream dynamics frames even
@@ -105,6 +112,13 @@ struct EnsembleResult
     # *every* trajectory and is opt-in.
     last_trajectory::Union{Nothing, SimulationResult}
 end
+# Back-compat: callers that predate `rejected` get an empty vector, which reads
+# as "none rejected" — true for every such caller, since the rejection path did
+# not exist when they were written.
 EnsembleResult(times, mean, var, n_trajectories, trajectory_results) = EnsembleResult(
-    times, mean, var, n_trajectories, trajectory_results, nothing
+    times, mean, var, n_trajectories, Int[], trajectory_results, nothing
+)
+EnsembleResult(times, mean, var, n_trajectories, rejected::Vector{Int},
+    trajectory_results) = EnsembleResult(
+    times, mean, var, n_trajectories, rejected, trajectory_results, nothing
 )

--- a/src/hamiltonian/terms/contact/contact.jl
+++ b/src/hamiltonian/terms/contact/contact.jl
@@ -4,13 +4,21 @@
 #
 #   DensityC0Term : H = (c0/2) n²                  (rank-0 channel)
 #   SpinC1Term    : H = (c1/2) |F|²                (rank-1 channel)
-#   TensorTerm    : H = (c2/2) |A|² + Σ c_S P_S    (rank-≥2 channels; KNOWN-LIMIT op=0)
+#   TensorTerm    : H = (c2/2) |A|² + Σ c_S P_S    (rank-≥2 channels)
 #
 # c0 sets the scalar contact (always present), c1 picks polar (>0) / FM
 # (<0) ground state, c2 and higher tensor coefficients are zero in the
-# Eu Phase-1 model (c0+c1+DDI) — see the [[sbi-telos-tensor-gradient-prereq]]
-# memo for the forward note on lifting Tensor's apply_operator KNOWN-LIMIT
-# when SBI structure-inference is run on all 7 channels.
+# Eu Phase-1 model (c0+c1+DDI).
+#
+# The `KNOWN-LIMIT op=0` marker on TensorTerm above, and the forward note about
+# "lifting" it for SBI structure-inference, were removed 2026-08-04: the limit
+# was lifted on 2026-06-09 and `apply_operator!(out, ::TensorTerm, …)` is
+# implemented at `:357` of this same file — 350 lines below the header that
+# denied it — covering the c2 singlet-pair and the `tensor_cache` higher-rank
+# channels, FD-gated by `test/oracles/test_term_consistency.jl` at ratio
+# 1.000000 for F = 2/3/6. `energy_gradient!` has been registry-only since the
+# same date, so LBFGS optimises tensor-active configurations rather than
+# bouncing them to ITP (CLAUDE.md, "Tensor c2/c4 ARE in `energy_gradient!`").
 #
 # Consolidation rationale: all three are auto-selected together via
 # `make_workspace` (the c₀/c₁ path vs scattering-lengths path branches on

--- a/src/solvers/twa.jl
+++ b/src/solvers/twa.jl
@@ -39,6 +39,10 @@ function run_twa(;
     M2_obs = nothing
     ref_times = nothing
     last_traj_result = nothing
+    # Contributing samples and the members refused. Separate counters because
+    # `n_traj` is what was ASKED for and the statistics are over what arrived.
+    n_used = 0
+    rejected = Int[]
 
     for i in 1:n_traj
         t_start = time_ns()
@@ -66,6 +70,26 @@ function run_twa(;
 
         traj_obs = _extract_trajectory_observables(result, grid, atom, obs_list)
 
+        # REFUSE a diverged member instead of folding it in. `_welford_update!`
+        # is cumulative and in place — `mean[I] += delta / i` — so a single NaN
+        # anywhere in a trajectory's observables destroys the mean and the
+        # variance for that observable for EVERY member after it, and there is
+        # no recovery and no record. Until 2026-08-04 `grep isfinite
+        # src/solvers/twa.jl` returned nothing: one diverging trajectory in a
+        # 200-member ensemble returned an all-NaN answer with n_trajectories
+        # still reading 200. 33 configs under `runs/` use `twa:`.
+        #
+        # Checked at the OBSERVABLE, not at psi: an ensemble is a statement
+        # about its observables, a trajectory may be finite in psi and produce a
+        # non-finite observable, and this is also the cheap place to look.
+        if !_all_finite(traj_obs)
+            push!(rejected, i)
+            verbose && @warn "TWA: trajectory $i produced a non-finite observable; \
+                              excluded from the ensemble" trajectory = i
+            continue
+        end
+        n_used += 1
+
         if ref_times === nothing
             ref_times = result.times
             mean_obs = Dict{Symbol, Vector{Array{Float64}}}()
@@ -77,8 +101,11 @@ function run_twa(;
         else
             for sym in keys(traj_obs)
                 for t_idx in eachindex(traj_obs[sym])
+                    # `n_used`, not `i`: Welford's 1/i weighting counts
+                    # CONTRIBUTING samples. Passing the loop index would give a
+                    # rejected member's slot a share of the weight.
                     _welford_update!(mean_obs[sym][t_idx], M2_obs[sym][t_idx],
-                        traj_obs[sym][t_idx], i)
+                        traj_obs[sym][t_idx], n_used)
                 end
             end
         end
@@ -91,17 +118,43 @@ function run_twa(;
         end
     end
 
-    # Finalize variance
+    # Finalize variance. `n_used`, not `n_traj`: dividing M2 by the number of
+    # trajectories REQUESTED rather than the number that contributed inflates
+    # the sample count and biases the variance low — a second, quieter error
+    # than the NaN, and one that would survive the fix above on its own.
     var_obs = Dict{Symbol, Vector{Array{Float64}}}()
     for sym in keys(M2_obs)
-        var_obs[sym] = if n_traj > 1
-            [m2 ./ (n_traj - 1) for m2 in M2_obs[sym]]
+        var_obs[sym] = if n_used > 1
+            [m2 ./ (n_used - 1) for m2 in M2_obs[sym]]
         else
             [zeros(size(m2)) for m2 in M2_obs[sym]]
         end
     end
 
-    EnsembleResult(ref_times, mean_obs, var_obs, n_traj, all_traj_results, last_traj_result)
+    isempty(rejected) ||
+        @warn "TWA ensemble: $(length(rejected)) of $n_traj trajectories were \
+               excluded for producing non-finite observables; mean and variance \
+               are over $n_used samples" rejected = rejected
+
+    EnsembleResult(ref_times, mean_obs, var_obs, n_used, rejected,
+        all_traj_results, last_traj_result)
+end
+
+"""
+    _all_finite(traj_obs) -> Bool
+
+Every value of every observable at every snapshot is finite.
+
+Guards `_welford_update!`, which is cumulative and in place, so one non-finite
+entry propagates to every later member with no recovery and no record.
+Short-circuits on the first offender — the common case is all-finite and pays
+one pass.
+"""
+function _all_finite(traj_obs)
+    for (_, series) in traj_obs, arr in series
+        all(isfinite, arr) || return false
+    end
+    true
 end
 
 """

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -101,6 +101,8 @@ const FAST_TESTS = [
     "workflow/test_docs_yaml_against_schema.jl",
     # A schema enum must name what the implementation can actually do.
     "workflow/test_schema_enum_matches_implementation.jl",
+    # One diverging TWA member used to NaN the mean for every member after it.
+    "solvers/test_twa_rejects_diverged_members.jl",
     # Model / Stage layer + the provenance cutover's steps 1, 1b and 2.
     "model/test_model_shape.jl",
     "model/test_model_toml_roundtrip.jl",

--- a/test/solvers/test_twa_rejects_diverged_members.jl
+++ b/test/solvers/test_twa_rejects_diverged_members.jl
@@ -1,0 +1,101 @@
+using Test
+using SpinorBEC
+using SpinorBEC: _all_finite, _welford_update!, EnsembleResult
+
+# One diverging member must not take the ensemble with it.
+#
+# `_welford_update!` is cumulative and in place — `mean[I] += delta / i` — so a
+# single NaN anywhere in a trajectory's observables destroys the mean and the
+# variance for every member AFTER it, with no recovery. Until 2026-08-04
+# `grep isfinite src/solvers/twa.jl` returned nothing: a 200-member ensemble
+# with one divergence returned an all-NaN answer while `n_trajectories` still
+# read 200. 33 configs under `runs/` use `twa:`.
+#
+# Two defects, not one. The second is quieter and would have survived a fix to
+# the first: the variance divided M2 by `n_traj` — the number REQUESTED — so
+# rejecting members without changing the denominator inflates the sample count
+# and biases the variance low.
+
+@testset "TWA rejects diverged members" begin
+    @testset "the finiteness guard sees what it must" begin
+        ok = Dict(:a => [Float64[1.0, 2.0], Float64[3.0]],
+            :b => [Float64[0.0]])
+        @test _all_finite(ok)
+        # …and each way a member can go bad
+        for bad in (NaN, Inf, -Inf)
+            d = Dict(:a => [Float64[1.0, bad]], :b => [Float64[0.0]])
+            @test !_all_finite(d)
+        end
+        # a NaN in a LATER observable, not the first — the loop must not stop
+        # at the first key
+        @test !_all_finite(Dict(:a => [Float64[1.0]], :b => [Float64[NaN]]))
+    end
+
+    @testset "Welford weighting counts contributing samples" begin
+        # The mean of 2 and 4 is 3 whether or not a third member was refused
+        # between them. Passing the LOOP INDEX instead of the used count gives
+        # the rejected slot a share of the weight and lands elsewhere.
+        m = [2.0]
+        M2 = [0.0]
+        _welford_update!(m, M2, [4.0], 2)      # second CONTRIBUTING sample
+        @test m[1] ≈ 3.0
+        # the same pair weighted as if it were samples 1 and 3
+        m2 = [2.0]
+        M2b = [0.0]
+        _welford_update!(m2, M2b, [4.0], 3)
+        @test m2[1] ≉ 3.0                       # ...and it does not
+    end
+
+    @testset "the result records what was refused" begin
+        # `rejected` is a vector, not a count: "none rejected" and "rejections
+        # not tracked" must not look alike, and a caller should be able to name
+        # the member.
+        r = EnsembleResult([0.0], Dict{Symbol, Vector{Array{Float64}}}(),
+            Dict{Symbol, Vector{Array{Float64}}}(), 3, [2], nothing, nothing)
+        @test r.rejected == [2]
+        @test r.n_trajectories == 3            # contributing, not requested
+        # the back-compat constructor reads as "none rejected", which is true
+        # of every caller written before the path existed
+        old = EnsembleResult([0.0], Dict{Symbol, Vector{Array{Float64}}}(),
+            Dict{Symbol, Vector{Array{Float64}}}(), 5, nothing)
+        @test old.rejected == Int[]
+    end
+
+    # THE ARM THE FIRST VERSION OF THIS FILE LACKED. Everything above tests the
+    # PIECES — the predicate, the weighting, the record — and every one of them
+    # stayed green when the rejection branch itself was disabled (measured:
+    # canary A, `if false && !_all_finite(...)`). Testing a guard's components
+    # without testing that the caller CONSULTS it is the same shape as a gate
+    # built from the thing under test: it never crosses into the code path where
+    # the defect lives.
+    #
+    # `run_twa_ensemble` needs a full workspace, so this reads the SOURCE: the
+    # loop must call the predicate and must skip on it. Cheap, and it fails for
+    # the right reason if someone removes the branch.
+    @testset "the ensemble loop actually consults the guard" begin
+        src = read(joinpath(@__DIR__, "..", "..", "src", "solvers", "twa.jl"), String)
+        # strip comments so the prose explaining the guard cannot satisfy it
+        code = join((split(l, '#')[1] for l in split(src, '\n')), "\n")
+        @test occursin("_all_finite(traj_obs)", code)
+        @test occursin(r"if\s*!\s*_all_finite\(traj_obs\)", code)
+        @test occursin(r"push!\(rejected,\s*i\)", code)
+        @test occursin("continue", code)
+        # the weighting and the denominator must use the used-count, not the
+        # loop index or the requested count
+        @test occursin(r"traj_obs\[sym\]\[t_idx\],\s*n_used", code)
+        @test occursin(r"n_used\s*-\s*1", code)
+        @test !occursin(r"m2\s*\./\s*\(n_traj\s*-\s*1\)", code)
+    end
+
+    # POSITIVE CONTROL on the whole argument: show that folding a NaN in
+    # DOES destroy the running mean, so the guard is not defending against a
+    # hypothetical.
+    @testset "positive control: an unguarded NaN is unrecoverable" begin
+        m = [1.0]
+        M2 = [0.0]
+        _welford_update!(m, M2, [NaN], 2)
+        @test isnan(m[1])
+        _welford_update!(m, M2, [1.0], 3)      # a healthy member afterwards
+        @test isnan(m[1])                      # …cannot repair it
+    end
+end


### PR DESCRIPTION
Three of the six remaining items in the unified design's "what is genuinely not
covered" list. One of them was a real defect in the solver.

## The TWA ensemble NaN'd itself, and then lied about the sample count

`grep isfinite src/solvers/twa.jl` returned nothing, and `_welford_update!` is
cumulative and in place — `mean[I] += delta / i` — so **one diverging trajectory
destroyed the mean and the variance for every member after it**, with no
recovery and no record. A 200-member ensemble with a single divergence returned
an all-NaN answer while `n_trajectories` still read 200. **33 configs under
`runs/` use `twa:`.**

`_all_finite(traj_obs)` now refuses a member before it is folded in, and the
refusal is recorded as `EnsembleResult.rejected::Vector{Int}` — a vector rather
than a count, so *"none rejected"* and *"rejections not tracked"* cannot look
alike and a caller can name the member. Checked at the **observable**, not at ψ:
an ensemble is a statement about its observables, and a trajectory can be finite
in ψ while producing a non-finite observable.

**A second defect, found while fixing the first and quieter than it.** The
variance divided M2 by `n_traj` — the number *requested*. Adding a rejection path
without touching that denominator would have replaced an obvious NaN with a wrong
number: inflated sample count, variance biased low. Both the Welford weighting
and the denominator now use the contributing count.

### The gate failed instructively

Its first version tested the predicate, the weighting and the record — and stayed
**green when the rejection branch was disabled outright** (`if false &&
!_all_finite(...)`). Every piece was covered; nothing checked that the loop
*consults* them. Same shape as a gate built from the thing under test: it never
crosses into the code path where the defect lives.

There is now an arm asserting the loop calls the guard, skips on it, and uses the
used-count in both places. Canaried three ways — disable the branch, blind the
predicate, restore the `n_traj` denominator — each reddens.

## Two rows closed by measurement

**Item 3 (`A2:R-OPEN-05`) — write amplification.** The requirement said the
executions-per-artifact mean had to be measured before committing to an
append-only `attempts/` shape, and that at 3 or more the index needs sharding.

| | |
|---|---|
| run directories under `runs/` | 294 |
| distinct config basenames | 176 |
| **mean directories per config** | **1.24** |
| most re-run | 4 |

Well under the threshold. Recorded with equal weight: **what this does not
measure.** There are **0 completion markers and 0 `_exit_summary.json`** anywhere
under `runs/`, so all 294 directories predate the record-keeping that would have
counted executions, and a re-run that overwrote its directory in place leaves no
trace. So 1.24 is a **lower bound** — quoted as one because the decision is
one-sided: nothing short of doubling reverses it.

**Item 8 (`A2:R-CHAIN-03`) — fork-resolution costs.** The complaint was that
54 MB for ψ against ~2.1 GB of L-BFGS two-loop memory came from issue #250 and
had never been checked. Recomputed from the shapes and the shipped defaults:
ψ at 64³×13 `ComplexF64` = **54.5 MB**; history at `m_lbfgs = 20` = **2.18 GB**;
ratio **40×**. Both reproduce, so #250 is no longer the authority — the
arithmetic is. What stays open is **not a number**: whether "replay from the
nearest held ancestor" is right depends on how often a fork lands mid-solve, and
nothing measures that. The row now says so instead of implying another
measurement is owed.

Section 5: **8 of 14 ids resolved, across 6 of 12 items.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)