### PR TITLE
[control, do not merge] valid docs-only diff must run the fast tier

### DIFF
--- a/docs/campaign/lessons_2026_08_04.md
+++ b/docs/campaign/lessons_2026_08_04.md
@@ -149,3 +149,6 @@ Neither is a computation.
 
 Anything measured at a single field, against a residual smaller than the field
 systematic, reproduces §5 of the campaign report.
+
+<!-- Positive control 2026-08-04: a PR whose ENTIRE diff is .md must still run the
+     fast tier, because test_docs_live_set.jl lives there and reads docs/**.md. -->


### PR DESCRIPTION
Positive control for the CI fix that landed in #322. **Not for merging.**

#325 was invalid: it branched off the PR carrying the `ci.yml` change, and the filter reads the PR's `base..head` diff rather than the last commit, so `code=true` and the fast tier ran regardless.

This branches from `main` with the fix already in. Its **entire** diff is one `.md` file.

- **fast tier runs for minutes** → the `|| needs.changes.outputs.docs` condition works
- **fast tier reports ~10 s** → it does not, and the docs gate is still unreachable from the only change that can break it

Closed as soon as it reports.