### PR TITLE
docs(tsubame): the NVMe scratch fits small grids only, and Lustre is not the fix

### DIFF
--- a/docs/guides/tsubame.md
+++ b/docs/guides/tsubame.md
@@ -70,6 +70,8 @@ pinned, project root off `$HOME`, group-volume headroom, `runs/` present, and (f
 
 Lustre is bad at many small writes; `dynamics/psi_snapshots_streamed/frame_NNNNN` emits one metadata op per frame, which stacks. `SPINORBEC_SCRATCH_DIR=$T4_TMPDIR` redirects `.tmp` files to NVMe and copies to Lustre on success.
 
+> ⚠️ **The node-local NVMe default only fits SMALL grids — but keep the scratch on NVMe anyway.** For n ≳ 100 per-dim, ψ snapshots (112³ F32 = 91 MB/frame) overrun node-local NVMe; the `tmp → runs/` (Lustre) move then dies `EXDEV` / `sendfile -122`. **Do NOT "fix" this by moving the scratch to Lustre** — JLD2 writes via mmap and **mmap on Lustre `SIGBUS`es** (`signal 7` at `unsafe_store!`). The correct fix is to **shrink the snapshot volume** so the jld2 fits NVMe: raise `save.every` (measured: n112 needs ~2000, n80 is fine at 300). Also reap leftover multi-GB run dirs and watch the group quota (`lfs quota -g tga-kozuma-kouhi /gs/fs`, ~1 TB) — over-quota silently breaks `git` and `qsub`.
+
 ## Edit-test-submit loop
 
 ```bash

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -996,6 +996,7 @@ const _COST = Dict{String, Float64}(
     "analysis/test_vorticity_berry.jl" => 8.4,
     "analysis/test_physics_level1.jl" => 7.8,
     "workflow/test_inspect_config.jl" => 7.7,
+    "workflow/test_vortex_density_movie.jl" => 6.0,
     "analysis/test_observables.jl" => 7.7,
     "oracles/test_physics_aware_sign_oracles.jl" => 7.6,
     "workflow/test_catalog_index.jl" => 7.4,


### PR DESCRIPTION
Two lines, salvaged from an abandoned worktree whose code had all landed on `main` by another route.

## What this adds

For `n ≳ 100` per-dim, ψ snapshots (112³ F32 = 91 MB/frame) overrun node-local NVMe and the `tmp → runs/` move dies `EXDEV` / `sendfile -122`. The tempting fix is to point `SPINORBEC_SCRATCH_DIR` at Lustre — and that is **worse**: JLD2 writes via mmap, and mmap on Lustre `SIGBUS`es (`signal 7` at `unsafe_store!`). The fix is to shrink the snapshot volume instead: raise `save.every` (measured — n112 needs ~2000, n80 is fine at 300).

Also records that an over-quota group volume silently breaks `git` and `qsub`, which does not present as a quota error.

Plus a `_COST` hand-out-order entry for `test/workflow/test_vortex_density_movie.jl`, which was already registered in a tier on `main` (`_tiers.jl:355`) but had no cost.

## Why the PR is this small — the branch it came from is already landed

`fix/rotating-basis-gpu-and-barnett-tooling` (52 commits, 311 files) is on the remote and preserved. Its code contribution turned out to be **entirely on `main` already**:

| on the branch | status on main |
|---|---|
| `vortex_density_movie.jl`, `dynamics_snapshots.jl`, `viz_dynamics_movie.py`, `test_vortex_density_movie.jl` | present and **byte-identical** — the 3-way apply was a no-op |
| inspect W4 severity, `rotating_frame_omega` + GPU `:block` → `:warn` | landed independently; main's wording kept |
| tier registration of the movie test | `_tiers.jl:355` |

The remaining 299 files are `runs/` data and movies, which do not belong in a PR.

## One thing deliberately not taken

`compute_gamma_lhy` in `hamiltonian/coefficients.jl` (+31). **Main deleted it on purpose** — `run_step_rotating/ground_state.jl:101` and `test_lima_pelster_q5.jl:28` both record the retirement — and its own docstring admitted it was a second, *disagreeing* declaration of the scalar LHY coefficient (`(128/(3√π))·√(|a_s/a_ho|³)·N·Q₅` against `scalar_lhy_coefficient`'s `(128√π/3)·(a_s/a_ho)^{5/2}·N^{3/2}·Q₅`) with a TODO to pick one. Re-adding it would revert a deliberate deletion and re-open exactly the duplication the HamTerm protocol exists to prevent.

The citation to `runs/eu_barnett_rotfield_clean/tsubame_rebuild_template.sh` and to `run_rebuild.jl` was also dropped: neither is on `main`, and `test/oracles/test_doc_run_citations_resolve.jl` would be entitled to fail on the dangling path. The warning is stated self-containedly instead.

## Verification type

Neither — this is operational documentation. The failure modes it describes (`EXDEV` on the move, `SIGBUS` at `unsafe_store!`, silent `git`/`qsub` breakage over quota) were observed on TSUBAME during that branch's work; the `save.every` thresholds are the values that were made to fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
