### PR TITLE
docs(evap): eta_start is 2.07, not the 4.5 this guide claimed in four places

### DIFF
--- a/docs/guides/evaporation_model.md
+++ b/docs/guides/evaporation_model.md
@@ -119,10 +119,22 @@ evaporation_diagnostics(r, trap, p)
 On the researched euv3 defaults: `collision_ratio_R ≈ 6.4×10³` (good-to-bad collisions
 ≫ the ~10²–10³ runaway threshold), `collisions_per_atom ≈ 6.7×10³` (≫ the few hundred
 needed — not collisionally limited), `γ_el ≈ 12 kHz`, `runaway = true`. The trap is
-**collisionally excellent**; the *only* marginal quantity is `eta_start ≈ 4.5` (the
-loaded depth vs `T₀ = 50 µK`, near the `eta_min = 4` floor). Real setups load at
-η ~ 7–10, so if your `eta_start` comes out near 4.5 the model is likely *under*estimating
-the loaded depth (raise `α`/power or lower `T₀` to match the measured loaded η).
+**collisionally excellent**. The marginal quantity is `eta_start`, and it is **worse than
+this document said until 2026-08-05**: the defaults give `eta_start = 2.07`, not the
+`≈ 4.5` claimed here and in three other places below. That is *under* the `eta_min = 4`
+floor, and real setups load at η ~ 5–10, so the loaded depth the model infers is
+unphysical by more than a factor of two. Measured by the very call this section tells you
+to make:
+
+```julia
+julia> evaporation_summary(run_euv3_evaporation()).eta_start
+2.0682
+```
+
+Treat every absolute number downstream of the defaults as suspect until the loaded depth
+is re-anchored (`α`/power up, or `T₀` down — the ramp comes from a 2023 notebook whose
+loaded temperature is not the 2022 PRL's 50 µK). Ratio-type conclusions (optimized vs lab
+ramp) are the ones that survive.
 
 Optimize the ramp for max `N_BEC`. Three optimizers, increasing in reach:
 
@@ -137,7 +149,8 @@ out.bo.best_p          # [duration_scale, final_power_scale, warp_γ]
 #     ramp's own ratios, so it can only improve. This is the trustworthy optimizer:
 #     a schedule the lab can actually run. On the experiment-matched defaults it finds
 #     N_BEC ≈ 3.2× the lab ramp by evaporating HARDER EARLY (steeper initial power
-#     drop, at high collision rate), η staying in the valid 4.5–11 range throughout.
+#     drop, at high collision rate). The "η stays in a valid 4.5–11 range" this line
+#     used to claim was false: η_start is 2.07 at these defaults (see above).
 trap = euv3_evap_trap(); p = EvapParams(; a_s=Eu151.a_s, tau_bg=15, K3=1.61e-40)
 out = optimize_ramp_monotone(trap, p, euv3_evaporation_ramp(); N0=3.5e6, T0=50e-6)
 out.ramp               # the optimized, monotone-decreasing FortRamp; out.fracs are the drops
@@ -157,12 +170,21 @@ evaporation works — across `K₃` ×0.5–1, `α` ×1.0–1.15, `τ_bg` 8–30
 *aggressive* schedule sits near two cliffs:
 
 - **Loaded-depth floor.** Evaporation can only start if the loaded `η_start = U/(k_BT₀)`
-  exceeds `eta_min ≈ 4`. At the researched defaults `η_start ≈ 4.5` — marginal (real
-  setups load at η ~ 7–10, so the model likely *under*estimates the loaded depth). If
-  `α` is ~15 % below calibration, `η_start < 4` and **no ramp evaporates at all** —
-  check `evaporation_summary(...).eta_start` before trusting any optimization.
+  exceeds `eta_min ≈ 4`. The defaults give `η_start = 2.07` — **already past the cliff**,
+  not "marginal at ≈ 4.5" as this bullet claimed. Real setups load at η ~ 5–10, so the
+  inferred loaded depth is too shallow by >2×, and no adverse `α` shift is needed to break
+  it. Check `evaporation_summary(...).eta_start` before trusting any optimization; that
+  advice was already here, and running it is what found this.
 - **3-body cliff.** The aggressive ramp reaches high density fast; if `K₃` is ~2× the
   fit, it over-loses and may miss BEC while the gentle lab ramp still reaches it.
+- **No `K₃` in the ab-initio band reproduces the measured endpoint.** Reaching the
+  measured `N_BEC = 5.02×10⁴` needs `K₃ ≈ 2.45×10⁻⁴⁰ m⁶/s` at `T₀ = 50 µK` and
+  `≈ 2.74×10⁻⁴⁰` at `T₀ = 18 µK` — both **2.5× above the top of the universal
+  van-der-Waals band** (`K₃ = 3C ℏa⁴/m`, `C ∈ [0,67]`, `a = 110a₀` ⇒ `≤ 1×10⁻⁴⁰`). The
+  shipped default `1.61×10⁻⁴⁰` is itself already above the band and still over-predicts
+  by 1.31×. So the endpoint gap is a **model deficiency, not a parameter to tune**, and a
+  "parameter-free prediction that brackets the measurement" is not available here. Swept
+  on 2026-08-05 over `K₃ ∈ [10⁻⁴²·³, 10⁻³⁹·³]` at both anchors.
 
 For a schedule that does **not** sit on a cliff, optimize the **worst case** over the
 calibration-uncertainty set:


### PR DESCRIPTION
Docs only, one file, two measured corrections. No code and no defaults change.

> **Disclosure I should have led with.** `docs/guides/evaporation_model.md` carries a
> **`FROZEN 2026-06-16` — "not maintained against the code, do not cite it as current"**
> banner. I did not mention that in the first version of this description, and it changes
> how you should weigh this PR.
>
> I still think the edit is right: a *specifically false number* is worse than a stale
> document, the banner does not stop someone reading the number, and #330 is the proof —
> its author read `η_start ≈ 4.5` here and built a T₀ re-anchoring on it. But if you would
> rather a finding like this lived in a live surface (`docs/audit/docs_inventory_2026-08-04.md`,
> or a gate) and the frozen guide were left alone, say so and I will move it.

## 1. `eta_start` is 2.07, not 4.5

`docs/guides/evaporation_model.md` asserted `eta_start ≈ 4.5` at the euv3 defaults in four places — "the *only* marginal quantity", "near the `eta_min = 4` floor", "η staying in the valid 4.5–11 range", and again in the cliff bullet. Measured on this tree:

```julia
julia> evaporation_summary(run_euv3_evaporation()).eta_start
2.0682
```

So the loaded depth the model infers is **not** marginal — it is already below the `eta_min = 4` floor, and unphysical by >2× against the η ~ 5–10 that real ODTs load at. No adverse `α` shift is needed to break it; it starts broken.

The same section already said *"check `evaporation_summary(...).eta_start` before trusting any optimization."* Running that one line is what found this.

## 2. No `K₃` in the ab-initio band reproduces the measured endpoint

Swept `K₃ ∈ [10⁻⁴²·³, 10⁻³⁹·³] m⁶/s` at both anchors. The measured `N_BEC = 5.02×10⁴` is reached only at:

| anchor | `K₃` reproducing the measurement |
|---|---|
| `T₀ = 50 µK` (shipped) | 2.45×10⁻⁴⁰ |
| `T₀ = 18 µK` | 2.74×10⁻⁴⁰ |

Both are **2.5× above the top of the universal van-der-Waals band** — `K₃ = 3C ℏa⁴/m`, `C ∈ [0,67]`, `a = 110a₀` ⇒ `≤ 1×10⁻⁴⁰`. The shipped default `1.61×10⁻⁴⁰` is itself already above the band, and still over-predicts by 1.31×.

That makes the endpoint gap a **model deficiency, not a parameter to tune**, and it means a "parameter-free prediction that brackets the measurement" is not available at these inputs.

## What is deliberately NOT changed

Re-anchoring is a physics call for the owner of this model, not a docs edit. Measured trade, on current `main`:

| | `T₀` | `K₃` | `η_start` | `N_BEC` / measured |
|---|---|---|---|---|
| shipped | 50 µK | 1.61e-40 | **2.07** | 1.31× |
| `T₀` only | 18 µK | 1.61e-40 | 5.75 | 1.47× |
| `T₀` + `K₃`=1e-41 | 18 µK | 1e-41 | 5.75 | 10.62× |
| `K₃` only | 50 µK | 1e-41 | **2.07** | 3.42× |

`T₀ = 18 µK` buys a physical `η_start` and costs endpoint agreement, because the fitted `K₃` was absorbing the error. Picking a row is not something this PR does.

## Verification type

**A** for the numbers themselves (they are what the shipped code computes). The `η ~ 5–10` loading range and the van-der-Waals band are **B/C** — literature, quoted not re-derived. The measured `5.02×10⁴ @ 349 nK` target is the repo's existing type-**C** anchor, unchanged.

## Gap this leaves open

Nothing gates these values. `eta_start` is tested only as `> 4` on a synthetic deep trap (`test_evaporation_tools.jl`) and for consistency with `res.eta[1]` (`test_evaporation.jl`); the euv3 defaults' value is unpinned, so it can drift again. A guard would have to either freeze 2.07 — wrong, it *should* move when the anchoring is fixed — or assert the known-broken state so it reddens on repair. That choice belongs with the re-anchoring decision, so it is not made here.

Supersedes the diagnosis half of #330, which is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
