### PR TITLE
A spatial-LHY substep was silently dropped, a guard was never called, and three caches keyed on the wrong thing

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -122,7 +122,7 @@ checking either.
 
 - admits: `src/workflow/experiment.jl:253`
 - admits: `src/workflow/experiments/pipeline/run_registry.jl:601`
-- admits: `src/workflow/experiments/pipeline/run_registry.jl:832`
+- admits: `src/workflow/experiments/pipeline/run_registry.jl:840`
 - admits: `src/workflow/experiments/pipeline/run_step_ground_state.jl:477`
 - **verifies**: `src/workflow/experiments/pipeline/run_step_ground_state.jl:541`
 
@@ -206,9 +206,9 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 251 files
+- `FAST_TESTS` — 254 files
 - `CI_EXTRA` — 113 files
-- `FULL_EXTRA` — 73 files
+- `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files
 - `ORACLE_TESTS` — 75 files
 - `INTEGRATION_TESTS` — 44 files

--- a/ext/SpinorBECCUDAExt/gpu_lhy_field.jl
+++ b/ext/SpinorBECCUDAExt/gpu_lhy_field.jl
@@ -33,18 +33,26 @@ end
 function _assert_uniform_lhy_grid(xs, m::Int)
     all(k -> abs((xs[k + 1] - xs[k]) - (xs[2] - xs[1])) <=
              1e-9 * max(abs(xs[2] - xs[1]), 1.0), 1:(m - 1)) ||
-        throw(ArgumentError(
-            "GPU LHY lookup needs a uniform density grid; got a non-uniform one " *
-            "with $m nodes. Build the table with `range(0, n_max; length=n)`."))
+        throw(
+            ArgumentError(
+                "GPU LHY lookup needs a uniform density grid; got a non-uniform one " *
+                "with $m nodes. Build the table with `range(0, n_max; length=n)`."),
+        )
     nothing
 end
 
-const _LHY_TABLE_CACHE = Dict{Tuple{UInt64, DataType}, Any}()
-
+# Routed through the shared scratch registry rather than a local
+# `Dict{objectid}`. `objectid` is address-derived for a struct with Vector
+# fields, and this cache held no reference to `l`, so once a table was collected
+# a later `TabulatedLHY` landing on the same address inherited its device copy —
+# silently, as a wrong LHY potential. `scratch_get!` is an `IdDict` whose key
+# tuple HOLDS the object, which both pins it against GC and makes the id
+# unreusable; `_to_device_cached` (foundation/backend.jl) spells out the same
+# rationale, and `foundation/scratch.jl` says the registry exists precisely to
+# replace ad-hoc IdDict caches like this one.
 function _device_lhy_table(l::SpinorBEC.TabulatedLHY, ::Type{RT},
     proto::CUDA.CuArray) where {RT}
-    key = (objectid(l), RT)
-    get!(_LHY_TABLE_CACHE, key) do
+    SpinorBEC.scratch_get!(:gpu_lhy_table, (l, RT)) do
         CUDA.CuArray(RT.(l.potential_values))
     end::CUDA.CuArray{RT, 1}
 end
@@ -96,11 +104,15 @@ end
     2.5 * e1 * n * sqrt(n)
 end
 
-const _SPATIAL_LHY_CACHE = Dict{UInt64, Any}()
-
+# Same change, same reason as `_device_lhy_table` above: the key held only the
+# address, not the object.
 function _device_spatial_table(l::SpinorBEC.SpatialLHY)
-    get!(_SPATIAL_LHY_CACHE, objectid(l)) do
-        (CUDA.CuArray(l.polarisations), CUDA.CuArray(l.e1_values))
+    SpinorBEC.scratch_get!(
+        :gpu_spatial_lhy_table, l
+    ) do
+        (
+            CUDA.CuArray(l.polarisations), CUDA.CuArray(l.e1_values)
+        )
     end::Tuple{CUDA.CuArray{Float64, 1}, CUDA.CuArray{Float64, 1}}
 end
 

--- a/ext/SpinorBECCUDAExt/gpu_raman.jl
+++ b/ext/SpinorBECCUDAExt/gpu_raman.jl
@@ -16,8 +16,6 @@ mutable struct GPURamanCache{D, T <: AbstractFloat}
     kr::CuArray{T, 2}                 # (N, 1)  k_eff · r per spatial point
 end
 
-const _GPU_RAMAN_CACHE = Dict{UInt64, Any}()
-
 function _get_gpu_raman_cache(
     psi::CuArray{Complex{T}},
     sm::SpinorBEC.SpinMatrices{D},
@@ -26,9 +24,26 @@ function _get_gpu_raman_cache(
     ndim::Int,
 ) where {D, N, T <: AbstractFloat}
     N_spatial = prod(ntuple(d -> size(psi, d), ndim))
-    key = hash((objectid(sm), raman.k_eff, N_spatial, D, T))
-    cache = get(_GPU_RAMAN_CACHE, key, nothing)
-    cache !== nothing && return cache::GPURamanCache{D, T}
+    # `grid` is IN the key. It was not, and the cached `kr` field below is built
+    # from `grid.x` — so two grids sharing only a total point count collided:
+    # 32x32x16 and 64x16x16 are both 16384, and so are the same shape in two
+    # different boxes. The second Raman workspace was served the first one's
+    # k·r phase.
+    #
+    # Keyed through the shared scratch registry (an `IdDict` whose key tuple
+    # holds the objects) rather than `hash(objectid(...))`, which held no
+    # reference to `sm` and so admitted an id reused after GC.
+    cache = SpinorBEC.scratch_get!(
+        :gpu_raman, (sm, grid, raman.k_eff, N_spatial, D, T)
+    ) do
+        _build_gpu_raman_cache(psi, raman, sm, grid, ndim, T, Val(D))
+    end
+    return cache::GPURamanCache{D, T}
+end
+
+function _build_gpu_raman_cache(psi, raman, sm, grid::SpinorBEC.Grid{N}, ndim,
+    ::Type{T}, ::Val{D}) where {N, D, T <: AbstractFloat}
+    N_spatial = prod(ntuple(d -> size(psi, d), ndim))
 
     F = T(sm.system.F)
     m_vals = T[F - T(c - 1) for c in 1:D]
@@ -55,7 +70,6 @@ function _get_gpu_raman_cache(
         CUDA.zeros(T, N_spatial, 1),
         CuArray(reshape(kr_host, N_spatial, 1)),
     )
-    _GPU_RAMAN_CACHE[key] = cache
     cache
 end
 

--- a/ext/SpinorBECVTKExt/vtk_export.jl
+++ b/ext/SpinorBECVTKExt/vtk_export.jl
@@ -107,6 +107,14 @@ function SpinorBEC.export_vtk_series(
                         label = m >= 0 ? "n_p$m" : "n_m$(abs(m))"
                         vti[label] = component_density(psi, 3, c)
                     end
+                else
+                    # The dispatch chain ended with no `else`, so an
+                    # unrecognised name contributed nothing and said nothing:
+                    # the user got a .pvd series missing the field they asked
+                    # for, opened it in ParaView, and saw no error anywhere.
+                    # `export_vtk` above warns for the same vocabulary and the
+                    # same kwarg; only the series form was silent.
+                    @warn "Unknown VTK field: $field"
                 end
             end
             pvd[t] = vti

--- a/src/foundation/scratch.jl
+++ b/src/foundation/scratch.jl
@@ -22,6 +22,36 @@ under multi-threading should partition by thread id in their `key`.
 """
 const SCRATCH_REGISTRY = IdDict{Symbol, IdDict{Any, Any}}()
 
+"""
+    scratch_clear!(category::Symbol...) → nothing
+
+Drop cached scratch. With no argument, drops everything.
+
+The registry deliberately holds STRONG references to both keys and values —
+that is what pins a host array against GC so no later array can reuse its
+address and inherit its device copy. The cost is that nothing in it is ever
+collectable, so a GPU buffer parked here survives `GC.gc()` and
+`CUDA.reclaim()` cannot return its memory to the driver either: reclaim only
+frees what the pool already considers free.
+
+The scan loop in `pipeline/run_registry.jl` drops the workspace and reclaims
+between points precisely to stop device buffers accumulating, and its own
+comment names k² as one of the things it is freeing — but the device k² copy
+lives HERE, not on the workspace, so that sequence could not reach it. Clearing
+between scan points is safe: every entry is a pure function of its key and is
+rebuilt on next use.
+"""
+function scratch_clear!(categories::Symbol...)
+    if isempty(categories)
+        empty!(SCRATCH_REGISTRY)
+    else
+        for c in categories
+            haskey(SCRATCH_REGISTRY, c) && empty!(SCRATCH_REGISTRY[c])
+        end
+    end
+    nothing
+end
+
 function scratch_get!(factory::Function, category::Symbol, key)
     cache = get!(SCRATCH_REGISTRY, category) do
         IdDict{Any, Any}()

--- a/src/hamiltonian/integrator/combined_spin_step.jl
+++ b/src/hamiltonian/integrator/combined_spin_step.jl
@@ -268,6 +268,16 @@ function _combined_step_unusable(ws::Workspace)
     ws.raman === nothing || return "Raman coupling is not supported yet"
     is_uniform(ws.zeeman) || return "a spatial Zeeman field B(r,t) is not supported"
     ws.light_shift === nothing || return "light_shift is not supported yet"
+    # `_half_potential_step_combined!` never calls `apply_spatial_lhy_spin_step!` —
+    # its only two call sites are in the general chain (split_step.jl:632, :708) —
+    # so a SpatialLHY workspace accepted here loses that substep entirely. The
+    # sibling guard `_spin_chain_reason` (spin_chain.jl) has carried this line
+    # since the substep was added; this one did not, which is what two
+    # independent lists of the same property produce. Measured 2026-08-08 on an
+    # 8^3 Rb87 DDI workspace: `spinor_lhy=:spatial` gave
+    # `_spin_chain_reason` = "a spatial-LHY spin substep sits between them" and
+    # `_combined_step_unusable` = nothing.
+    _lhy_needs_spin(ws.lhy) && return "a spatial-LHY spin substep is not carried"
     ws.ddi_bufs === nothing &&
         return "DDI buffers are required (enable_ddi=true; the spin-density and Φ scratch lives there)"
     nothing

--- a/src/hamiltonian/integrator/propagators.jl
+++ b/src/hamiltonian/integrator/propagators.jl
@@ -719,8 +719,26 @@ function _update_batched_kinetic_phase!(
         # GPU: `k_squared` is a host Array — broadcasting it into a device
         # kernel is illegal (non-bitstype). Move it to a device array that
         # matches `kp` first, then build the phase on-device.
-        k_sq_dev = similar(kp, RT, size(k_squared))
-        copyto!(k_sq_dev, k_squared)
+        #
+        # CACHED. This used to `similar` + `copyto!` on EVERY call, re-uploading
+        # an immutable array: 16.0 MiB per call at 128³ Float64, and this
+        # function runs once per step under `split_step_midpoint!` and
+        # `rk4ip_step!`, three times per step under the Yoshida cores, and twice
+        # per step in the Richardson adaptive loop. `_to_device_cached`'s own
+        # docstring (`foundation/backend.jl`) names this exact k² re-upload as
+        # the defect it was written to remove — on the OPERATOR face, which was
+        # fixed; the propagator face was not.
+        #
+        # Keyed on `(device array type, RT, k_squared)` and NOT on size: two
+        # grids of equal shape and different box size share a shape and differ
+        # in k², which is the trap `cached_kspace_filter` above documents.
+        # Holding `k_squared` in the key also pins it against GC, so no later
+        # array can reuse its address and inherit the entry.
+        k_sq_dev = scratch_get!(:kinetic_phase_k2, (typeof(kp), RT, k_squared)) do
+            d = similar(kp, RT, size(k_squared))
+            copyto!(d, k_squared)
+            d
+        end
         kp_view = selectdim(kp, ndim + 1, 1)
         if imaginary_time
             kp_view .= exp.(-half .* k_sq_dev .* dt_t) .* inv_npts

--- a/src/hamiltonian/integrator/yoshida.jl
+++ b/src/hamiltonian/integrator/yoshida.jl
@@ -92,6 +92,18 @@ function run_simulation_yoshida!(
     comp = composition isa Symbol ? _resolve_composition(composition) : composition
     _assert_composition_keys(comp)
 
+    # Checked ONCE, before any stepping: neither `MEANFIELD_MIDPOINT_ENABLED[]`
+    # nor `ws.ddi` changes during the run, so a composition the DDI path cannot
+    # realise should cost nothing rather than fail on the first accepted step.
+    #
+    # `_assert_jump_realisable` was DEFINED and never called — an edit script
+    # aborted before writing, and the gate that should have caught it called the
+    # guard directly instead of going through this entry point. So the DDI path
+    # went on silently running `omelyan_pefrl` / `blanes_moan_srkn6b` at order 2.
+    _assert_jump_realisable(
+        composition, comp, MEANFIELD_MIDPOINT_ENABLED[] && ws.ddi !== nothing
+    )
+
     dt = clamp(adaptive.dt_init, adaptive.dt_min, adaptive.dt_max)
 
     psi_old = similar(ws.state.psi)

--- a/src/workflow/experiments/pipeline/run_registry.jl
+++ b/src/workflow/experiments/pipeline/run_registry.jl
@@ -739,6 +739,14 @@ function _run_yaml_scan(data::Dict, scan::OverrideScan, run_dir, env; verbose=tr
             # a 16 GB device before CUDA's allocator reclaims (each
             # workspace pins ~150 MB across psi/fft_buf/k²/ddi_kernel/...).
             result = nothing
+            # BEFORE the GC: the scratch registry holds strong references by
+            # design (that is what pins a host array against address reuse), so
+            # anything parked there — including the device k² copy this comment
+            # claims to be freeing — survives `GC.gc()` and is invisible to
+            # `CUDA.reclaim()`, which only returns memory the pool already
+            # considers free. Every entry is a pure function of its key, so
+            # dropping them between points costs a rebuild and nothing else.
+            scratch_clear!()
             GC.gc()
             _maybe_cuda_reclaim()
         end

--- a/src/workflow/io/dashboard/cache.jl
+++ b/src/workflow/io/dashboard/cache.jl
@@ -76,9 +76,12 @@ const _OPEN_JLD_MAX = 32
 #   _PREPACK_INFLIGHT      in-flight prepack-warmer task IDs
 #   _DASHBOARD_CACHE_DIRNAME  on-disk atlas blobs (per run dir)
 #
-# Two helpers below are the canonical entry points for invalidation:
-# `clear_all_caches!` (used by /api/refresh) and `invalidate_path!`
-# (used when a single run regenerates).
+# Two helpers below are the invalidation entry points. `clear_all_caches!` is
+# the one in use — /api/refresh calls it. `invalidate_path!` has NO caller
+# today; this comment claimed it was "used when a single run regenerates", in
+# the present tense, and it never has been. It is kept because it is the right
+# primitive for a file watcher, and it is now correct — see its own docstring
+# for the matching bug that made it a no-op even if it had been called.
 
 """Drop every cache layer at once. Used by /api/refresh."""
 function clear_all_caches!(data_cache::Dict, psi_cache::Dict)
@@ -99,10 +102,23 @@ function clear_all_caches!(data_cache::Dict, psi_cache::Dict)
 end
 
 """Drop every cache entry that references `fpath` so the next request
-reads it fresh. Other runs' caches are preserved."""
+reads it fresh. Other runs' caches are preserved.
+
+NO CALLER as of 2026-08-08 — see the comment above. It was also a no-op if
+called: the two loops below used opposite `occursin` argument orders, and the
+`data_cache` one asked whether the whole cache KEY is a substring of the path.
+Those keys are `"<run_name>#<live_count>"` (`routes/misc.jl`), so the `#3`
+suffix is never in a file path and the test could not match — the
+fixing-the-wrong-`occursin`-argument class this repository has hit before. The
+run name is the part before `#`, and that IS a path component, so the
+comparison is made on the prefix.
+
+`psi_cache` keys embed the full path (`"phase_bin:<fpath>#snap=..."`), so that
+loop's direction was already right and is unchanged."""
 function invalidate_path!(data_cache::Dict, psi_cache::Dict, fpath::String)
     for k in collect(keys(data_cache))
-        occursin(k, fpath) && delete!(data_cache, k)
+        run_name = first(split(k, '#'))
+        !isempty(run_name) && occursin(run_name, fpath) && delete!(data_cache, k)
     end
     for k in collect(keys(psi_cache))
         occursin(fpath, k) && delete!(psi_cache, k)

--- a/src/workflow/io/dashboard/routes/autopilot_queue.jl
+++ b/src/workflow/io/dashboard/routes/autopilot_queue.jl
@@ -41,11 +41,22 @@ function _route_autopilot_queue(path::String)
         "\"dry_run\":", is_autopilot_dry_run(qr),
         ",\"paused\":", is_autopilot_paused(qr),
         "}")
+    # A failed `list_queue` used to become `QueueEntry[]`, which serialises
+    # identically to a healthy empty state — so a locked, missing or corrupt
+    # queue root rendered as "no jobs queued" in a 200 with no error field, and
+    # neither the operator nor the front end could tell. Absence folding into
+    # health at a boundary; the same shape as the divergence-kill keys, the
+    # budget gate summing zeros, and the preflight that could only pass.
+    #
+    # Still not throwing: one bad state directory must not take the whole queue
+    # view down. The failure is REPORTED instead, per state.
+    failed = String[]
     for st_str in (wanted === nothing ? _QUEUE_STATES_JSON : (wanted,))
         st = Symbol(st_str)
         entries = try
             list_queue(st; qr=qr)
-        catch
+        catch e
+            push!(failed, "$(st_str): $(replace(string(e), '"' => "'"))")
             QueueEntry[]
         end
         print(out_io, ",")
@@ -55,6 +66,10 @@ function _route_autopilot_queue(path::String)
             print(out_io, _entry_to_json(e, qw_medians))
         end
         print(out_io, "]")
+    end
+    if !isempty(failed)
+        print(out_io, ",\"unreadable\":[",
+            join(("\"$(f)\"" for f in failed), ","), "]")
     end
     print(out_io, "}")
     return (200, "application/json", String(take!(out_io)))

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -79,6 +79,8 @@ const FAST_TESTS = [
     "workflow/test_slack_alerts_report_delivery.jl",
     "workflow/test_inert_dynamics_keys_are_refused.jl",
     "hamiltonian/test_absorbing_boundary_honours_the_step.jl",
+    "hamiltonian/test_two_spin_step_guards_agree.jl",
+    "hamiltonian/test_kinetic_phase_uploads_k2_once.jl",
     "workflow/test_plan_cache_is_keyed_on_the_box.jl",
     "workflow/test_failure_evidence_reaches_the_reader.jl",
     "workflow/test_dashboard_does_not_invent_a_time_axis.jl",
@@ -716,6 +718,7 @@ const FULL_EXTRA = [
     # host k-space arrays (k², 1/|k|, √(1/|k|)) against device buffers.
     "gpu/test_spgpe_gpu_cpu_parity.jl",
     "gpu/test_gpu_tabulated_lhy_parity.jl",
+    "gpu/test_gpu_device_caches_key_on_the_object.jl",
     "gpu/test_gpu_lhy_term_faces.jl",
     # Same bug class again, this time in the dispatch itself: `energy_gradient!`
     # chose CPU vs GPU from `psi`, while computing on `ws.state.psi` and writing

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -80,6 +80,7 @@ const FAST_TESTS = [
     "workflow/test_inert_dynamics_keys_are_refused.jl",
     "hamiltonian/test_absorbing_boundary_honours_the_step.jl",
     "hamiltonian/test_two_spin_step_guards_agree.jl",
+    "workflow/test_absence_is_not_reported_as_health.jl",
     "hamiltonian/test_kinetic_phase_uploads_k2_once.jl",
     "workflow/test_plan_cache_is_keyed_on_the_box.jl",
     "workflow/test_failure_evidence_reaches_the_reader.jl",

--- a/test/gpu/test_gpu_device_caches_key_on_the_object.jl
+++ b/test/gpu/test_gpu_device_caches_key_on_the_object.jl
@@ -1,0 +1,160 @@
+using Test
+import CUDA
+using SpinorBEC
+
+# The CUDA extension's device caches must key on the objects they describe.
+#
+# Three of them keyed on a bare `objectid` (or a hash of one) and held no
+# reference to the object:
+#
+#   `_get_gpu_raman_cache`   hash((objectid(sm), k_eff, N_spatial, D, T))
+#   `_device_lhy_table`      (objectid(l), RT)
+#   `_device_spatial_table`  objectid(l)
+#
+# Two distinct defects follow. The first is an outright key omission: the Raman
+# cache's `kr` field is `k_eff · r` built from `grid.x`, and `grid` was not in
+# the key — only `N_spatial`. So two grids sharing a point count collided, and
+# 32x32x16 and 64x16x16 are both 16384, as is the same shape in a different box.
+#
+# MEASURED on an RTX 5070 Ti, 2026-08-08, two 8^3 grids at box 6.0 and 12.0:
+#
+#   old key   same cache object returned: true    max|kr_A - kr_B| = 0.0
+#   new key   same cache object returned: false   max|kr_A - kr_B| = 2.625
+#
+# and 2.625 is exactly max|kr_A| — doubling the box doubles k·r, so the
+# difference equals the original. The second grid was being handed the first
+# grid's phase, silently and exactly.
+#
+# The second defect is the bare `objectid`: it is address-derived for a struct
+# with Vector fields, and with no reference held the id is reusable after GC, so
+# a later object landing on the same address inherits a stale device table. All
+# three now go through `SpinorBEC.scratch_get!`, an `IdDict` whose key tuple
+# holds the objects — which pins them and makes the id unreusable. That is the
+# mechanism `_to_device_cached` documents, and `foundation/scratch.jl` says the
+# registry exists to replace exactly these ad-hoc IdDicts.
+
+if !CUDA.functional()
+    @info "CUDA not functional — skipping GPU device-cache key gate"
+else
+    const _EXT = Base.get_extension(SpinorBEC, :SpinorBECCUDAExt)
+
+    @testset "GPU device caches key on the object, not its address" begin
+        sm = spin_matrices(1)
+        ram = RamanCoupling{3}(0.5, 0.0, (1.0, 0.0, 0.0))
+        psi = CUDA.zeros(ComplexF64, 8, 8, 8, 3)
+
+        gA = make_grid(GridConfig((8, 8, 8), (6.0, 6.0, 6.0)))
+        gB = make_grid(GridConfig((8, 8, 8), (12.0, 12.0, 12.0)))
+
+        cA = _EXT._get_gpu_raman_cache(psi, sm, ram, gA, 3)
+        cB = _EXT._get_gpu_raman_cache(psi, sm, ram, gB, 3)
+
+        # CALIBRATION. The two grids must genuinely differ in the quantity the
+        # cache derives, or "they get different entries" proves nothing.
+        @testset "the two grids give different k·r" begin
+            @test gA.config.box_size != gB.config.box_size
+            @test prod(gA.config.n_points) == prod(gB.config.n_points)  # the collision
+            krA, krB = Array(cA.kr), Array(cB.kr)
+            @test maximum(abs, krA) > 1e-6
+            @test maximum(abs, krA .- krB) > 1e-6
+            # doubling the box doubles k·r, so the difference IS the original
+            @test maximum(abs, krA .- krB) ≈ maximum(abs, krA) rtol = 1e-12
+        end
+
+        @testset "different grids are not served the same cache" begin
+            @test !(cA === cB)
+        end
+
+        # NEGATIVE CONTROL: it must still be a cache. Keying on more must not
+        # trade a wrong answer for a rebuilt device buffer on every step.
+        @testset "the same (sm, grid, k_eff) still reuses" begin
+            @test _EXT._get_gpu_raman_cache(psi, sm, ram, gA, 3) === cA
+            @test _EXT._get_gpu_raman_cache(psi, sm, ram, gB, 3) === cB
+        end
+
+        # The LHY tables: same registry, same contract. Two tables with
+        # different content must not share a device buffer.
+        @testset "the LHY device tables key on the table" begin
+            mkws(c0) = make_workspace(;
+                grid=make_grid(GridConfig((8, 8, 8), (6.0, 6.0, 6.0))),
+                atom=Rb87, interactions=InteractionParams(Dict(0 => c0, 1 => 0.02)),
+                potential=HarmonicTrap((1.0, 1.0, 1.0)),
+                spinor_lhy=:polar_contact, backend=CUDABackend(),
+                sim_params=SimParams(; dt=1.0e-3, n_steps=1, save_every=1))
+
+            wsA, wsB = mkws(1.0), mkws(4.0)
+            @test wsA.lhy isa SpinorBEC.TabulatedLHY
+            @test wsB.lhy isa SpinorBEC.TabulatedLHY
+
+            # CALIBRATION: the two tables must genuinely differ, or "they get
+            # different entries" is vacuous.
+            @test maximum(abs, wsA.lhy.potential_values .-
+                               wsB.lhy.potential_values) > 1e-12
+
+            proto = CUDA.zeros(Float64, 8)
+            t1 = _EXT._device_lhy_table(wsA.lhy, Float64, proto)
+            @test _EXT._device_lhy_table(wsA.lhy, Float64, proto) === t1  # cached
+            t2 = _EXT._device_lhy_table(wsB.lhy, Float64, proto)
+            @test !(t2 === t1)
+            @test maximum(abs, Array(t2) .- Array(t1)) > 1e-12
+        end
+
+        # Not every `objectid` key is a defect, and banning the token outright
+        # would be the enumeration-instead-of-property mistake. The four below
+        # are SAFE for a reason worth stating: their cached content is a
+        # function of the OTHER key components, so `objectid` is redundant and a
+        # collision serves a correct value.
+        #
+        #   gpu_spin_mixing.jl:33          hash((objectid(sm), N, D, T))
+        #   gpu_ddi_rotation.jl:28         hash((objectid(sm), N, D, T))
+        #   gpu_spin_rotation_taylor.jl:47 hash((objectid(sm), D, T))
+        #       V / λ / m_vals / the tridiagonal bands are the spin algebra —
+        #       fixed by D and T alone. (Note the reason is NOT "the value keeps
+        #       a reference to `sm`": `GPUSMCache` and `SpinTridiagCoef` hold
+        #       only CuArrays and a scalar. Checked, because that WAS the
+        #       explanation offered and it is wrong.)
+        #   gpu_energy.jl:27               hash((objectid(ws), size(psi)))
+        #       pure scratch buffers, sized by `size(psi)`, which is in the key.
+        #
+        # The three that were NOT safe are the ones fixed here: the Raman cache
+        # derived `kr` from a `grid` absent from the key, and the two LHY tables
+        # cached the object's OWN data with nothing else identifying it.
+        @testset "every objectid key in the extension is a declared-safe one" begin
+            root = normpath(joinpath(@__DIR__, "..", "..", "ext",
+                "SpinorBECCUDAExt"))
+            expected = Set([
+                "gpu_spin_mixing.jl", "gpu_ddi_rotation.jl",
+                "gpu_spin_rotation_taylor.jl", "gpu_energy.jl",
+            ])
+            found = Dict{String, Int}()
+            for f in readdir(root; join=true)
+                endswith(f, ".jl") || continue
+                for l in eachline(f)
+                    startswith(strip(l), "#") && continue
+                    occursin("objectid(", l) &&
+                        (found[basename(f)] = get(found, basename(f), 0) + 1)
+                end
+            end
+            surprises = setdiff(keys(found), expected)
+            isempty(surprises) || println(
+                "\n  a new objectid-keyed cache appeared in: ",
+                join(sort(collect(surprises)), ", "),
+                "\n  Either its content is fixed by the rest of the key — then add it\n",
+                "  to `expected` with that reason — or it is the Raman/LHY defect again.")
+            @test isempty(surprises)
+
+            # POSITIVE CONTROL: the scan must still SEE the declared four, or an
+            # empty `surprises` means the walk read nothing.
+            @test length(intersect(keys(found), expected)) == 4
+
+            # and the three fixed caches must be on the registry
+            uses = 0
+            for f in readdir(root; join=true)
+                endswith(f, ".jl") || continue
+                uses += count(l -> !startswith(strip(l), "#") &&
+                                   occursin("scratch_get!", l), collect(eachline(f)))
+            end
+            @test uses >= 3
+        end
+    end
+end

--- a/test/hamiltonian/test_composer_order_conditions.jl
+++ b/test/hamiltonian/test_composer_order_conditions.jl
@@ -34,7 +34,8 @@ using LinearAlgebra
 using SpinorBEC
 using SpinorBEC:
     _COMP_YOSHIDA, _COMP_SUZUKI, _COMP_BLANES_MOAN_SRKN6B,
-    _COMP_OMELYAN_PEFRL, _COMP_YOSHIDA_S6, _assert_jump_realisable
+    _COMP_OMELYAN_PEFRL, _COMP_YOSHIDA_S6, _assert_jump_realisable,
+    MEANFIELD_MIDPOINT_ENABLED
 
 const _N = 8
 const _L = 4.0
@@ -178,5 +179,42 @@ end
         # the negative control: if nothing were demoted the loop above would be
         # vacuous on its throwing arm
         @test count(c -> c[2].jump_order < c[2].order, _COMPOSERS) == 2
+    end
+
+    # THROUGH THE REAL ENTRY POINT. The arm above calls the guard directly, and
+    # that is not enough: the first version of this fix defined
+    # `_assert_jump_realisable` and never called it — an aborted edit dropped the
+    # call site — and this file stayed green through a commit claiming the DDI
+    # path refuses. It did not. Drive `run_simulation_yoshida!` itself.
+    @testset "run_simulation_yoshida! refuses at the entry point" begin
+        g = make_grid(GridConfig{3}((8, 8, 8), (6.0, 6.0, 6.0)))
+        mk(ddi) = make_workspace(;
+            grid=g, atom=resolve_atom(:Na23),
+            interactions=InteractionParams(Dict(0 => 1.0, 1 => 0.03)),
+            potential=HarmonicTrap((1.0, 1.0, 1.0)),
+            enable_ddi=ddi, c_dd=ddi ? 1.0 : 0.0,
+            sim_params=SimParams(; dt=1.0e-3, n_steps=1, save_every=1))
+
+        # CALIBRATION for the fixture: the guard keys on `ws.ddi !== nothing`,
+        # so the two workspaces must actually differ in that field or both arms
+        # below test the same branch.
+        ws_ddi, ws_plain = mk(true), mk(false)
+        @test ws_ddi.ddi !== nothing
+        @test ws_plain.ddi === nothing
+        @test MEANFIELD_MIDPOINT_ENABLED[]   # else `use_mid` is false for both
+
+        # it must throw BEFORE stepping — this call costs nothing if it does
+        @test_throws ArgumentError run_simulation_yoshida!(
+            ws_ddi; t_end=1.0e-3, save_interval=1.0e-3,
+            composition=:blanes_moan_srkn6b)
+        @test_throws ArgumentError run_simulation_yoshida!(
+            ws_ddi; t_end=1.0e-3, save_interval=1.0e-3,
+            composition=:omelyan_pefrl)
+
+        # NEGATIVE CONTROL: without DDI the same composition is fine, so the
+        # guard is not simply rejecting these two names everywhere.
+        r = run_simulation_yoshida!(ws_plain; t_end=2.0e-3, save_interval=2.0e-3,
+            composition=:blanes_moan_srkn6b)
+        @test r.n_accepted > 0
     end
 end

--- a/test/hamiltonian/test_kinetic_phase_uploads_k2_once.jl
+++ b/test/hamiltonian/test_kinetic_phase_uploads_k2_once.jl
@@ -1,0 +1,116 @@
+using Test
+using SpinorBEC
+using SpinorBEC: _update_batched_kinetic_phase!, BatchedKineticCache,
+    SCRATCH_REGISTRY
+
+# The GPU branch must not re-upload k² on every call.
+#
+# `Grid.k_squared` is a host `Array` even for a GPU workspace, so when the
+# kinetic phase buffer is device-resident the phase builder cannot broadcast it
+# directly. It used to `similar` + `copyto!` a fresh device array EVERY CALL —
+# 128³ Float64 = 16.0 MiB re-uploaded per call, of an array that never changes.
+#
+# Call frequency (the default `split_step!` does NOT call it — the phase is built
+# once in `make_workspace` — which bounds the blast radius):
+#   split_step_midpoint!   1x/step   (and the rotating_basis loop, unconditionally)
+#   rk4ip_step!            1x/step
+#   the Yoshida cores      3x/step
+#   the Richardson loop    2x/step   (unguarded)
+#
+# `_to_device_cached`'s docstring in `foundation/backend.jl` names this exact k²
+# re-upload as the defect it was written to remove. It was removed on the
+# OPERATOR face (`terms/kinetic.jl` uses the cached form); the propagator face
+# kept the uncached copy.
+#
+# THIS SUITE HAS NO GPU. It exercises the non-`Array` branch with a minimal
+# AbstractArray wrapper — enough to prove the CACHING contract, which is what
+# regressed. The device semantics are covered by `test/gpu/`.
+
+"A non-`Array` AbstractArray, so `kp isa Array` is false and the else-branch runs."
+struct NotAnArray{T, N} <: AbstractArray{T, N}
+    data::Array{T, N}
+end
+Base.size(a::NotAnArray) = size(a.data)
+Base.getindex(a::NotAnArray, i...) = getindex(a.data, i...)
+Base.setindex!(a::NotAnArray, v, i...) = setindex!(a.data, v, i...)
+Base.similar(::NotAnArray, ::Type{T}, dims::Dims) where {T} = Array{T}(undef, dims)
+
+function fresh_cache(n)
+    kp = NotAnArray(zeros(ComplexF64, n, n, n, 1))
+    BatchedKineticCache(nothing, nothing, kp)
+end
+
+entries() =
+    haskey(SCRATCH_REGISTRY, :kinetic_phase_k2) ?
+    length(SCRATCH_REGISTRY[:kinetic_phase_k2]) : 0
+
+@testset "the kinetic phase uploads k² once per array, not per call" begin
+    haskey(SCRATCH_REGISTRY, :kinetic_phase_k2) &&
+        empty!(SCRATCH_REGISTRY[:kinetic_phase_k2])
+
+    n = 8
+    k2 = [Float64(i + j + k) for i in 1:n, j in 1:n, k in 1:n]
+    cache = fresh_cache(n)
+
+    # CALIBRATION. If the else-branch were never taken — `kp isa Array` true, or
+    # the function returning early — nothing would be cached and `entries()`
+    # would stay 0, which is also what a *perfectly* cached implementation looks
+    # like after zero calls. Establish the branch runs and does work first.
+    @testset "the device branch is the one under test" begin
+        @test !(cache.kinetic_phase_bc isa Array)
+        @test entries() == 0
+        _update_batched_kinetic_phase!(cache, k2, 0.01, false)
+        @test entries() == 1
+        # and it actually wrote a phase, rather than caching and doing nothing
+        @test any(!iszero, cache.kinetic_phase_bc.data)
+    end
+
+    @testset "repeated calls reuse the same device array" begin
+        before = SCRATCH_REGISTRY[:kinetic_phase_k2]
+        obj = first(values(before))
+        for dt in (0.02, 0.03, 0.04)
+            _update_batched_kinetic_phase!(cache, k2, dt, false)
+        end
+        @test entries() == 1                       # no new upload per call
+        @test first(values(SCRATCH_REGISTRY[:kinetic_phase_k2])) === obj
+    end
+
+    @testset "changing dt still changes the phase" begin
+        _update_batched_kinetic_phase!(cache, k2, 0.01, false)
+        a = copy(cache.kinetic_phase_bc.data)
+        _update_batched_kinetic_phase!(cache, k2, 0.05, false)
+        b = copy(cache.kinetic_phase_bc.data)
+        # caching k² must not accidentally cache the PHASE
+        @test maximum(abs, a .- b) > 1e-6
+    end
+
+    # NEGATIVE CONTROL, and the one that matters. A cache keyed on SIZE would
+    # hand the second grid the first grid's k², which is the trap
+    # `cached_kspace_filter` documents twenty lines above the fix. Two arrays of
+    # equal shape and different values must get separate entries and separate
+    # phases.
+    @testset "a different k² of the same size is not served the first one" begin
+        k2b = 2.0 .* k2
+        cache2 = fresh_cache(n)
+        _update_batched_kinetic_phase!(cache2, k2b, 0.01, false)
+        @test entries() == 2
+
+        ca = fresh_cache(n)
+        cb = fresh_cache(n)
+        _update_batched_kinetic_phase!(ca, k2, 0.01, false)
+        _update_batched_kinetic_phase!(cb, k2b, 0.01, false)
+        @test maximum(abs, ca.kinetic_phase_bc.data .- cb.kinetic_phase_bc.data) > 1e-6
+    end
+
+    # NO SOURCE SCAN. The first version asserted "no bare `copyto!(_, k_squared)`
+    # remains" and flagged the fix itself: the copy is still there, inside the
+    # cached factory, which is exactly where it belongs. Deciding whether a line
+    # sits inside a `do` block from its text is re-implementing Julia's grammar
+    # in a regex — the move that already produced a wrong tier count in this
+    # tree. The behavioural arms above are strictly stronger anyway: the
+    # uncached form never touches the registry, so `entries()` would be 0 and
+    # the calibration arm fails. Verified by canary, both directions.
+
+    haskey(SCRATCH_REGISTRY, :kinetic_phase_k2) &&
+        empty!(SCRATCH_REGISTRY[:kinetic_phase_k2])
+end

--- a/test/hamiltonian/test_two_spin_step_guards_agree.jl
+++ b/test/hamiltonian/test_two_spin_step_guards_agree.jl
@@ -1,0 +1,158 @@
+using Test
+using FFTW
+using LinearAlgebra
+using SpinorBEC
+using SpinorBEC: _spin_chain_reason, _combined_step_unusable_full,
+    _rtp_use_combined_step, COMBINED_SPIN_STEP_ENABLED, DEALIAS_2_3_ENABLED,
+    _lhy_needs_spin
+
+# Two guards, one property, and they had drifted apart.
+#
+# `_spin_chain_reason` (spin_chain.jl) decides whether the FUSED spin chain may
+# replace the general chain. `_combined_step_unusable` (combined_spin_step.jl)
+# decides the same thing for the COMBINED half-potential step. Both answer "does
+# an operator sit inside the region I am about to collapse into one rotation?",
+# both are hand-written lists, and neither derives from the other.
+#
+# MEASURED 2026-08-08, 8^3 Rb87 + DDI, one workspace per condition:
+#
+#   condition            spin_chain   combined    rtp selector
+#   baseline             no           no          uses combined
+#   c2 != 0              declines     declines    declines
+#   tensor               declines     declines    declines
+#   raman                declines     declines    declines
+#   spatial LHY          declines     ->NOTHING<- ->USES COMBINED<-
+#   spatial Zeeman       declines     declines    declines
+#   transverse Zeeman    declines     no          declines   (selector catches it)
+#   magnetic gradient    declines     no          uses combined
+#   dealias on           declines     no          uses combined
+#
+# The `spatial LHY` row was the defect: `_half_potential_step_combined!` never
+# calls `apply_spatial_lhy_spin_step!` — its only two call sites are in the
+# general chain, split_step.jl:632 and :708 — so a `spinor_lhy=:spatial`
+# workspace took the combined path with that substep silently absent. Reachable
+# from YAML with `dynamics: {spin_step: combined, lhy: {kind: spatial}}`; no
+# config under `runs/` sets either, so nothing in the tree was affected.
+#
+# The last three rows diverge LEGITIMATELY and that is why this file declares a
+# table instead of asserting the two lists are equal:
+#   * magnetic gradient — the combined path calls `_apply_mg_to_V!` /
+#     `_remove_mg_from_V!` itself (combined_spin_step.jl:186,188,195,197).
+#   * transverse Zeeman — the combined rotation MERGES it (docstring at
+#     combined_spin_step.jl:323); `_rtp_use_combined_step` declines it anyway.
+#   * dealias — the RTP loop applies the Orszag filter itself, around whichever
+#     half-V it chose (run_loops.jl:163-166 and :174-177).
+# Each of those was checked by reading the code, not assumed. A row whose
+# `combined_carries_it` is `true` is a claim that the combined path handles the
+# operator, and the citation is in the table.
+
+@testset "the two spin-step guards agree, or say why not" begin
+    grid = make_grid(GridConfig((8, 8, 8), (6.0, 6.0, 6.0)))
+    inter = InteractionParams(Dict(0 => 20.0, 1 => -0.4))
+    sp = SimParams(; dt=0.005, n_steps=1, imaginary_time=false)
+    base = (; grid, atom=Rb87, interactions=inter, zeeman=ZeemanParams(0.3, 0.0),
+        potential=HarmonicTrap((1.0, 1.0, 1.0)), sim_params=sp,
+        enable_ddi=true, c_dd=1.0, ddi_padding=false, fft_flags=FFTW.ESTIMATE)
+    mk(; kw...) = make_workspace(; merge(base, NamedTuple(kw))...)
+
+    "A polarisation ramp — SpatialLHY tabulates against |⟨F⟩|/F, so a uniform
+    spinor makes the table degenerate and the arm would pass for a fixture
+    reason rather than a physics one."
+    ramp = let psi = zeros(ComplexF64, 8, 8, 8, 3)
+        for I in CartesianIndices((8, 8, 8))
+            x = grid.x[1][I[1]]
+            f = clamp((x + 3.0) / 6.0, 0.0, 1.0)
+            a = exp(-x^2 / 8)
+            psi[I, 1] = a * sqrt(f)
+            psi[I, 2] = a * sqrt(1 - f)
+        end
+        psi
+    end
+
+    # name => (build, combined_carries_it, why)
+    CASES = [
+        ("c2 != 0", () -> let ip = InteractionParams(Dict(0 => 20.0, 1 => -0.4, 2 => 0.2))
+                (mk(; interactions=ip), ip)
+            end, false, ""),
+        ("tensor",
+            () -> (
+                mk(; atom=Cr52,
+                    interactions=InteractionParams(Dict(0 => 0.0, 1 => 0.0, 4 => 0.05))),
+                inter), false, ""),
+        ("raman", () -> (mk(; raman=RamanCoupling{3}(0.5, 0.0, (0.0, 0.0, 0.0))),
+                inter), false, ""),
+        ("spatial LHY", () -> (mk(; spinor_lhy=:spatial, psi_init=ramp), inter),
+            false, ""),
+        ("spatial Zeeman",
+            () -> (
+                mk(; zeeman=ZeemanParams(),
+                    spatial_zeeman=spatial_zeeman_field(grid; bz=(x, y, z) -> 0.3 + 0.01x)),
+                inter), false, ""),
+        ("transverse Zeeman",
+            () -> (
+                mk(;
+                    zeeman=SpinorBEC.ZeemanField{Nothing}(
+                        (0.1, 0.0, 0.3, 0.0), nothing,
+                        (nothing, nothing, nothing, nothing)),
+                ), inter),
+            true, "the combined rotation merges it (combined_spin_step.jl:323)"),
+        ("magnetic gradient",
+            () -> (mk(; magnetic_gradient=MagneticGradient{3}(0.1, 1, 1.0)),
+                inter), true,
+            "the combined path applies and removes it itself (combined_spin_step.jl:186-197)"),
+    ]
+
+    # CALIBRATION. Every arm below is about a guard DECLINING. A baseline that
+    # already declines would make all of them pass for the wrong reason, and a
+    # `_spin_chain_reason` that declined everything would too.
+    @testset "the baseline is accepted by both" begin
+        w = mk()
+        @test _spin_chain_reason(w, inter, copy(w.state.psi)) === nothing
+        @test _combined_step_unusable_full(w) === nothing
+        COMBINED_SPIN_STEP_ENABLED[] = true
+        @test _rtp_use_combined_step(w)
+        COMBINED_SPIN_STEP_ENABLED[] = false
+    end
+
+    @testset "$name" for (name, build, combined_carries, why) in CASES
+        ws, ip = build()
+
+        # both arms need the fusion guard to fire, or the row is not about what
+        # it says it is about
+        fusion = _spin_chain_reason(ws, ip, copy(ws.state.psi))
+        @test fusion !== nothing
+
+        combined = _combined_step_unusable_full(ws)
+        if combined_carries
+            # the divergence is DECLARED — and the reason must be recorded, so a
+            # future `true` cannot be added without someone writing down why
+            @test !isempty(why)
+            @test combined === nothing
+        else
+            isnothing(combined) && println(
+                "\n  `$name` declines the fusion but the combined step accepts it.\n",
+                "  Either the combined path carries the operator — then set\n",
+                "  combined_carries_it=true with a file:line — or it drops it\n",
+                "  silently, which is the defect this file exists for.")
+            @test combined !== nothing
+        end
+    end
+
+    # And the production selector must refuse the one that was actually broken.
+    @testset "the RTP selector refuses SpatialLHY" begin
+        old = COMBINED_SPIN_STEP_ENABLED[]
+        COMBINED_SPIN_STEP_ENABLED[] = true
+        try
+            w = mk(; spinor_lhy=:spatial, psi_init=ramp)
+            @test _lhy_needs_spin(w.lhy)
+            @test !_rtp_use_combined_step(w)
+            # NEGATIVE CONTROL: the same selector, same flag, a workspace whose
+            # only difference is the LHY kind, must still take the combined path
+            w0 = mk(; psi_init=ramp)
+            @test !_lhy_needs_spin(w0.lhy)
+            @test _rtp_use_combined_step(w0)
+        finally
+            COMBINED_SPIN_STEP_ENABLED[] = old
+        end
+    end
+end

--- a/test/workflow/test_absence_is_not_reported_as_health.jl
+++ b/test/workflow/test_absence_is_not_reported_as_health.jl
@@ -1,0 +1,141 @@
+using Test
+using SpinorBEC
+using SpinorBEC: scratch_get!, scratch_clear!, SCRATCH_REGISTRY
+using SpinorBEC.Dashboard: invalidate_path!
+
+# Four places where a thing that did not happen looked like a thing that was fine.
+#
+# This file gates the three that are checkable without a GPU or an HTTP server,
+# plus the scratch-registry eviction they all depend on. The VTK one is in
+# `ext/SpinorBECVTKExt` and needs WriteVTK, so it is asserted at source level
+# only — on CODE lines, because a comment explaining the fix is not the fix.
+
+const _QUEUE_ROUTE = normpath(
+    joinpath(@__DIR__, "..", "..", "src", "workflow",
+        "io", "dashboard", "routes", "autopilot_queue.jl"),
+)
+const _VTK = normpath(joinpath(@__DIR__, "..", "..", "ext", "SpinorBECVTKExt",
+    "vtk_export.jl"))
+const _RUN_REGISTRY = normpath(
+    joinpath(@__DIR__, "..", "..", "src", "workflow",
+        "experiments", "pipeline", "run_registry.jl"),
+)
+
+codelines(p) = [l for l in eachline(p) if !startswith(strip(l), "#")]
+
+@testset "absence is not reported as health" begin
+    # ---- 1. the scratch registry can be emptied ----------------------------
+    #
+    # It holds STRONG references to keys and values by design — that is what
+    # pins a host array against address reuse. The consequence is that a device
+    # buffer parked there survives `GC.gc()`, and `CUDA.reclaim()` cannot return
+    # its memory because reclaim only frees what the pool already considers
+    # free. The scan loop drops the workspace and reclaims between points, and
+    # its own comment names k² among the things it frees — but the device k²
+    # copy lives in the registry, not on the workspace, so that sequence could
+    # not reach it.
+    @testset "scratch_clear! actually evicts" begin
+        scratch_clear!()
+        a, b = [1.0, 2.0], [3.0, 4.0]
+        scratch_get!(() -> copy(a), :probe_a, a)
+        scratch_get!(() -> copy(b), :probe_b, b)
+
+        # CALIBRATION: the puts must have landed, or "it is empty afterwards"
+        # is true of a registry that never stored anything.
+        @test length(SCRATCH_REGISTRY) == 2
+        @test length(SCRATCH_REGISTRY[:probe_a]) == 1
+
+        scratch_clear!(:probe_a)
+        @test isempty(SCRATCH_REGISTRY[:probe_a])
+        @test length(SCRATCH_REGISTRY[:probe_b]) == 1   # selective, not global
+
+        scratch_clear!()
+        @test isempty(SCRATCH_REGISTRY)
+
+        # and it must still be a cache afterwards
+        v1 = scratch_get!(() -> copy(a), :probe_a, a)
+        @test scratch_get!(() -> copy(a), :probe_a, a) === v1
+        scratch_clear!()
+    end
+
+    @testset "the scan loop clears before it collects" begin
+        code = codelines(_RUN_REGISTRY)
+        i = findfirst(l -> occursin("scratch_clear!()", l), code)
+        g = findfirst(l -> occursin("GC.gc()", l), code)
+        r = findfirst(l -> occursin("_maybe_cuda_reclaim()", l), code)
+        @test i !== nothing
+        @test g !== nothing && r !== nothing
+        # ordering is the whole point: clearing after the GC frees nothing
+        @test i < g < r
+    end
+
+    # ---- 2. a queue read failure is reported, not rendered as "no jobs" ----
+    @testset "the queue route reports an unreadable state" begin
+        code = codelines(_QUEUE_ROUTE)
+        # CALIBRATION: the route is being read and still has the catch we care
+        # about, or the assertions below pass on an empty file.
+        @test any(l -> occursin("list_queue(", l), code)
+        @test any(l -> occursin("QueueEntry[]", l), code)
+
+        # ANCHORED to the `list_queue` catch specifically. A first version took
+        # `findfirst(occursin("catch"))` and landed on an unrelated one three
+        # hundred lines earlier — a scan that finds *a* match rather than *the*
+        # match reports on the wrong code and says nothing about it.
+        li = findfirst(l -> occursin("list_queue(st", l), code)
+        @test li !== nothing
+        window = join(code[li:min(length(code), li + 4)], " ")
+        @test occursin("catch e", window)
+        @test occursin("push!(failed", window)
+        # the old shape: a bare `catch` that discards the exception
+        @test !occursin("catch\n", window)
+        # ...and the response must carry the failure out
+        @test any(l -> occursin("unreadable", l), code)
+    end
+
+    # ---- 3. invalidate_path! matches the keys it is given -------------------
+    #
+    # The `data_cache` loop asked whether the whole cache KEY is a substring of
+    # the path. Keys are `"<run_name>#<live_count>"`, so the `#3` suffix is
+    # never in a file path and the test could not match — the wrong-`occursin`-
+    # argument class. The run name IS a path component.
+    @testset "invalidate_path! drops the run it is asked about" begin
+        fpath = "/data/runs/eu151_klaus_barnett/point_003.jld2"
+        data = Dict{Any, Any}(
+            "eu151_klaus_barnett#3" => "cached json",
+            "eu151_klaus_barnett#7" => "cached json",
+            "some_other_run#3" => "keep me",
+        )
+        psi = Dict{Any, Any}(
+            "phase_bin:$(fpath)#snap=0#axis=z#slice=4" => [1.0],
+            "phase_bin:/data/runs/other/point_001.jld2#snap=0" => [2.0],
+        )
+
+        invalidate_path!(data, psi, fpath)
+
+        @test !haskey(data, "eu151_klaus_barnett#3")
+        @test !haskey(data, "eu151_klaus_barnett#7")   # every live_count, not one
+        @test haskey(data, "some_other_run#3")          # other runs preserved
+        @test !haskey(psi, "phase_bin:$(fpath)#snap=0#axis=z#slice=4")
+        @test haskey(psi, "phase_bin:/data/runs/other/point_001.jld2#snap=0")
+
+        # NEGATIVE CONTROL: a path belonging to no cached run must delete
+        # nothing, or the arm above would pass on an implementation that clears
+        # everything — which is `clear_all_caches!`, a different function.
+        data2 = Dict{Any, Any}("eu151_klaus_barnett#3" => "x")
+        psi2 = Dict{Any, Any}("phase_bin:/nowhere/p.jld2#snap=0" => [1.0])
+        invalidate_path!(data2, psi2, "/data/runs/unrelated_run/point_001.jld2")
+        @test length(data2) == 1
+        @test length(psi2) == 1
+    end
+
+    # ---- 4. the VTK series exporter says something about a name it cannot use
+    @testset "export_vtk_series warns on an unknown field" begin
+        code = codelines(_VTK)
+        # CALIBRATION: both exporters are in this file and both have a dispatch
+        # chain over `field`.
+        @test count(l -> occursin("function SpinorBEC.export_vtk", l), code) >= 2
+        @test count(l -> occursin("Unknown VTK field", l), code) == 2
+        # the series form had no `else` at all; both must have one now
+        @test count(l -> occursin("field === :component_densities", l), code) == 2
+    end
+end


### PR DESCRIPTION
Four defects found by verifying a code-sweep's findings against the code and then measuring each one. Every claim here was adversarially reviewed before being acted on; three further claims were refuted and are not in this PR.

## 1. The combined spin step dropped the spatial-LHY substep

`_combined_step_unusable` did not check `_lhy_needs_spin`. Measured on an 8³ Rb87 + DDI workspace:

| | `_spin_chain_reason` | `_combined_step_unusable` | `_rtp_use_combined_step` |
|---|---|---|---|
| baseline | accepts | accepts | uses combined |
| `spinor_lhy=:spatial` | **declines** | **accepts** | **uses combined** |

`_half_potential_step_combined!` never calls `apply_spatial_lhy_spin_step!` — its only two call sites are in the general chain — so the substep was silently absent. Reachable from YAML with `dynamics: {spin_step: combined, lhy: {kind: spatial}}`. No config under `runs/` sets either, so nothing in the tree was affected.

Two hand-written lists of overlapping properties, neither derived from the other. The new gate declares the correspondence as a table rather than asserting the lists are equal: a condition that declines the fusion must also decline the combined step, unless it is marked `combined_carries_it` **with a file:line**. Three divergences are legitimate — magnetic gradient, transverse Zeeman, dealias — and each citation was checked by reading the code. Two of them looked like defects and are not.

## 2. `_assert_jump_realisable` was defined and never called

So the DDI path went on silently running `omelyan_pefrl` / `blanes_moan_srkn6b` at **order 2** — 4 and 6 stages per step for the order one Strang step already delivers. #331 widened the kwarg annotation, which fixed the symptom CI saw; the guard itself stayed dead code.

It now runs once at function entry, and `test_composer_order_conditions.jl` drives `run_simulation_yoshida!` with a real DDI workspace instead of calling the guard directly — calling it directly is why the omission survived.

## 3. `k²` was re-uploaded to the GPU on every call

16.0 MiB at 128³ Float64, of an immutable array. Once per step under `split_step_midpoint!` and `rk4ip_step!`, three times under the Yoshida cores, twice in the Richardson loop. The default `split_step!` does not call it, which bounds the blast radius.

`_to_device_cached`'s own docstring names this exact k² re-upload as the defect it was written to remove — on the operator face, which was fixed. Now routed through `scratch_get!`, keyed on the array's identity and **not** on size, since two boxes share a shape.

## 4. Three CUDA caches keyed on the wrong thing

The Raman cache omitted `grid` from a key whose `kr` field is `k_eff·r` built from `grid.x`. Measured on an RTX 5070 Ti, two 8³ grids at box 6.0 and 12.0:

```
old key   same cache object: true    max|kr_A - kr_B| = 0.0
new key   same cache object: false   max|kr_A - kr_B| = 2.625
```

2.625 is exactly `max|kr_A|` — doubling the box doubles k·r, so the second grid was being handed the first grid's phase, silently and exactly.

`_device_lhy_table` and `_device_spatial_table` keyed on a bare `objectid` and held no reference, so an id reused after GC inherits a stale device table. All three now use `scratch_get!`, whose key tuple holds the object and thereby pins it.

The four remaining `objectid` keys in the extension are safe, and the gate declares them with the reason: their content is fixed by the rest of the key (`D`, `T`, `size(psi)`), so a collision serves a correct value. The explanation originally offered for them — "the cached value keeps a reference to `sm`" — is wrong; `GPUSMCache` and `SpinTridiagCoef` hold only CuArrays and a scalar.

## Gates

All new, all canaried in both directions, all registered in `test/_tiers.jl`:

- `test/hamiltonian/test_two_spin_step_guards_agree.jl` — 23 assertions
- `test/hamiltonian/test_kinetic_phase_uploads_k2_once.jl` — 9, no GPU needed
- `test/gpu/test_gpu_device_caches_key_on_the_object.jl` — 17, verified on hardware
- `test/hamiltonian/test_composer_order_conditions.jl` — extended to 43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Second commit: four places where nothing-happened looked like nothing-wrong

1. **The scratch registry could not be emptied.** It holds strong references by design — that is what pins a host array against address reuse — so a device buffer parked there survives `GC.gc()`, and `CUDA.reclaim()` cannot return its memory (reclaim only frees what the pool already considers free). The scan loop drops the workspace and reclaims between points *precisely* to stop device buffers accumulating, and its own comment names k² among the things it frees — but the device k² copy lives in the registry, not on the workspace. This got worse with the three caches moved onto the registry in the first commit. `scratch_clear!` added and called **before** the GC.

2. **`/api/queue` rendered a read failure as an empty state.** `catch; QueueEntry[]` serialises identically to a healthy empty queue, in a 200 with no error field — a locked or corrupt queue root read as "no jobs queued". Still not throwing (one bad state directory must not take the view down); the failure now travels out in an `unreadable` field.

3. **`invalidate_path!` was dead code that would not have worked.** Zero call sites, while the comment above it claimed in the present tense that it is "used when a single run regenerates". The two loops also used opposite `occursin` argument orders, and the `data_cache` one asked whether the whole cache KEY is a substring of the path — keys are `"<run_name>#<live_count>"`, so the `#3` suffix is never in a file path and it could not match.

4. **`export_vtk_series` dropped unknown field names silently.** No `else` on its dispatch chain: a .pvd series missing the requested field, opened in ParaView with no error anywhere. `export_vtk` warns for the same vocabulary and the same kwarg; only the series form was quiet.

Gated by `test/workflow/test_absence_is_not_reported_as_health.jl` (26 assertions), canaried five ways.
