### PR TITLE
fix(test): the interrupt harness's race guard was check-then-act

### DIFF
--- a/test/helpers/interrupt_harness.jl
+++ b/test/helpers/interrupt_harness.jl
@@ -1,0 +1,53 @@
+# Delivering an interrupt to a running solve, without a window.
+#
+# Four gates race a background `run_yaml` task: wait for it to reach a known
+# point, then interrupt it and assert the run is NOT served from cache. Each of
+# them used to ask `istaskdone` first and `schedule` second:
+#
+#     won_race = !istaskdone(task)
+#     @test won_race
+#     won_race && schedule(task, InterruptException(); error=true)
+#
+# That is check-then-act. The solve can finish between the two, and then
+# `schedule` throws `ErrorException("schedule: Task not runnable")` from outside
+# any `@test` — which aborts the whole FILE and takes the sibling gates with it.
+# Observed twice under `SPINORBEC_TEST_WORKERS=auto`, most recently 1 run in 5.
+# The guard was written precisely to stop that, and could not, because the
+# predicate is not the act.
+#
+# `deliver_interrupt!` closes the window by making the delivery its own test:
+# the only way to know a task was still runnable is to have scheduled it. A lost
+# race becomes a clean `false` the caller turns into a named `@test` failure,
+# never an error that hides its siblings.
+
+"""
+    deliver_interrupt!(task) -> Bool
+
+Send `InterruptException` to `task`, returning whether it landed. `false` means
+the task had already finished — the race was lost and the caller measured
+nothing, which is a FAILURE, not an error. Any other `schedule` problem is
+rethrown, so a real bug in the harness still names itself.
+"""
+function deliver_interrupt!(task::Task)
+    try
+        schedule(task, InterruptException(); error=true)
+        true
+    catch e
+        # Julia raises a plain ErrorException with this message from `enq_work`.
+        # Match on it rather than on the type, which is far too broad to swallow.
+        e isa ErrorException && occursin("not runnable", e.msg) || rethrow()
+        false
+    end
+end
+
+"""
+    warn_lost_race(won::Bool)
+
+Emit the shared diagnosis for a lost interrupt race. Kept next to
+[`deliver_interrupt!`](@ref) so the four call sites cannot drift in wording.
+"""
+function warn_lost_race(won::Bool)
+    won || @warn "interrupt harness LOST THE RACE: the run finished before the " *
+        "interrupt was delivered, so this gate measured nothing"
+    won
+end

--- a/test/model/test_admission_requires_marker.jl
+++ b/test/model/test_admission_requires_marker.jl
@@ -40,6 +40,7 @@ using SpinorBEC: _gs_stage_dir, _run_step, GroundStateStep,
     make_grid, GridConfig, InteractionParams, resolve_atom,
     marker_path, incomplete_marker_path, admit_payload, read_complete_marker,
     write_complete_marker, _reset_unmarked_warnings!
+include(joinpath(@__DIR__, "..", "helpers", "interrupt_harness.jl"))
 
 probe_gs_params(; tol=1.0e-6) = Dict{String, Any}(
     "atom" => "Rb87",
@@ -277,12 +278,10 @@ end
                     @test isfile(itp_ckpt)
                     # A lost race must be a clean FAILURE that names itself, never an
                     # ErrorException("schedule: Task not runnable") that aborts the whole FILE
-                    # and takes its sibling gates with it.
-                    won_race = !istaskdone(task)
-                    won_race || @warn "interrupt harness LOST THE RACE: the run finished before " *
-                        "the interrupt landed; this gate measured nothing"
+                    # and takes its sibling gates with it. The delivery IS the check —
+                    # see test/helpers/interrupt_harness.jl.
+                    won_race = warn_lost_race(deliver_interrupt!(task))
                     @test won_race
-                    won_race && schedule(task, InterruptException(); error=true)
                     try
                         wait(task)
                         fetch(task)

--- a/test/model/test_interrupted_dynamics_recomputes.jl
+++ b/test/model/test_interrupted_dynamics_recomputes.jl
@@ -33,6 +33,7 @@ using YAML
 using SpinorBEC
 using SpinorBEC: marker_path, incomplete_marker_path, admit_payload, _has_result,
     _run_simulation_standard!, _run_simulation_leapfrog!, _reset_unmarked_warnings!
+include(joinpath(@__DIR__, "..", "helpers", "interrupt_harness.jl"))
 
 # 1-D, 64 points, F=1, no DDI: the cheapest workspace that still exercises the
 # real V/K/V chain both loops run.
@@ -194,15 +195,15 @@ const DYN_DURATION = 100.0
         @test isfile(live)
         # A lost race must be a clean FAILURE that names itself, never an
         # ErrorException("schedule: Task not runnable") that aborts the whole FILE
-        # and takes its sibling gates with it.
-        won_race = !istaskdone(task)
-        won_race || @warn "interrupt harness LOST THE RACE: the run finished before " *
-            "the interrupt landed; this gate measured nothing"
+        # and takes its sibling gates with it. The delivery IS the check — see
+        # test/helpers/interrupt_harness.jl. Delivered here rather than after the
+        # `live_step` assertions below, which only widened the window; the status
+        # file is already on disk, so reading it after the interrupt is fine.
+        won_race = warn_lost_race(deliver_interrupt!(task))
         @test won_race
         live_step = JSON.parse(read(live, String))["step"]
         @test live_step >= 1
 
-        won_race && schedule(task, InterruptException(); error=true)
         task_returned_normally = try
             wait(task)
             true

--- a/test/model/test_interrupted_run_recomputes.jl
+++ b/test/model/test_interrupted_run_recomputes.jl
@@ -49,6 +49,7 @@ using YAML
 using SpinorBEC
 using SpinorBEC: marker_path, incomplete_marker_path, admit_payload,
     _reset_unmarked_warnings!
+include(joinpath(@__DIR__, "..", "helpers", "interrupt_harness.jl"))
 
 # 1-D, 64 points, CPU. The step budget is large so that the interrupt lands far
 # from convergence; the recomputation still finishes in a few seconds.
@@ -83,17 +84,12 @@ interrupt_probe_config() = Dict{String, Any}(
         # The two preconditions that stop this gate passing for the wrong
         # reason: the ITP really ran, and it is still running when we hit it.
         @test isfile(itp_ckpt)
-        # If the solve already finished we have not measured the property, and
-        # `schedule` on a finished task throws ErrorException("schedule: Task not
-        # runnable"), which aborts the whole FILE and takes the sibling gates with
-        # it. Observed once under load, when this file ran after the dynamics
-        # interrupt file. A lost race must be a clean FAILURE that names itself,
-        # never an error that hides its siblings.
-        won_race = !istaskdone(task)
-        won_race || @warn "interrupt harness LOST THE RACE: the run finished before the " *
-            "interrupt was delivered, so this gate measured nothing"
+        # If the solve already finished we have not measured the property. The
+        # delivery IS the check — see test/helpers/interrupt_harness.jl for why
+        # asking `istaskdone` first cannot work. A lost race is a clean FAILURE
+        # that names itself, never an error that hides its siblings.
+        won_race = warn_lost_race(deliver_interrupt!(task))
         @test won_race
-        won_race && schedule(task, InterruptException(); error=true)
         task_returned_normally = try
             wait(task)
             true
@@ -180,17 +176,12 @@ end
             sleep(0.02)
         end
         @test isfile(itp_ckpt)
-        # If the solve already finished we have not measured the property, and
-        # `schedule` on a finished task throws ErrorException("schedule: Task not
-        # runnable"), which aborts the whole FILE and takes the sibling gates with
-        # it. Observed once under load, when this file ran after the dynamics
-        # interrupt file. A lost race must be a clean FAILURE that names itself,
-        # never an error that hides its siblings.
-        won_race = !istaskdone(task)
-        won_race || @warn "interrupt harness LOST THE RACE: the run finished before the " *
-            "interrupt was delivered, so this gate measured nothing"
+        # If the solve already finished we have not measured the property. The
+        # delivery IS the check — see test/helpers/interrupt_harness.jl for why
+        # asking `istaskdone` first cannot work. A lost race is a clean FAILURE
+        # that names itself, never an error that hides its siblings.
+        won_race = warn_lost_race(deliver_interrupt!(task))
         @test won_race
-        won_race && schedule(task, InterruptException(); error=true)
         @test try
             wait(task)
             true
@@ -209,4 +200,32 @@ end
         res = joinpath(run_dir, "result.jld2")
         !isfile(res) || @test !isfile(marker_path(res))
     end
+end
+
+# The canary for the harness itself (#346). The gates above can only ever
+# exercise `deliver_interrupt!`'s WINNING branch — a lost race is by definition
+# the rare one — so without this the losing branch would be untested code that
+# only ever runs on the day it matters. That is exactly how the predecessor
+# failed: it was written to turn a lost race into a clean failure, and nobody
+# could show that it did.
+@testset "deliver_interrupt! reports a lost race instead of throwing (#346)" begin
+    finished = @async 1 + 1
+    wait(finished)
+    @test istaskdone(finished)
+    # The old `istaskdone`-then-`schedule` shape threw here, outside any @test,
+    # killing the whole file.
+    @test deliver_interrupt!(finished) === false
+    @test warn_lost_race(false) === false
+
+    running = @async (sleep(120); :never)
+    while !istaskstarted(running)
+        sleep(0.01)
+    end
+    @test deliver_interrupt!(running) === true
+    @test warn_lost_race(true) === true
+    try
+        wait(running)
+    catch
+    end
+    @test istaskdone(running)
 end


### PR DESCRIPTION
Fixes #346.

Four gates race a background `run_yaml`, wait for it to reach a known point, then interrupt it. All four asked `istaskdone` and only then called `schedule`:

```julia
won_race = !istaskdone(task)
@test won_race
won_race && schedule(task, InterruptException(); error=true)
```

That is check-then-act. The solve can finish between the two, and `schedule` then throws `ErrorException("schedule: Task not runnable")` from **outside any `@test`**, which aborts the whole file and takes its sibling gates with it — precisely what the guard's own comment said it was preventing.

## The fix

`test/helpers/interrupt_harness.jl` makes the delivery its own check: the only way to know a task was still runnable is to have successfully scheduled it, so there is no window.

```julia
won_race = warn_lost_race(deliver_interrupt!(task))
@test won_race
```

A lost race returns `false` and becomes a named `@test` failure. Any `schedule` error other than `"not runnable"` is rethrown, so a genuine harness bug still names itself instead of being swallowed.

## All four sites, not just the one that failed

| file | sites |
|---|---|
| `test_interrupted_run_recomputes.jl` | 2 |
| `test_interrupted_dynamics_recomputes.jl` | 1 |
| `test_admission_requires_marker.jl` | 1 |

The dynamics site had the **widest** window of the four — two assertions sat between its check and its act. The interrupt now goes first there; the live-status file is already on disk, so reading it afterwards is unaffected.

## A canary, because the losing branch is otherwise never run

The four gates can only exercise the *winning* branch — a lost race is the rare one by construction — so the losing branch would be code that first executes on the day it matters. **That is exactly how the predecessor failed**: it was written to turn a lost race into a clean failure, and nothing could show that it did.

The new testset drives both branches and asserts the returns. It is not decorative: running it emits

```
┌ Warning: interrupt harness LOST THE RACE: the run finished before the interrupt
│ was delivered, so this gate measured nothing
```

which is the path that used to throw.

## Verification

Clean tree, all three files: **19/19 + 8/8** (run) + **26/26 + 24/24** (dynamics) + **55/55** (admission) + **6/6** (canary).

The original #346 sighting was isolated across five runs — 1 in 5 under `SPINORBEC_TEST_WORKERS=auto`, and 0 in 4 across serial runs and unmodified `main` — so it is load-dependent, not caused by whatever branch was under test.

## One thing worth knowing

These files **cannot run on a dirty tree at all.** The second `run_yaml` hits `_assert_point_provenance`, which refuses with *"the tree was dirty on one side, so neither commit identifies the code"*. That is by design (architectural commitment 4) and unrelated to this fix — but it means a local edit-and-run loop on these gates has to commit first, and my first verification run failed for exactly that reason before I recognised it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
