### PR TITLE
docs(eu): retract the hysteresis reading #352 overturned — FROZEN was not enough

### DIFF
--- a/docs/guides/eu_adiabatic_protocol.md
+++ b/docs/guides/eu_adiabatic_protocol.md
@@ -2,6 +2,37 @@
 
 > **FROZEN 2026-07-28.** Describes the tree as of that date and is **not maintained** against the code — do not cite it as current.
 > Live sources: `CLAUDE.md`, `docs/index.md`, and the code itself. Audit: `docs/audit/docs_inventory_2026-08-04.md`.
+>
+> ## ⚠ RETRACTED 2026-08-18: the hysteresis reading below does not survive
+>
+> §"Result at κ = 1.8" reports a loop of **[≈27, > 100] µG** and a sharp falling-leg
+> conversion at **27.4 µG**. Re-measured under #335 (PR #352,
+> `docs/guides/eu_kappa_hysteresis_loop.md`): **that is not a hysteresis loop.** A
+> B_z ramp conserves J_z, and the two branches sit in different J_z sectors at every
+> field (polarised −5.750 at 90 µG → −1.262 at 20; flower −4.346 at 65 → −1.088 at
+> 20), so **no ramp at any rate converts between them**. What the ramp does is slide
+> along its own J_z surface, trading S_z for L_z one for one — Einstein–de Haas.
+> With both legs over one window at one pin, no leg converts at any of seven rates
+> from 1.8 ms to 1750 ms, at κ = 1.8 or κ = 0.9.
+>
+> This document states the selection rule itself, for the κ ramp, in
+> §"Why: J_z is conserved and the ground state is in another sector" — including the
+> sentence *"a B_z ramp is no better, since B_z F_z commutes with J_z too."* It was
+> not applied to the field-ramp result in the same document. **That is the specific
+> error to learn from: a selection rule written for one protocol applies to every
+> other protocol in the same document.**
+>
+> Two further numbers here are pin artefacts rather than physics. The 27.4 µG jump
+> reproduces exactly at this document's own pin (ε = 0.001 → ⟨F⊥⟩ 0.800 → 3.577
+> against the 3.58 reported below) and **halves** at ε = 0.002 (0.829 → 2.214), so
+> the conversion amplitude is a strong function of the residual transverse field —
+> at values one to two orders below any lab's. And the "flower survives to 100 µG"
+> reading is not supported: the flower branch **ends at 68.4 ± 0.15 µG**, measured
+> statically; it merely takes longer than a ramp to fall once past its spinodal.
+>
+> What survives: the κ dependence, the static branch structure, and the protocol
+> machinery. What replaces the loop width as the deliverable: a discrete
+> Stern-Gerlach level count, 6–7 populated m_F at κ = 1.8 against 3–4 at κ = 0.9.
 
 The Einstein–de Haas measurement was a quench; this asks the ground-state question.
 Can the chiral/flower phase be *prepared*? Three protocol classes were built and

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,8 @@ docs/
 | End-to-end walkthrough (calibration → YAML → run → analyze) | `guides/lab_user_tutorial.md` |
 | YAML pattern recipes (scan, droplet, calibration, …) | `guides/pipeline_cookbook.md` |
 | Klaus 2022 / Eu fast-Larmor production path | `guides/klaus_regime.md` |
-| Preparing the weak-field Eu chiral ground state (B ramp / κ ramp / z torque) | `guides/eu_adiabatic_protocol.md` |
+| Preparing the weak-field Eu chiral ground state (B ramp / κ ramp / z torque) — **its hysteresis reading is RETRACTED, see the next row** | `guides/eu_adiabatic_protocol.md` |
+| The κ-dependent transition, re-measured: the "loop" is a J_z slide; the deliverable is a Stern-Gerlach level count | `guides/eu_kappa_hysteresis_loop.md` |
 | Upgrade old configs after a convention change | `guides/migration_guide.md` |
 | Pick the right precision / save_every / k_cut | `guides/performance_tuning.md` |
 | Finite-T reservoirs / second-scale evaporation (full SPGPE) | `guides/spgpe.md` |


### PR DESCRIPTION
#352（#335）の後始末です。あのキャンペーンが覆した予測を、文脈が残っているうちに撤回します。

## FROZEN では足りなかった

`docs/guides/eu_adiabatic_protocol.md` には `FROZEN 2026-07-28 — do not cite it as current` が付いています。これは読者に「細部は動いているかもしれない」と警告しますが、**その文書の看板の結論が誤っている**とは警告しません。`docs/index.md` から辿った読者は、前を向く手がかりのないまま撤回済みの読みを受け取ります。

#352 が測ったこと: B_z ランプは J_z を保存し、2つの分枝はどの磁場でも別の J_z セクタにいるので、どのレートでも渡れません。`[≈27, > 100] µG` のループと 27.4 µG の鋭い変換は、分枝変換ではなく Einstein–de Haas のセクタスライドです。

## 再利用できるのは「誤りの形」のほう

撤回文には訂正だけでなく誤りそのものを書きました:

> この文書自身が、κ ランプについて §"Why: J_z is conserved and the ground state is in another sector" で選択則を述べている — *"a B_z ramp is no better, since B_z F_z commutes with J_z too."* という一文を含めて。それが同じ文書内の磁場ランプの結果には適用されていない。

**ある文書が1つのプロトコルについて選択則を書いたら、それは同じ文書の他の全プロトコルにも当てはまる。** 転用できるのはこれで、27.4 µG という数字ではありません。

## artefact と明示した数字2つ

- 27.4 µG のジャンプは**その文書自身の pin で厳密に再現します** — ε = 0.001 で ⟨F⊥⟩ 0.800 → 3.577（文書の報告値 3.58 に対し）— そして ε = 0.002 では**半分**になります（0.829 → 2.214）。つまり変換振幅は残留横磁場の強い関数で、しかもどの実験室よりも1〜2桁小さい値の領域での話です。厳密に再現できたことが、これを「2つのコードの不一致」ではなく測定にしています。
- 「flower は 100 µG まで生き残る」は支持されません。flower 分枝は **68.4 ± 0.15 µG で終わります**（静的測定、格子 0.2 % 収束）。spinodal を越えた後、落ちるのにランプより時間がかかるだけです — 分枝の端から 0.75 µG 越えた点で 434 ms かけて ⟨F⊥⟩ が 0.041 しか動きません。

生き残るものも明記しました: κ 依存性、静的分枝構造、プロトコル機構。

`docs/index.md` に後継の行を足し、先行文書に印を付けました。

ローカルで確認したゲート: `test_docs_live_set.jl`、`test_doc_run_citations_resolve.jl`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
