### PR TITLE
fix(memory-audit): a hyphen in a real filename made link_targets invent an orphan

### DIFF
--- a/scripts/audit_memory.py
+++ b/scripts/audit_memory.py
@@ -335,11 +335,27 @@ _LINK = re.compile(r"\[\[([^\]]+)\]\]|\]\(([A-Za-z0-9_\-]+)\.md\)")
 
 
 def link_targets(text):
-    """Every stem this text points at, in EITHER link form."""
+    """Every stem this text points at, in EITHER link form.
+
+    Yields the literal stem AND its hyphen->underscore normalisation, because
+    only one of the two can be right and this function cannot tell which: it
+    does not know the file set. Callers already filter with `in texts`.
+
+    Normalising unconditionally was a defect. It exists so a `[[link-with-
+    hyphens]]` finds a file named with underscores, but it also rewrote
+    hyphens that are part of the real name -- `gotcha_doc_p_q_table_was_
+    computed_at_1e-4_of_the_field_2026_08_19` became `..._1e_4_...`, matched
+    nothing, and the file was reported as an orphan while MEMORY.md linked it
+    correctly. That is a FALSE ORPHAN, the same failure class the `reachable`
+    docstring below records being fixed once already, and it points the reader
+    at a healthy file to "repair".
+    """
     for wiki, md in _LINK.findall(prose(text)):
         raw = wiki or md
         key = raw[:-3] if raw.endswith(".md") else raw
-        yield key.replace("-", "_")
+        yield key
+        if "-" in key:
+            yield key.replace("-", "_")
 
 
 def reachable(texts, roots):
@@ -402,6 +418,23 @@ def main():
         print("CALIBRATION FAILED: MEMORY.md reaches nothing; the link graph is "
               "not being parsed and every count below would be fiction.",
               file=sys.stderr)
+        return 2
+
+    # Both link spellings must resolve, on a synthetic pair rather than on
+    # whatever happens to be in the store. `link_targets` used to normalise
+    # every hyphen to an underscore, so a file whose real name contains one
+    # (`..._at_1e-4_of_the_field_...`) was reported as an orphan while the
+    # index linked it correctly -- a FALSE orphan, which sends the reader to
+    # "repair" a healthy file. Asserting both arms is what discriminates:
+    # yielding only the literal stem breaks the second, only the normalised
+    # one breaks the first.
+    _probe = {"a-b_c": "", "d_e_f": "",
+              "root": "see [[a-b_c]] and ](d-e-f.md)"}
+    _got = reachable(_probe, {"root"})
+    if not {"a-b_c", "d_e_f"} <= _got:
+        print("CALIBRATION FAILED: link_targets resolves only one hyphen "
+              f"spelling (reached {sorted(_got)}); orphan counts would be "
+              "fiction in the direction that invents work.", file=sys.stderr)
         return 2
 
     index_text = "".join(prose(texts.get(i, "")) for i in indexes)


### PR DESCRIPTION
`scripts/audit_memory.py` の `link_targets` が、リンク先の**すべてのハイフンをアンダースコアに書き換えて**いました。この正規化は `[[link-with-hyphens]]` からアンダースコア名のファイルを引くためのものですが、無条件に適用すると**実名の一部であるハイフン**まで壊します:

```
gotcha_doc_p_q_table_was_computed_at_1e-4_of_the_field_2026_08_19
                                      ^^^^
```

が `..._1e_4_...` になって何にも一致せず、**MEMORY.md が正しくリンクしているのに unreachable と報告**されていました。audit は非ゼロ終了し、壊れていないファイルを「直せ」と指す状態でした。

## なぜ実害か

これは **false orphan** で、**高くつく方向に**外します。このスクリプトの存在意義は「unreachable な memory は二度と読まれない」という点にあるので、偽の1件は存在しない問題の修理にセッションを送り込み、さらに悪いことに**カウント自体への信頼を壊します**。

## 修正

両方の綴りを yield し、呼び出し側（既に `in texts` でフィルタしている）に選ばせます。`link_targets` はファイル集合を知らないので、自分では選べません。

## 較正（想定ではなく）

合成2ファイルのプローブで **`[[a-b_c]]` と `](d-e-f.md)` の両方**が解決することを assert します。リテラルだけを yield すると後者が、正規化だけを yield すると前者が落ちるので、**対にして初めて判別力を持ちます**（片腕だけのプローブなら今回のバグを通していました）。

コピーで修正を巻き戻して確認済み: プローブが発火し `rc=2`、どちらの綴りが失われたかを名指しします。

```
CALIBRATION FAILED: link_targets resolves only one hyphen spelling
(reached ['d_e_f', 'root']); orphan counts would be fiction in the
direction that invents work.
```

修正後の audit: `unreachable files : 0` / `OK`。

#354 のマージ後に `reference_klaus_adiabatic_elimination` を re-anchor していて見つけたものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
