### PR TITLE
fix(scripts): a queued run has no jobs yet — that is PENDING, not unobservable

### DIFF
--- a/scripts/watch_until_done.sh
+++ b/scripts/watch_until_done.sh
@@ -29,6 +29,12 @@
 #   exit 2  TIMEOUT  deadline hit with units unfinished -- NOT green, result unknown
 #   exit 3  UNKNOWN  the subject could not be observed, or finished without recording
 #
+# UNKNOWN means "could not look", never "nothing to look at yet". A `gh-run`
+# polled in the seconds after a push has no jobs and is PENDING, not
+# unobservable -- see `poll_gh_run`. Conflating the two made the script return
+# UNKNOWN on healthy runs if you started it promptly, which is precisely when
+# you want to start it.
+#
 # Run it backgrounded. Foregrounding it defeats point 1.
 #
 # `local-pid` needs `--rc-file` because **a PID disappearing says nothing about
@@ -65,9 +71,28 @@ done
 # UNKNOWN -- never into "nothing pending, therefore done".
 
 # --- GitHub Actions ---------------------------------------------------------
+# An empty job list has TWO causes and they must not share a verdict:
+#
+#   the run cannot be read at all (bad id, gh failure)  -> unobservable, UNKNOWN
+#   the run exists and is queued, jobs not created yet   -> PENDING, keep watching
+#
+# Emitting nothing for both was this script's own failure mode turned inward. It
+# never said green, so the safety property held -- but it stopped watching a
+# perfectly healthy run and reported "absence is not health" about a run that was
+# merely young, which makes it unusable in the first seconds after a push. The
+# canary below had a comment conceding the behaviour and routed AROUND it
+# ("a queued run ... answers with an empty list, so that leg raced") instead of
+# treating it as the defect it was.
 poll_gh_run() {
-    gh run view "$1" --json jobs \
-        -q '.jobs[] | "\(.status)|\(.conclusion // "")|\(.name)"' 2>/dev/null
+    local jobs status
+    jobs=$(gh run view "$1" --json jobs \
+        -q '.jobs[] | "\(.status)|\(.conclusion // "")|\(.name)"' 2>/dev/null)
+    if [ -n "$jobs" ]; then printf '%s\n' "$jobs"; return 0; fi
+    # No jobs. Ask the RUN itself which of the two cases this is.
+    status=$(gh run view "$1" --json status -q '.status' 2>/dev/null)
+    [ -n "$status" ] || return 0              # cannot observe        -> UNKNOWN
+    [ "$status" != "completed" ] || return 0  # finished, recorded 0  -> UNKNOWN
+    echo "$status||run $1 is $status, no jobs created yet"
 }
 
 # --- TSUBAME 4 (UGE, not Slurm) ---------------------------------------------
@@ -197,9 +222,33 @@ canary() {
     echo "[gh-run] UNKNOWN from an id that does not exist"
     _leg "nonexistent run id" 3 gh-run 999999999999
 
-    # TIMEOUT against a live LOCAL process, not a CI run: a queued run whose jobs
-    # have not materialised yet answers with an empty list, so that leg raced
-    # between TIMEOUT and UNKNOWN. A sleeping pid is pending by construction.
+    # The two causes of an empty job list must land on DIFFERENT verdicts. A real
+    # queued run cannot be summoned on demand and the window is seconds wide, so
+    # stub `gh` and drive `poll_gh_run` directly -- the function under test is the
+    # real one, only its dependency is faked.
+    echo "[gh-run] a queued run with no jobs yet is PENDING, not UNKNOWN"
+    mkdir -p "$tmp/bin"
+    cat > "$tmp/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"--json jobs"*)   exit 0 ;;          # run is real; no jobs materialised yet
+  *"--json status"*) echo "queued" ;;
+esac
+STUB
+    chmod +x "$tmp/bin/gh"
+    local got_pending got_unobs
+    got_pending=$( PATH="$tmp/bin:$PATH"; poll_gh_run 12345 )
+    # Negative control: gh cannot answer at all -> still empty -> still UNKNOWN.
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$tmp/bin/gh"; chmod +x "$tmp/bin/gh"
+    got_unobs=$( PATH="$tmp/bin:$PATH"; poll_gh_run 12345 )
+    if [ -n "$got_pending" ] && [ -z "$got_unobs" ]; then
+        echo "  ok   queued -> pending; unreadable -> empty (UNKNOWN preserved)"
+    else
+        echo "  FAIL: queued gave '$got_pending', unreadable gave '$got_unobs'"; fails=1
+    fi
+
+    # TIMEOUT against a live LOCAL process rather than a CI run: a sleeping pid is
+    # pending by construction, with no scheduler latency to race.
     echo "[local-pid] TIMEOUT without waiting for one"
     ( sleep 30 ) & local p_slow=$!
     TIMEOUT_OVERRIDE=0 _leg "live pid, 0 s budget" 2 local-pid "$p_slow"


### PR DESCRIPTION
#344 の作業中に見つけた計器の欠陥。単独で読めるように別 PR にした。

## 症状

push 直後に `watch_until_done.sh gh-run <id>` を起動すると、健全な run に対して

```
VERDICT=UNKNOWN  gh-run 32212640790 returned nothing -- absence is not health
```

を返して**監視をやめる**。run 32212640790 で実際に踏んだ。

## 原因

`poll_gh_run` が**2つの無関係な状態で同じ「空」を返す**、そして `watch` は空を UNKNOWN に写す:

| 状態 | 正しい判定 |
|---|---|
| run が読めない（存在しない id、gh の失敗） | **UNKNOWN**（観測できない） |
| run は実在し queued、jobs がまだ生成されていない | **PENDING**（若いだけ） |

**このスクリプト自身が防ぐために書かれた混同が、内側に向いていた** — *jobs* の不在を
*観測可能性* の不在に畳み込んでいる。green とは言わなかったので安全性は保たれたが、
「起動して欲しいまさにその瞬間」に使えない。

さらに: canary には**この挙動を認めるコメントが既にあった** —
> a queued run whose jobs have not materialised yet answers with an empty list,
> so that leg raced between TIMEOUT and UNKNOWN

そして TIMEOUT の脚を local pid に**迂回させて**いた。欠陥として読まずに回避していた。
そのコメントを今回の修正の引用元にしてある。

## 修正

`poll_gh_run` は job list が空のとき **run 自身に status を訊く**:

- `completed` 以外 → pending 行を出す（監視継続）
- `completed` かつ jobs 0本 → 空のまま（＝何も記録せず終了 → UNKNOWN）
- そもそも読めない → 空のまま（→ UNKNOWN）

## canary

新しい脚を追加。**2つの原因が別の判定に着地すること**を pin する。
実物の queued run は召喚できず窓は数秒なので `gh` を stub し、**本物の
`poll_gh_run` を直接**駆動する（依存だけを偽装、テスト対象は本物）。

**陰性対照つき**: `gh` が exit 1 する stub で UNKNOWN が今も到達可能であることを
確認する。これが無いと「全部 pending に見せる」実装でも脚が通ってしまう。

検証:

```
queued run     -> [queued||run 12345 is queued, no jobs created yet]
unreadable run -> []
completed,0jobs-> []
```

canary 全体 green（gh-run 3脚 / local-pid 4脚 / tsubame-job 12ジョブを qacct と独立照合、
GREEN と RED の両方を含む）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
