### PR TITLE
research(analysis): #361 の修正が「誰も見ていない量」で何を動かしたか (#361)

### DIFF
--- a/docs/validation/bdg_ddi_verdict_delta_361.md
+++ b/docs/validation/bdg_ddi_verdict_delta_361.md
@@ -1,0 +1,94 @@
+# What the #361 DDI-block fix moved in quantities no test pins
+
+> **FROZEN 2026-08-19.** A dated A/B between two commits, not a description of
+> the tree. Reproduce with `runs/bdg_ddi_verdict_delta/measure_ungated.jl` at the
+> two revisions named below.
+
+#361 warned that correcting the coefficient would move existing verdicts and
+asked for the diff. CI answered the gated half: with the fix in place every
+physics gate passes unchanged — `test_level4_{f1,general_F}_phase_emergence.jl`,
+`test_lhy_full_bdg_closed_form_parity.jl`, `test_bogoliubov_anchor.jl`,
+`test_bdg_fd_hessian.jl`, `test_trapped_bdg_spectrum.jl`. The only red was
+`docs/STATE.md`'s tier count. So the warning does not bind on anything the suite
+asserts.
+
+This file is the other half: the outputs that are consumed and never asserted.
+
+**A/B.** `68b38dc7` (before) against `7e6770c2` (after), which differ by the fix
+and its oracle and nothing else. Both measured on TSUBAME, job 8442687, one
+process each, `node_o`. Fixture is production-shaped ¹⁵¹Eu: $F=6$,
+$N = 5\times10^4$, $\omega_\text{ref} = 2\pi\cdot116$ Hz, `c1_ratio` $= 1/36$,
+$c_\text{total} = 4813.403574$, $c_{dd} = 216.700165$, $n_0 = 3.313\times10^{-3}$
+(Thomas-Fermi peak), zero field, seeds `stretched` ($m=+F$) and `polar` ($m=0$)
+— the two the phase-diagram config uses.
+
+**The negative control holds.** With `c_dd = 0` the `full_bdg` energy density is
+bit-identical across the two revisions (`5.4885846139e+01` stretched,
+`1.4745687026e+01` polar), so every difference below is the DDI block and nothing
+else. Without that arm the deltas would not be evidence.
+
+## Mean-field BdG: growth rates and the most unstable direction
+
+`instability_angular_map`, 13 θ × 24 φ, `k_max = 6`, `n_k = 40`. This is what
+`triple_point` consumes — it depends on the fix only through
+`bogoliubov_spectrum.max_growth_rate` — and what `analyzers/stability.jl` reports.
+
+| quantity | before | after | change |
+|---|---:|---:|---|
+| **stretched** max growth over directions | 3.5010 | 2.0307 | **−42 %** |
+| **stretched** mean growth | 1.6155 | 1.0297 | −36 % |
+| **stretched** most unstable direction | θ = 0.262 (15°) | θ = 1.571 (90°) | **axial → equatorial** |
+| **stretched** lowest branch at k=1, k ∥ z | 3.4870 | 0.9360 | −73 % |
+| **polar** max growth | 13.948 | 0.3708 | **−97 %** |
+| **polar** mean growth | 5.972 | 0.3708 | −94 % |
+| **polar** growth at k ∥ z | **exactly 0** | 0.3527 | the missing normal block |
+| **polar** growth at k ⊥ z | 13.948 | 0.3527 | −97 % |
+
+Three of these are qualitative rather than numerical.
+
+**The most unstable direction moved from 15° to 90°** for the stretched state.
+Any consumer that reads `most_unstable_direction` — the boundary tracer, the
+`bogoliubov_mode` analyzer's mode extraction, a figure of the instability map —
+was pointing at a different place on the sphere.
+
+**The polar state had exactly zero growth along z and 13.9 across it.** That is
+the signature of the defect rather than a physical anisotropy: with the normal
+block missing, the polar instability was carried by the anomalous block alone.
+After the fix the map is direction-independent to the printed digits (max = mean
+= 0.3708), and 38× smaller.
+
+**The magnitude fell in every case.** The old normal block was twice the correct
+size on a polarized state and structurally wrong on a polar one, and both errors
+inflated the growth rate — so any past "this configuration is dynamically
+unstable" verdict from this instrument was biased toward instability, not away
+from it.
+
+## ε_LHY: not quotable at this fixture, by the code's own report
+
+`full_bdg` ε_LHY with the DDI active moved −2.1 % (stretched, 86.231 → 84.418)
+and +43 % (polar, 21.908 → 31.417). **Neither number is quotable**, because both
+revisions print, at this fixture,
+
+> FullBdG LHY: mean field is dynamically unstable (max Im ω = 3.6 / 2.03). The
+> zero-point sum drops the complex branches while the counterterms still subtract
+> all 13 of them, so ε_LHY is scheme-dependent here.
+
+which is exactly the condition `docs/validation/full_bdg_scheme_dependence_eu_f6.md`
+documents. A scheme-dependent value differencing by 43 % between two coefficient
+conventions says nothing about either. What the same warning *does* report
+cleanly is that the instability it measures fell with the fix: **max Im ω 3.6 →
+2.03**, consistent with the growth-rate table.
+
+Closing the ε_LHY question needs a mean-field-**stable** (F, c₀, c₁, q) point, not
+this one. That is a separate measurement and it belongs with #337.
+
+## What this does not cover
+
+`triple_point`'s triple-point coordinates themselves, which would need its
+L-BFGS boundary solves; the argument above is that its only channel from this fix
+is `max_growth_rate`, quantified here. And the trapped instrument
+`trapped_bdg_frequencies` (#339), whose disagreement opened #361, is not on `main`
+yet — the closed-form anchor
+(`test/oracles/test_dipolar_bogoliubov_anchor.jl`) settles the coefficient without
+it, and #339's own `@test_broken` should turn into an unexpected pass when it
+lands.

--- a/runs/bdg_ddi_verdict_delta/measure_ungated.jl
+++ b/runs/bdg_ddi_verdict_delta/measure_ungated.jl
@@ -1,0 +1,69 @@
+# What the #361 DDI-block fix moves in quantities NO test pins.
+#
+# CI answered the gated half: every physics gate passed unchanged. This driver
+# answers the rest — the outputs that are consumed but never asserted, so a
+# coefficient change moves them while the suite stays green:
+#
+#   1. `instability_angular_map` — max growth rate and the most unstable
+#      direction. `triple_point` (`src/solvers/continuation/triple_point.jl`)
+#      depends on the fix ONLY through `bogoliubov_spectrum.max_growth_rate`,
+#      so this covers it without paying for its L-BFGS solves.
+#   2. the phonon and lowest spin branch at fixed k, along and across z.
+#   3. `full_bdg` ε_LHY with the DDI active — the `_lhy_bdg_stiffness` path.
+#
+# Run the SAME file against two checkouts (pre- and post-fix) and diff:
+#
+#   julia --project=<worktree> runs/bdg_ddi_verdict_delta/measure_ungated.jl
+#
+# Production-shaped Eu fixture: N = 5e4, ω_ref = 2π·116 Hz, c1_ratio = 1/36,
+# c_dd from the atom, n₀ the Thomas-Fermi peak.
+
+using SpinorBEC
+using SpinorBEC: interaction_params_from_constraint, compute_c_total,
+                 compute_c_dd_dimless, _lhy_bdg_energy_density
+using Printf
+
+const F = 6
+const D = 13
+const N_ATOMS = 50_000
+const OMEGA_REF = 2π * 116.0
+
+c_total = compute_c_total(Eu151; N_atoms=N_ATOMS, omega_ref=OMEGA_REF)
+c_dd = compute_c_dd_dimless(Eu151; N_atoms=N_ATOMS, omega_ref=OMEGA_REF)
+mu_tf = 0.5 * (15 * c_total / (4π))^(2 / 5)
+n0 = mu_tf / c_total
+ip = interaction_params_from_constraint(; c_total=c_total, c1_ratio=1 / 36, F=F)
+zee = ZeemanParams(0.0, 0.0)
+
+stretched = zeros(ComplexF64, D);
+stretched[1] = 1.0;
+polar = zeros(ComplexF64, D);
+polar[7] = 1.0;
+
+println("# git: ", strip(read(`git rev-parse HEAD`, String)))
+@printf("c_total = %.6f   c_dd = %.6f   n0 = %.8e\n", c_total, c_dd, n0)
+
+for (name, sp) in (("stretched", stretched), ("polar", polar))
+    imap = instability_angular_map(; spinor=sp, n0=n0, F=F, interactions=ip,
+        zeeman=zee, c_dd=c_dd, k_max=6.0, n_k=40, n_theta=13, n_phi=24)
+    g = imap.growth_map
+    @printf("%-10s angular_map: max=%.10e  mean=%.10e  argmax=(θ=%.4f, φ=%.4f)\n",
+        name, maximum(g), sum(g) / length(g),
+        imap.theta[argmax(g)[1]], imap.phi[argmax(g)[2]])
+
+    for (dir, dname) in (((0.0, 0.0, 1.0), "k∥z"), ((1.0, 0.0, 0.0), "k⊥z"))
+        res = bogoliubov_spectrum(; spinor=sp, n0=n0, F=F, interactions=ip,
+            zeeman=zee, c_dd=c_dd, k_max=2.0, n_k=3, k_direction=dir)
+        w = sort(real.(res.omega[:, 2]))
+        pos = filter(>(1e-9), w)
+        @printf("%-10s %s branches(k=1): %s   max_growth=%.10e\n", name, dname,
+            join((@sprintf("%.8f", x) for x in pos[1:min(4, end)]), " "),
+            res.max_growth_rate)
+    end
+
+    eps_lhy = _lhy_bdg_energy_density(sp, n0, F, ip, zee, c_dd, 200.0, 250, 160)
+    @printf("%-10s full_bdg eps_LHY (c_dd on)  = %.10e\n", name, eps_lhy)
+    eps_c = _lhy_bdg_energy_density(sp, n0, F, ip, zee, 0.0, 200.0, 250, 1)
+    @printf("%-10s full_bdg eps_LHY (c_dd off) = %.10e  [control: must not move]\n",
+        name, eps_c)
+end


### PR DESCRIPTION
#361 の最後のチェックボックス「修正で動く既存 verdict を洗い出す」。#367 の CI が**ゲートされている側**は答えました（物理ゲート全通過、赤は `docs/STATE.md` のカウントだけ）。これは**ゲートされていない側**です。

A/B: `68b38dc7`(before) vs `7e6770c2`(after) —— 差は DDI ブロック修正とその oracle だけ。TSUBAME job 8442687、production 形の Eu fixture（F=6, N=5e4, ω_ref=2π·116 Hz, c1_ratio=1/36, c_dd=216.70, n₀=3.313e-3, 場ゼロ、seed は相図 config と同じ stretched/polar）。

**陰性対照が効いています**: `c_dd = 0` の `full_bdg` エネルギー密度が両リビジョンで完全一致（stretched `5.4885846139e+01`、polar `1.4745687026e+01`）。だから以下の差分はすべて DDI ブロックだけの効果です。これが無ければ数字は証拠になりません。

## 平均場 BdG — 成長率と最不安定方向

| 量 | before | after | 変化 |
|---|---:|---:|---|
| **stretched** 方向最大成長率 | 3.5010 | 2.0307 | **−42 %** |
| **stretched** 平均成長率 | 1.6155 | 1.0297 | −36 % |
| **stretched** 最不安定方向 | θ=0.262 (15°) | θ=1.571 (90°) | **軸方向 → 赤道方向** |
| **stretched** k=1, k∥z の最低分枝 | 3.4870 | 0.9360 | −73 % |
| **polar** 最大成長率 | 13.948 | 0.3708 | **−97 %** |
| **polar** 平均成長率 | 5.972 | 0.3708 | −94 % |
| **polar** k∥z の成長率 | **厳密に 0** | 0.3527 | 欠けていた normal ブロック |
| **polar** k⊥z の成長率 | 13.948 | 0.3527 | −97 % |

質的に読むべきものが3つあります。

**最不安定方向が 15° → 90° に動いた**（stretched）。`most_unstable_direction` を読む消費者 —— 境界追跡、`bogoliubov_mode` のモード抽出、不安定性マップの図 —— は球面上の別の場所を指していました。

**polar は z 方向に厳密ゼロ、横方向に 13.9** でした。これは物理的異方性ではなく**欠陥の指紋**で、normal ブロックが無いぶん不安定性を anomalous ブロックだけが担っていたということ。修正後は表示桁で方向依存性が消え（max = mean = 0.3708）、38 倍小さい。

**全ケースで大きさが下がった**。旧 normal ブロックは偏極状態で2倍、polar で構造的に誤りで、どちらも成長率を過大にする向きでした ⇒ この計器が過去に出した「動的に不安定」判定は**不安定側にバイアス**がかかっていた（安全側ではない）。

## ε_LHY は、コード自身の申告により quotable ではない

`full_bdg` の ε_LHY は −2.1 %（stretched 86.231→84.418）、**+43 %**（polar 21.908→31.417）動きましたが、**どちらも引用できません**。両リビジョンがこの fixture で

> FullBdG LHY: mean field is dynamically unstable (max Im ω = 3.6 / 2.03) … ε_LHY is scheme-dependent here

と印字しています（`docs/validation/full_bdg_scheme_dependence_eu_f6.md` が記述している条件そのもの）。scheme 依存の値を2つの規約間で差分しても何も測っていません。同じ警告が**きれいに**報告しているのは、その不安定性自体が下がったこと: **max Im ω 3.6 → 2.03**（成長率の表と整合）。

ε_LHY を閉じるには平均場が**安定**な (F, c₀, c₁, q) 点が必要で、それは別測定・#337 の担当です。

## 触れていないもの

`triple_point` の3重点座標そのもの（L-BFGS 境界解が必要）。ただしこの修正からの唯一の経路は `bogoliubov_spectrum.max_growth_rate` で、それは上で定量化しています。#339 の `trapped_bdg_frequencies` は main に無いまま。

型: **A**（同一 fixture のコード A/B、陰性対照つき）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)