### PR TITLE
fix(mutation): three stale anchors made the whole harness refuse to start

### DIFF
--- a/test/mutation/catalog.jl
+++ b/test/mutation/catalog.jl
@@ -353,7 +353,10 @@ const MUTANTS = Mutant[
          data labelled `phase_classify` that a different analyzer produced — \
          the aliased-dispatch silent-bug factory the convention exists to stop."),
     Mutant(:gs_interactions_inherit_over_explicit,
-        "src/workflow/experiments/pipeline/run_step_ground_state.jl",
+        # Relocated body, unchanged text: `_resolve_gs_interactions` moved out of
+        # run_step_ground_state.jl into resolve_gs.jl. Retargeting the path is the
+        # whole fix — the anchor still matches once at resolve_gs.jl:75.
+        "src/workflow/experiments/pipeline/resolve_gs.jl",
         r"    if haskey\(p, \"interactions\"\)\n        return _parse_gs_interactions\(p\[\"interactions\"\], atom\)\n    elseif ws_prev !== nothing\n        return ws_prev\.interactions",
         "    if ws_prev !== nothing\n        return ws_prev.interactions\n    elseif haskey(p, \"interactions\")\n        return _parse_gs_interactions(p[\"interactions\"], atom)",
         :path_default, :fatal,
@@ -525,25 +528,43 @@ const MUTANTS = Mutant[
         "The named wrapper stops forwarding `phi`, so every caller asking for an \
          in-plane direction gets phi = 0. `:transverse_x` is exactly this call, and \
          the wrapper's whole contract is that it is `init_psi` with a name."),
+    # Both entries below used to anchor on `_gs_cache_key` — a hand-listed dict
+    # laundered through `_hashable`. Cutover step 3 DELETED that key (see the
+    # essay at run_step_ground_state.jl:191) and split admission in two:
+    # `gs_model(r)` carries the physics, `_gs_stage_params(r, p)` the numerics.
+    # The two CONTRACTS are unchanged, so the mutants are retargeted rather than
+    # retired — one per half, still injecting "id blind to physics" and "id
+    # sensitive to non-physics".
     Mutant(:gs_cache_key_ignores_interactions,
-        "src/workflow/experiments/pipeline/run_step_ground_state.jl",
-        r"        \"c\" => _hashable\(interactions\.c\),",
-        "        # mutant: interaction channels dropped from the cache key",
+        "src/workflow/experiments/pipeline/resolve_gs.jl",
+        # Anchored on c1, NOT on the c4/c6 extra ranks. Blanking `c_extra_*` was
+        # tried first and is a DEGENERATE KNOB: no fixture under test/model/ and no
+        # committed config under runs/ sets `c4:`/`c6:`, so `ranks` is already empty
+        # and the "mutation" changes no byte. It duly reported ESCAPED from a probe
+        # containing test_gs_admission_axes.jl, which would have read as a gap in
+        # the one file whose job is that partition. c1 is live in every fixture
+        # (c1_ratio = -0.01 / -0.02 / 0.0), so a miss here is a real miss.
+        r"        c0=get\(c, 0, 0\.0\),\n        c1=get\(c, 1, 0\.0\),",
+        "        c0=get(c, 0, 0.0),\n        c1=0.0,",
         :drop, :fatal,
-        "the GS stage cache's 'sensitivity to real physics' contract",
-        "Drops the scattering channels from the cache key, so changing c0/c1 hits a \
-         STALE cached ground state. The run reports success and reuses the wrong \
-         physics — the worst shape a cache bug can take, because nothing looks \
-         broken."),
+        "the GS admission id's 'sensitivity to real physics' contract",
+        "Drops the spin-dependent coupling from the artifact id while the SOLVE still \
+         reads it from `GSResolved`, so two configs differing only in c1 address the \
+         same stage artifact. The store is content-addressed and SHARED, so this \
+         serves one config's ground state to a different question. The run reports \
+         success and reuses the wrong physics — the worst shape a cache bug can take, \
+         because nothing looks broken."),
     Mutant(:gs_cache_key_includes_metadata,
         "src/workflow/experiments/pipeline/run_step_ground_state.jl",
-        r"        \"v\" => 1,                                    # key-schema version",
-        "        \"v\" => 1, \"analyze\" => _hashable(get(p, \"analyze\", nothing)),",
+        r"        tol=r\.tol,\n        n_steps=r\.n_steps,",
+        "        tol=r.tol,\n        analyze=string(get(p, \"analyze\", nothing)),\n        n_steps=r.n_steps,",
         :drop, :subtle,
-        "the cache's 'INSENSITIVE to non-physics' contract",
-        "Folds a NON-physics key (the analyze block) into the cache key, so adding an \
-         analyzer invalidates a ground state that is physically identical. Silent: \
-         the answers stay right and only the cost changes."),
+        "the GS admission id's 'INSENSITIVE to non-physics' contract",
+        "Folds a NON-physics key (the analyze block) into the numerics half of the \
+         admission id, so adding an analyzer invalidates a ground state that is \
+         physically identical. Silent: the answers stay right and only the cost \
+         changes. `test/model/test_gs_admission_axes.jl` partitions every GS_SCHEMA \
+         key and is the file that should see this."),
     Mutant(:b_block_cartesian_direction_guard,
         "src/workflow/experiments/schema/B_block.jl",
         r"    has_cartesian && has_direction &&\n        throw\(",


### PR DESCRIPTION
## 何が壊れていたか

`test/mutation/` の harness が**起動しなくなっていた**。62個の mutant のうち3個の anchor が stale で、`run.jl` は stale が1個でもあると `error()` で止まる — これは正しい設計（何もマッチしない mutant は何もテストしていない）だが、結果として**1つの関数が引っ越しただけで62クラス全部が無効**になる。

GS admission cutover 以降ずっとこの状態だったので、**mutation sweep は一度も走っていない**。CI の per-PR 時間の大半を占める高コストのテストファイルが「何か1つでも欠陥を捕まえるのか」を訊かれたことがない、という状態の原因がこれ。

## 3件の内訳

| mutant | 何が起きたか | 対応 |
|---|---|---|
| `gs_interactions_inherit_over_explicit` | `_resolve_gs_interactions` が `run_step_ground_state.jl` → `resolve_gs.jl` へ移動。本文はバイト一致 | path だけ差し替え（anchor はそのまま1回マッチ） |
| `gs_cache_key_ignores_interactions` | anchor 先の `_gs_cache_key` + `_hashable` が cutover step 3 で**削除**。物理は `gs_model(r)` へ | `_interaction_spec` へ retarget（「id が物理に鈍感」） |
| `gs_cache_key_includes_metadata` | 同上。数値は `_gs_stage_params(r, p)` へ | `_gs_stage_params` の返り NamedTuple へ retarget（「id が非物理に敏感」） |

契約（*id は物理に敏感 / 非物理に鈍感*）は両方とも生きているので、retire ではなく retarget。

## 最初の retarget が degenerate knob だった（catalog にコメントで残した）

物理側の1回目は `c_extra_ranks` / `c_extra_values` を空にするものだった。ところが:

- `test/model/` の fixture で `c4:` / `c6:` を設定しているものが**ゼロ**
- `runs/` の committed config でも**ゼロ**

つまり `ranks` は既に空で、この「mutation」は**1バイトも変えていない**。

それが `test_gs_admission_axes.jl` を含む probe に対して堂々と **ESCAPED**（＝どのテストも捕まえなかった）を返した。あのファイルの仕事はまさに「`GS_SCHEMA` の全キーを分割し、1軸ずつ動かして id が動くことを assert する」なので、**そのまま報告すれば「最重要 gate に穴」という偽の発見**になっていた。

`c1` へ張り替え。全 fixture で live（`c1_ratio` = -0.01 / -0.02 / 0.0）なので、ここで捕まらなければ本物の miss。

## 検証

3 mutant × 3 probe file で確認:

```
gs_interactions_inherit_over_explicit: 0 file(s)   ← この狭い probe では想定内
gs_cache_key_ignores_interactions:     1 file(s)  ← ONLY test for this class
    model/test_corpus_resolves.jl
gs_cache_key_includes_metadata:        1 file(s)  ← ONLY test for this class
    model/test_gs_admission_axes.jl

Negative control: 0 files differed with no mutation applied
```

物理感度側を捕まえているのが `corpus_resolves` であって `admission_axes` ではない点は、full sweep の結果と合わせて別途見る価値がある。

## この PR の外側

これを前提に、全62 mutant × per-PR 全面（tier=ci、382ファイル）を `--max-cost 400`（高コストファイルを初めて pool に入れる）で流している。4 shard 逐次、完了は 2026-08-20 の朝。結果が出たら「証拠に基づく `fast` tier」（`run.jl` の minimum-cost cover）と deletion candidate の一覧が別 PR になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
