### PR TITLE
docs(campaign): 「何も gate していない」は注意書きではなく作業項目

### DIFF
--- a/docs/campaign/CAMPAIGN.md
+++ b/docs/campaign/CAMPAIGN.md
@@ -90,6 +90,20 @@ claim must carry a machine-checkable predicate (a test name or a grep assertion)
 set-equivalence meta-test. Four rows discharging themselves within three days,
 silently, is the argument for it: nothing told anyone.
 
+**And a `KNOWN-LIMIT` that says a coefficient is gated by NOTHING is a defect
+report, not a caveat.** `test_bogoliubov_anchor.jl` carried exactly that sentence
+about the DDI block of the homogeneous BdG. When the block was finally derived
+(#361, 2026-08-19) it was wrong in two independent ways at once — the normal term
+was the Hartree piece, which is identically zero for a uniform cloud, so it was
+2× on a polarized state and structurally absent on a polar one — and the μ it fed
+depended on the probe direction, in four hand-written copies of one assembly.
+Neither could have survived a single gate. The rule that follows is cheap:
+**when a header names an ungated coefficient, treat that sentence as the work
+item, and do not read the absence of red as agreement.** The correction moved the
+most-unstable direction of a production Eu fixture from 15° to 90°
+(`docs/validation/bdg_ddi_verdict_delta_361.md`) while every gated verdict stayed
+green — which is what "gated by nothing" means in numbers.
+
 ---
 
 ## 4. Guards — fail-closed, on every campaign job


### PR DESCRIPTION
CAMPAIGN.md §3 は既に「KNOWN-LIMIT には、限界が解けたら落ちる述語を付けろ」を要求しています。#361 は**その逆向き**で、代償が大きかった側です。

`test_bogoliubov_anchor.jl` は「DDI ブロックはどのテストにも留められていない」と**自分で書いていました**。実際に導出したら、そのブロックは**同時に2通り**間違っていました:

- normal 項が Hartree 項 —— 一様凝縮体では `Q(q=0)=0` により**恒等的にゼロ**の項。偏極状態では2倍、polar では構造的に欠落。
- そこから作られる μ が**探触子の方向に依存**していた。しかも1つの組み立ての手書きコピー4か所すべてで。

修正を通しても**ゲートされた verdict は全部緑のまま**で、その間に production 形 Eu fixture の最不安定方向は **15° → 90°** に動きました（`docs/validation/bdg_ddi_verdict_delta_361.md`）。この2つを並べたものが「何も gate していない」の数値的な意味なので、campaign セッションが読む場所に1段落だけ置きます。

規則は安いです: **ヘッダが未 gate の係数を名指ししていたら、その文を作業項目として扱い、赤が出ないことを一致と読むな。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)