### PR TITLE
feat(mutation): probe the per-PR surface, and let one job be four

### DIFF
--- a/scripts/submit_mutation_sweep.sh
+++ b/scripts/submit_mutation_sweep.sh
@@ -23,9 +23,19 @@
 # 2-3 mutant smoke before sizing h_rt for the full catalog — the per-mutant cost
 # is dominated by precompile and by which probe set was chosen, not by the
 # mutation itself.
+#
+# WHY node_q AND NOT gpu_h. `gpu_h` is a MIG half-GPU with FOUR cores, and this
+# script's own `SBEC_WORKERS` default is 12 — it was asking for 3x the cores the
+# directive reserved, so the probe ran three deep on every slot. `node_q` is one
+# FULL H100 with 48 cores (別表3 coef 0.250 against gpu_h's 0.100), and per unit
+# of work it is both faster and cheaper here: the cost formula weights actual
+# wall-clock 0.7 against 0.1 on reserved h_rt, so a 4-core node holding the job
+# open 3x longer loses more on the 0.7 term than it saves on the coefficient.
+# Measured shape at 12 workers: probe makespan ~400 s against ~4542 s of serial
+# work, i.e. the 48 cores are the thing being bought.
 #$ -cwd
 #$ -N sbec_mutation
-#$ -l gpu_h=1
+#$ -l node_q=1
 #$ -l h_rt=8:00:00
 #$ -j y
 
@@ -52,6 +62,12 @@ MUT_PROBE=${SBEC_MUT_PROBE:-grounded_cheap}
 MUT_ARGS=(--probe "${MUT_PROBE//+/,}")
 [ -n "$MUT_IDS" ] && MUT_ARGS+=(--mutants "${MUT_IDS//+/,}")
 [ -n "${SBEC_MUT_MAXCOST:-}" ] && MUT_ARGS+=(--max-cost "$SBEC_MUT_MAXCOST")
+# `k_n` on the wire, `k/n` to the harness — the same substitution the probe and
+# mutant lists get, for the same reason. Without a shard knob the full catalog is
+# one job whose h_rt has to cover every class, and a job that dies at hour 11
+# of 12 leaves nothing: the harness writes its report once, at the end. `k` is
+# ZERO-INDEXED (`--shard` asserts 0 <= k < n), so 4 shards are 0_4 1_4 2_4 3_4.
+[ -n "${SBEC_MUT_SHARD:-}" ] && MUT_ARGS+=(--shard "${SBEC_MUT_SHARD//_//}")
 # Same reasoning as submit_test_tier.sh: each worker is an independent julia
 # process holding SpinorBEC + CUDA, so memory and not the node's 384 cores is
 # what bounds this.

--- a/test/mutation/run.jl
+++ b/test/mutation/run.jl
@@ -68,6 +68,17 @@ function _probe_spec(spec::AbstractString)
         copy(ORACLE_TESTS)
     elseif spec == "fast"
         select_tests("fast")
+    elseif spec in ("ci", "integration")
+        # The per-PR surface. `fast` + `oracles` + `integration` is what the three
+        # PR jobs run between them, so "which of these files earns the 14 minutes
+        # it costs" is a question about `ci` and cannot be asked with any narrower
+        # spec. Delegated to `select_tests` rather than listed: a second copy of a
+        # tier is a second declaration of it.
+        #
+        # Not expressible as a file list on the qsub side either — `-v` splits on
+        # commas AND spaces, and `ci` is 382 files, so the wire format that works
+        # for a handful of paths does not reach here at all.
+        select_tests(spec)
     elseif startswith(spec, "dir:")
         # Every tier-listed file under a subdirectory. The question "which of
         # test/workflow/ earns its runtime?" needs the whole directory in the


### PR DESCRIPTION
> #371 に積んである（base = `fix/mutation-catalog-stale-anchors`）。あちらが先。

## なぜ必要だったか

「per-PR の各テストは自分の実行時間ぶんの価値があるか」を訊くのに、道具が2つ足りなかった。

### 1. `ci` probe spec

問いの対象は per-PR 3ジョブが分担して回す **382ファイル**。既存 spec はどれも届かない — `fast` はその3つのうちの1つ、`oracles` がもう1つ、`grounded_cheap` は claim class で絞る、`dir:` はディレクトリ単位。

ファイルリストを明示的に渡す道も**塞がっている**: qsub の `-v` はカンマ**と空白**の両方で分割するので、382パスのリストは wire を越えられない。

`ci` / `integration` はどちらも `select_tests` に委譲した。tier を所有しているのはあちらで、ここで並べ直すのは tier の第二宣言になる。

### 2. GPU submit path の shard ノブ

`run.jl` には前から `--shard k/n` があり `scripts/tsubame/submit_mutation.sh` は配線済みだったが、**GPU 側の `submit_mutation_sweep.sh` には無かった**。結果、全カタログは h_rt が62クラス全部を覆わないといけない1ジョブになる。harness は report を**最後に一度だけ**書くので、12時間中11時間目に死ぬジョブは何も答えない。

4 shard 並列は wall-clock を約10 h → 約2.5 h にする。追加コストは約0.1点（課金式が actual に 0.7、予約 h_rt に 0.1 の重みなので、予約項が4本になっても効きは小さい）。

`k` は**0始まり**（`--shard` が `0 <= k < n` を assert する）なので4分割は `0_4 1_4 2_4 3_4`。

## ついでに直した実バグ

スクリプトは `gpu_h=1`（**MIG 半GPU・4コア**）を予約しながら `SBEC_WORKERS` の既定が **12** だった。probe が全スロットで3重に走っていた。

`node_q=1`（フル H100・48コア）に変更。係数は 0.250 vs 0.100 で高いが、**単位仕事あたりでは安い**: 課金は actual wall-clock に 0.7、予約に 0.1 の重みなので、4コアのノードがジョブを約3倍長く開けておく損が係数の得を上回る。

## GPU ノードが選択でないことの再掲

shard ノブを置いた場所に書いた。**SKIP したテストは GREEN であって unknown ではない** — この harness の `:unknown` は「worker が死んだ」の意味。

なので CPU ノードだと `ci` probe 中の真に GPU 依存な2ファイル

- `test_level0_gpu_cpu_consistency.jl`
- `oracles/test_gpu_cpu_per_term_parity.jl`

は走って skip して green を返し、**「何も捕まえなかったファイル」と区別できなくなる** — 走れなかったという理由で deletion candidate 一覧に載る。

## 検証状況

TSUBAME に専用 checkout（`bec-mut-earnci`、SHA 固定）を作り、2 mutant × `ci` probe の smoke を投入済み（job 8443066、node_q、h_rt 1:30）。smoke の目的は欠陥探しではなく**測定** — `--probe ci` がそのツリーで解決すること、node_q で CUDA assertion が通ること、そして本番4 shard の h_rt を決める mutant あたりコスト。submit スクリプト自身の header が全カタログ前にこれを要求している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
