### PR TITLE
docs(runs): flower-protocol の図 README が「誰も持っていないツリー」を現在形で説明していた

### DIFF
--- a/runs/eu151_flower_protocol_edh/figures/README.md
+++ b/runs/eu151_flower_protocol_edh/figures/README.md
@@ -1,5 +1,23 @@
 # Eu-151 Flower Protocol (EDH) — Figures
 
+> **Nothing below this line is in `main`, as of 2026-08-19.** This file is the
+> only tracked thing in the directory. Every figure it names, and every
+> `scripts/flower_protocol_edh/*.py` renderer it cites, lives on
+> `feat/goto-rtp-k3-matsui` / `feat/edh-vs-flower-*` — PRs #27 and #33, both
+> **closed unmerged** on 2026-07-23 — and the `scripts/` tree they assumed was
+> retired wholesale by `e2159486` (217 one-off drivers, replaced by the
+> allowlist charter). A reader who goes looking for these files will not find
+> them in any checkout of `main`.
+>
+> It is kept because the naming convention below is still the right one, and
+> because #26 needs it: the K₃ comparison those figures back was measured on a
+> commit that fails 13 of the 14 refs in `docs/campaign/fix_list.toml`,
+> including all four DDI integrator corrections, so it has to be re-measured
+> rather than re-rendered. See the inventory on #26.
+>
+> The present tense in the rest of this file describes that branch's tree, not
+> this one.
+
 This directory holds **committed** rendered media (PNG / GIF) from the
 flower-protocol simulations. Heavy raw data (`*.h5`, `*.jld2`) lives
 under `../data/` and is **not** tracked.


### PR DESCRIPTION
#26 の棚卸し中に見つけたものです。

`runs/eu151_flower_protocol_edh/figures/README.md` は**自分のディレクトリで唯一の tracked file** で、そこに列挙されている GIF/PNG 5本と `scripts/flower_protocol_edh/*.py` renderer 6本は、**main のどのチェックアウトにも存在しません**:

- 図と driver は `feat/goto-rtp-k3-matsui` / edh-vs-flower ブランチ上（PR #27・#33、どちらも 2026-07-23 に unmerged で close）
- 前提にしていた `scripts/` ツリーは `e2159486` が one-off driver 217 本ごと retire 済み

にもかかわらず全部**現在形**で書かれているので、読んだ人は存在しないファイルを探しに行きます。

削除ではなく **ref にアンカー**しました。命名規約自体はいまも正しく、#26 がこのポインタを必要とするからです —— あの K₃ 比較は `fix_list.toml` の14 refs のうち **13 を祖先に持たない** commit で測られており（DDI 積分器の4本を含む ⇒ **あの RTP は DDI 下で1次精度で走っていた**）、再レンダーではなく**再測定**が要ります。

`docs/` 配下には `test_doc_run_citations_resolve.jl` があって同種の腐りを止めていますが、`runs/**/README.md` はその射程外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)