### PR TITLE
docs(isotope-q): name the three pre-registered axes that did not run as specified

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -207,10 +207,10 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
 - `FAST_TESTS` — 259 files
-- `CI_EXTRA` — 129 files
+- `CI_EXTRA` — 130 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files
-- `ORACLE_TESTS` — 83 files
+- `ORACLE_TESTS` — 84 files
 - `INTEGRATION_TESTS` — 52 files
 
 ## Validation ladder — instruments present on disk

--- a/docs/guides/eu_isotope_q_prediction.md
+++ b/docs/guides/eu_isotope_q_prediction.md
@@ -223,6 +223,22 @@ more seeds is strictly better.
 
 ## 5. Measurements
 
+### 5.0 Which pre-registered axes actually ran, and which did not
+
+§2 is the pre-registration and it is left as written. Three of its axes were **not** run
+as specified, and that is stated here rather than left to be inferred from the absence of
+a table — a campaign that silently drops an axis reads as one that covered it.
+
+| axis | pre-registered | what ran | consequence |
+|---|---|---|---|
+| **grid** | 48³ and 64³ | **16³ (smoke) and 32³** | The FM boundary (§5.4) has **no resolution check**. It is quoted as a bracket, q ∈ [15.6, 29.5], and the collapse *ratio* is a difference of two arms at the same grid, so a common-mode grid error cancels from it — but the absolute bracket is one grid only. |
+| **a_s(¹⁵³Eu)** | ±10 %, ±30 % | **×1.3 on the magnon route only** | The a_S-freedom claim (§5.5) is exact there and is *measured* at +30 %, which is the stronger test; the GS arms never varied a_s, so §5.4's boundary field carries no a_s error bar beyond its c₁ dependence. |
+| **DDI on/off** | both, on the ground state | **both on the magnon route (§5.5); ground state ran secular-on only** | Whether the FM boundary is contact- or dipole-driven is therefore **not decided**, which is why §5.4 attributes q_c to \|c₁\|n without separating the dipolar share. |
+
+None of these touches the deliverable in §6: the magnon ratio is analytic in the modes and
+carries the DDI on/off control and the a_s control that matter to it. They bound §5.4,
+which is already labelled "a drawing of parameter space, not a prediction".
+
 ### 5.1 The isotope map — three numbers, one of them exact
 
 Gated by `test/analysis/test_isotope_q_map.jl`.


### PR DESCRIPTION
#364 のフォローアップ。**私が入れた不備の自己申告です。**

`docs/guides/eu_isotope_q_prediction.md` の §2（事前登録）は 7 軸を宣言していますが、うち 3 軸は宣言どおりに走っていません:

| 軸 | 事前登録 | 実際に走ったもの |
|---|---|---|
| grid | 48³ と 64³ | **16³（smoke）と 32³** |
| a_s(¹⁵³Eu) | ±10 %, ±30 % | **マグノン経路のみ ×1.3** |
| DDI on/off | 基底状態で両方 | **マグノン経路のみ両方**、GS は secular-on だけ |

マージ済みの版はこれを書いていませんでした。表が無いことから読者に推測させる形になっており、**軸を黙って落としたキャンペーンは、その軸をカバーしたキャンペーンと同じに読めます** — 本リポジトリの "no silent caps" が防ごうとしている失敗そのものです。

§2 は事前登録なので**書き換えず**、§5.0 に逸脱表を追加して各々の帰結を明記しました:

- FM 境界（§5.4）に**解像度チェックが無い**。ブラケット q ∈ [15.6, 29.5] は 1 グリッドのみ。ただし collapse **比**は同一グリッドの 2 アームの差なので、共通モードのグリッド誤差は相殺します。
- a_S 非依存の主張（§5.5）はマグノン経路では厳密で、しかも +30 % で**測って**います（±10 % より強い試験）。一方 GS アームは a_s を振っていないので、§5.4 の境界磁場には c₁ 依存以上の誤差棒がありません。
- FM 境界が接触駆動か双極子駆動か**未決**。だから §5.4 は q_c を \|c₁\|n に帰属させたまま、双極子の寄与を分離していません。

**§6 の成果物には触れません**: マグノン比はモードについて解析的で、それを縛る 2 つの対照（DDI を切ると動く / a_s ×1.3 で動かない）は実施済み。3 軸が縛るのは §5.4 で、そこは元から「予言ではなくパラメータ空間の描画」とラベルしてあります。ただし「解像度チェックが無い」「双極子の寄与を分離していない」は、ほのめかすより書いたほうが具体的です。

型 A。ドキュメントのみの変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
