### PR TITLE
ci: raise the fast and oracle budgets, because a timeout here deletes evidence instead of failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,9 +127,23 @@ jobs:
     # =auto): the files are split into one independent julia process per CPU
     # thread (see test/runtests.jl). Test wall-time ~8 min serial → ~3-4 min on
     # the 4-vCPU runner; with setup/precompile ~3-5 min the job lands ~6-8 min.
-    # 15 min stays as generous headroom — a bump signals a real regression,
-    # not CI flake.
-    timeout-minutes: 15
+    # "~6-8 min" and "15 min stays as generous headroom" above are both stale,
+    # measured 2026-08-19 over ten consecutive runs: 8.2 / 9.1 / 10.2 / 10.5 /
+    # 10.6 / 10.9 / 11.2 / 11.5 / 12.0 minutes — median 10.6, and one run hit
+    # the ceiling at 15.3 and was killed. Raised 15 → 25 for the same reason as
+    # `oracles` below, and the reason is not "a red went away":
+    #
+    # GitHub reports a timeout as `cancelled`, not `failure`. A killed job
+    # therefore produces no verdict in a status nobody reads as a failure — and
+    # on a POST-MERGE run that is the only look anything ever takes at the
+    # merged tree. The comment above says a bump signals a real regression; it
+    # cannot, if the bump silently deletes the measurement instead of failing.
+    #
+    # Not licence to grow into: if the median passes ~15 the answer is a cheaper
+    # tier, not a third raise. The runner's own `_COST` drift warnings are the
+    # early signal, and they are already firing (test_level0_gpu_cpu_consistency
+    # takes 76 s against a declared 3).
+    timeout-minutes: 25
     env:
       # The steps below honour `docs` as well as `code`, because the FAST tier
       # contains `test_docs_live_set.jl`, whose INPUT is `docs/**.md`. Gating it
@@ -191,7 +205,25 @@ jobs:
     # minutes) so they are a per-PR merge gate. GPU-only oracle assertions
     # (gpu_cpu_per_term_parity) still no-op here — they need a GPU runner
     # (nightly / TSUBAME), not the CPU ubuntu runner.
-    timeout-minutes: 15
+    #
+    # 15 → 25 on 2026-08-19, from measurement rather than to make a red go away.
+    # "a few minutes" above is stale: nine consecutive runs took 7.2 / 7.7 /
+    # 10.0 / 10.7 / 11.0 / 11.6 / 12.4 / 13.4 minutes, i.e. a p95 sitting ON the
+    # old ceiling, and two runs hit it (15m15s, 15m17s).
+    #
+    # WHY THIS IS WORSE THAN A SLOW JOB, and the reason it is worth a number
+    # rather than a retry: GitHub reports a timeout as `cancelled`, NOT
+    # `failure`. Both casualties were POST-MERGE runs on `main` — the only runs
+    # that ever see the merged tree, as the concurrency comment at the top of
+    # this file says — so the evidence was discarded, and discarded in a status
+    # that does not read as a failure. A gate that silently stops producing a
+    # verdict is the failure mode this whole job exists to prevent.
+    #
+    # 25 is ~1.9x the observed median and ~1.5x more headroom than the old
+    # ceiling gave. It is NOT licence to grow into: if the median passes ~15,
+    # the answer is to make the tier cheaper, not to raise this again. The
+    # per-file `_COST` drift warnings the runner prints are the early signal.
+    timeout-minutes: 25
     env:
       SPINORBEC_TEST_TIER: oracles
       SPINORBEC_TEST_WORKERS: auto


### PR DESCRIPTION
`test`（fast）と `oracles` の両方が `timeout-minutes: 15` を持ち、**両方ともそれに殺されています**。推測ではなく実測です — 各10 run 連続:

| ジョブ | 実測（分） | |
|---|---|---|
| Test (tier=fast) | 8.2 / 9.1 / 10.2 / 10.5 / 10.6 / 10.9 / 11.2 / 11.5 / 12.0 | + **15.3 で kill が1回** |
| Oracle gates | 7.2 / 7.7 / 10.0 / 10.7 / 11.0 / 11.6 / 12.4 / 13.4 | + **15.2 で kill が2回** |

中央値 ~10.6 / ~11、**p95 が天井に乗っています**。コメントにある "~6-8 min" と "a few minutes" は、実測に対しておよそ2倍ずれています。

## なぜ「遅いジョブ」より悪いのか

**GitHub はタイムアウトを `failure` ではなく `cancelled` と報告します。** 殺されたジョブは verdict を出さず、しかも失敗として読めない status に入ります。

そして**3件の犠牲は全て post-merge の main run** でした。このファイル冒頭の concurrency コメント自身がこう書いています:

> a PR's checks run against the base it was cut from, not the base it lands on … cancelling it discards the only evidence

つまり実際に起きていたのは「マージする → main 自身の検証が黙って答えを出さなくなる → ダッシュボードには赤でないものが出る」です。

さらに、`test` 側のコメントが budget の目的として書いている **"a bump signals a real regression, not CI flake" は成立していません** — 超えたときに測定値が消えるなら、budget は regression を知らせられません。

## 25 分の根拠

観測中央値の約 2.3 倍。**育っていい余地ではありません**: どちらかの中央値が ~15 を超えたら、答えは3度目の引き上げではなく tier を安くすることです。早期警報は runner 自身が出している `_COST` drift 警告で、**既に鳴っています**（`test_level0_gpu_cpu_consistency.jl` が宣言 3 秒に対し実測 76 秒）。

## 私の寄与

oracles が天井に届いた一因として: `test_dipolar_magnetostriction_magnitude.jl`（#354 で追加）が当該ジョブの約 100 秒、**8 % 程度**を占めます。双極子 Thomas-Fermi 閉形式に対する粗格子 ITP 3本です。主因ではありませんが、既に限界近くだったジョブに私が載せた負荷ではあります。

## 検証

`.github/workflows/ci.yml` のみの変更。YAML パース確認済み、全ジョブの budget は changes=5 / test=25 / oracles=25 / integration=30 / format=10 / bench=none。

なお本 PR 自身の CI が、引き上げ後の budget で回る最初の実例になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
