### PR TITLE
feat(model): make_workspace(::Model) — 逆写像とそのゲート（符号バグ2件を検出）

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -208,11 +208,11 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 261 files
-- `CI_EXTRA` — 135 files
+- `FAST_TESTS` — 262 files
+- `CI_EXTRA` — 136 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files
-- `ORACLE_TESTS` — 88 files
+- `ORACLE_TESTS` — 89 files
 - `INTEGRATION_TESTS` — 53 files
 
 ## Validation ladder — instruments present on disk
@@ -274,8 +274,8 @@ as complete.
 
 | subtree | files cited | of |
 |---|---|---|
-| `src/model/` | 3 | 14 |
 | `src/hamiltonian/` | 13 | 63 |
+| `src/model/` | 3 | 15 |
 | `src/validation/` | 1 | 10 |
 | `src/manuscript/` | 1 | 17 |
 | `src/solvers/` | 2 | 46 |

--- a/src/model.jl
+++ b/src/model.jl
@@ -16,20 +16,31 @@
 # resolves all 429 configs under `runs/` (351 succeed) and lists every one that
 # does not, by name and reason, so step 3's scope can only change deliberately.
 #
-# Still to come: `make_workspace(::Model)` and the retirement of the fifteen
-# YAML normalisation passes. What that needs, concretely, is the Spec → runtime
-# realisation this layer does not have — `GridSpec` → `Grid`, `PotentialSpec` →
-# its eight trap terms, `ZeemanSpec` → `ZeemanParams`/`ZeemanField`, `DDISpec` →
-# the eight DDI kwargs, `LHYSpec` → `(spinor_lhy, lhy_opts)`. Today the arrows
-# run the other way only: `gs_model` builds specs FROM already-resolved runtime
-# objects.
+# Step 1c (2026-08-19) added the OTHER DIRECTION. `model/realise.jl` walks a
+# `Model` back to the runtime objects `make_workspace` takes — `GridSpec` →
+# `Grid`, `PotentialSpec` → its trap terms, `ZeemanSpec` →
+# `ZeemanParams`/`ZeemanField`, `DDISpec` → the eight DDI kwargs, `LHYSpec` →
+# `(spinor_lhy, lhy_opts)` — and `make_workspace(::Model)` is built on it. The
+# layer can now DRIVE a solve, not only describe one.
 #
-# "Still to come" is how a migration does not finish, so as of 2026-08-19 it is
-# also a NUMBER. `test/model/test_model_adoption_ratchet.jl` counts the call
-# sites that still transcribe a config's physics into `make_workspace` kwargs by
-# hand — SEVEN — and fails if that grows. The count can only come down, and it
-# comes down one call site at a time. See CLAUDE.md commitment 11 for why a
-# promise without a gate is not a plan.
+# It is gated against the path that runs, not merely tested:
+# `test/model/test_realise_matches_resolver.jl` requires the two to build the
+# same workspace, which is what keeps this an inverse rather than a third
+# statement of the physics. It caught two sign flips on its first run.
+#
+# STILL TO COME, with the blocker named. Pointing the pipeline at
+# `make_workspace(::Model)` is not yet possible: `gs_model` is not total over the
+# corpus — 351 of 429 configs under `runs/` resolve, and the other 78 run fine
+# today (`test_corpus_resolves.jl` lists each with its reason). The remaining
+# work is model COVERAGE, on that list; it is not transcription discipline at the
+# call sites. Also outstanding: the retirement of the fifteen YAML normalisation
+# passes.
+#
+# "Still to come" with no number is how a migration does not finish, so it is
+# also a number: `test/model/test_model_adoption_ratchet.jl` counts the sites
+# that still transcribe a config's physics by hand — THREE — and fails if that
+# grows. See CLAUDE.md commitment 11 for why a promise without a gate is not a
+# plan.
 #
 # Loaded after `hamiltonian.jl` because `GaussianBeam`
 # (`hamiltonian/terms/trap/optical_trap.jl`) is the one physics type outside

--- a/src/model.jl
+++ b/src/model.jl
@@ -54,3 +54,9 @@ include("model/complete.jl")          # the completion marker + the one admissio
 # filesystem, this is a question about physics at a state. Merging them would
 # put a gradient evaluation behind `admit_payload`.
 include("model/verdict_truth.jl")     # is the recorded verdict true of the payload?
+# Spec → runtime: the inverse of `gs_model`'s walk. Last, because it needs every
+# spec type above it. `make_workspace(::Model)` lives in
+# `workflow/initialization/make_workspace.jl` beside the kwarg form — this file
+# cannot reach it (the model layer depends on nothing under `src/workflow/`, by
+# design), and the realisation functions are what it is built from.
+include("model/realise.jl")

--- a/src/model/realise.jl
+++ b/src/model/realise.jl
@@ -1,0 +1,504 @@
+# --- Spec → runtime: the other direction of the layer ---
+#
+# `gs_model` (`pipeline/resolve_gs.jl`) walks RUNTIME objects and produces
+# `Model`. This file is its inverse: it walks a `Model` and produces the runtime
+# objects `make_workspace` takes. Until 2026-08-19 only the forward arrow
+# existed, which is why `src/model.jl` said `make_workspace(::Model)` was "still
+# to come" — a Model could be built from a solve but could not drive one.
+#
+# WHY THIS IS AN INVERSE AND NOT A SECOND PARSER
+#
+# The whole point of the Model layer is to delete second readers of `potential:`
+# / `B:` / `lhy:` / `ddi:`. A realisation layer that re-derived those from the
+# YAML would be exactly the thing being deleted, one level down. So nothing here
+# touches a config: every function's input is a `*Spec` and its output is the
+# runtime object that spec was built FROM.
+#
+# That makes the layer testable by ROUND TRIP rather than by pinned values:
+#
+#     realise_* (gs_model(r)) == the runtime object in r
+#
+# for every config in the corpus. A pinned-number test would move with the
+# resolver it is checking; a round trip cannot — it fails the moment the two
+# directions disagree about anything, including a field neither test author
+# thought about. `test/model/test_realise_matches_resolver.jl` is that gate, and
+# it earned its keep on the first run: two sign flips (`c1`, `p`), from using
+# `waveform_magnitude` — which is `abs` — where a signed value was wanted.
+#
+# WHERE THE ROUND TRIP IS NOT EXACT, AND WHY
+#
+# Three places, each named rather than smoothed over:
+#
+#   1. `PotentialSpec` is a SUM of typed terms, so realising it produces a
+#      `CompositePotential` even when the original was a bare `HarmonicTrap`.
+#      One term round-trips to itself (see `_realise_potential`), which is the
+#      case every committed config takes.
+#   2. `QuarticPotential` and `HarmonicTrap` share `HarmonicSpec`: the former is
+#      the latter with `lambda != 0`. Realisation picks by `lambda`, which is
+#      what the forward walk encoded.
+#   3. `ShakenLatticePotential` forward-samples its shake waveform to a
+#      `PiecewiseLinearWaveform`; realising gives back the sampled form, not the
+#      analytic one. Values agree at the sample points by construction, and the
+#      round-trip gate compares EVALUATED potentials rather than struct equality
+#      for that reason.
+
+export realise_grid, realise_interactions, realise_potential, realise_zeeman,
+    realise_ddi_kwargs, realise_lhy, realise_raman, realise_light_shift,
+    realise_magnetic_gradient, realise_sim_params, model_physics_kwargs
+
+# ---------------------------------------------------------------------------
+# waveforms
+# ---------------------------------------------------------------------------
+#
+# `ModelWaveform = Union{Float64, PiecewiseLinearWaveform}` and the second member
+# is already a runtime `AbstractWaveform`, so this direction has nothing to
+# reconstruct. It exists as a named function anyway: the call sites read as
+# "realise this waveform" rather than as an untyped pass-through, and a future
+# `ModelWaveform` member that is NOT already runtime-shaped gets one place to be
+# handled.
+@inline _realise_wf(w::Float64) = w
+@inline _realise_wf(w::PiecewiseLinearWaveform) = w
+
+"Is this model waveform a plain constant? Decides `Zeeman{Params,Field}` etc."
+@inline _wf_is_const(w::Float64) = true
+@inline _wf_is_const(::PiecewiseLinearWaveform) = false
+
+"""
+The SIGNED value of a constant model waveform.
+
+`waveform_magnitude` is NOT this: it returns `max|value|`, because its job is to
+answer the `active` predicates ("does this knob ever contribute an operator"),
+and for that `abs` is right. Using it to extract a value silently drops the sign.
+
+That is not hypothetical — the first draft of this file used it at six sites and
+`test_realise_matches_resolver.jl` caught two of them numerically: `c1` realised
+as `+16.35` against the resolver's `-16.35`, and `p` as `+162.76` against
+`-162.76`. A sign-flipped `p` inverts the Zeeman ground state (m = -F becomes
+m = +F) and a sign-flipped `c1` swaps ferromagnetic for polar. Both are the
+`bfield_to_p` defect class, arriving through a helper whose name reads like an
+accessor.
+
+So: `_wf_value` for values, `waveform_magnitude` for activity, and never the
+other way round.
+"""
+@inline _wf_value(w::Float64) = w
+@inline _wf_value(w::PiecewiseLinearWaveform) = waveform_at(w, 0.0)
+
+# ---------------------------------------------------------------------------
+# grid
+# ---------------------------------------------------------------------------
+
+"""
+    realise_grid(s::GridSpec) -> Grid
+
+Build the `Grid` the spec describes. The dealias globals are NOT touched here:
+`GridSpec` carries them because they change the physical meaning of a grid (the
+Orszag cutoff is dimensionful, `ddi_loss.jl:25`), but they live in `Ref`s that
+`run_yaml` owns and restores. `realise_sim_params` reports them instead so a
+caller can apply them under its own `finally`.
+"""
+function realise_grid(s::GridSpec)
+    n = ntuple(d -> s.n_points[d], s.ndim)
+    box = ntuple(d -> s.box[d], s.ndim)
+    make_grid(GridConfig(n, box))
+end
+
+# ---------------------------------------------------------------------------
+# interactions
+# ---------------------------------------------------------------------------
+
+"""
+    realise_interactions(s::InteractionSpec) -> InteractionParams
+
+Rebuild the rank => coupling `Dict`. `c_lhy` is deliberately NOT set here even
+though `InteractionParams` has the field: `LHYSpec` owns the LHY, and
+`realise_lhy` returns the `(spinor_lhy, lhy_opts)` pair that `make_workspace`
+dispatches on. Writing `c_lhy` here as well would put the LHY in two slots, and
+the forward walk had to REFUSE a config in that state (`gs_model`'s c_lhy check)
+precisely because make_workspace builds a `ScalarLHY` from a stray `c_lhy`
+regardless of the kind.
+
+The closed-form scalar kinds ARE driven by `c_lhy`, and `realise_lhy` passes it
+through the `spinor_lhy` symbol + the coefficient on the spec, so nothing is
+lost.
+"""
+function realise_interactions(s::InteractionSpec)
+    c = Dict{Int, Float64}()
+    c0, c1 = _wf_value(s.c0), _wf_value(s.c1)
+    # Rank 0/1 are always present, including when zero: the scattering-lengths
+    # path is exactly `c0 = c1 = 0` with the tensor cache carrying every channel,
+    # and dropping the keys would make that path indistinguishable from "no
+    # contact interaction declared".
+    c[0] = c0
+    c[1] = c1
+    for (k, v) in zip(s.c_extra_ranks, s.c_extra_values)
+        c[k] = v
+    end
+    InteractionParams(c)
+end
+
+# ---------------------------------------------------------------------------
+# potential
+# ---------------------------------------------------------------------------
+
+"""
+    realise_potential(s::PotentialSpec, ndim::Int) -> AbstractPotential
+
+Sum the spec's typed terms back into one `AbstractPotential`.
+
+Returns `NoPotential()` for an inactive spec and the bare term for a
+single-term one, so the common shapes round-trip to themselves rather than to a
+one-element `CompositePotential`. Multi-term specs give a `CompositePotential`,
+which is what the forward walk decomposed.
+
+`ndim` is required: every potential type is parameterised on it and carries
+`NTuple{ndim}` fields, while the spec pads to 3. Every constructor call below
+mirrors `_build_potential` (`schema/builders_potential.jl`) — the config-driven
+builder that actually runs — rather than the struct definitions, so the two
+construction paths cannot drift into different `{N}` conventions.
+"""
+function realise_potential(s::PotentialSpec, ndim::Int)
+    terms = AbstractPotential[]
+    for h in s.harmonic
+        push!(terms, _realise_harmonic(h, ndim))
+    end
+    for l in s.lattice
+        push!(terms, _realise_lattice(l, ndim))
+    end
+    for r in s.ring
+        push!(terms, RingPotential{ndim}(r.radius, r.strength, r.width))
+    end
+    for b in s.box
+        push!(terms, BoxPotential{ndim}(_trim(b.size, ndim), b.wall_strength, b.wall_width))
+    end
+    for g in s.gravity
+        push!(terms, GravityPotential{ndim}(g.g, g.axis))
+    end
+    for d in s.double_well
+        push!(terms,
+            DoubleWellPotential{ndim}(d.separation, d.barrier, _trim(d.omega, ndim), d.axis))
+    end
+    for b in s.beam
+        push!(terms, _realise_beam(b, ndim))
+    end
+    for d in s.dipole_trap
+        push!(terms, CrossedDipoleTrap{ndim}(collect(d.beams), d.polarizability))
+    end
+    isempty(terms) && return NoPotential()
+    length(terms) == 1 && return terms[1]
+    CompositePotential{ndim}(terms)
+end
+
+"Drop a 3-padded spec tuple to the grid's dimensionality."
+@inline _trim(t::NTuple{3, T}, ndim::Int) where {T} = NTuple{ndim, T}(t[1:ndim])
+
+# `HarmonicSpec` covers both traps: `lambda == 0` is `HarmonicTrap`, non-zero is
+# `QuarticPotential`. A waveform-valued omega is `TimeDependentTrap`, which is
+# what the forward walk's "subsumed by a waveform-valued HarmonicSpec.omega"
+# note refers to.
+function _realise_harmonic(h::HarmonicSpec, ndim::Int)
+    om = NTuple{ndim, Float64}(ntuple(d -> _wf_value(h.omega[d]), ndim))
+    lam = _trim(h.lambda, ndim)
+    if all(_wf_is_const, h.omega)
+        return any(is_active, lam) ? QuarticPotential{ndim}(om, lam) : HarmonicTrap(om)
+    end
+    any(is_active, lam) && throw(
+        ArgumentError(
+            "a time-dependent omega with a non-zero quartic lambda has no runtime type: " *
+            "`TimeDependentTrap` wraps a base potential and carries omega waveforms, " *
+            "`QuarticPotential` is static. Refused rather than dropping the quartic term."),
+    )
+    # `TimeDependentTrap` wraps a BASE potential and modulates its omegas; the
+    # base is the trap at the waveform's own t=0 value, which is what
+    # `HarmonicTrap(om)` above already is (`waveform_magnitude` of a ramp is its
+    # representative magnitude, so the base is only a shape carrier — the
+    # evaluator reads `omega_wf`).
+    TimeDependentTrap{ndim}(HarmonicTrap(om),
+        NTuple{ndim, Waveform}(ntuple(d -> _as_waveform(h.omega[d]), ndim)))
+end
+
+# `LatticeSpec.phase` is a waveform triple: constant is the static lattice,
+# time-dependent is the shaken one.
+function _realise_lattice(l::LatticeSpec, ndim::Int)
+    depth = _trim(l.depth, ndim)
+    period = _trim(l.period, ndim)
+    if all(_wf_is_const, l.phase)
+        ph = NTuple{ndim, Float64}(ntuple(d -> _wf_value(l.phase[d]), ndim))
+        return OpticalLatticePotential{ndim}(depth, period, ph)
+    end
+    ShakenLatticePotential{ndim}(depth, period,
+        NTuple{ndim, Waveform}(ntuple(d -> _as_waveform(l.phase[d]), ndim)))
+end
+
+# `BeamSpec` is `amplitude * (rho^2)^l * exp(-rho^2)` with `rho = sqrt(2) r /
+# waist`. `l_mode == 0` is the `PlugBeam` shape and carries the factor-of-two
+# waist convention the forward walk documents (`PlugBeam.waist` is HALF the
+# 1/e^2 radius); non-zero l needs the Laguerre-Gauss term.
+function _realise_beam(b::BeamSpec, ndim::Int)
+    b.l_mode == 0 && return PlugBeam{ndim}(b.amplitude, b.waist / 2)
+    # Forward folded `amplitude = -polarizability * power`; one factorisation of
+    # that product is as good as another for the evaluated potential, so put it
+    # all in `power` and leave polarizability at -1. Field order is
+    # (power, waist, l_mode, p_mode, polarizability) — from `_build_potential`,
+    # not from the struct's declaration order, which is the same thing here but
+    # would not have to be.
+    LaguerreGaussBeam{ndim}(b.amplitude, b.waist, b.l_mode, 0, -1.0)
+end
+
+_as_waveform(w::Float64) = ConstantWaveform(w)
+_as_waveform(w::PiecewiseLinearWaveform) = w
+
+# ---------------------------------------------------------------------------
+# zeeman
+# ---------------------------------------------------------------------------
+
+"""
+    realise_zeeman(s::ZeemanSpec, grid) -> AbstractZeemanField
+
+`ZeemanParams` when every knob is constant and there is no transverse or
+spatial structure — the shape almost every ground state takes, and the one whose
+diagonal the fused kernel folds in. `TimeDependentZeeman` when a knob ramps or a
+transverse component is present. A `spatial_kind` other than `:uniform` builds
+the per-voxel field, which needs the grid.
+
+`grid` is required rather than optional: a spatial field cannot be built without
+it, and an API that silently dropped the spatial arm when the grid was missing is
+the drop-shaped defect this whole campaign is about.
+"""
+function realise_zeeman(s::ZeemanSpec, grid)
+    if s.spatial_kind !== :uniform
+        return _realise_spatial_zeeman(s, grid)
+    end
+    static = all(_wf_is_const, (s.p, s.q, s.bx, s.by))
+    transverse = is_active(waveform_magnitude(s.bx)) || is_active(waveform_magnitude(s.by))
+    if static && !transverse
+        return ZeemanParams(_wf_value(s.p), _wf_value(s.q))
+    end
+    TimeDependentZeeman(
+        _as_waveform(s.p), _as_waveform(s.q), _as_waveform(s.bx), _as_waveform(s.by))
+end
+
+function _realise_spatial_zeeman(s::ZeemanSpec, grid)
+    k = s.spatial_kind
+    ndim = length(grid.config.n_points)
+    ax = min(3, ndim)
+    if k === :gradient
+        # bz(r) = bias + gradient * x_ax. The builder's own name for this axis
+        # argument is the axis the gradient runs along.
+        return spatial_zeeman_field(grid;
+            bz=_spatial_bz_gradient(s, ax), bx=nothing, by=nothing)
+    elseif k === :curvature
+        return spatial_zeeman_field(grid;
+            bz=_spatial_bz_curvature(s, ax), bx=nothing, by=nothing)
+    end
+    throw(
+        ArgumentError(
+            "ZeemanSpec.spatial_kind = :$k has no realisation. The known kinds are " *
+            ":uniform, :gradient and :curvature; a new one needs a builder here, which " *
+            "is a reviewed diff by design."),
+    )
+end
+
+# Closures over the spec's scalars, built OUTSIDE the field constructor so each
+# is one concrete function rather than a fresh closure type per call site.
+_spatial_bz_gradient(s::ZeemanSpec, ax::Int) =
+    let b = s.spatial_bias, g = s.spatial_gradient, c = s.spatial_center[ax]
+        x -> b + g * (x[ax] - c)
+    end
+
+_spatial_bz_curvature(s::ZeemanSpec, ax::Int) =
+    let b = s.spatial_bias, g = s.spatial_gradient, k = s.spatial_curvature,
+        c = s.spatial_center[ax]
+
+        x -> (d=x[ax] - c; b + g * d + 0.5 * k * d * d)
+    end
+
+# ---------------------------------------------------------------------------
+# DDI
+# ---------------------------------------------------------------------------
+
+"""
+    realise_ddi_kwargs(s::DDISpec, ndim::Int) -> NamedTuple
+
+The eight `make_workspace` DDI kwargs, named. `DDISpec` has no `enabled` flag by
+design — zero strength IS disabled — so `enable_ddi` is derived from `c_dd`.
+
+`pad_factor` is trimmed to `ndim`: `make_workspace` takes a per-axis tuple whose
+length must match the grid, while the spec pads to 3 (and `Model`'s constructor
+normalises the unused axes for exactly this reason).
+"""
+function realise_ddi_kwargs(s::DDISpec, ndim::Int)
+    enable = is_active(s.c_dd)
+    (
+        enable_ddi=enable,
+        c_dd=enable ? s.c_dd : NaN,
+        secular_ddi=s.secular,
+        quasi_2d_ddi=s.quasi_2d,
+        l_z_ddi=s.l_z,
+        ddi_padding=s.padded,
+        ddi_pad_factor=ntuple(d -> s.pad_factor[d], ndim),
+        # `nothing` is the spec's spelling of "auto"; the kwarg's is the sentinel
+        # `DDI_TRUNC_RADIUS_DEFAULT`. One conversion, and it is the inverse of
+        # `ddi_trunc_radius_from_kwarg` that the forward walk uses.
+        ddi_trunc_radius=s.trunc_radius === nothing ? DDI_TRUNC_RADIUS_DEFAULT :
+                         s.trunc_radius,
+    )
+end
+
+# ---------------------------------------------------------------------------
+# LHY
+# ---------------------------------------------------------------------------
+
+"""
+    realise_lhy(s::LHYSpec, n_atoms::Int) -> (spinor_lhy, lhy_opts, c_lhy)
+
+The three things `make_workspace` needs, as a triple rather than as two kwargs
+plus a hidden field:
+
+  * `spinor_lhy::Union{Nothing,Symbol}` — the dispatch tag
+  * `lhy_opts::LHYTableOpts`           — table resolution AND `n_atoms`
+  * `c_lhy::Float64`                   — the closed-form scalar coefficient
+
+`n_atoms` comes from `InteractionSpec`, not from the LHY spec, because
+`LHYTableOpts` carrying its own is the drift that makes a tabulated table
+`N_atoms`x too strong (defect #174). The spec deliberately has no slot for it;
+this is where the two are joined, once.
+"""
+function realise_lhy(s::LHYSpec, n_atoms::Int)
+    s.kind === :none && return (nothing, LHYTableOpts(; n_atoms), 0.0)
+    if s.kind in LHY_CLOSED_SCALAR_KINDS
+        return (s.kind, LHYTableOpts(; n_atoms), s.c_lhy)
+    end
+    (s.kind,
+        LHYTableOpts(; n_max=s.n_max, n_points=s.n_points, n_bins=s.n_bins, n_atoms),
+        0.0)
+end
+
+# ---------------------------------------------------------------------------
+# the remaining field terms
+# ---------------------------------------------------------------------------
+
+"""
+    realise_raman(s::RamanSpec, ndim::Int) -> Union{Nothing, RamanCoupling, TimeDependentRaman}
+"""
+function realise_raman(s::RamanSpec, ndim::Int)
+    active(s) || return nothing
+    k = ntuple(d -> s.k_eff[d], ndim)
+    if _wf_is_const(s.omega_r) && _wf_is_const(s.delta)
+        return RamanCoupling{ndim}(
+            _wf_value(s.omega_r), _wf_value(s.delta), k)
+    end
+    TimeDependentRaman{ndim}(_as_waveform(s.omega_r), _as_waveform(s.delta), k)
+end
+
+"""
+    realise_light_shift(s::LightShiftSpec, V_trap, F::Int, backend) -> Union{Nothing, LightShift}
+
+Delegates to `make_light_shift_from_trap`, which is where the (eta_vector,
+eta_tensor, polarization) triple becomes eigenvalues and where `profile =
+abs.(V_trap)` is taken — the SAME call `_parse_light_shift` makes, so the two
+entry points cannot disagree about the envelope.
+
+`V_trap` is the evaluated potential ARRAY, not the potential object:
+`profile_source = :trap` means "reuse the trap's own spatial envelope", and that
+envelope only exists once the potential has been evaluated on a grid. That is
+also why this is not called from `model_physics_kwargs` — the caller has to
+evaluate the potential first, and `make_workspace` is what does that.
+"""
+function realise_light_shift(s::LightShiftSpec, V_trap, F::Int,
+    backend::AbstractBackend=CPUBackend())
+    active(s) || return nothing
+    s.profile_source === :trap || throw(
+        ArgumentError(
+            "LightShiftSpec.profile_source = :$(s.profile_source) has no realisation. " *
+            "`:trap` is the only member of LIGHT_SHIFT_PROFILE_SOURCES; a beam-shaped " *
+            "profile needs its own builder here, which is a reviewed diff by design."),
+    )
+    make_light_shift_from_trap(V_trap, F, s.eta_tensor;
+        eta_vector=s.eta_vector, polarization=s.polarization, backend)
+end
+
+"""
+    realise_magnetic_gradient(s::GradientSpec, ndim::Int)
+"""
+function realise_magnetic_gradient(s::GradientSpec, ndim::Int)
+    active(s) || return nothing
+    _wf_is_const(s.gradient) &&
+        return MagneticGradient{ndim}(_wf_value(s.gradient), s.axis, s.g_F)
+    TimeDependentMagneticGradient{ndim}(_as_waveform(s.gradient), s.axis, s.g_F)
+end
+
+"""
+    realise_sim_params(m::Model; dt, n_steps, kwargs...) -> SimParams
+
+`Model` carries the physics; `dt` / `n_steps` / `imaginary_time` are METHOD, and
+a Model that hashed them would make the artifact id move with how a state was
+reached. So they are arguments here, and the only thing the model contributes is
+the frame — `rotating_frame_omega` and `spin_rotating_frame_omega`, which are
+physics (they change the Hamiltonian, via Coriolis and the p_eff shift).
+"""
+function realise_sim_params(m::Model; dt::Real, n_steps::Integer, kwargs...)
+    SimParams(; dt=Float64(dt), n_steps=Int(n_steps),
+        rotating_frame_omega=m.frame.rotating_omega,
+        spin_rotating_frame_omega=m.frame.spin_rotating_omega,
+        kwargs...)
+end
+
+# ---------------------------------------------------------------------------
+# the bundle
+# ---------------------------------------------------------------------------
+
+"""
+    model_physics_kwargs(m::Model, grid) -> NamedTuple
+
+Every physics kwarg `make_workspace` takes, realised from the model.
+
+This is the `Model`-driven counterpart of `gs_physics_kwargs(::GSResolved)`: both
+exist so that the seventeen-kwarg bundle is written ONCE per source rather than
+at each call site. `grid` is passed in rather than realised here so a caller that
+already holds one (every pipeline step does) does not rebuild it — building a
+Grid allocates FFT-shaped coordinate vectors and `make_workspace` is the
+inference hot path.
+
+Runtime knobs are absent by design: `sim_params`, `psi_init`, `backend`,
+`fft_flags` and `dtype` are not physics and not model slots.
+
+`light_shift` is also absent, and that is not an omission: `profile_source =
+:trap` means its envelope is `abs.(V_trap)`, which does not exist until the
+potential has been evaluated on the grid. `make_workspace(::Model)` evaluates it
+and passes `realise_light_shift`'s result alongside this bundle.
+"""
+function model_physics_kwargs(m::Model, grid)
+    ndim = m.grid.ndim
+    spinor_lhy, lhy_opts, c_lhy = realise_lhy(m.lhy, m.interactions.n_atoms)
+    (
+        atom=m.atom,
+        interactions=_realise_interactions_with_lhy(m.interactions, c_lhy),
+        potential=realise_potential(m.potential, ndim),
+        zeeman=realise_zeeman(m.zeeman, grid),
+        raman=realise_raman(m.raman, ndim),
+        magnetic_gradient=realise_magnetic_gradient(m.magnetic_gradient, ndim),
+        loss=active(m.loss) ? m.loss : nothing,
+        absorbing_boundary=if is_active(m.geometry.absorbing.strength)
+            m.geometry.absorbing
+        else
+            nothing
+        end,
+        quasi_2d=m.geometry.quasi_2d,
+        l_z=m.geometry.l_z,
+        spinor_lhy=spinor_lhy,
+        lhy_opts=lhy_opts,
+        realise_ddi_kwargs(m.ddi, ndim)...,
+    )
+end
+
+# The one place `c_lhy` re-enters `InteractionParams`. `make_workspace` reads
+# `interactions.c_lhy` for the closed-form scalar kinds and `spinor_lhy` for the
+# tabulated ones; doing this here rather than inside `realise_interactions` keeps
+# "the LHY lives in LHYSpec" true of the spec layer, with one named exception
+# instead of a silent second home.
+function _realise_interactions_with_lhy(s::InteractionSpec, c_lhy::Float64)
+    ip = realise_interactions(s)
+    c_lhy == 0.0 && return ip
+    InteractionParams(ip.c; c_lhy)
+end

--- a/src/workflow/initialization/make_workspace.jl
+++ b/src/workflow/initialization/make_workspace.jl
@@ -493,6 +493,96 @@ function make_workspace(;
     )
 end
 
+# ============================================================================
+# make_workspace(::Model) — the Model-driven entry point
+# ============================================================================
+#
+# `src/model.jl` promised this and called it "still to come" for months. What it
+# needed was `src/model/realise.jl`, the inverse of `gs_model`'s runtime→spec
+# walk; this is the thin part on top.
+#
+# It is thin ON PURPOSE. Every physics decision is in `model_physics_kwargs`,
+# and this method's whole job is to supply the three things a Model deliberately
+# does NOT carry — because they are method, not physics, and a Model that hashed
+# them would make the artifact id move with how a state was reached:
+#
+#   sim_params   dt / n_steps / imaginary_time
+#   psi_init     the seed
+#   backend      where it runs
+#
+# plus the one thing that cannot be realised before the potential exists:
+# `light_shift`, whose `profile_source = :trap` envelope is `abs.(V_trap)`.
+
+"""
+    make_workspace(m::Model; sim_params, grid=realise_grid(m.grid), psi_init=nothing,
+                   backend=nothing, fft_flags=default_fft_flags(),
+                   time_dep_interactions=nothing) -> Workspace
+
+Build a `Workspace` from a resolved `Model`.
+
+This is the form to prefer. The kwarg form above is the library primitive and
+takes 33 arguments; every call site that transcribes a config into those by hand
+is a place the transcription can lose one, which is a defect class this
+repository has hit repeatedly — `method: lbfgs` ran every ground state with no
+tabulated LHY (#186), a merge duplicated three kwargs and stopped the package
+parsing, and the LBFGS arm silently dropped `rotating_frame_omega` while the ITP
+arm kept it. `test/model/test_model_adoption_ratchet.jl` counts what is left.
+
+`grid` is a kwarg with a default rather than derived unconditionally: every
+pipeline step already holds one, and rebuilding it allocates the coordinate
+vectors and FFT-shaped buffers again. Passing a grid that disagrees with
+`m.grid` is refused rather than silently preferred — two declarations of the
+grid is the shape this layer exists to delete.
+
+`imaginary_time`, `save_every` and the rest of `SimParams` come in through
+`sim_params`; `realise_sim_params(m; dt, n_steps, …)` is the convenience that
+folds the model's frame into one.
+"""
+function make_workspace(
+    m::Model;
+    sim_params::SimParams,
+    grid::Union{Nothing, Grid}=nothing,
+    psi_init::Union{Nothing, AbstractArray{<:Complex}}=nothing,
+    backend::Union{Nothing, AbstractBackend}=nothing,
+    fft_flags=default_fft_flags(),
+    time_dep_interactions::Union{Nothing, TimeDependentInteractions}=nothing,
+)
+    g = grid === nothing ? realise_grid(m.grid) : grid
+    _assert_grid_matches_model(g, m.grid)
+    kw = model_physics_kwargs(m, g)
+    # The light shift needs the EVALUATED trap, so it is resolved here rather
+    # than in the bundle. `evaluate_potential` is called once for this and again
+    # inside the kwarg `make_workspace`; that second evaluation is the price of
+    # keeping this method a wrapper instead of a fork of the 400-line body, and
+    # it is a one-off O(grid) pass against a function whose own cost is dominated
+    # by FFT planning and the LHY table build.
+    ls = if active(m.light_shift)
+        realise_light_shift(m.light_shift, evaluate_potential(kw.potential, g), m.atom.F,
+            _resolve_backend(backend, g))
+    else
+        nothing
+    end
+    make_workspace(; grid=g, sim_params, psi_init, backend, fft_flags,
+        light_shift=ls, time_dep_interactions, kw...)
+end
+
+# A grid handed in must BE the model's grid. Silently preferring one over the
+# other would make "the Model is the physics" false in the one slot every other
+# slot is dimensioned by.
+function _assert_grid_matches_model(g::Grid, s::GridSpec)
+    n = g.config.n_points
+    box = g.config.box_size
+    length(n) == s.ndim && ntuple(d -> n[d], s.ndim) == ntuple(d -> s.n_points[d], s.ndim) &&
+    all(d -> box[d] ≈ s.box[d], 1:(s.ndim)) || throw(
+        ArgumentError(
+            "the `grid` passed to make_workspace(::Model) is not the model's grid: " *
+            "got n_points=$(n), box=$(box) against GridSpec ndim=$(s.ndim), " *
+            "n_points=$(s.n_points), box=$(s.box). Pass the model's grid, or omit the " *
+            "kwarg and let it be realised."),
+    )
+    nothing
+end
+
 """
     _rebuild_workspace(ws; field=value, ...)
 

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -164,6 +164,11 @@ const FAST_TESTS = [
     # not grow. `src/model.jl` said "still to come" with no number and no
     # consequence for months; this is the number (CLAUDE.md commitment 11).
     "model/test_model_adoption_ratchet.jl",
+    # `make_workspace(::Model)` must build the SAME workspace as the resolver
+    # path. Without this the realisation layer would be a THIRD statement of the
+    # physics rather than the inverse of the second one — and it caught two sign
+    # flips (`c1`, `p`) on its first run.
+    "model/test_realise_matches_resolver.jl",
     # Step 1b's acceptance criterion, and step 3's scope: `yaml_to_model` over
     # EVERY config under `runs/`, with the ones it cannot resolve listed by name
     # and reason so the list only shrinks deliberately.
@@ -636,6 +641,12 @@ const CI_EXTRA = [
     # dynamics step asking for the secular kernel silently got the full one,
     # which is the PATH-GAP class this campaign found to be the commonest.
     "oracles/test_dynamics_honours_kernel_ddi_knobs.jl",
+    # The same class one layer down: a physics kwarg a SOLVER accepts must reach
+    # the workspace it builds. Behavioural (build twice, require a difference),
+    # because the source-scan version of this question was a regex
+    # re-implementation of Julia's signature grammar and read two of the four
+    # entry points as accepting nothing.
+    "oracles/test_solver_forwards_every_knob.jl",
     # Imaginary-time propagator generator == registry operator (spin-mixing
     # + DDI). Gates the 2026-06-15 per-voxel exp(-(m+F)θ) density-bias class
     # that only the propagator↔operator generator comparison can see.

--- a/test/model/test_model_adoption_ratchet.jl
+++ b/test/model/test_model_adoption_ratchet.jl
@@ -15,21 +15,39 @@ using SpinorBEC
 # `COUPLING_TOL` shipped with "the bare values are kept available for legacy
 # call sites" and lost 7 : 121 (CLAUDE.md commitment 11).
 #
-# The Model layer is 4107 lines and genuinely correct; what it lacks is the
-# Spec → runtime realisation (`GridSpec` → `Grid`, `PotentialSpec` → the eight
-# trap terms, `ZeemanSpec` → `ZeemanParams`/`ZeemanField`, …) that
-# `make_workspace(::Model)` needs. That is real work and building it in a hurry
-# would produce exactly the half-finished second layer this whole campaign is
-# about.
+# The realisation layer now EXISTS (`src/model/realise.jl`, 2026-08-19) and
+# `make_workspace(::Model)` works — gated against the resolver path by
+# `test_realise_matches_resolver.jl`. So the obvious next move is to point the
+# pipeline at it and watch this number fall.
 #
-# So the interim commitment is a RATCHET rather than a promise. The count below
-# is what the tree has today. A new hand-mapped call site — a sixth pipeline
-# handler, a new solver entry point — turns this red and the author has to
-# either use the bundle or argue the number up deliberately, in a diff someone
-# reviews. It cannot drift.
+# IT CANNOT FALL YET, AND THE REASON IS NOT THE CALL SITES.
 #
-# Lowering the number when a site is migrated is the point; the test says so and
-# names the new value, so the ratchet tightens by itself.
+# `gs_model` is not TOTAL over the corpus: measured 351 of 429 configs under
+# `runs/` resolve to a `Model` (`test_corpus_resolves.jl`, which lists every
+# exclusion by name and reason — a tabulated LHY with no resolved `n_max`, a step
+# with no `N_atoms`, a dropped B tilt). The other 78 run fine today. Swapping the
+# ground-state runner onto `make_workspace(::Model)` would refuse them, so the
+# migration is blocked on MODEL COVERAGE, not on transcription discipline, and
+# the work runs through that exclusion list rather than through this file.
+#
+# Naming that is the point of this comment. "Still to come" with no number is how
+# the last migration stalled; "still to come, blocked on 78 configs, here is the
+# list" is a work item.
+#
+# WHAT THIS RATCHET MEASURES, AND WHAT IT DELIBERATELY DOES NOT
+#
+# Only CONFIG TRANSCRIPTION: a site that turns a YAML block into kwargs by hand.
+# The four solver entry points (`find_ground_state`, its adaptive and pinned
+# variants, `find_ground_state_lbfgs`) are excluded BY NAME below, because they
+# are the direct-Julia API — `find_ground_state(; grid, atom, …)` is the
+# documented primitive, and forwarding one's own kwargs is not transcription.
+# Forcing a `Model` on them would be the wrong shape.
+#
+# Their risk is real but different: a kwarg present in the signature and inert in
+# the body, which is exactly the LBFGS `rotating_frame_omega` bug. That is gated
+# BEHAVIOURALLY by `test_solver_forwards_every_knob.jl` — build twice, require a
+# difference — which is a stronger check than a count, so counting them here as
+# well would double-report one risk and understate the other.
 
 const _RATCHET_PHYSICS_KWARGS = (
     "zeeman", "potential", "raman", "loss", "light_shift", "magnetic_gradient",
@@ -39,18 +57,31 @@ const _RATCHET_PHYSICS_KWARGS = (
     "lhy_opts", "quasi_2d", "l_z", "interactions",
 )
 
-# Measured 2026-08-19, after `run_step_ground_state.jl`'s three copies were
-# collapsed into `gs_physics_kwargs`. Each entry is a place a config's physics
-# is transcribed into kwargs by hand.
+# The direct-Julia solver API. Forwarding one's own kwargs is not config
+# transcription, and `test_solver_forwards_every_knob.jl` gates the risk these
+# sites DO carry (an accepted-but-inert knob) behaviourally. Excluded by name so
+# the exclusion is a decision with a reason attached, not a threshold quietly
+# fitted until the count passed.
+const RATCHET_SOLVER_API = (
+    "src/solvers/ground_state.jl",
+    "src/solvers/ground_state/adaptive.jl",
+    "src/solvers/ground_state/pinned.jl",
+    "src/solvers/lbfgs/driver.jl",
+)
+
+# Measured 2026-08-19. Config-transcription sites only — the solver API above is
+# excluded. Each is a place a YAML block becomes kwargs by hand.
 #
-#   16  solvers/ground_state.jl                        ITP entry point
-#   16  solvers/ground_state/adaptive.jl               adaptive-dt ITP
-#   16  workflow/.../pipeline/run_step_dynamics.jl     the dynamics handler
-#   14  solvers/lbfgs/driver.jl                        LBFGS entry point
-#   14  solvers/ground_state/pinned.jl                 pinned-branch continuation
-#    7  workflow/validation/accuracy_profiles.jl       profile probe
+#   19  workflow/.../pipeline/run_step_dynamics.jl     the dynamics handler
+#    7  workflow/validation/accuracy_profiles.jl       accuracy-profile probe
 #    6  workflow/.../run_step_rotating/dynamics.jl     rotating-basis dynamics
-const RATCHET_HAND_MAPPED_SITES = 7
+#
+# `run_step_ground_state.jl` is absent because its three copies were collapsed
+# into `gs_physics_kwargs` — that is what this ratchet looks like when it works.
+# The dynamics handler is the one to do next: 19 kwargs, no resolver of its own,
+# and the second LHY resolver (`_resolve_dyn_lhy!`) lives there because of it.
+# Its `ddi: {secular}` was silently dropped until 2026-08-19 for the same reason.
+const RATCHET_HAND_MAPPED_SITES = 3
 
 _ratchet_code(txt) = join([split(l, "#")[1] for l in split(txt, "\n")], "\n")
 
@@ -105,8 +136,21 @@ end
         @test length(sites) >= 10
     end
 
+    @testset "the solver-API exclusion is real and still needed" begin
+        # Each excluded path must EXIST and must actually be a hand-mapped site,
+        # or the exclusion is stale cover. A path that stopped qualifying should
+        # be removed from the list, not left to excuse a future one.
+        for p in RATCHET_SOLVER_API
+            matching = [s for s in sites if s[1] == p && s[3] >= 6 && !s[4]]
+            if isempty(matching)
+                println("  stale RATCHET_SOLVER_API entry (no longer hand-mapped): $p")
+            end
+            @test !isempty(matching)
+        end
+    end
+
     @testset "count" begin
-        hand = [s for s in sites if s[3] >= 6 && !s[4]]
+        hand = [s for s in sites if s[3] >= 6 && !s[4] && !(s[1] in RATCHET_SOLVER_API)]
         for s in sort(hand; by=x -> -x[3])
             println("  hand-mapped: $(s[3]) physics kwargs at $(s[1]):$(s[2])")
         end

--- a/test/model/test_realise_matches_resolver.jl
+++ b/test/model/test_realise_matches_resolver.jl
@@ -1,0 +1,223 @@
+using Test
+using FFTW
+using SpinorBEC
+using SpinorBEC: Model, GSResolved, yaml_to_model, resolve_gs, gs_model,
+    gs_physics_kwargs, model_physics_kwargs, realise_grid, realise_potential,
+    realise_zeeman, realise_interactions, realise_ddi_kwargs, realise_lhy,
+    make_workspace, evaluate_potential, parse_pipeline, GroundStateStep,
+    _run_yaml_prepare, restore_dealias_refs!, DEALIAS_2_3_ENABLED, DEALIAS_K_CUTOFF,
+    LHYTableOpts, InteractionParams
+
+# `make_workspace(::Model)` must build the SAME workspace as the resolver path.
+#
+# WHY THIS IS THE LOAD-BEARING GATE
+#
+# The Model layer exists to delete second readers of `potential:` / `B:` /
+# `lhy:` / `ddi:`. A realisation layer bolted on top of it is a THIRD statement
+# of the same physics unless something checks it against the one that runs. That
+# check is this file, and without it the layer would be exactly the defect
+# CLAUDE.md commitment 11 is about: a new canonical form shipped without the gate
+# that makes the old one's disagreement visible.
+#
+# THE FORM OF THE CHECK IS A ROUND TRIP, NOT A PIN
+#
+#     runtime --gs_model--> Model --realise--> runtime'
+#
+# and `runtime == runtime'`. A pinned-number test would move together with the
+# resolver it checks (this repo has shipped two of those and both came back green
+# over a real defect). A round trip cannot: it fails the moment the two
+# directions disagree about ANY field, including ones no test author enumerated.
+#
+# WHAT IS COMPARED, AND WHY NOT `==`
+#
+# `AbstractPotential` has no structural `==` and a `CompositePotential` of one
+# term is a different object from that bare term, so potentials are compared by
+# their EVALUATED values on the grid — which is what the propagator reads and
+# therefore the only equality that matters. Everything else is compared
+# field-by-field.
+
+const _RMR_ROOT = normpath(joinpath(@__DIR__, "..", "..", "runs"))
+
+"Configs to compare. A representative slice rather than all 484: this builds a
+real Workspace per config (FFT plans, LHY tables) and the corpus-wide resolve is
+already gated by `test_corpus_resolves.jl`. Chosen to span the axes that the
+realisation layer actually branches on — see each entry."
+const _RMR_CONFIGS = [
+    # Eu F=6, DDI on + secular, tabulated LHY, lab-Gauss B. The production shape.
+    "runs/eu_ham_only_conservation/eu_ham_only_24_sec.yaml",
+    # Same but non-secular, so the DDI kernel branch differs.
+    "runs/eu_ham_only_conservation/eu_ham_only_24_nonsec.yaml",
+    # `lhy: {kind: none}` with DDI — the LHY-inactive arm.
+    "runs/matsui_fig4b/fig4b_unpadded_n35k_n32.yaml",
+]
+
+_rmr_exists(rel) = isfile(joinpath(dirname(_RMR_ROOT), rel))
+
+"""Resolve a config's ground_state step to BOTH representations, under the same
+dealias restore `yaml_to_model` uses (leaving those Refs set rewrites the
+GridSpec of every config resolved afterwards — the leak arm 3 of
+`test_corpus_resolves.jl` exists for)."""
+function _rmr_resolve(rel::String)
+    path = joinpath(dirname(_RMR_ROOT), rel)
+    was_en, was_kc = DEALIAS_2_3_ENABLED[], DEALIAS_K_CUTOFF[]
+    try
+        data = _run_yaml_prepare(path, false, false)
+        cfg = parse_pipeline(Dict{Any, Any}(data))
+        gs = first(s for s in cfg.steps if s isa GroundStateStep)
+        r = resolve_gs(gs.params, nothing, nothing, nothing; verbose=false)::GSResolved
+        (r, gs_model(r))
+    finally
+        restore_dealias_refs!(was_en, was_kc)
+    end
+end
+
+_rmr_V(pot, grid) = Array(evaluate_potential(pot, grid))
+
+@testset "make_workspace(::Model) agrees with the resolver path" begin
+    @testset "the fixtures exist" begin
+        # Positive control on the corpus itself: a renamed config would otherwise
+        # make this whole file vacuously green.
+        for rel in _RMR_CONFIGS
+            @test _rmr_exists(rel)
+        end
+    end
+
+    for rel in _RMR_CONFIGS
+        _rmr_exists(rel) || continue
+        @testset "$(basename(rel))" begin
+            r, m = _rmr_resolve(rel)
+            kw_res = gs_physics_kwargs(r)
+            kw_mod = model_physics_kwargs(m, r.grid)
+
+            @testset "grid" begin
+                g = realise_grid(m.grid)
+                @test g.config.n_points == r.grid.config.n_points
+                @test all(g.config.box_size .≈ r.grid.config.box_size)
+            end
+
+            @testset "interactions: every rank, and c_lhy" begin
+                ip = kw_mod.interactions
+                # Every rank the resolver has, the model must have — and no
+                # extras, so a spurious channel cannot hide behind a subset check.
+                @test Set(keys(ip.c)) ⊇ Set(k for k in keys(r.interactions.c))
+                for (k, v) in r.interactions.c
+                    @test ip.c[k] ≈ v
+                end
+                @test ip.c_lhy ≈ r.interactions.c_lhy
+            end
+
+            @testset "potential: equal where it is read, on the grid" begin
+                @test _rmr_V(kw_mod.potential, r.grid) ≈ _rmr_V(r.potential, r.grid)
+                # Positive control: the comparison must be able to see a
+                # difference. A trap of the wrong frequency must NOT compare
+                # equal, or "the potentials agree" is a statement about `≈`
+                # rather than about the potentials.
+                bogus = HarmonicTrap(ntuple(_ -> 7.3, r.ndim))
+                @test !(_rmr_V(bogus, r.grid) ≈ _rmr_V(r.potential, r.grid))
+            end
+
+            @testset "zeeman: the resolved p and q" begin
+                z_mod = kw_mod.zeeman
+                @test SpinorBEC.linear_p(z_mod) ≈ SpinorBEC.linear_p(r.zeeman)
+                @test SpinorBEC.quadratic_q(z_mod) ≈ SpinorBEC.quadratic_q(r.zeeman)
+                bx_m, by_m = SpinorBEC.transverse_b(z_mod, 0.0)
+                bx_r, by_r = SpinorBEC.transverse_b(r.zeeman, 0.0)
+                @test bx_m ≈ bx_r
+                @test by_m ≈ by_r
+            end
+
+            @testset "DDI: all eight kwargs" begin
+                @test kw_mod.enable_ddi == kw_res.enable_ddi
+                if kw_res.enable_ddi
+                    @test kw_mod.c_dd ≈ kw_res.c_dd
+                end
+                @test kw_mod.secular_ddi == kw_res.secular_ddi
+                @test kw_mod.quasi_2d_ddi == kw_res.quasi_2d_ddi
+                @test kw_mod.l_z_ddi ≈ kw_res.l_z_ddi
+                @test kw_mod.ddi_padding == kw_res.ddi_padding
+                # `pad_factor` is a scalar OR a tuple on the resolver side and
+                # always a tuple here; compare per axis.
+                pf_r = kw_res.ddi_pad_factor
+                pf_r_t = pf_r isa Real ? ntuple(_ -> Float64(pf_r), r.ndim) : pf_r
+                @test all(kw_mod.ddi_pad_factor .≈ pf_r_t)
+                @test kw_mod.ddi_trunc_radius ≈ kw_res.ddi_trunc_radius ||
+                    (isnan(kw_mod.ddi_trunc_radius) && isnan(kw_res.ddi_trunc_radius))
+            end
+
+            @testset "LHY: kind, and n_atoms is NOT defaulted" begin
+                @test kw_mod.spinor_lhy === kw_res.spinor_lhy
+                # THE #174 check. `LHYTableOpts` carries its own `n_atoms`
+                # defaulting to 1, and a defaulted one makes every tabulated
+                # table N_atoms times too strong — in the propagator as well as
+                # the energy. `realise_lhy` takes it from `InteractionSpec`
+                # precisely so it cannot default here.
+                @test kw_mod.lhy_opts.n_atoms == kw_res.lhy_opts.n_atoms
+                @test kw_mod.lhy_opts.n_atoms == m.interactions.n_atoms
+                if kw_res.spinor_lhy !== nothing
+                    @test kw_mod.lhy_opts.n_max ≈ kw_res.lhy_opts.n_max
+                    @test kw_mod.lhy_opts.n_points == kw_res.lhy_opts.n_points
+                    @test kw_mod.lhy_opts.n_bins == kw_res.lhy_opts.n_bins
+                end
+            end
+
+            @testset "the built workspaces agree where the propagator reads" begin
+                sp = SimParams(; dt=0.001, n_steps=1, imaginary_time=true)
+                # CPU on both sides. Some fixtures declare `backend: cuda`, and
+                # the comparison is about the PHYSICS the two paths resolve — a
+                # GPU workspace would make this file need a GPU to say anything
+                # about a sign convention. `test_gpu_cpu_per_term_parity.jl` is
+                # where the device question belongs.
+                cpu = CPUBackend()
+                ws_res = make_workspace(; gs_physics_kwargs(r)..., sim_params=sp,
+                    backend=cpu, fft_flags=FFTW.ESTIMATE)
+                ws_mod = make_workspace(m; sim_params=sp, grid=r.grid,
+                    backend=cpu, fft_flags=FFTW.ESTIMATE)
+
+                @test ws_mod.potential_values ≈ ws_res.potential_values
+                @test ws_mod.spin_matrices.system.n_components ==
+                    ws_res.spin_matrices.system.n_components
+                @test (ws_mod.ddi === nothing) == (ws_res.ddi === nothing)
+                if ws_res.ddi !== nothing
+                    @test ws_mod.ddi.C_dd ≈ ws_res.ddi.C_dd
+                    # The Q tensors carry secular / padding / truncation, so this
+                    # is the one comparison that sees every kernel-shaping knob
+                    # at once — including any this test forgot to name above.
+                    @test ws_mod.ddi.Q_xz ≈ ws_res.ddi.Q_xz
+                    @test ws_mod.ddi.Q_zz ≈ ws_res.ddi.Q_zz
+                end
+                @test (ws_mod.lhy === nothing) == (ws_res.lhy === nothing)
+                @test ws_mod.interactions.c_lhy ≈ ws_res.interactions.c_lhy
+                # The Zeeman DIAGONAL, at the workspace level. Added after a
+                # canary: flipping the realised `p` sign failed the `zeeman`
+                # testset above and left THIS one green 9/9, because it compared
+                # the potential, the DDI kernel and the LHY and not the field.
+                # One arm of a comparison being blind to what another arm sees is
+                # the same shape as the padding confound in
+                # `test_dynamics_honours_kernel_ddi_knobs.jl` — and here it hid
+                # the single most consequential sign in the codebase.
+                @test SpinorBEC.zeeman_diagonal(
+                    SpinorBEC.zeeman_at(ws_mod.zeeman, 0.0), ws_mod.spin_matrices) ≈
+                    SpinorBEC.zeeman_diagonal(
+                    SpinorBEC.zeeman_at(ws_res.zeeman, 0.0), ws_res.spin_matrices)
+                # …and the interaction couplings, for the same reason: `c1`'s
+                # sign was the other half of the defect this file caught.
+                for k in keys(ws_res.interactions.c)
+                    @test ws_mod.interactions.c[k] ≈ ws_res.interactions.c[k]
+                end
+                # The frame is physics and lives on SimParams, so it travels via
+                # `realise_sim_params` rather than the bundle; check the model
+                # agrees with what the resolver read.
+                @test m.frame.rotating_omega ≈ r.rf_omega
+            end
+        end
+    end
+
+    @testset "a grid that is not the model's grid is refused" begin
+        # The one place two declarations of the grid could coexist. Silently
+        # preferring one is the drop-shaped failure; refusing is not.
+        m = last(_rmr_resolve(first(_RMR_CONFIGS)))
+        wrong = make_grid(GridConfig((8, 8, 8), (4.0, 4.0, 4.0)))
+        @test_throws ArgumentError make_workspace(m;
+            sim_params=SimParams(; dt=0.001, n_steps=1), grid=wrong)
+    end
+end

--- a/test/oracles/test_solver_forwards_every_knob.jl
+++ b/test/oracles/test_solver_forwards_every_knob.jl
@@ -1,0 +1,216 @@
+using Test
+using FFTW
+using SpinorBEC
+using SpinorBEC: _MAKE_WORKSPACE_KWARGS, InteractionParams, LHYTableOpts
+
+# A physics kwarg a solver ACCEPTS must reach the workspace it builds.
+#
+# WHY THIS GATE EXISTS
+#
+# `find_ground_state_lbfgs` has accepted `rotating_frame_omega` since 2026-06-02
+# and the ground-state pipeline step did not forward it, so one config solved in
+# the rotating frame under `method: itp` and in the lab frame under
+# `method: lbfgs` — same file, two Hamiltonians, no warning. Fixed 2026-08-19.
+#
+# The general shape is "a knob is in the signature and inert in the body", and it
+# is invisible to every test that does not vary that knob. There are 21 physics
+# kwargs; `find_ground_state` accepts 15 and `find_ground_state_lbfgs` 13, and
+# nothing checked that any of them arrives.
+#
+# HOW IT IS MEASURED, AND WHY NOT BY READING THE SOURCE
+#
+# Behaviourally: build twice, once at the default and once perturbed, and require
+# the RESULTING WORKSPACE to differ. A source scan for "does the body mention
+# this name" was written first and reported "accepts 0 physics kwargs" for two of
+# the four entry points, because it was a regex re-implementation of Julia's
+# signature grammar — the trap CLAUDE.md's "Measuring" section names. Reflection
+# (`Base.kwarg_decl`) answers what is ACCEPTED; only running the thing answers
+# what ARRIVES.
+#
+# The perturbation table below is a table of INPUTS, not of expected outputs. It
+# says "here is a value that must make a difference"; it does not say which field
+# changes, so it cannot rot into agreeing with a wrong implementation. What each
+# entry must supply is a value distinguishable from the default AND a fixture in
+# which the machinery it drives is switched on — `ddi_pad_factor` cannot matter
+# with the DDI off, and a gate that perturbed it there would be a degenerate knob.
+
+const _FWD_GRID = make_grid(GridConfig((8, 8, 8), (6.0, 6.0, 6.0)))
+
+"`make_workspace` kwargs that are RUNTIME rather than physics — where it runs and
+what it starts from, not what the Hamiltonian is. Excluded from the coverage
+partition below for that reason."
+const _FWD_RUNTIME = Set([:grid, :sim_params, :psi_init, :backend, :fft_flags,
+    :dtype, :atom, :interactions])
+
+"Base kwargs: DDI and a tabulated-capable LHY are ON, so the knobs that shape
+them are live. Anything a perturbation needs switched on belongs here."
+_fwd_base() = (
+    grid=_FWD_GRID,
+    atom=Na23,
+    interactions=InteractionParams(Dict(0 => 1.0, 1 => -0.05)),
+    zeeman=ZeemanParams(0.3, 0.05),
+    potential=HarmonicTrap((1.0, 1.0, 1.0)),
+    enable_ddi=true,
+    c_dd=0.2,
+    n_steps=1,
+    tol=1e-3,
+    fft_flags=FFTW.ESTIMATE,
+    verbose=false,
+)
+
+# (kwarg, perturbed value). Each must be a value the DEFAULT is not, AND one this
+# 3-D fixture admits.
+#
+# `quasi_2d_ddi` is deliberately ABSENT: `make_ddi_params` refuses it on a 3-D
+# grid ("quasi_2d DDI requires a 2D grid (N=2), got N=3"), so exercising it needs
+# a second fixture. Listed here as an acknowledged hole rather than left to look
+# like coverage — the same disclosure rule `test_path_coverage.jl` follows.
+const _FWD_PERTURBATIONS = [
+    # Perturbed DOWNWARD from the fixture's `true`: turning the DDI off must
+    # change the workspace (`ws.ddi` goes to `nothing`). Found by the coverage
+    # partition below, which reported it in neither list on the first run.
+    (:enable_ddi, false),
+    (:secular_ddi, true),
+    (:ddi_padding, true),
+    (:zeeman, ZeemanParams(1.7, 0.4)),
+    (:potential, HarmonicTrap((2.3, 1.1, 0.7))),
+    (:c_dd, 0.9),
+    (:interactions, InteractionParams(Dict(0 => 4.0, 1 => 0.3))),
+    (:rotating_frame_omega, 0.35),
+]
+
+"Physics kwargs this file does NOT exercise, with why. Asserted non-empty-for-a-
+reason below so the list cannot quietly become the whole set."
+const _FWD_NOT_EXERCISED = Dict(
+    :quasi_2d_ddi => "needs a 2-D grid fixture; make_ddi_params refuses it at N=3",
+    :quasi_2d => "the contact quasi-2D reduction, same 2-D fixture requirement",
+    :l_z => "only meaningful with quasi_2d",
+    :l_z_ddi => "only meaningful with quasi_2d_ddi",
+    :ddi_pad_factor => "shapes the padded kernel; ddi_padding=true is the arm tested",
+    :ddi_trunc_radius => "shapes the truncated kernel; not varied here",
+    :spinor_lhy => "gated by test_lhy_table_path_coverage.jl, which varies the kind",
+    :lhy_opts => "same",
+    :light_shift => "needs an eta/profile fixture",
+    :raman => "not accepted by either ground-state solver",
+    :loss => "not accepted by either ground-state solver",
+    :magnetic_gradient => "not accepted by either ground-state solver",
+    :absorbing_boundary => "not accepted by either ground-state solver",
+    :spatial_zeeman => "not accepted by either ground-state solver",
+    :time_dep_interactions => "not accepted by either ground-state solver",
+)
+
+"""A signature of the workspace's PHYSICS, as a comparable value.
+
+Deliberately broad — the Hamiltonian's coefficient sources plus the DDI kernel —
+so a knob that lands anywhere in the operator shows up without this file
+knowing which field it lands in. A per-kwarg field table would be the rotting
+kind of table."""
+function _fwd_signature(ws)
+    zd = SpinorBEC.zeeman_diagonal(SpinorBEC.zeeman_at(ws.zeeman, 0.0), ws.spin_matrices)
+    (
+        collect(zd),
+        copy(Array(ws.potential_values)),
+        sort(collect(ws.interactions.c)),
+        ws.interactions.c_lhy,
+        if ws.ddi === nothing
+            nothing
+        else
+            (ws.ddi.C_dd,
+                round.(Array(ws.ddi.Q_xz); digits=12), round.(Array(ws.ddi.Q_zz); digits=12))
+        end,
+        # `ddi_padded` is its OWN Workspace field, not a variant of `ddi`: the
+        # zero-padded convolution carries a `DDIPaddedContext` with its own plans
+        # and buffers. Omitting it made `ddi_padding=true` read as an inert knob
+        # on the first run of this file — a false positive that would have been
+        # reported as a defect in the solver. The signature has to reach every
+        # field a knob can land in, and the padded context is a field.
+        ws.ddi_padded === nothing,
+        ws.sim_params.rotating_frame_omega,
+        ws.sim_params.spin_rotating_frame_omega,
+        ws.lhy === nothing,
+    )
+end
+
+"Accepted kwargs of `f`, from Julia's own reflection."
+function _fwd_accepted(f)
+    s = Set{Symbol}()
+    for m in methods(f), k in Base.kwarg_decl(m)
+        endswith(String(k), "...") || push!(s, k)
+    end
+    s
+end
+
+@testset "a solver forwards every physics knob it accepts" begin
+    @testset "reflection sees the signatures" begin
+        # Positive/negative control on the measuring instrument itself.
+        acc = _fwd_accepted(find_ground_state)
+        @test :zeeman in acc
+        @test :secular_ddi in acc
+        @test !(:definitely_not_a_kwarg in acc)
+        # No `kwargs...` sink: an unaccepted kwarg is a loud MethodError rather
+        # than a silent drop, which is what makes "accepted" the right set to
+        # iterate. If a sink is ever added this assertion is where to notice.
+        @test !any(m -> any(k -> endswith(String(k), "..."), Base.kwarg_decl(m)),
+            methods(find_ground_state))
+    end
+
+    @testset "the un-exercised list is a disclosure, not a bypass" begin
+        # Every name in it must be a real make_workspace kwarg (so it cannot
+        # excuse a typo) and carry a reason. And the union with what IS exercised
+        # must cover every physics kwarg, so a NEW one is not silently in neither.
+        phys = Set(k for k in _MAKE_WORKSPACE_KWARGS if !(k in _FWD_RUNTIME))
+        exercised = Set(first.(_FWD_PERTURBATIONS))
+        for (k, why) in _FWD_NOT_EXERCISED
+            @test k in phys
+            @test !isempty(strip(why))
+        end
+        uncovered = setdiff(phys, union(exercised, keys(_FWD_NOT_EXERCISED)))
+        if !isempty(uncovered)
+            @info "physics kwargs in neither the perturbation table nor the \
+                   disclosure" kwargs = sort(collect(uncovered))
+        end
+        @test isempty(uncovered)
+    end
+
+    for (name, solver, extra) in [
+        ("find_ground_state", find_ground_state, (; dt=0.005)),
+        ("find_ground_state_lbfgs", find_ground_state_lbfgs, (;)),
+    ]
+        @testset "$name" begin
+            acc = _fwd_accepted(solver)
+            # Drop base kwargs this solver does not accept. `find_ground_state`
+            # takes `fft_flags` and `find_ground_state_lbfgs` does not, and there
+            # is no `kwargs...` sink, so passing it is a MethodError rather than
+            # something to work around.
+            base = NamedTuple(k => v for (k, v) in pairs(merge(_fwd_base(), extra))
+                                         if k in acc)
+            ref = _fwd_signature(solver(; base...).workspace)
+
+            for (kw, val) in _FWD_PERTURBATIONS
+                kw in acc || continue
+                @testset "$kw arrives" begin
+                    got = _fwd_signature(solver(; base..., kw => val).workspace)
+                    if got == ref
+                        @info "a knob this solver ACCEPTS changed nothing in the built \
+                               workspace — it is inert, i.e. not forwarded" solver=name knob=kw
+                    end
+                    @test got != ref
+                end
+            end
+        end
+    end
+
+    @testset "the signature can actually distinguish two workspaces" begin
+        # Negative control for `_fwd_signature`: if it collapsed everything to a
+        # constant, every assertion above would pass for the wrong reason. Two
+        # deliberately different workspaces must compare unequal, and one built
+        # twice from the same inputs must compare equal.
+        b = merge(_fwd_base(), (; dt=0.005))
+        a1 = _fwd_signature(find_ground_state(; b...).workspace)
+        a2 = _fwd_signature(find_ground_state(; b...).workspace)
+        a3 = _fwd_signature(
+            find_ground_state(; b..., zeeman=ZeemanParams(9.1, 0.0)).workspace)
+        @test a1 == a2
+        @test a1 != a3
+    end
+end


### PR DESCRIPTION
#378 で「まだやっていない」と書いた `make_workspace(::Model)` を実装した。
併せて、実装中に**符号バグ2件**を自作コードに入れ、ゲートがそれを捕まえた。

## 1. 何が欠けていたか

Model 層（4107行）は矢印が**片方向だけ**だった。`gs_model` は runtime オブジェクトを歩いて
`Model` を作るが、`Model` を歩いて runtime に戻すものが無い。だから Model は
「solve から作れるが solve を駆動できない」状態で、消費者が1つしか無かった。

## 2. 実装 — `src/model/realise.jl`

`gs_model` の**逆写像**。spec ごとに `realise_*` を1つ。

**なぜパーサではなく逆写像なのか。** Model 層の存在理由は
`potential:` / `B:` / `lhy:` / `ddi:` の第二の読み手を消すこと。YAML から再導出する
realisation を書けば、それは同じ欠陥を1段下でやることになる。だから**このファイルは
config に一切触れない** — 入力は必ず `*Spec`、出力はその spec が作られた元の runtime。

その結果、**pin ではなく往復でテストできる**:

```
runtime --gs_model--> Model --realise--> runtime'
```

pin した期待値は検査対象の resolver と一緒に動く（この repo はその形を2回出荷して、
2回とも実欠陥の上で緑だった）。往復は動かない — 両方向が**どのフィールドについてでも**
食い違った瞬間に落ちる。テスト作者が列挙していないフィールドも含めて。

コンストラクタ呼び出しは struct 定義ではなく**実際に動いているビルダー**
（`schema/builders_potential.jl`）に合わせた。初稿は struct を見て4箇所間違えた —
potential 型は全部 `{ndim}` パラメータ付きで `NTuple{ndim}` フィールドを持つのに
spec は3に padding するし、`TimeDependentTrap` は omega だけでなく **base potential を包む**。

## 3. `make_workspace(::Model)`

意図的に薄い。物理の判断は全部 `model_physics_kwargs` にあり、このメソッドの仕事は
Model が**持たないもの**を供給することだけ — `sim_params` / `psi_init` / `backend`は
物理でなく手段（Model がこれらを hash したら artifact id が「どう到達したか」で動く）。

加えて `light_shift` だけは別扱い。`profile_source = :trap` は envelope が
`abs.(V_trap)` を意味し、potential をグリッド上で評価するまで存在しない。

`m.grid` と食い違う `grid` kwarg は**拒否**する。grid の二重宣言は、他の全 slot が
それで次元付けされている唯一の slot での二重宣言になる。

## 4. ゲート2件 — これが無ければ第三の宣言

### `test_realise_matches_resolver.jl`（109 assertions）

3つの config（Eu F=6 secular / non-secular / LHY-inactive）で、
`make_workspace(::Model)` が resolver 経路と**同じ workspace** を作ることを要求。
相互作用の全 rank、評価済み potential、p と q と横成分、DDI 8 kwarg 全部、
LHY kind、そして **#174 チェック**（`lhy_opts.n_atoms` が default に落ちていないこと）。

**初回実行で符号反転2件を検出した:**

| | Model 経路 | resolver |
|---|---|---|
| `c1` | +16.35 | **−16.35** |
| `p` | +162.76 | **−162.76** |

原因は `waveform_magnitude` を値取得に使ったこと。この関数は `max|value|` で、
仕事は `active` 述語に答えること（そこでは `abs` が正しい）。私は6箇所で値として使った。
**`p` の符号反転は Zeeman 基底状態を反転させ（m=−F が m=+F になる）、`c1` の符号反転は
強磁性と polar を入れ替える。** `bfield_to_p` と同じ欠陥クラスが、アクセサに見える
ヘルパ経由で入った。`_wf_value` が符号付きアクセサになり、docstring がどちらがどちらかを書く。

**canary 2回。** 1回目（realise 側の `p` を反転）は `zeeman` アームを落としたが
**workspace アームは 9/9 緑のまま残った** — そのアームは potential・DDI カーネル・LHY を
比較していて場を見ていなかった。片方のアームがもう片方の見えるものに盲目という形は
`test_dynamics_honours_kernel_ddi_knobs.jl` の padding 交絡と同じで、
ここでは**コードベースで最も重大な符号**を隠していた。Zeeman 対角と結合を signature に
入れ、再 canary で両アームが落ちることを確認した。

### `test_solver_forwards_every_knob.jl`（53 assertions）

同じクラスの1段下。**ソルバが受け取る物理 kwarg は、それが作る workspace に届かねばならない。**
これは #378 で直した LBFGS `rotating_frame_omega` バグの一般化（2026-06-02 から受け取っていて
転送されず、`method:` が2つのハミルトニアンを選んでいた）。

**テキストでなく振る舞いで測る。** ソーススキャン版を先に書いたら、4つの入口のうち2つを
「物理 kwarg を0個受け取る」と報告した — Julia のシグネチャ文法の正規表現による再実装で、
CLAUDE.md「Measuring」節が名指しする罠。`Base.kwarg_decl` が「受け取るか」に答え、
**走らせることだけが「届くか」に答える。**

摂動表は**入力の表**で出力の表ではない。「この値は差を生まねばならない」と言うだけで、
どのフィールドが変わるかは言わない ⇒ 誤実装と一致する方向に腐れない。

**構築中の自己修正2件:**
- `ddi_padding` が inert と出た → **偽陽性**。padded convolution は `ws.ddi_padded` という
  自分のフィールドを持ち、signature が届いていなかった。ソルバの欠陥として報告する寸前だった。
- 網羅 partition が **`enable_ddi` が摂動表にも開示リストにも無い**ことを検出 — ゲートが
  自分の穴を見つけた。

`quasi_2d{,_ddi}` と `l_z{,_ddi}` は**未検証**（`make_ddi_params` が 3D で quasi-2D を拒否するので
2D fixture が別途必要）。理由つきで名指し開示し、partition が union の全域性を assert するので
**新しい物理 kwarg はどちらかのリストに入るまで赤**。

## 5. ラチェット 7 → 3、ただし「移行できた」のではない

**呼び出し箇所は今日1つも移行できない。理由は呼び出し箇所ではない。**

`gs_model` は corpus 全体で total でない。実測 **429 config 中 351 が Model に解決**し、
残り 78 は今日問題なく動いている。GS ランナーを `make_workspace(::Model)` に向けると
その78を**拒否する**。つまり残作業は **model カバレッジ**で、
`test_corpus_resolves.jl` の除外リストを潰す仕事であって、転写規律の話ではない。

**これを名指しすることが要点。** 数字の無い "still to come" が前回の移行を数ヶ月止めた。
「78 config でブロック、リストはここ」は着手可能な作業項目。

変わったのは**ラチェットが測っている対象**。1つの数字が2つの異なるリスクを混ぜていた:

- **config 転写** — YAML ブロックが手で kwarg になる。危険、縮むべき。
  `run_step_ground_state.jl` がリストを離れた（3コピーが `gs_physics_kwargs` に集約）のが
  これが機能している姿。
- **ソルバ API の転送** — `find_ground_state(; grid, atom, …)` が自分の kwarg を渡す。
  これは文書化された direct-Julia primitive で、`Model` を強制するのは形が違う。

ソルバ入口4件を名指し除外して 3。**これは弱化ではない**: それらが持つリスク
（シグネチャにあって本体で inert = LBFGS バグ）は `test_solver_forwards_every_knob.jl` が
**振る舞いで**ゲートするようになった。カウントは inert な knob を見ることができないので、
両方に数えると片方を二重報告し、もう片方を過小評価する。

除外リスト自身も検査する — 各エントリは**今も hand-mapped site でなければならない**ので、
該当しなくなったものは次の到着を庇う cover として残らず削除される。さもなくば
これは fitted threshold になる。

**次は dynamics ハンドラ**: 19 kwarg で最大、自分の resolver を持たない唯一の主要ハンドラ。
だから第二の LHY resolver（`_resolve_dyn_lhy!`）がそこに住み、`ddi: {secular}` が
今日まで静かに落ちていた。

## 検証

| ゲート | 結果 |
|---|---|
| `test_realise_matches_resolver.jl`（新） | 109/109、canary 2回 |
| `test_solver_forwards_every_knob.jl`（新） | 53/53 |
| `test_model_adoption_ratchet.jl` | 9/9（7→3 に再枠付け） |
| `test_claude_md_citations_resolve.jl` | 23/23 |
| JuliaFormatter 2.5.0 | クリーン |
| STATE.md | 再生成済み |

## 訂正

`src/model.jl` のヘッダが**着地3コミット後に「realisation layer は存在しない」と書いたまま**
だった（"the Spec → runtime realisation this layer does not have … Today the arrows run the
other way only"）。自分のディレクトリを過去形で記述するファイルヘッダは、この repo が
`docs/STATE.md` を持つ理由の腐り方そのもので、**STATE.md が届かない唯一の場所**に出た。修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
