### PR TITLE
fix(pipeline): 宣言した物理を落とす ground_state ステップを拒否する（klaus_hybrid 2件が誤った磁場向きで走っていた）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,22 @@ Umbrella files `Foo.jl` `include` sub-files in dependency order; public exports 
     - `apply_step!` — implemented for all 14 registry terms, but the free-function cascade stayed legal, so **11 of the 14 have zero production callers** and are green in tests that production does not run.
 
     "Keep the old form for legacy call sites" is how a migration becomes permanent, and a permanently half-finished migration is *two live declarations of the same physics* — the exact thing the new layer was built to delete. So: the PR that introduces the canonical form either migrates every caller, or lands a gate (grep meta-test, `calibrated_scan`, mutation entry) that makes the next new caller of the old form red. **An unmigrated caller with no gate is not "deferred cleanup"; it is the defect, already shipped.**
+12. **Before relaxing a constraint that looks too strict, RUN the thing it is guarding.** A plausible explanation of why a bound is unnecessary is not evidence, because a wrong premise produces an explanation of exactly the same quality as a right one. The only difference is visible on execution.
+
+    Measured 2026-08-19: this happened four times in one session, and the reasoning was physically sound every time.
+
+    | read as | actually |
+    |---|---|
+    | the 14-term registry should drive the propagator; 11 unused `apply_step!` are dead | `:diagonal` FUSES four terms into one per-voxel kernel — one transcendental instead of D=13 |
+    | two mutants targeting a deleted function should be retired | their CONTRACTS survived the deletion; `main` retargeted them and kept the coverage |
+    | `waveform_magnitude` reads a waveform's value | it is the largest absolute value. Used at six sites it flipped the signs of `p` and `c1` — the Zeeman ground state and ferromagnetic-vs-polar |
+    | `_is_trivial_direction`'s `θ == 0` is too narrow; θ = π is axial so the sign rides in `p` | the GS path ignores the direction ENTIRELY. θ ∈ {0, 1, π/2, π} all give `p = -147.955`, `(bx,by) = (0,0)` |
+
+    The last one is the sharpest, because **an existing test said so and I edited it.** Its comment read "on this path a tilted field silently runs along +z"; I read it, kept my inference above it, and relaxed the predicate. Thirty seconds of resolving that block at four θ would have ended it — and that is what eventually did.
+
+    So, in order: (1) construct one input the constraint rejects; (2) run it in the relaxed world and look; (3) only then edit. **A test that contradicts you is evidence, not an obstacle** — if you cannot reconstruct why it was written, you have not yet earned the right to change it.
+
+    And pin the PREMISE beside the constraint, so the next reader does not have to re-derive it: `test_gs_refuses_dropped_physics.jl` asserts the four-θ collapse as well as the refusal, so the day `theta` becomes live on that path the guard goes red instead of quietly outliving its reason. This is the general shape — a conservative-looking bound is either a lost reason or a live constraint, and only an executed probe distinguishes them.
 
 ## Workflow model (spec → CAS → run → observe)
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -125,8 +125,8 @@ checking either.
 - admits: `src/workflow/experiment.jl:253`
 - admits: `src/workflow/experiments/pipeline/run_registry.jl:601`
 - admits: `src/workflow/experiments/pipeline/run_registry.jl:840`
-- admits: `src/workflow/experiments/pipeline/run_step_ground_state.jl:491`
-- **verifies**: `src/workflow/experiments/pipeline/run_step_ground_state.jl:548`
+- admits: `src/workflow/experiments/pipeline/run_step_ground_state.jl:549`
+- **verifies**: `src/workflow/experiments/pipeline/run_step_ground_state.jl:606`
 
 Whether that ratio is a gap is judgement — `:unmarked` being a HIT is a dated
 migration allowance argued at `src/model/complete.jl`, not an oversight — so
@@ -209,10 +209,10 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
 - `FAST_TESTS` — 265 files
-- `CI_EXTRA` — 136 files
+- `CI_EXTRA` — 137 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files
-- `ORACLE_TESTS` — 89 files
+- `ORACLE_TESTS` — 90 files
 - `INTEGRATION_TESTS` — 53 files
 
 ## Validation ladder — instruments present on disk

--- a/src/workflow/experiments/pipeline/run_step_ground_state.jl
+++ b/src/workflow/experiments/pipeline/run_step_ground_state.jl
@@ -26,6 +26,63 @@
 #     each cell to its own recon winner with no index coupling. Fails loud when
 #     nothing matches — never silently falls back to a Gaussian seed.
 
+"""
+    _refuse_dropped_physics(r::GSResolved)
+
+Refuse to RUN a ground-state step that declares physics this path discards.
+
+`GSResolved.dropped_physics` has existed since cutover step 1b and only
+`gs_model` consulted it — so a config in that state got no `Model` (loudly) and
+ran anyway (silently). The run is the half that produces numbers, so that was
+the wrong way round.
+
+MEASURED 2026-08-19, over the 455 ground-state steps that resolve: exactly TWO
+configs are affected, both by `B_direction`, and both are already wrong.
+
+`runs/klaus_hybrid/klaus_hybrid_{nostir_control,magnetostir_omega_m0p74}.yaml`
+declare `B: {B_mag: "0.01 Gauss", theta: 3.14159}` — the field along −z — with
+`initial_state: m_minus_F`. That pairing is the ANTI-ALIGNED stretched state,
+which is the whole point of an EdH experiment. What runs is `p = -147.955`, the
+same value `theta: 0` produces: the direction is dropped and the field points
+along +z, i.e. the ALIGNED state.
+
+The two are not a detail. Per
+`gotcha_edh_needs_the_anti_aligned_stretched_state_2026_08_19` the rotation
+enhancement is +16.5 % anti-aligned against −0.45 % aligned — the effect the
+configs exist to measure is absent in the arm that actually runs.
+
+Verified by construction rather than by reading: resolving the same block at
+`theta ∈ {0, 1, π/2, π}` gives `p = -147.955` and `(bx, by) = (0, 0)` every
+time. The GS path takes `B_mag` and ignores the direction entirely.
+
+This does not repair those configs — which spelling the author wants (`Bz:
+-0.01`, or dropping the tilt) is a physics choice — it stops them producing a
+number that looks fine.
+"""
+function _refuse_dropped_physics(r::GSResolved)
+    isempty(r.dropped_physics) && return nothing
+    # The escape hatch the message names. Present because a refusal with no
+    # override turns a forensic re-run of a known-wrong config into a patch, and
+    # because this repo's other provenance refusal
+    # (`SPINORBEC_ALLOW_STALE_POINTS`) is shaped the same way. It WARNS rather
+    # than passing quietly: an override that says nothing is a default.
+    if lowercase(get(ENV, "SPINORBEC_ALLOW_DROPPED_GS_PHYSICS", "0")) in
+        ("1", "true", "on", "yes")
+        @warn "running a ground_state step that declares physics this path drops" dropped =
+            r.dropped_physics
+        return nothing
+    end
+    throw(
+        ArgumentError(
+            "ground_state step declares " * join(r.dropped_physics, ", ") *
+            ", which the spinor ground-state path does not read — the run would " *
+            "silently use different physics from the one declared. Move the block to " *
+            "a step that reads it, delete it, or express the same physics in a key " *
+            "this path does read (a tilted `B_mag`/`theta` is `Bz` with a sign here). " *
+            "Set SPINORBEC_ALLOW_DROPPED_GS_PHYSICS=1 to run anyway."),
+    )
+end
+
 _seed_bz_gauss(x::Real) = Float64(x)
 _seed_bz_gauss(x::AbstractString) = parse(Float64, split(String(x))[1])
 
@@ -402,6 +459,7 @@ function _run_step(
     # THE shared resolution. Every slot below is read off `r`; nothing in this
     # method parses a physics block. `yaml_to_model` consumes the same call.
     r = resolve_gs(p, grid_prev, atom_prev, ws_prev; verbose)::GSResolved
+    _refuse_dropped_physics(r)
     method = r.method
     atom = r.atom
     grid, ndim = r.grid, r.ndim

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -664,6 +664,12 @@ const CI_EXTRA = [
     # re-implementation of Julia's signature grammar and read two of the four
     # entry points as accepting nothing.
     "oracles/test_solver_forwards_every_knob.jl",
+    # A ground_state step that declares physics this path drops must REFUSE
+    # rather than run. `dropped_physics` existed since cutover 1b and only
+    # `gs_model` read it, so such a config got no Model loudly and ran silently —
+    # the run being the half that produces numbers. Two committed configs are
+    # affected and both were running a +z field where they declare −z.
+    "oracles/test_gs_refuses_dropped_physics.jl",
     # Imaginary-time propagator generator == registry operator (spin-mixing
     # + DDI). Gates the 2026-06-15 per-voxel exp(-(m+F)θ) density-bias class
     # that only the propagator↔operator generator comparison can see.
@@ -1124,6 +1130,14 @@ const _COST = Dict{String, Float64}(
     # CI (23 s locally) — the default 3.0 s estimate reddened the cost-model gate,
     # which is that gate doing its job on a new file.
     "model/test_realise_agrees_over_corpus.jl" => 24.0,
+    # Builds a ground state per perturbation, over BOTH fixtures (3-D and the new
+    # 2-D one) and both solvers: ~20 solves at 8³/8². Measured 59 s. It landed in
+    # #386 with no entry at all, which is the same omission #389 hit one PR later
+    # — unnoticed there only because `test_state_doc_is_current.jl` failed first.
+    "oracles/test_solver_forwards_every_knob.jl" => 60.0,
+    # Two 8³ pipeline steps (the refusal and the override arms) plus four
+    # resolutions for the premise assertion. Measured 34 s.
+    "oracles/test_gs_refuses_dropped_physics.jl" => 34.0,
     # Reads ~700 .jl files line by line. No Julia compute at all; measured 0.5 s.
     "model/test_no_ambient_module_refs.jl" => 1.0,
     # One tiny 1-D 5-step ITP through `run_pipeline` (the positive control) plus

--- a/test/oracles/test_gs_refuses_dropped_physics.jl
+++ b/test/oracles/test_gs_refuses_dropped_physics.jl
@@ -1,0 +1,148 @@
+using Test
+using SpinorBEC
+using SpinorBEC: GroundStateStep, parse_pipeline, _run_yaml_prepare, _run_step,
+    resolve_gs, GSResolved, restore_dealias_refs!, DEALIAS_2_3_ENABLED,
+    DEALIAS_K_CUTOFF, linear_p, transverse_b
+
+# A ground-state step that declares physics this path does not read must REFUSE,
+# not run.
+#
+# WHY
+#
+# `GSResolved.dropped_physics` has existed since cutover step 1b and only
+# `gs_model` consulted it. So a config in that state got no Model — loudly — and
+# ran anyway, silently. The run is the half that produces numbers.
+#
+# THE LIVE CASE, measured 2026-08-19 over all 455 resolving ground-state steps:
+# exactly two configs, both `B_direction`, both already wrong.
+#
+#   runs/klaus_hybrid/klaus_hybrid_nostir_control.yaml
+#   runs/klaus_hybrid/klaus_hybrid_magnetostir_omega_m0p74.yaml
+#
+# Both declare `B: {B_mag: "0.01 Gauss", theta: 3.14159}` — the field along −z —
+# together with `initial_state: m_minus_F`. That pairing is the ANTI-ALIGNED
+# stretched state, which is what an EdH experiment is about. What runs is
+# `p = -147.955`: the same number `theta: 0` gives, i.e. the field along +z and
+# the state ALIGNED. Per
+# `gotcha_edh_needs_the_anti_aligned_stretched_state_2026_08_19` the rotation
+# enhancement is +16.5 % anti-aligned against −0.45 % aligned, so the effect
+# those configs exist to measure is absent from the arm that actually ran.
+#
+# WHAT THIS FILE PINS, AND WHAT IT DOES NOT
+#
+# It pins the REFUSAL. It does not repair the two configs: which spelling the
+# author wants (`Bz` with a sign, or no tilt) is a physics choice. It also pins
+# the underlying fact — that the GS path ignores `theta` entirely — because a
+# future change making `theta` live would make the refusal wrong, and this is
+# where that should surface.
+
+const _RDP_DIR = mktempdir()
+
+const _RDP_BASE = """
+pipeline:
+  - ground_state:
+      atom: Eu151
+      grid: {n: [8, 8, 8], box: [6.0, 6.0, 6.0]}
+      interactions: {N_atoms: 1000, omega_ref: 691.15, c1_ratio: -0.01}
+      potential: {type: harmonic, omega: [1.0, 1.0, 1.0]}
+      B: {__BBLOCK__}
+      ddi: {enabled: false}
+      lhy: {kind: none}
+      method: itp
+      n_steps: 2
+      dt: 0.002
+      tol: 1.0e-6
+      backend: cpu
+"""
+
+function _rdp_write(name, bblock)
+    p = joinpath(_RDP_DIR, name)
+    # `__BBLOCK__` rather than `{BBLOCK}`: the braces belong to the YAML flow
+    # mapping, and substituting a string containing them produced `B: {{...}}`,
+    # which YAML rejects with a parse error the test then mistook for a refusal.
+    body = replace(_RDP_BASE, "__BBLOCK__" => bblock)
+    write(p, body)
+    p
+end
+
+"Run `f` with the dealias globals restored — `_run_yaml_prepare` leaves them set."
+function _rdp_guarded(f)
+    was_en, was_kc = DEALIAS_2_3_ENABLED[], DEALIAS_K_CUTOFF[]
+    try
+        f()
+    finally
+        restore_dealias_refs!(was_en, was_kc)
+    end
+end
+
+function _rdp_gs_step(path)
+    cfg = parse_pipeline(Dict{Any, Any}(_run_yaml_prepare(path, false, false)))
+    first(s for s in cfg.steps if s isa GroundStateStep)
+end
+
+"`:ran`, or the exception message."
+function _rdp_run(path)
+    _rdp_guarded() do
+        try
+            _run_step(_rdp_gs_step(path), nothing, nothing, nothing, nothing; verbose=false)
+            :ran
+        catch e
+            e isa ArgumentError ? e.msg : sprint(showerror, e)
+        end
+    end
+end
+
+@testset "a ground_state step refuses physics it would drop" begin
+    @testset "the GS path really does ignore the field direction" begin
+        # The premise. If this ever stops being true — if `theta` becomes live on
+        # this path — the refusal below is wrong and should be deleted, and this
+        # is the assertion that says so rather than leaving a stale guard.
+        ps = Float64[]
+        for θ in ("0.0", "1.0", "1.5707963", "3.14159")
+            p = _rdp_write("theta_$(replace(θ, "." => "p")).yaml",
+                "B_mag: 0.01, theta: $θ, phi: 0.0")
+            r = _rdp_guarded() do
+                resolve_gs(_rdp_gs_step(p).params, nothing, nothing, nothing;
+                    verbose=false)::GSResolved
+            end
+            push!(ps, linear_p(r.zeeman))
+            @test transverse_b(r.zeeman, 0.0) == (0.0, 0.0)
+        end
+        # Every θ gives the SAME p — including θ = π, which physically is the
+        # opposite field. That is the drop.
+        @test all(≈(ps[1]), ps)
+    end
+
+    @testset "a declared-but-dropped direction is refused" begin
+        p = _rdp_write("tilted.yaml", "B_mag: 0.01, theta: 3.14159, phi: 0.0")
+        msg = _rdp_run(p)
+        @test msg !== :ran
+        @test occursin("does not read", msg)
+        @test occursin("B_direction", msg)
+    end
+
+    @testset "an axial field still runs" begin
+        # The negative control. A refusal that fired on everything would pass the
+        # arm above while breaking the corpus, and 453 of the 455 resolving
+        # ground-state steps are this shape.
+        @test _rdp_run(_rdp_write("axial.yaml", "Bz: 0.01")) === :ran
+        # …including the trivial `theta: 0` direction block, which
+        # `apply_B_block_normalize!` leaves behind for a purely axial field and
+        # which names nothing dropped.
+        @test _rdp_run(_rdp_write("theta0.yaml", "B_mag: 0.01, theta: 0.0, phi: 0.0")) === :ran
+    end
+
+    @testset "the override runs, and says so" begin
+        # An override that passed quietly would be a default. `@warn` is the
+        # difference, and the same shape `SPINORBEC_ALLOW_STALE_POINTS` uses.
+        p = _rdp_write("tilted_override.yaml", "B_mag: 0.01, theta: 3.14159, phi: 0.0")
+        withenv("SPINORBEC_ALLOW_DROPPED_GS_PHYSICS" => "1") do
+            @test_logs (:warn,) match_mode = :any begin
+                @test _rdp_run(p) === :ran
+            end
+        end
+        # …and it is off by default, so the refusal above was not an artefact of
+        # the environment this suite happens to run in.
+        @test !haskey(ENV, "SPINORBEC_ALLOW_DROPPED_GS_PHYSICS")
+    end
+end

--- a/test/oracles/test_solver_forwards_every_knob.jl
+++ b/test/oracles/test_solver_forwards_every_knob.jl
@@ -79,13 +79,43 @@ const _FWD_PERTURBATIONS = [
     (:rotating_frame_omega, 0.35),
 ]
 
+# The 2-D fixture. `quasi_2d` and `quasi_2d_ddi` are refused on a 3-D grid
+# (`make_workspace.jl:120`, `convolution.jl:17`), so the four knobs that ride
+# them were disclosed as un-exercised when this file only had the 3-D fixture.
+# They are exercised now, which is what a disclosure list is FOR — it names the
+# hole so the hole can be closed, rather than letting absence read as coverage.
+const _FWD_GRID_2D = make_grid(GridConfig((8, 8), (6.0, 6.0)))
+
+"2-D base. `l_z` is set because `quasi_2d` refuses a non-positive one, so the
+perturbation has to arrive with its companion — which is itself the point of
+`quasi_2d` and `l_z` being one physical choice in two kwargs."
+_fwd_base_2d() = (
+    grid=_FWD_GRID_2D,
+    atom=Na23,
+    interactions=InteractionParams(Dict(0 => 1.0, 1 => -0.05)),
+    zeeman=ZeemanParams(0.3, 0.05),
+    potential=HarmonicTrap((1.0, 1.0)),
+    enable_ddi=true,
+    c_dd=0.2,
+    n_steps=1,
+    tol=1e-3,
+    fft_flags=FFTW.ESTIMATE,
+    verbose=false,
+)
+
+# (kwarg, perturbed value, extra kwargs the perturbation needs to be legal).
+const _FWD_PERTURBATIONS_2D = [
+    (:quasi_2d, true, (; l_z=0.7)),
+    (:quasi_2d_ddi, true, (; l_z_ddi=0.7)),
+    # `l_z` alone, with quasi_2d already on in both arms, so this isolates the
+    # length itself rather than the mode switch.
+    (:l_z, 1.3, (; quasi_2d=true)),
+    (:l_z_ddi, 1.3, (; quasi_2d_ddi=true)),
+]
+
 "Physics kwargs this file does NOT exercise, with why. Asserted non-empty-for-a-
 reason below so the list cannot quietly become the whole set."
 const _FWD_NOT_EXERCISED = Dict(
-    :quasi_2d_ddi => "needs a 2-D grid fixture; make_ddi_params refuses it at N=3",
-    :quasi_2d => "the contact quasi-2D reduction, same 2-D fixture requirement",
-    :l_z => "only meaningful with quasi_2d",
-    :l_z_ddi => "only meaningful with quasi_2d_ddi",
     :ddi_pad_factor => "shapes the padded kernel; ddi_padding=true is the arm tested",
     :ddi_trunc_radius => "shapes the truncated kernel; not varied here",
     :spinor_lhy => "gated by test_lhy_table_path_coverage.jl, which varies the kind",
@@ -159,7 +189,8 @@ end
         # excuse a typo) and carry a reason. And the union with what IS exercised
         # must cover every physics kwarg, so a NEW one is not silently in neither.
         phys = Set(k for k in _MAKE_WORKSPACE_KWARGS if !(k in _FWD_RUNTIME))
-        exercised = Set(first.(_FWD_PERTURBATIONS))
+        exercised = union(Set(first.(_FWD_PERTURBATIONS)),
+            Set(t[1] for t in _FWD_PERTURBATIONS_2D))
         for (k, why) in _FWD_NOT_EXERCISED
             @test k in phys
             @test !isempty(strip(why))
@@ -195,6 +226,36 @@ end
                                workspace — it is inert, i.e. not forwarded" solver=name knob=kw
                     end
                     @test got != ref
+                end
+            end
+
+            # The 2-D arm. `quasi_2d` and `quasi_2d_ddi` are refused at N=3
+            # (`make_workspace.jl:120`, `convolution.jl:17`), so these four knobs
+            # were disclosed as un-exercised while this file had only the 3-D
+            # fixture. Closing a disclosed hole is what the disclosure is for.
+            base2d = NamedTuple(
+                k => v for (k, v) in pairs(merge(_fwd_base_2d(), extra))
+                           if k in acc
+            )
+            # Skip the whole arm rather than half-run it if the solver cannot take
+            # the 2-D base — silently comparing an incomplete fixture is the
+            # degenerate-knob trap.
+            if all(k -> k in acc, (:quasi_2d, :l_z)) ||
+                all(k -> k in acc, (:quasi_2d_ddi, :l_z_ddi))
+                ref2d = _fwd_signature(solver(; base2d...).workspace)
+                for (kw, val, companions) in _FWD_PERTURBATIONS_2D
+                    # A perturbation needs BOTH its knob and its companions
+                    # accepted: `quasi_2d` without `l_z` throws ("quasi_2d
+                    # requires l_z > 0"), which is the API saying they are one
+                    # physical choice.
+                    (kw in acc && all(k -> k in acc, keys(companions))) || continue
+                    @testset "$kw arrives (2-D)" begin
+                        got = _fwd_signature(
+                            solver(; base2d..., companions..., kw => val).workspace)
+                        got == ref2d && @info "a 2-D knob this solver ACCEPTS changed \
+                                               nothing in the built workspace" solver=name knob=kw
+                        @test got != ref2d
+                    end
                 end
             end
         end


### PR DESCRIPTION
## 実バグ: klaus_hybrid の2 config が誤った磁場向きで走る

```yaml
B: {B_mag: "0.01 Gauss", theta: 3.14159}   # −z を宣言
initial_state: m_minus_F                    # 反平行ストレッチ状態を意図
```

実行結果は `p = -147.955` — これは `theta: 0` が与えるのと**同じ値**、つまり **+z（平行）**。

記憶 `gotcha_edh_needs_the_anti_aligned_stretched_state_2026_08_19` によれば、
回転増強は**反平行 +16.5 % に対し平行 −0.45 %**。この2 config が測ろうとしている効果が、
実際に走っているアームには存在しない。

θ ∈ {0, 1, π/2, π} すべてで `p = -147.955`、`(bx, by) = (0, 0)`。
spinor GS 経路は `B_mag` を取り、**方向を一切読まない**。

## なぜ気づかれなかったか

`GSResolved.dropped_physics` は cutover 1b から存在したが、**`gs_model` しか見ていなかった**。
結果：

| | 挙動 |
|---|---|
| Model 構築 | **拒否**（大声） |
| 実行 | **成功**（静か） |

数値を produce するのは実行の側なので、逆向きだった。実行時にも拒否するようにした。

**影響範囲は変更前に測定**：455 の解決可能な ground_state ステップ中、該当は **2件のみ**、
どちらも既に誤った物理で走っている。他の dropped キー（`quasi_2d` / `l_z` / `raman` /
`a_s` / `ddi_pad` / `B_magnitude_gauss`）は **0件**。

config 自体は直していない — `Bz` に符号を付けるのか傾きを消すのかは著者の物理判断。
`SPINORBEC_ALLOW_DROPPED_GS_PHYSICS=1` で override 可（`@warn` 付き、
`SPINORBEC_ALLOW_STALE_POINTS` と同じ形）。

## 逆方向の修正を出しかけた

最初の試みは**拒否のほうを「直した」**。`_is_trivial_direction` が `θ == 0` しか
認めないのを狭すぎると読み、θ=π も p の符号で運ばれると考えて述語を緩め、
**それに反する既存テストを書き換えた**。

2つの測定が止めた：

1. π を6桁で書くと `sin θ = 2.65e-6` ⇒ `ROTATION_TOL` 版も失敗
2. 決定的 — θ ∈ {0, 1, π/2, π} すべてで `p` が同一、横成分ゼロ

方向は一切運ばれていない。**旧述語が正しく、書き換えようとしていたテストが
私の誤りを教えていた。** 全面撤回。

ゲートは拒否だけでなく**前提も pin する**：`theta` がこの経路で live になれば
4θ アサーションが赤になり、拒否は陳腐化した guard として残らず削除される。

## 同セッションの開示リストから

**2D fixture 追加** — `quasi_2d` / `quasi_2d_ddi` / `l_z` / `l_z_ddi` が
「未検証」から実アサーション6件へ（ITP 4 + LBFGS 2、LBFGS は接触 quasi-2D 対を受け取らない）。
開示リストは 19 → 15。**開示はそのためにある。**

**`_COST` 登録** — #386 がこのファイルを登録なしで landed していた。
59 s vs 既定 3.0 s は次回 drift guard を赤にする。#389 で同じ omission を踏んだが、
そこでは `test_state_doc_is_current.jl` が先に落ちたため気づかなかった。

## 検証

| ゲート | 結果 |
|---|---|
| `test_gs_refuses_dropped_physics.jl`（新） | 13/13 |
| `test_solver_forwards_every_knob.jl` | 51/51（2D アーム込み） |
| `test_state_doc_is_current.jl` | 42/42 |
| `test_tier_membership.jl` | 全 arm 緑 |
| JuliaFormatter 2.5.0 | クリーン |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
