### PR TITLE
feat(klaus2022): parameterise the reproduction for a cluster ensemble, and move the runs to TSUBAME

### DIFF
--- a/scripts/klaus2022/submit_stripes.sh
+++ b/scripts/klaus2022/submit_stripes.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# TSUBAME (UGE) submit: one seed of the Klaus 2022 vortex-stripe ensemble.
+#
+#   qsub -g tga-kozuma-kouhi -N klaus_s1 \
+#     -v KLAUS_SEED=1,KLAUS_HOLD_S=1.1,KLAUS_TAG=_s1 \
+#     scripts/klaus2022/submit_stripes.sh
+#
+# WHY THIS EXISTS. The committed stripes arm ran 500 ms as ONE realization and
+# reached 4.67x its isotropic null against a pre-registered 5x
+# (`docs/validation/klaus2022_primary_source.md` §6d). That is not a
+# disagreement with the paper — it is us under-running the paper's own analysis:
+# their Fig. 4c stripe signal is 115 frames between 700 ms and 1.1 s, averaged.
+# So the re-measurement is longer runs, several seeds, and the window they used.
+#
+# AND WHY ON TSUBAME. The first three arms were run on the local WSL2 box — 4.7
+# hours of it — against a standing norm that every Julia run of this size goes
+# to the cluster (`feedback_use_tsubame_for_heavy_compute`, already corrected
+# four times). The scalar eGPE path is CPU-only (`Array`, no CUDA extension), so
+# "no GPU path" was never a reason not to submit: TSUBAME has CPU nodes.
+#
+# ONE SEED PER JOB. The seeds are independent realizations, so a kill costs one
+# of them rather than the ensemble, and each writes its OWN results file —
+# concurrent jobs sharing one JSON is a read-modify-write race that would
+# silently keep whichever finished last.
+#$ -cwd
+#$ -l cpu_16=1
+#$ -l h_rt=8:00:00
+#$ -j y
+#$ -o logs/tsubame/
+
+set -u
+export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH:-/gs/fs/tga-kozuma-kouhi/shared/.julia}"
+JULIA="${SPINORBEC_TSUBAME_JULIA:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia}"
+
+cd "${KLAUS_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/klaus2022}" || exit 1
+mkdir -p logs/tsubame runs/klaus2022 out
+
+echo "host=$(hostname) date=$(date) pwd=$(pwd)"
+echo "commit=$(git rev-parse --short HEAD) dirty=$(git status --porcelain -- src test | wc -l)"
+
+# The hash alone is not evidence about what ran: a shared tree can be edited
+# under a running job, and an aborted checkout leaves HEAD at the intended
+# commit while the tree holds other files. Refuse rather than produce a result
+# nobody can attribute — on `src/` and `test/` specifically, since that is what
+# the package is built from. Same guard as scripts/tsubame/_preamble.sh; this
+# tree is its own worktree so it does not source that file's `cd`.
+if [ "$(git status --porcelain -- src test | wc -l)" -ne 0 ]; then
+    echo "REFUSING: src/ or test/ is dirty in $(pwd) — result would not be attributable"
+    git status --porcelain -- src test | head -20
+    exit 2
+fi
+
+export KLAUS_SEED="${KLAUS_SEED:-1}"
+export KLAUS_HOLD_S="${KLAUS_HOLD_S:-1.1}"
+export KLAUS_TAG="${KLAUS_TAG:-_s${KLAUS_SEED}}"
+# Per-job output. NOT the committed record: that one belongs to the runs that
+# produced it, and an ensemble member overwriting it would make the gate read a
+# different experiment than the one its thresholds were registered for.
+export KLAUS_RESULTS="${KLAUS_RESULTS:-$(pwd)/out/klaus2022_ensemble${KLAUS_TAG}.json}"
+
+echo "seed=$KLAUS_SEED hold_s=$KLAUS_HOLD_S tag=$KLAUS_TAG"
+echo "results=$KLAUS_RESULTS"
+
+# `-t` matches the requested cores; FFTW threads are set from it inside the
+# script. The dynamics is FFT-bound, so this is the knob that matters.
+time "$JULIA" --project=. -t 16 scripts/klaus2022_reproduce.jl stripes
+rc=$?
+echo "EXIT_RC=$rc"
+exit $rc

--- a/scripts/klaus2022/submit_stripes.sh
+++ b/scripts/klaus2022/submit_stripes.sh
@@ -58,12 +58,24 @@ export KLAUS_TAG="${KLAUS_TAG:-_s${KLAUS_SEED}}"
 # different experiment than the one its thresholds were registered for.
 export KLAUS_RESULTS="${KLAUS_RESULTS:-$(pwd)/out/klaus2022_ensemble${KLAUS_TAG}.json}"
 
-echo "seed=$KLAUS_SEED hold_s=$KLAUS_HOLD_S tag=$KLAUS_TAG"
+# `KLAUS_SMOKE=1` renders every code path on the SMALL grid, for the
+# "smoke-test before any >10 min launch" rule. It is a real flag rather than
+# something a caller can approximate: passing an env var the script does not
+# read is silent, and the first submission of this job did exactly that —
+# `-v KLAUS_SMOKE_ARGS=1` was ignored, so a 30-minute walltime would have been
+# spent on a 1.1 s production run and killed with nothing to show.
+EXTRA=""
+if [ "${KLAUS_SMOKE:-0}" = "1" ]; then
+    EXTRA="--smoke"
+    echo "SMOKE: small grid, short hold — not a production result"
+fi
+
+echo "seed=$KLAUS_SEED hold_s=$KLAUS_HOLD_S tag=$KLAUS_TAG smoke=${KLAUS_SMOKE:-0}"
 echo "results=$KLAUS_RESULTS"
 
 # `-t` matches the requested cores; FFTW threads are set from it inside the
 # script. The dynamics is FFT-bound, so this is the knob that matters.
-time "$JULIA" --project=. -t 16 scripts/klaus2022_reproduce.jl stripes
+time "$JULIA" --project=. -t 16 scripts/klaus2022_reproduce.jl stripes $EXTRA
 rc=$?
 echo "EXIT_RC=$rc"
 exit $rc

--- a/scripts/klaus2022/submit_stripes.sh
+++ b/scripts/klaus2022/submit_stripes.sh
@@ -22,6 +22,13 @@
 # of them rather than the ensemble, and each writes its OWN results file —
 # concurrent jobs sharing one JSON is a read-modify-write race that would
 # silently keep whichever finished last.
+#
+# THE RESOURCE CLASS IS NOT OVERRIDABLE FROM THE COMMAND LINE. Adding
+# `-l cpu_4=1` to the qsub alongside the `#$ -l cpu_16=1` below is REJECTED
+# outright — "Job is rejected because of multiple specifying of gpu_? and cpu_?
+# parameters at one time" — so trying a smaller class to get scheduled sooner
+# means editing this line, not passing a flag. `h_rt` overrides fine, which is
+# what makes the smoke usable.
 #$ -cwd
 #$ -l cpu_16=1
 #$ -l h_rt=8:00:00

--- a/scripts/klaus2022_reproduce.jl
+++ b/scripts/klaus2022_reproduce.jl
@@ -27,7 +27,25 @@ FFTW.set_num_threads(Threads.nthreads())
 using SpinorBEC
 
 const ROOT = normpath(joinpath(@__DIR__, ".."))
-const RESULTS = joinpath(ROOT, "docs", "validation", "klaus2022_results.json")
+
+# Every knob a cluster ensemble needs, and NOTHING that changes what a default
+# invocation does: each default is the value the committed
+# `klaus2022_results.json` was produced with, so re-running bare reproduces the
+# same record rather than a differently-parameterised one.
+#
+# `KLAUS_RESULTS` exists because concurrent jobs must not share an output file.
+# Three seeds writing one JSON is a read-modify-write race that would silently
+# keep whichever finished last.
+const RESULTS = get(ENV, "KLAUS_RESULTS",
+    joinpath(ROOT, "docs", "validation", "klaus2022_results.json"))
+const WIGNER_SEED = parse(Int, get(ENV, "KLAUS_SEED", "20260818"))
+const RESULT_TAG = get(ENV, "KLAUS_TAG", "")
+# Hold time in SECONDS of laboratory time. The paper reads its stripe structure
+# over 700 ms - 1.1 s (Fig. 4c, 115 frames in the rotating frame); the committed
+# 500 ms run under-ran that window, which is §6d's account of why the stripe arm
+# reached 4.67x its null against a pre-registered 5x.
+const HOLD_S = parse(Float64, get(ENV, "KLAUS_HOLD_S", "0.5"))
+const CONTROL_HOLD_S = parse(Float64, get(ENV, "KLAUS_CONTROL_HOLD_S", "0.6"))
 
 # --- Published values and the pre-registered verdict thresholds (§6) ---
 
@@ -120,7 +138,7 @@ function arm_ar_ramp(smoke)
             "kind" => "scalar_egpe", "duration" => dur, "dt" => 0.002,
             "B_direction" => Dict("theta" => THETA35, "omega" => 1.0,
                 "ramp_rate" => RAMP_RATE),
-            "wigner_seed" => Dict("kT" => 8.33, "seed" => 20260818),
+            "wigner_seed" => Dict("kT" => 8.33, "seed" => WIGNER_SEED),
             "save" => Dict("every" => 100))),
     ]
     res, secs = run_arm(steps)
@@ -191,10 +209,11 @@ function stripe_frames(cols, times, stir, dx, dy; k_lo, k_hi, sigma_px)
 end
 
 function arm_stripes(smoke; control::Bool)
-    hold = smoke ? 0.15 * SECOND : (control ? 0.6 * SECOND : 0.5 * SECOND)
+    hold = smoke ? 0.15 * SECOND :
+           (control ? CONTROL_HOLD_S * SECOND : HOLD_S * SECOND)
     dyn = Dict(
         "kind" => "scalar_egpe", "dt" => 0.002,
-        "wigner_seed" => Dict("kT" => 8.33, "seed" => 20260818),
+        "wigner_seed" => Dict("kT" => 8.33, "seed" => WIGNER_SEED),
         "save" => Dict("every" => smoke ? 100 : 500, "column_density" => true),
     )
     bdir = Dict("theta" => THETA35, "omega" => 0.75)
@@ -309,12 +328,14 @@ end
 
 out["published"] = Dict(string(k) => v for (k, v) in pairs(PUBLISHED))
 out["accept"] = Dict(string(k) => v for (k, v) in pairs(ACCEPT))
+out["wigner_seed"] = WIGNER_SEED
+out["hold_s"] = out["arm"] == "control" ? CONTROL_HOLD_S : HOLD_S
 out["git_hash"] = strip(read(`git rev-parse HEAD`, String))
 out["dirty"] = !isempty(strip(read(`git status --porcelain`, String)))
 out["timestamp"] = string(now())
 
 all_results = isfile(RESULTS) ? JSON.parsefile(RESULTS) : Dict{String, Any}()
-key = out["smoke"] ? out["arm"] * "_smoke" : out["arm"]
+key = out["smoke"] ? out["arm"] * "_smoke" : out["arm"] * RESULT_TAG
 all_results[key] = out
 open(RESULTS, "w") do f
     JSON.print(f, all_results, 2)

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -127,6 +127,10 @@ const _SCRIPTS_ALLOWLIST = Set([
     "klaus2022_reproduce.jl",
     "klaus2022_reanalyse.jl",
     "klaus2022_figures.py",
+    # The ensemble re-measurement at the paper's own analysis window
+    # (700 ms - 1.1 s, Fig. 4c), one seed per job. A cluster submit wrapper —
+    # category 3, same as the other `submit_*.sh` above.
+    "klaus2022/submit_stripes.sh",
     # ── validation probes still cited as live instruments ──
     "validation/matsui_dataset_to_csv.jl",
     "validation/rk4ip_gpu_cost_probe.jl",


### PR DESCRIPTION
Klaus 2022 の stripes アームを、**論文自身の解析窓で**、**クラスタで**測り直すための道具です。

## 直すもの — 科学の側

コミット済みの stripes アームは **500 ms を1実現**で走らせ、等方 null の **4.67 倍**（事前登録した閾値 5）に留まりました。これは REJECT として記録済みで、`klaus2022_primary_source.md` §6d に理由も書いてあります:

> 論文との不一致ではなく、**論文自身の解析を過小に走らせた**結果

彼らの Fig. 4c のストライプ信号は **700 ms〜1.1 s の 115 フレーム平均**です。こちらは半分の時間を1実現で測りました。だから再測定は「論文の窓・複数シード」。

## 直すもの — 手続きの側

最初の3アームは**ローカルの WSL2 機で 4.7 時間**回しました。この規模の Julia 実行はクラスタへ、という規範に反しています（`feedback_use_tsubame_for_heavy_compute`、このセッション以前に既に4回是正されている）。

そこに至った理由づけは「scalar eGPE 経路に GPU 拡張が無い」でした。事実ではありますが**理由になっていません** — TSUBAME には CPU ノードがあり、規範の主旨は「ワークステーションを半日占有しない」ことです。判断対象を「GPU か否か」に狭めて、「どこで走らせるか」を問い直していませんでした。

## パラメータ化は既定で無効

新しい env knob はすべて、**コミット済み `klaus2022_results.json` を生んだ値**を既定値にしています。素の実行は同じ記録を再現し、別パラメータの何かにはなりません。

| knob | 既定 | |
|---|---|---|
| `KLAUS_SEED` | 20260818 | Wigner 種 |
| `KLAUS_HOLD_S` | 0.5 | stripes の hold（実験室秒） |
| `KLAUS_CONTROL_HOLD_S` | 0.6 | θ ramp 前の control hold |
| `KLAUS_TAG` | `""` | 結果キーの接尾辞 |
| `KLAUS_RESULTS` | コミット済み JSON | 出力先 |

`KLAUS_RESULTS` が要るのは、**同時実行のジョブが出力ファイルを共有できない**からです。3シードが1つの JSON を read-modify-write すると、最後に終わったものだけが黙って残ります。アンサンブルは `out/` に書き、**コミット済み記録には触りません** — あれは it を生んだ run のもので、上書きするとゲートが「閾値を登録した実験とは別の実験」を読むことになります。

各記録は自分の `wigner_seed` と `hold_s` も刻むようにしました。結果がその日のスクリプトの状態を暗黙に継承するのではなく、**自分が生まれた knob を名乗る**ようにするためです。

## 投入スクリプト

1ジョブ1シード（独立な実現なので kill が1本で済む）。**クラスタ worktree の `src/` か `test/` が dirty なら拒否**します — `scripts/tsubame/_preamble.sh` が持つのと同じガードで、理由も同じ: 共有ツリーは実行中に編集されうるので、コミットハッシュだけでは何が走ったかの証拠になりません。

## 実測で分かった制約2件（コードに記録済み）

**1. 資源クラスは submit 時に上書きできない。** `#$ -l cpu_16=1` を持つスクリプトに CLI で `-l cpu_4=1` を足すと UGE が拒否します（"multiple specifying of gpu_? and cpu_? parameters at one time"）。小さい枠で順番待ちを飛ばすにはディレクティブ自体を編集するしかありません。`h_rt` は上書き可能で、それが smoke を 30 分で回せる理由です。

**2. 自分の smoke を踏み抜きかけた。** 最初の投入で `-v KLAUS_SMOKE_ARGS=1` という**スクリプトが読まない変数**を渡していました。何も警告されず、30 分の walltime で 1.1 秒の本番が走って kill されるところでした。「>10 分の launch 前に smoke」という規範を smoke そのものの中で破りかけた形です。qdel して、**実際に読まれる `KLAUS_SMOKE`** を足し、ログに smoke か否かを印字するようにしました。

## 検証したこと / していないこと

**した**: knob が記録に載ること、素の実行がコミット済みキーを無傷で書くこと、allowlist ゲート、TSUBAME 上で `scalar_egpe` / `evolve_stage` / Klaus ref が到達可能なこと（専用 worktree を現 main で作成、precompile 62 秒）。

**していない**: **クラスタ上での実行そのもの。** 投入したジョブ 8444494 は `qw` のままです。原因は容量ではなく、グループ自身のバックログ（別セッションの 30 running / 17 qw、クラスタには 3892 スロット空き）で、こちらから早める手はありません。

つまりこの PR は**道具であって結果ではありません**。測定値が出たら別途報告します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
