### PR TITLE
fix(campaign): corpus を反平行準備へ、そして「回転支援」は遠心力だった (#343 後続)

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -208,11 +208,11 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 265 files
-- `CI_EXTRA` — 137 files
+- `FAST_TESTS` — 266 files
+- `CI_EXTRA` — 138 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files
-- `ORACLE_TESTS` — 90 files
+- `ORACLE_TESTS` — 91 files
 - `INTEGRATION_TESTS` — 53 files
 
 ## Validation ladder — instruments present on disk

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -208,7 +208,7 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 263 files
+- `FAST_TESTS` — 264 files
 - `CI_EXTRA` — 135 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files

--- a/docs/archive/klaus_quench_protocol_pivot_2026-05-26.md
+++ b/docs/archive/klaus_quench_protocol_pivot_2026-05-26.md
@@ -7,6 +7,15 @@
 > carries the full argument is `docs/manuscript/klaus_protocol_sheet.md`; the 11x
 > quadratic-Zeeman correction is measured NOT to apply in this nT band
 > (`q/p = 2.3e-8` at 2.6 nT, `ed3be749`).
+>
+> **RE-DERIVED 2026-08-19. `0.468 ± 0.003` is superseded by `0.68 ± 0.04`**, and
+> the mechanism changed with it: the response is **even in Ω** (so the chirality
+> rule this document builds on is void), and a *static* radial trap weakened to
+> `ω_eff = √(ω_⊥² − Ω²)` reproduces the entire effect to 0.06–0.19 % — the
+> enhancement is **centrifugal, not Coriolis, and rotation is not required at
+> all**. Authority: `docs/campaign/edh_quench_polarisation_decision.md` §9.
+> Every `0.468` below is history. Gated by
+> `test/test_retracted_numbers_carry_their_replacement.jl`.
 
 <!-- promoted from agent memory `klaus_quench_protocol_pivot_2026_05_26.md` on 2026-07-31; historical record, not an SSoT -->
 <!-- Eu spinor rotation+quench protocol — 2-phase rotation-prep+weak-field-quench scan. Load-bearing observable is post-quench m=-5,-4 excitation, not bare ⟨F_z⟩. Called the "rotation-assisted EdH quench" since 2026-08-19; the protocol design is original to this project and was never proposed by any published paper. -->

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -33,6 +33,9 @@ measurements, not tests).
 | 2 | How many stored runs does the new row disqualify? | **0 marginally.** All 200 gateable runs were already disqualified by older refs; 3 more have no producing commit at all |
 | 3 | Does the field sign move the load-bearing observables? | **Yes, by ×2.2 to ×5.0.** Peak P_{−5,−4} 0.244 → 0.530; peak \|L_z\| 0.020 → 0.101. Nothing depending on either is quotable without re-derivation. §3 |
 | 3b | Does the *rotation enhancement* survive the corrected field sign? | **No.** +15.8 % pre-fix vs **−0.45 %** post-fix, with the Ω knob proved live at both. `\|Ω\|/ω_⊥ = 0.468 ± 0.003` is not re-derivable as posed. §3.4 |
+| 7 | What replaces `\|Ω\|/ω_⊥ = 0.468 ± 0.003`? | **`\|Ω*\|/ω_⊥ = 0.68 ± 0.04`** at the anti-aligned preparation, +24.9 % over Ω=0. Two digits, not three. §9.1 |
+| 8 | Is the enhancement chirality-matched, as the sheet says? | **No.** The response is **even in Ω** to ≤ 0.124 %; Ω=0 is the minimum and both senses enhance equally. §9.2 |
+| 9 | Then what is the mechanism? | **Centrifugal, not Coriolis.** A *static* trap weakened to ω_eff = √(ω_⊥²−Ω²) reproduces the whole effect to **0.06–0.19 %**. **Rotation is not needed** — weaken the radial trap to ≈ 0.73 ω_⊥. §9.3 |
 | 4 | Align the rotation-assisted EdH quench series to m=−F? | **No — and stop saying it in `m`.** The measured criterion is *aligned vs anti-aligned with B*. the EdH quench needs the **anti-aligned (Zeeman-highest)** state; under the project's +B_z that is m=+F. §4 |
 | 4b | Is `eu151_klaus_phi_phys` really "the one Eu arc on the other side"? | **No.** `p > 0` puts m=+F at the *bottom*, so it is aligned like everything else — and therefore on the wrong side for the EdH quench. #343 §2's premise was an m-label comparison across two field parameterisations. §4.2 |
 | 5 | Is the stored `(init m × Ω)` "mirror" pair still a mirror? | **No — `bce2068f` broke it.** Repaired here, and the repair is confirmed by measurement to 5 digits (§3.6 arm G). §5 |
@@ -434,12 +437,17 @@ It did not find observables insensitive enough to skip; it found that the
 headline prescription is **not re-derivable as posed** and has to be replaced by
 a different measurement.
 
-### 6.1 Re-derive — 2 items
+### 6.1 Re-derive — 2 items, **both discharged 2026-08-19**
 
-| # | item | why, and what changes |
+| # | item | outcome |
 |---|---|---|
-| R1 | **The Ω operating window** (`\|Ω\|/ω_⊥ = 0.468 ± 0.003 @ 2.6 nT`, and the `0.3 @ 1.3 nT` / `[0.5,0.6] @ 5.2 nT` rows with it) | **Not a refinement — a re-posing.** At the aligned preparation there is no optimum (−0.45 %). Re-derive at the **anti-aligned** preparation (m=+F, B_z>0), where the enhancement is +16.5 %. Until then the sheet's three-significant-figure window has no measured basis on current code and must not go to the lab |
-| R2 | **The 6 acceptance gates** in `klaus_quench_protocol_spec_2026_05_26.md` | The `(init m × Ω)` reversal-symmetry gate is now *measured* to hold to 5 digits (§3.6, arms E and G), so it re-derives green — but only against the **repaired** pair (§5). The other five have not been re-run |
+| R1 | **The Ω operating window** (`\|Ω\|/ω_⊥ = 0.468 ± 0.003 @ 2.6 nT`) | **DONE — §9.1/9.2/9.3.** Not a refinement but a re-posing, and then a replacement: `\|Ω*\|/ω_⊥ = 0.68 ± 0.04`, +24.9 % over Ω=0. The response is **even in Ω**, so the chirality rule is void, and a **static** weakened trap reproduces the whole effect — the operative variable is ω_⊥,eff ≈ 0.73 ω_⊥, not Ω |
+| R2 | **The 6 acceptance gates** in `klaus_quench_protocol_spec_2026_05_26.md` | **DONE — §9.4.** 5 of 6 pass on criteria fixed before launch. G6 (N=5×10⁴, P_exc rises) **fails**, for a reason R1 explains. G3 passes at 2.47 %, refuting the sheet's "4-digit match" by two orders of magnitude |
+
+The `0.3 @ 1.3 nT` and `[0.5, 0.6] @ 5.2 nT` rows were **not** re-derived: they
+are the same prescription at other fields, and §9.3 says the whole family is
+parameterised by the wrong variable. They should be re-posed as a trap-frequency
+scan at each field, not re-fitted in Ω.
 
 ### 6.2 Do NOT re-derive — with the reason, so nobody re-opens it
 
@@ -464,6 +472,140 @@ a different measurement.
   factor-2.2 and the +16.5 % vs −0.45 % split are far outside any plausible
   seed scatter, but the *values* are not converged results and are not quotable
   as such.
+
+### 6.4 Status — both discharged 2026-08-19
+
+The corpus was retargeted (52 production arms to m=+F at B_z>0, 2 mirror arms to
+m=−F at B_z<0, all declaring `# anti-aligned-seed:`) and R1/R2 then ran. Results
+in §9. **R1 did not return a refined 0.468; it returned a different number and a
+different mechanism.**
+
+---
+
+## 9. R1 / R2 — measured at the anti-aligned preparation
+
+All CPU, 32³ unless stated, one seed, `lhy: none`. Observable is peak
+P_{m_init∓1, m_init∓2} over the streamed trajectory, **relative to the prepared
+state**. Configs are the committed ones, unmodified.
+
+### 9.1 R1 — the Ω operating window
+
+The 20 `*_holdonly_delay2ms_refine.yaml` cells — the same protocol, grid and
+delay the 0.468 came from, so this is a re-derivation of the same quantity.
+
+| Ω | peak P_adj | Ω | peak P_adj |
+|---:|---:|---:|---:|
+| −1.00 | 0.44063 | −0.42 | 0.58978 |
+| −0.90 | 0.50132 | −0.38 | 0.58018 |
+| −0.80 | 0.61730 | −0.34 | 0.56998 |
+| **−0.70** | **0.65905** | −0.30 | 0.55964 |
+| −0.66 | 0.65258 | −0.20 | 0.53616 |
+| −0.62 | 0.64131 | −0.10 | 0.52902 |
+| −0.58 | 0.63022 | **0.00** | **0.52748** |
+| −0.54 | 0.62053 | +0.10 | 0.52940 |
+| −0.50 | 0.61088 | +0.30 | 0.56027 |
+| −0.46 | 0.59943 | +0.50 | 0.61164 |
+
+Against the criteria fixed **before** launch:
+
+| | criterion | measured | |
+|---|---|---|---|
+| C1 | interior maximum required | max at Ω = −0.70, falling to 0.441 at −1.00 | **PASS** |
+| C2 | enhancement over Ω=0 > 5 % | 0.65905 / 0.52748 = **+24.9 %** | **PASS** |
+| C3 | ≥5-pt parabolic fit, negative curvature, vertex inside window | \|Ω\| ∈ [0.58, 0.80], c₂ = −2.70, vertex 0.682, fit rms 4.7e−3 | **PASS** |
+| C4 | digits limited by the fit | δ ≈ 0.042 ⇒ two digits, not three | **applied** |
+
+> **|Ω*| / ω_⊥ = 0.68 ± 0.04 at B = 2.6 nT.**
+> This **replaces** `0.468 ± 0.003`. The old value is not recovered, and its
+> third significant figure is not supportable at one seed.
+
+### 9.2 The response is EVEN in Ω — the stated mechanism is not what acts
+
+| \|Ω\| | P_adj(+Ω) | P_adj(−Ω) | rel diff |
+|---:|---:|---:|---:|
+| 0.10 | 0.52940 | 0.52902 | **0.071 %** |
+| 0.30 | 0.56027 | 0.55964 | **0.113 %** |
+| 0.50 | 0.61164 | 0.61088 | **0.124 %** |
+
+The sheet's mechanism is **odd** in Ω — "matched chirality (Ω·sign(m_init) < 0)
+lowers the mode energy", ΔE = −Ω·ℓ. An effect that is even in Ω to 0.12 % cannot
+come from that term. Ω = 0 is the *minimum*; **both** senses of rotation enhance,
+equally.
+
+### 9.3 The decisive control: it is CENTRIFUGAL, not Coriolis
+
+The rotating frame also carries −½Ω²ρ², which is even in Ω and weakens the radial
+trap to ω_eff = √(ω_⊥² − Ω²). Test: replace rotation in the hold with a **static
+trap already weakened to that ω_eff**, Ω = 0, everything else identical
+(`potential` is a dynamics-step field, so this is clean).
+
+| \|Ω\| | rotating | static ω_eff | rel diff | ω_eff |
+|---:|---:|---:|---:|---:|
+| 0.70 | 0.65905 | **0.65864** | **0.06 %** | 0.7141 |
+| 0.50 | 0.61088 | **0.61205** | **0.19 %** | 0.8660 |
+
+peak P_exc agrees too (0.72168 / 0.72073 and 0.75743 / 0.75829).
+
+**A static, non-rotating trap reproduces the entire "rotation-assisted"
+enhancement to 0.06–0.19 %.** The control carries its own positive control: had
+the per-step `potential:` override been silently ignored, these arms would have
+returned the Ω = 0 value 0.527, not 0.659.
+
+**Consequences, and they are large:**
+
+1. **Chirality is irrelevant to this observable.** "Rotate against the stretched-
+   spin direction" is not a prescription — either sense works, identically.
+2. **Rotation is not required at all.** The operative variable is the effective
+   radial trap frequency. The optimum |Ω*| = 0.68 corresponds to
+   **ω_⊥,eff ≈ 0.73 ω_⊥**, i.e. simply weaken the radial trap by ~27 %. That is a
+   far easier laboratory prescription than mechanically rotating an anisotropic
+   trap, and it removes the whole "sign-convention mapping from simulation Ω to
+   lab rotation direction" caveat.
+3. **The upper bound has a physical origin**: the cascade collapses as
+   |Ω| → ω_⊥ = 1 (peak P_exc 0.76 → 0.49), which is where the effective radial
+   trap vanishes. The window is bounded by the centrifugal limit, not by a
+   resonance.
+
+*Marked as hypothesis, not measured here:* the microscopic reason a softer radial
+trap helps (larger cloud, lower kinetic cost for the ℓ ≠ 0 orbital modes the spin
+flip must populate). The **variable** is established; the mechanism behind the
+variable is not.
+
+### 9.4 R2 — the acceptance gates
+
+Criteria fixed before launch and **not** inherited from the sheet.
+
+| gate | criterion | measured | verdict |
+|---|---|---|---|
+| G1 DDI off → 0 | < 0.005 | **0.00000** | PASS |
+| G2 no B quench → 0 | < 0.005 | **0.00016** | PASS |
+| G3 32³ ↔ 64³ | \|rel\| < 5 % | **+2.47 %** (0.61698 → 0.63223) | PASS |
+| G4 mirror symmetry | \|rel\| < 1e−3 | 0.61698 vs 0.61698, **< 1e−5** | PASS |
+| G5 dt/2 reproducibility | \|rel\| < 1 % | **0.029 %** | PASS |
+| G6 N = 5×10⁴, P_exc rises | sign | 0.81531 vs 0.81613, **−0.10 %** | **FAIL** |
+
+**G4** is the repaired pair from §5, now with both members anti-aligned; it
+agrees to five decimals, which is a stronger result than the sheet's "3-digit".
+
+**G6 fails as posed, and the reason is in R1.** Ω does not create excitation, it
+*concentrates* it: peak P_exc is flat to |Ω| ≈ 0.6 while P_adj rises 24 %. At
+N = 5×10⁴ the cascade is already saturated (P_exc = 0.816), so there is no room
+for the +30 % the sheet claims. On the adjacent-pair observable the enhancement is
+there: P_adj **+6.4 %** (0.36119 vs 0.33956). The sheet's own row carried
+"(with metric caveat)"; the caveat was load-bearing.
+
+**G3 passes the criterion but refutes the sheet's stated precision.** The sheet
+claims a "4-digit match" between 32³ and 64³. Measured: **+2.47 %** on peak
+P_adj (0.61698 → 0.63223) and +2.05 % on peak P_exc — a **2-digit** agreement,
+two orders of magnitude looser than advertised. That is fine for a converged
+result and is why the criterion here was set at 5 %, but "4-digit" was never a
+credible resolution claim for a nonlinear cascade and should not be repeated.
+The residual is one-signed (64³ higher on both observables), i.e. 32³ slightly
+under-resolves the cascade rather than scattering about it.
+
+**Cost note for whoever runs this next:** the 64³ arm took 3026 s against ~590 s
+at 32³ on the same core — 5.1×, not the 8× the cell count suggests, because the
+FFT work does not scale linearly and the run is partly memory-bound (3.0 GB RSS).
 
 <!-- REDERIVE -->
 

--- a/docs/manuscript/klaus_protocol_sheet.md
+++ b/docs/manuscript/klaus_protocol_sheet.md
@@ -29,8 +29,34 @@
 > **2026-05-26's gates and 2026-05-26's field convention**. It is left as
 > written because it is what the record said; it is not a claim about today.
 >
-> **One of those gates is now known to be un-re-runnable as written** (2026-08-19,
-> #343). The "(init m × Ω sign) reversal symmetry — 3-digit match" row in the
+> ## RE-DERIVED 2026-08-19 — three of this sheet's central claims do not survive
+>
+> The corpus was retargeted to the ANTI-ALIGNED preparation (the EdH cascade only
+> runs from the Zeeman-HIGHEST stretched state) and the Ω scan re-run. Full
+> record and criteria: `docs/campaign/edh_quench_polarisation_decision.md` §9.
+>
+> 1. **`|Ω|/ω_⊥ = 0.468 ± 0.003` → `|Ω*|/ω_⊥ = 0.68 ± 0.04`.** The optimum moves
+>    and the third significant figure is not supportable at one seed. The
+>    "Three-regime Ω operating window" table below, and every 0.5 / 0.3 / 0.7
+>    recommendation in it, is superseded.
+> 2. **Chirality does not matter.** The response is **even in Ω** to ≤ 0.124 %
+>    (±0.1, ±0.3, ±0.5 all agree), and Ω = 0 is the *minimum*. So step 5's
+>    "chirality opposite to the initial spin polarisation", the Mechanism
+>    one-liner's `Ω·sign(m_init) < 0`, and the falsification row "rotation
+>    chirality may be wrong — try the opposite trap rotation" are all wrong: both
+>    senses enhance identically.
+> 3. **You do not need to rotate the trap at all.** A *static* radial trap
+>    weakened to ω_eff = √(ω_⊥² − Ω²) reproduces the entire enhancement to
+>    **0.06–0.19 %**. The effect is CENTRIFUGAL, not Coriolis. The lab
+>    prescription becomes **weaken the radial trap to ≈ 0.73 ω_⊥** — no rotating
+>    anisotropic trap, and the "sign-convention mapping from simulation Ω to lab
+>    rotation direction" caveat disappears with it.
+>
+> The upper bound also has a physical origin rather than a resonance: the cascade
+> collapses as |Ω| → ω_⊥, where the effective radial trap vanishes.
+>
+> **One of the 6 acceptance gates is now known to be un-re-runnable as written**
+> (2026-08-19, #343). The "(init m × Ω sign) reversal symmetry — 3-digit match" row in the
 > validation chain below compared `klaus_quench_omm0p5_keeprot` against
 > `klaus_quench_omp0p5_keeprot_mFplus`. At the time those two flipped all three
 > axial quantities — m, Ω **and B_z** — so they were a genuine mirror pair.

--- a/runs/eu151_klaus_phi_phys/config.yaml
+++ b/runs/eu151_klaus_phi_phys/config.yaml
@@ -16,6 +16,12 @@
 #  fields that the mixin would otherwise drop into them.
 # ─────────────────────────────────────────────────────────────────────
 
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. `H = -p·F_z` with p > 0 puts m=+F lowest, so the anti-aligned seed here
+#   is m=-F, i.e. init_m_idx = 13. Measured 2026-08-19 (#343): rotation contrast
+#   +16.5 % anti-aligned against -0.45 % aligned.
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
+
 defaults: {kind: rotating_basis, backend: gpu}
 
 mixins:
@@ -34,10 +40,15 @@ pipeline:
   # LHY scalar.
   - ground_state:
       use: [eu151_klaus_phys]
-      B: {p: 26700.0}                             # Klaus-regime Bz for Eu
+      B: {p: 26700.0}                             # fast-Larmor-regime Bz for Eu
       ddi: {enabled: true}
       lhy: {kind: scalar}
-      init_m_idx: 1
+      # c=1 is m=+F and c=13 is m=-F. `H = -p·F_z`, so p > 0 puts m=+F at the
+      # BOTTOM of the ladder — the schema default here is `p_z > 0 ? 1 : D`
+      # (run_step_rotating/ground_state.jl), so `init_m_idx: 1` was never a
+      # choice, it was the default, and it prepared the Zeeman GROUND state.
+      # 1 -> 13 on 2026-08-19: the EdH cascade only runs from the HIGHEST state.
+      init_m_idx: 13
       init_sigma: 1.5
       dt: 0.005
       n_steps: 1500

--- a/runs/klaus_quench/klaus_quench_om0p0.yaml
+++ b/runs/klaus_quench/klaus_quench_om0p0.yaml
@@ -13,6 +13,12 @@
 #   → rotation_prep (10.0 ms, B=0.01 G, Ω=0.0, DDI=true)
 #   → B_quench (1.0 ms, B ramp true, Ω=0.0, DDI=true)
 #   → weak_field_hold (10.0 ms, B=2.6e-5 G, Ω=0.0, DDI=true)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -32,7 +38,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_om0p0_N50k.yaml
+++ b/runs/klaus_quench/klaus_quench_om0p0_N50k.yaml
@@ -10,6 +10,12 @@
 #   B_rot / B_final       : 0.01 G  /  2.6000000000000002e-5 G  (2.6 nT magnitude)
 #   dt scale              : 1.0
 #   N_atoms               : 50000
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -29,7 +35,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_om0p0_dt2.yaml
+++ b/runs/klaus_quench/klaus_quench_om0p0_dt2.yaml
@@ -10,6 +10,12 @@
 #   B_rot / B_final       : 0.01 G  /  2.6000000000000002e-5 G  (2.6 nT magnitude)
 #   dt scale              : 0.5
 #   N_atoms               : 10000
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -29,7 +35,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_om0p0_n64.yaml
+++ b/runs/klaus_quench/klaus_quench_om0p0_n64.yaml
@@ -8,6 +8,12 @@
 #   DDI in dynamics       : true
 #   B quench applied      : true
 #   rotation kept in hold : false
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -27,7 +33,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p1_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p1_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p2_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p2_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p3.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p3.yaml
@@ -13,6 +13,12 @@
 #   → rotation_prep (10.0 ms, B=0.01 G, Ω=-0.3, DDI=true)
 #   → B_quench (1.0 ms, B ramp true, Ω=0.0, DDI=true)
 #   → weak_field_hold (10.0 ms, B=2.6e-5 G, Ω=0.0, DDI=true)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -32,7 +38,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p34_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p34_holdonly_delay2ms_refine.yaml
@@ -1,8 +1,14 @@
 # Klaus Ω refinement around the parabolic-interpolation vertex (Ω*≈0.42).
 # Source: scripts/validation/klaus_omega_refine_gen.jl
 #   Ω/ω_⊥ = -0.34
-#   B_hold = 2.6 nT, matched chirality (m=-F, Ω<0), hold-only,
+#   B_hold = 2.6 nT, matched chirality (m=+F, Ω<0), hold-only,
 #   rotation-start delay = 2 ms (the protocol-optimal delay).
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p38_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p38_holdonly_delay2ms_refine.yaml
@@ -1,8 +1,14 @@
 # Klaus Ω refinement around the parabolic-interpolation vertex (Ω*≈0.42).
 # Source: scripts/validation/klaus_omega_refine_gen.jl
 #   Ω/ω_⊥ = -0.38
-#   B_hold = 2.6 nT, matched chirality (m=-F, Ω<0), hold-only,
+#   B_hold = 2.6 nT, matched chirality (m=+F, Ω<0), hold-only,
 #   rotation-start delay = 2 ms (the protocol-optimal delay).
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p3_DDIoff.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p3_DDIoff.yaml
@@ -13,6 +13,12 @@
 #   → rotation_prep (10.0 ms, B=0.01 G, Ω=-0.3, DDI=false)
 #   → B_quench (1.0 ms, B ramp true, Ω=0.0, DDI=false)
 #   → weak_field_hold (10.0 ms, B=2.6e-5 G, Ω=0.0, DDI=false)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -32,7 +38,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p3_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p3_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p3_keeprot.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p3_keeprot.yaml
@@ -8,6 +8,12 @@
 #   DDI in dynamics       : true
 #   B quench applied      : true
 #   rotation kept in hold : true
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -27,7 +33,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p3_keeprot_Bf1p3.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p3_keeprot_Bf1p3.yaml
@@ -2,7 +2,13 @@
 # Source: scripts/validation/klaus_quench_batch4_gen.jl
 #   Ω/ω_⊥ = -0.3
 #   B_final = -1.3000000000000001e-5 G (1.3 nT)
-#   keep_rot, m=-F init, DDI on.
+#   keep_rot, m=+F init (anti-aligned), DDI on.
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p3_keeprot_Bf5p2.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p3_keeprot_Bf5p2.yaml
@@ -2,7 +2,13 @@
 # Source: scripts/validation/klaus_quench_batch4_gen.jl
 #   Ω/ω_⊥ = -0.3
 #   B_final = -5.2000000000000004e-5 G (5.2 nT)
-#   keep_rot, m=-F init, DDI on.
+#   keep_rot, m=+F init (anti-aligned), DDI on.
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p42_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p42_holdonly_delay2ms_refine.yaml
@@ -1,8 +1,14 @@
 # Klaus Ω refinement around the parabolic-interpolation vertex (Ω*≈0.42).
 # Source: scripts/validation/klaus_omega_refine_gen.jl
 #   Ω/ω_⊥ = -0.42
-#   B_hold = 2.6 nT, matched chirality (m=-F, Ω<0), hold-only,
+#   B_hold = 2.6 nT, matched chirality (m=+F, Ω<0), hold-only,
 #   rotation-start delay = 2 ms (the protocol-optimal delay).
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p46_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p46_holdonly_delay2ms_refine.yaml
@@ -1,8 +1,14 @@
 # Klaus Ω refinement around the parabolic-interpolation vertex (Ω*≈0.42).
 # Source: scripts/validation/klaus_omega_refine_gen.jl
 #   Ω/ω_⊥ = -0.46
-#   B_hold = 2.6 nT, matched chirality (m=-F, Ω<0), hold-only,
+#   B_hold = 2.6 nT, matched chirality (m=+F, Ω<0), hold-only,
 #   rotation-start delay = 2 ms (the protocol-optimal delay).
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5.yaml
@@ -13,6 +13,12 @@
 #   → rotation_prep (10.0 ms, B=0.01 G, Ω=-0.5, DDI=true)
 #   → B_quench (1.0 ms, B ramp true, Ω=0.0, DDI=true)
 #   → weak_field_hold (10.0 ms, B=2.6e-5 G, Ω=0.0, DDI=true)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -32,7 +38,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p54_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p54_holdonly_delay2ms_refine.yaml
@@ -1,8 +1,14 @@
 # Klaus Ω refinement around the parabolic-interpolation vertex (Ω*≈0.42).
 # Source: scripts/validation/klaus_omega_refine_gen.jl
 #   Ω/ω_⊥ = -0.54
-#   B_hold = 2.6 nT, matched chirality (m=-F, Ω<0), hold-only,
+#   B_hold = 2.6 nT, matched chirality (m=+F, Ω<0), hold-only,
 #   rotation-start delay = 2 ms (the protocol-optimal delay).
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p58_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p58_holdonly_delay2ms_refine.yaml
@@ -1,8 +1,14 @@
 # Klaus Ω refinement around the parabolic-interpolation vertex (Ω*≈0.42).
 # Source: scripts/validation/klaus_omega_refine_gen.jl
 #   Ω/ω_⊥ = -0.58
-#   B_hold = 2.6 nT, matched chirality (m=-F, Ω<0), hold-only,
+#   B_hold = 2.6 nT, matched chirality (m=+F, Ω<0), hold-only,
 #   rotation-start delay = 2 ms (the protocol-optimal delay).
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_DDIoff.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_DDIoff.yaml
@@ -13,6 +13,12 @@
 #   → rotation_prep (10.0 ms, B=0.01 G, Ω=-0.5, DDI=false)
 #   → B_quench (1.0 ms, B ramp true, Ω=0.0, DDI=false)
 #   → weak_field_hold (10.0 ms, B=2.6e-5 G, Ω=0.0, DDI=false)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -32,7 +38,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_holdonly.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_holdonly.yaml
@@ -10,6 +10,12 @@
 #   B_rot / B_final       : 0.01 G  /  2.6000000000000002e-5 G  (2.6 nT magnitude)
 #   dt scale              : 1.0
 #   N_atoms               : 10000
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -29,7 +35,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_holdonly_delay1ms.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_holdonly_delay1ms.yaml
@@ -1,8 +1,14 @@
 # Klaus 2-phase quench — rotation start-delay test (batch 4 C).
 # Source: scripts/validation/klaus_quench_batch4_gen.jl
-#   matched chirality (m=-F init, Ω=-0.5)
+#   matched chirality (m=+F init, Ω=-0.5)
 #   weak-field hold starts with NO rotation for first 1.0 ms,
 #   then Ω = -0.5 for remaining 9.0 ms.
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_holdonly_delay2ms.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_holdonly_delay2ms.yaml
@@ -1,8 +1,14 @@
 # Klaus 2-phase quench — rotation start-delay test (batch 4 C).
 # Source: scripts/validation/klaus_quench_batch4_gen.jl
-#   matched chirality (m=-F init, Ω=-0.5)
+#   matched chirality (m=+F init, Ω=-0.5)
 #   weak-field hold starts with NO rotation for first 2.0 ms,
 #   then Ω = -0.5 for remaining 8.0 ms.
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_holdonly_delay2ms_refine.yaml
@@ -1,8 +1,14 @@
 # Klaus Ω refinement around the parabolic-interpolation vertex (Ω*≈0.42).
 # Source: scripts/validation/klaus_omega_refine_gen.jl
 #   Ω/ω_⊥ = -0.5
-#   B_hold = 2.6 nT, matched chirality (m=-F, Ω<0), hold-only,
+#   B_hold = 2.6 nT, matched chirality (m=+F, Ω<0), hold-only,
 #   rotation-start delay = 2 ms (the protocol-optimal delay).
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_holdonly_delay5ms.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_holdonly_delay5ms.yaml
@@ -1,8 +1,14 @@
 # Klaus 2-phase quench — rotation start-delay test (batch 4 C).
 # Source: scripts/validation/klaus_quench_batch4_gen.jl
-#   matched chirality (m=-F init, Ω=-0.5)
+#   matched chirality (m=+F init, Ω=-0.5)
 #   weak-field hold starts with NO rotation for first 5.0 ms,
 #   then Ω = -0.5 for remaining 5.0 ms.
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_keeprot.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_keeprot.yaml
@@ -8,7 +8,7 @@
 #   B quench applied      : true
 #   rotation kept in hold : true
 #
-# mirror-pair: klaus_quench_omp0p5_keeprot_mFplus.yaml
+# mirror-pair: klaus_quench_omp0p5_keeprot_mirror.yaml
 #   (the chirality mirror flips Omega, m AND B_z — see that file's header)
 #
 # Pipeline:
@@ -16,6 +16,12 @@
 #   → rotation_prep (10.0 ms, B=0.01 G, Ω=-0.5, DDI=true)
 #   → B_quench (1.0 ms, B ramp true, Ω=-0.5, DDI=true)
 #   → weak_field_hold (10.0 ms, B=2.6e-5 G, Ω=-0.5, DDI=true)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -35,7 +41,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_keeprot_Bf10.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_keeprot_Bf10.yaml
@@ -10,6 +10,12 @@
 #   B_rot / B_final       : 0.01 G  /  0.0001 G  (10.0 nT magnitude)
 #   dt scale              : 1.0
 #   N_atoms               : 10000
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -29,7 +35,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_keeprot_Bf1p3.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_keeprot_Bf1p3.yaml
@@ -10,6 +10,12 @@
 #   B_rot / B_final       : 0.01 G  /  1.3000000000000001e-5 G  (1.3 nT magnitude)
 #   dt scale              : 1.0
 #   N_atoms               : 10000
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -29,7 +35,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_keeprot_Bf5p2.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_keeprot_Bf5p2.yaml
@@ -10,6 +10,12 @@
 #   B_rot / B_final       : 0.01 G  /  5.2000000000000004e-5 G  (5.2 nT magnitude)
 #   dt scale              : 1.0
 #   N_atoms               : 10000
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -29,7 +35,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_keeprot_DDIoff.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_keeprot_DDIoff.yaml
@@ -8,6 +8,12 @@
 #   DDI in dynamics       : false
 #   B quench applied      : true
 #   rotation kept in hold : true
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -27,7 +33,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_keeprot_N50k.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_keeprot_N50k.yaml
@@ -10,6 +10,12 @@
 #   B_rot / B_final       : 0.01 G  /  2.6000000000000002e-5 G  (2.6 nT magnitude)
 #   dt scale              : 1.0
 #   N_atoms               : 50000
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -29,7 +35,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_keeprot_dt2.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_keeprot_dt2.yaml
@@ -10,6 +10,12 @@
 #   B_rot / B_final       : 0.01 G  /  2.6000000000000002e-5 G  (2.6 nT magnitude)
 #   dt scale              : 0.5
 #   N_atoms               : 10000
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -29,7 +35,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_keeprot_mirror.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_keeprot_mirror.yaml
@@ -1,9 +1,9 @@
 # Klaus 2-phase quench protocol (batch 3 killer controls) — auto-generated.
 # Source: scripts/validation/klaus_quench_batch3_gen.jl
 #
-# Cell : klaus_quench_omp0p5_keeprot_mFplus
-#   initial state         : m_plus_F    (m_sign = +F)
-#   Ω/ω_⊥ scan magnitude  : 0.5
+# Cell : klaus_quench_omm0p5_keeprot_mirror
+#   initial state         : m_minus_F   (m_sign = -F)
+#   Ω/ω_⊥ scan magnitude  : -0.5
 #   Ω applied in          : prep=true  quench=true  hold=true
 #   DDI in dynamics       : true
 #   B quench applied      : true
@@ -11,14 +11,33 @@
 #   dt scale              : 1.0
 #   N_atoms               : 10000
 #
-# mirror-pair: klaus_quench_omm0p5_keeprot.yaml
+# mirror-pair: klaus_quench_omp0p5_keeprot.yaml
 #
-# B_z is NEGATIVE here and positive in the partner, deliberately: the
-# chirality-reversing mirror flips every AXIAL quantity — Omega, m, and B_z —
-# and B is axial. See the sibling file
-# klaus_quench_omm0p5_keeprot_mFplus.yaml for the full note on how bce2068f
-# broke this pair while repairing each file correctly (#343, 2026-08-19).
+# B_z is NEGATIVE here and positive in the partner, and that is the point.
+# The chirality-reversing mirror (y -> -y) acts on EVERY axial quantity:
+# L_z -> -L_z (so Omega flips), F -> mirrored (so m flips), and B is axial too
+# (so B_z flips). Flipping only Omega and m gives a pair that is not a mirror.
+#
+# History, because this pair has been broken once already. It was a genuine
+# mirror pair until 2026-07-29, when bce2068f flipped B_z on the 211 configs
+# pinning m=-F and — correctly, given what it could know — left the m=+F ones
+# alone. Each file was then right and the PAIR was broken: both sat at
+# B_z = +0.01 G, so the sheet's "(init m x Omega sign) reversal symmetry"
+# gate was comparing an uphill Zeeman cascade against a downhill one. Repaired
+# 2026-08-19 (#343): the mirror ROLE recovers the intent bce2068f could not, and
+# arm G of that measurement reproduced the partner to five digits.
+#
+# Retargeted the same day: the whole corpus moved to the ANTI-ALIGNED
+# preparation, so this file now carries m=-F (highest at B_z<0) against the
+# partner's m=+F (highest at B_z>0). Both ends of the mirror are anti-aligned,
+# which is the only regime in which the effect being mirrored exists at all.
 # Gated by test/workflow/test_mirror_pairs_flip_every_axial_quantity.jl.
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -38,7 +57,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_plus_F
+      initial_state: m_minus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000
@@ -47,7 +66,7 @@ pipeline:
   - dynamics:   # rotation_prep
       duration: 6.9115
       dt: 0.005
-      rotating_frame_omega: 0.5
+      rotating_frame_omega: -0.5
       B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
       ddi: {enabled: true, secular: false}
       lhy: {kind: none}
@@ -61,7 +80,7 @@ pipeline:
   - dynamics:   # B_quench
       duration: 0.69115
       dt: 0.001
-      rotating_frame_omega: 0.5
+      rotating_frame_omega: -0.5
       B: {Bz: {from: -0.01, to: -2.6000000000000002e-5, duration: 0.6911504}, theta: 0.0, phi: 0.0}
       ddi: {enabled: true, secular: false}
       lhy: {kind: none}
@@ -73,7 +92,7 @@ pipeline:
   - dynamics:   # weak_field_hold
       duration: 6.9115
       dt: 0.005
-      rotating_frame_omega: 0.5
+      rotating_frame_omega: -0.5
       B: {Bz: "-2.6000000000000002e-5 Gauss", theta: 0.0, phi: 0.0}
       ddi: {enabled: true, secular: false}
       lhy: {kind: none}

--- a/runs/klaus_quench/klaus_quench_omm0p5_keeprot_n64.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_keeprot_n64.yaml
@@ -8,6 +8,12 @@
 #   DDI in dynamics       : true
 #   B quench applied      : true
 #   rotation kept in hold : true
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -27,7 +33,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p5_noBquench.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p5_noBquench.yaml
@@ -13,6 +13,12 @@
 #   → rotation_prep (10.0 ms, B=0.01 G, Ω=-0.5, DDI=true)
 #   → B_quench (1.0 ms, B ramp false, Ω=0.0, DDI=true)
 #   → weak_field_hold (10.0 ms, B=0.01 G, Ω=0.0, DDI=true)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -32,7 +38,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p62_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p62_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p66_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p66_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p7.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p7.yaml
@@ -13,6 +13,12 @@
 #   → rotation_prep (10.0 ms, B=0.01 G, Ω=-0.7, DDI=true)
 #   → B_quench (1.0 ms, B ramp true, Ω=0.0, DDI=true)
 #   → weak_field_hold (10.0 ms, B=2.6e-5 G, Ω=0.0, DDI=true)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -32,7 +38,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p7_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p7_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p7_keeprot.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p7_keeprot.yaml
@@ -8,6 +8,12 @@
 #   DDI in dynamics       : true
 #   B quench applied      : true
 #   rotation kept in hold : true
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -27,7 +33,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p7_keeprot_Bf1p3.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p7_keeprot_Bf1p3.yaml
@@ -2,7 +2,13 @@
 # Source: scripts/validation/klaus_quench_batch4_gen.jl
 #   Ω/ω_⊥ = -0.7
 #   B_final = -1.3000000000000001e-5 G (1.3 nT)
-#   keep_rot, m=-F init, DDI on.
+#   keep_rot, m=+F init (anti-aligned), DDI on.
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p7_keeprot_Bf5p2.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p7_keeprot_Bf5p2.yaml
@@ -2,7 +2,13 @@
 # Source: scripts/validation/klaus_quench_batch4_gen.jl
 #   Ω/ω_⊥ = -0.7
 #   B_final = -5.2000000000000004e-5 G (5.2 nT)
-#   keep_rot, m=-F init, DDI on.
+#   keep_rot, m=+F init (anti-aligned), DDI on.
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p8_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p8_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm0p9_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm0p9_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omm1p0_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omm1p0_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omp0p0_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omp0p0_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omp0p1_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omp0p1_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omp0p3.yaml
+++ b/runs/klaus_quench/klaus_quench_omp0p3.yaml
@@ -13,6 +13,12 @@
 #   → rotation_prep (10.0 ms, B=0.01 G, Ω=0.3, DDI=true)
 #   → B_quench (1.0 ms, B ramp true, Ω=0.0, DDI=true)
 #   → weak_field_hold (10.0 ms, B=2.6e-5 G, Ω=0.0, DDI=true)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -32,7 +38,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omp0p3_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omp0p3_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omp0p3_keeprot.yaml
+++ b/runs/klaus_quench/klaus_quench_omp0p3_keeprot.yaml
@@ -8,6 +8,12 @@
 #   DDI in dynamics       : true
 #   B quench applied      : true
 #   rotation kept in hold : true
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -27,7 +33,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omp0p5.yaml
+++ b/runs/klaus_quench/klaus_quench_omp0p5.yaml
@@ -13,6 +13,12 @@
 #   → rotation_prep (10.0 ms, B=0.01 G, Ω=0.5, DDI=true)
 #   → B_quench (1.0 ms, B ramp true, Ω=0.0, DDI=true)
 #   → weak_field_hold (10.0 ms, B=2.6e-5 G, Ω=0.0, DDI=true)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -32,7 +38,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omp0p5_holdonly_delay2ms_refine.yaml
+++ b/runs/klaus_quench/klaus_quench_omp0p5_holdonly_delay2ms_refine.yaml
@@ -1,5 +1,11 @@
-# Klaus dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=-F).
+# Dense Ω scan @ canonical protocol (hold_only, delay=2ms, B=2.6 nT, m=+F).
 # Source: scripts/validation/klaus_omega_dense_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -19,7 +25,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omp0p5_keeprot.yaml
+++ b/runs/klaus_quench/klaus_quench_omp0p5_keeprot.yaml
@@ -9,8 +9,14 @@
 #   B quench applied      : true
 #   rotation kept in hold : true
 #
-# mirror-pair: klaus_quench_omm0p5_keeprot_mFplus.yaml
+# mirror-pair: klaus_quench_omm0p5_keeprot_mirror.yaml
 #   (the chirality mirror flips Omega, m AND B_z — see that file's header)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -30,7 +36,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench/klaus_quench_omp0p5_keeprot_mirror.yaml
+++ b/runs/klaus_quench/klaus_quench_omp0p5_keeprot_mirror.yaml
@@ -1,9 +1,9 @@
 # Klaus 2-phase quench protocol (batch 3 killer controls) — auto-generated.
 # Source: scripts/validation/klaus_quench_batch3_gen.jl
 #
-# Cell : klaus_quench_omm0p5_keeprot_mFplus
-#   initial state         : m_plus_F    (m_sign = +F)
-#   Ω/ω_⊥ scan magnitude  : -0.5
+# Cell : klaus_quench_omp0p5_keeprot_mirror
+#   initial state         : m_minus_F   (m_sign = -F)
+#   Ω/ω_⊥ scan magnitude  : 0.5
 #   Ω applied in          : prep=true  quench=true  hold=true
 #   DDI in dynamics       : true
 #   B quench applied      : true
@@ -11,23 +11,20 @@
 #   dt scale              : 1.0
 #   N_atoms               : 10000
 #
-# mirror-pair: klaus_quench_omp0p5_keeprot.yaml
+# mirror-pair: klaus_quench_omm0p5_keeprot.yaml
 #
-# B_z is NEGATIVE here and positive in the partner, and that is the point.
-# The chirality-reversing mirror (y -> -y) acts on EVERY axial quantity:
-# L_z -> -L_z (so Omega flips), F -> mirrored (so m flips), and B is axial too
-# (so B_z flips). Flipping only Omega and m gives a pair that is not a mirror.
-#
-# This file and its partner were a genuine mirror pair until 2026-07-29, when
-# bce2068f flipped B_z on the 211 configs that pinned m=-F and — correctly, given
-# what it could know — left the m=+F ones alone. Each file was then right and the
-# PAIR was broken: both sat at B_z = +0.01 G, so the sheet's
-# "(init m x Omega sign) reversal symmetry, 3-digit match" gate was comparing an
-# uphill Zeeman cascade against a downhill one. Repaired 2026-08-19 (#343) by
-# flipping the field, which is the determinate repair HERE — bce2068f's stated
-# blocker was that "flip the field" and "flip the seed" are both consistent and
-# the intent is unrecoverable from the file, and the mirror role recovers it.
+# B_z is NEGATIVE here and positive in the partner, deliberately: the
+# chirality-reversing mirror flips every AXIAL quantity — Omega, m, and B_z —
+# and B is axial. See the sibling file
+# klaus_quench_omm0p5_keeprot_mirror.yaml for the full note on how bce2068f
+# broke this pair while repairing each file correctly (#343, 2026-08-19).
 # Gated by test/workflow/test_mirror_pairs_flip_every_axial_quantity.jl.
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -47,7 +44,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_plus_F
+      initial_state: m_minus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000
@@ -56,7 +53,7 @@ pipeline:
   - dynamics:   # rotation_prep
       duration: 6.9115
       dt: 0.005
-      rotating_frame_omega: -0.5
+      rotating_frame_omega: 0.5
       B: {Bz: "-0.01 Gauss", theta: 0.0, phi: 0.0}
       ddi: {enabled: true, secular: false}
       lhy: {kind: none}
@@ -70,7 +67,7 @@ pipeline:
   - dynamics:   # B_quench
       duration: 0.69115
       dt: 0.001
-      rotating_frame_omega: -0.5
+      rotating_frame_omega: 0.5
       B: {Bz: {from: -0.01, to: -2.6000000000000002e-5, duration: 0.6911504}, theta: 0.0, phi: 0.0}
       ddi: {enabled: true, secular: false}
       lhy: {kind: none}
@@ -82,7 +79,7 @@ pipeline:
   - dynamics:   # weak_field_hold
       duration: 6.9115
       dt: 0.005
-      rotating_frame_omega: -0.5
+      rotating_frame_omega: 0.5
       B: {Bz: "-2.6000000000000002e-5 Gauss", theta: 0.0, phi: 0.0}
       ddi: {enabled: true, secular: false}
       lhy: {kind: none}

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -30,6 +30,10 @@ const FAST_TESTS = [
     # reachable, and every commit cited in campaign/manuscript prose is either a
     # listed correction or an explicitly-reasoned non-correction (#343).
     "test_campaign_fix_list_gate.jl",
+    # A retracted number may not appear without its replacement IN THE SAME FILE.
+    # `0.468` survived weeks in an experimentalist sheet that carried its own
+    # retraction at the top — documents are read by section, not from the top.
+    "test_retracted_numbers_carry_their_replacement.jl",
     # A declared mirror pair must flip EVERY axial quantity (Omega, m AND B_z).
     # bce2068f repaired two configs correctly one at a time and broke the mirror
     # relationship between them; nothing recorded that they were a pair (#343).

--- a/test/model/test_prose_does_not_move_identity.jl
+++ b/test/model/test_prose_does_not_move_identity.jl
@@ -144,8 +144,25 @@ using SpinorBEC: Model, Stage, artifact_id, content_id, GridSpec, InteractionSpe
                 "runs/config_texture_stir_movie_f5bf647e.pre_masscurrent/config.yaml",
                 "runs/config_texture_stir_movie_f5bf647e.pre_strict/config.yaml",
             ])
+
+            # RENAMED is not DELETED, and filing one as the other would be a lie
+            # that costs the archive its point. These two moved when the corpus
+            # was retargeted to the anti-aligned preparation: after it they hold
+            # m=-F, so `_mFplus` had become a false name. The recorded PROSE is
+            # deliberately left as harvested — rewriting a record to match a
+            # later rename defeats what the record is for — and only the pointer
+            # is tracked here. The new path must EXIST, so this cannot become a
+            # dumping ground for genuine drift.
+            const_renamed = Dict(
+                "runs/klaus_quench/klaus_quench_omm0p5_keeprot_mFplus.yaml" => "runs/klaus_quench/klaus_quench_omm0p5_keeprot_mirror.yaml",
+                "runs/klaus_quench/klaus_quench_omp0p5_keeprot_mFplus.yaml" => "runs/klaus_quench/klaus_quench_omp0p5_keeprot_mirror.yaml",
+            )
+            for (old, new) in const_renamed
+                @test isfile(joinpath(root, new))
+            end
+
             missing_paths = [p for p in recorded if !isfile(joinpath(root, p))]
-            @test Set(missing_paths) ⊆ const_deleted
+            @test Set(missing_paths) ⊆ union(const_deleted, keys(const_renamed))
 
             # POSITIVE CONTROL: the scan can actually see a `metadata:` block,
             # or `isempty(still)` above is satisfied by a broken reader.

--- a/test/test_retracted_numbers_carry_their_replacement.jl
+++ b/test/test_retracted_numbers_carry_their_replacement.jl
@@ -1,0 +1,106 @@
+# A retracted number may not appear in a document without its replacement.
+#
+# WHY THIS EXISTS
+#
+# `|Omega|/omega_perp = 0.468 +- 0.003` sat in `klaus_protocol_sheet.md` — an
+# experimentalist-facing sheet, quoted to three significant figures — for weeks
+# after the corpus it came from had been shown to be in the wrong regime, and it
+# was re-derived (2026-08-19) to `0.68 +- 0.04` with a different MECHANISM: the
+# response is even in Omega, so the chirality rule the sheet built around it is
+# void, and a static weakened trap reproduces the whole effect.
+#
+# The failure mode is not that the retraction was missing. It was written, at the
+# top of the file. The failure mode is that the number appears again 200 lines
+# later in a table, and a reader who lands there by search or by scrolling to
+# "what Omega should I use" never sees it. Documents are read by section, not
+# from the top.
+#
+# So: wherever a retracted value appears, its replacement must appear in the SAME
+# file. That is cheap, it is mechanical, and it does not require anyone to
+# remember the retraction — the gate remembers.
+#
+# This is deliberately a REGISTRY and not a one-off. Adding a row is the act of
+# retracting a number, and it costs one line.
+
+using SpinorBEC
+using Test
+
+include(joinpath(@__DIR__, "helpers", "calibrated_scan.jl"))
+
+const _REPO = normpath(joinpath(@__DIR__, ".."))
+
+"""
+    Retraction(pattern, replacement, why)
+
+`pattern` — how the retracted value is written (a Regex, because "0.468" and
+"0.468 ± 0.003" and "0.468±0.003" are the same claim).
+`replacement` — a Regex that must ALSO match somewhere in the same file.
+`why` — printed on failure, so the person who trips it does not have to go
+digging for what changed.
+"""
+struct Retraction
+    pattern::Regex
+    replacement::Regex
+    why::String
+end
+
+const RETRACTIONS = [
+    Retraction(
+        r"0\.468",
+        r"0\.68",
+        "|Omega*|/omega_perp = 0.468 ± 0.003 was re-derived 2026-08-19 to " *
+        "0.68 ± 0.04 at the anti-aligned preparation, AND the mechanism changed: " *
+        "the response is even in Omega (so chirality is irrelevant) and a static " *
+        "weakened trap reproduces it (so rotation is not required). " *
+        "Authority: docs/campaign/edh_quench_polarisation_decision.md §9.",
+    ),
+]
+
+"""Every `.md` under `docs/`, excluding the dated audit dumps."""
+function _docs()
+    out = String[]
+    root = joinpath(_REPO, "docs")
+    for (dir, dirs, files) in walkdir(root)
+        filter!(d -> !(d in (".git", "node_modules", "worktrees")), dirs)
+        occursin(joinpath("docs", "audit"), dir) && continue
+        for f in files
+            endswith(f, ".md") && push!(out, relpath(joinpath(dir, f), _REPO))
+        end
+    end
+    sort(out)
+end
+
+@testset "a retracted number never appears without its replacement" begin
+    docs = _docs()
+    @test !isempty(docs)
+
+    mktempdir() do d
+        for r in RETRACTIONS
+            # Real probe FILES, because the predicate reads its argument. A
+            # bare sentinel string would throw on `read`, and the throw would
+            # look like a broken gate rather than a miswired control.
+            bad = joinpath(d, "carries_retracted_only.md")
+            good = joinpath(d, "carries_both.md")
+            write(bad, "the value is 0.468 ± 0.003\n")
+            write(good, "0.468 ± 0.003 was superseded by 0.68 ± 0.04\n")
+
+            offend(f) =
+                let body = read(isabspath(f) ? f : joinpath(_REPO, f), String)
+                    occursin(r.pattern, body) && !occursin(r.replacement, body)
+                end
+
+            # Must SEE a file carrying only the retracted value, and must REJECT
+            # one that also carries the replacement — otherwise "no offenders"
+            # is the same string as "the pattern matches nothing".
+            offenders = calibrated_scan(
+                docs; match=offend, present=bad, absent=good,
+                describe=f -> isabspath(f) ? basename(f) : f,
+            )
+            isempty(offenders) || println(
+                "  quotes a retracted number with no " *
+                "replacement in the same file:\n    ",
+                join(offenders, "\n    "), "\n  → ", r.why)
+            @test offenders == String[]
+        end
+    end
+end

--- a/test/workflow/test_config_zeeman_seed_agreement.jl
+++ b/test/workflow/test_config_zeeman_seed_agreement.jl
@@ -249,14 +249,16 @@ end
             @test haskey(gs, "atom")                        # came from the mixin
             atom = _atom_of(gs)
             @test atom !== nothing
-            # …and the config is self-consistent: p > 0 puts m=+F at the BOTTOM
-            # of the ladder, and it seeds m=+F. #343 §2 read this as "the only Eu
-            # arc on the opposite side"; it is not — comparing m labels across two
-            # field parameterisations is what made it look that way. It is ALIGNED
-            # like everything else, and (docs/campaign/edh_quench_polarisation_decision.md
-            # §4.2) that is the wrong side for the EdH quench.
-            @test _m_lowest(gs, atom) === :plus_F
-            @test _seed_of(gs, atom) === :plus_F
+            # `H = -p·F_z` with p > 0 puts m=+F at the BOTTOM of the ladder, so
+            # the ANTI-ALIGNED seed here is m=-F — `init_m_idx: 13`, retargeted
+            # 2026-08-19 from the schema default of 1. #343 §2 read this config
+            # as "the only Eu arc on the opposite side"; it was not — comparing m
+            # labels across two field parameterisations is what made it look that
+            # way — and it was on the wrong side for a different reason.
+            @test _m_lowest(gs, atom) === :plus_F     # p > 0 ⇒ m=+F is lowest
+            @test _seed_of(gs, atom) === :minus_F     # …so m=-F is the highest
+            # Deliberate, and it must SAY so, or the gate is right to flag it.
+            @test occursin(_ANTIALIGNED, read(p, String))
         end
     end
 


### PR DESCRIPTION
#369（#343）の後続。決定文書 §6.3 が挙げた依存順 **config → R1 → R2** を全部走らせた結果です。

判定・全データ: **`docs/campaign/edh_quench_polarisation_decision.md` §9**（LIVE）

---

## 結論を先に

**`|Ω|/ω_⊥ = 0.468 ± 0.003` → `|Ω*|/ω_⊥ = 0.68 ± 0.04`。**
だがこれは数字の話ではありません。**機構が違いました。**

> **増強は遠心力であって Coriolis ではない。カイラリティは無関係。そもそも回転は要らない。**
> 径方向トラップを **≈0.73 ω_⊥** に弱めるだけでよい。

---

## 1. Corpus を反平行準備へ（52 + 2 本）

#343 で「EdH カスケードは Zeeman **最高**状態からしか走らない」と測ったのに、corpus は平行側 = 自分の効果が存在しない領域にいました。

- 生産 52 本: `m_minus_F @ Bz>0` → **`m_plus_F @ Bz>0`**
- ミラー 2 本: `m_plus_F @ Bz<0` → **`m_minus_F @ Bz<0`**、`_mFplus` → **`_mirror`** に改名（m=−F を持つので旧名は嘘になる）

**Bz は一切触っていません** — `bce2068f` の規律（生産は正の Bz）を保ち、ミラーの負 Bz は「軸性量を全部反転する」という #343 §5 の規則そのものだからです。全54本が `# anti-aligned-seed:` を宣言。

`runs/eu151_klaus_phi_phys/` は綴りが違うだけで同じ移動: `B: {p: 26700}` かつ `H = −p·F_z` なので p>0 は m=+F を**最低**にする ⇒ 反平行種は `init_m_idx: 13`。旧値 1 は選択ですらなく**スキーマ既定**（`p_z > 0 ? 1 : D`）でした。

## 2. R1 — Ω 動作窓（20点、事前固定基準）

| | 基準 | 実測 | |
|---|---|---|---|
| C1 | 内部極大が必要 | Ω=−0.70 で極大、−1.00 で 0.441 まで低下 | PASS |
| C2 | Ω=0 比 >5 % | **+24.9 %**（0.65905 / 0.52748） | PASS |
| C3 | 5点放物線適合・負曲率・頂点が窓内 | c₂=−2.70、頂点 0.682、rms 4.7e−3 | PASS |
| C4 | 桁は適合が決める | δ≈0.042 ⇒ **2桁**、3桁ではない | 適用 |

## 3. 機構が違った（本題）

**応答が Ω に対して偶**:

| \|Ω\| | P(+Ω) | P(−Ω) | 差 |
|---|---|---|---|
| 0.10 | 0.52940 | 0.52902 | 0.071 % |
| 0.30 | 0.56027 | 0.55964 | 0.113 % |
| 0.50 | 0.61164 | 0.61088 | 0.124 % |

sheet の機構 `ΔE = −Ω·ℓ`（matched chirality）は Ω に**奇**。Ω=0 が**最小**で両向きが等しく増強する ⇒ **それは働いていない**。

**決定的対照**（`potential` が dynamics ステップのフィールドなので clean に組める）— hold の回転を、同じ `ω_eff = √(ω_⊥²−Ω²)` に**静的に弱めたトラップ**（Ω=0）で置換:

| \|Ω\| | 回転あり | 静的 ω_eff | 差 |
|---|---|---|---|
| 0.70 | 0.65905 | **0.65864** | **0.06 %** |
| 0.50 | 0.61088 | **0.61205** | **0.19 %** |

peak P_exc も一致（0.72168/0.72073、0.75743/0.75829）。

**陽性対照内蔵**: ステップ単位の `potential:` が無視されていたら Ω=0 の値 0.527 が返るはず。実測 0.659 なので上書きは効いています。

上限も物理的で、|Ω| → ω_⊥ で有効トラップが消えカスケードが崩壊（peak P_exc 0.76 → 0.49）。共鳴ではありません。

*仮説として明示* — 柔らかい径方向トラップがなぜ効くか（雲が大きくなり ℓ≠0 軌道モードの運動エネルギー代償が下がる）は**測っていません**。効く**変数**は確定、その背後は未確定。

## 4. R2 — 受け入れゲート 6/6 実行

| gate | 基準 | 実測 | |
|---|---|---|---|
| G1 DDI off | < 0.005 | 0.00000 | PASS |
| G2 no B quench | < 0.005 | 0.00016 | PASS |
| G3 32³↔64³ | < 5 % | **+2.47 %** | PASS |
| G4 mirror | < 1e−3 | **< 1e−5** | PASS |
| G5 dt/2 | < 1 % | 0.029 % | PASS |
| G6 N=5e4 で P_exc 上昇 | 符号 | **−0.10 %** | **FAIL** |

- **G6 FAIL の理由は R1 が説明**: Ω は励起を増やさず**集中**させる（peak P_exc は |Ω|≲0.6 で平坦、P_adj は 24 % 上昇）。N=5×10⁴ では既に飽和（0.816）で +30 % の余地がない。隣接対では **+6.4 %**。sheet 自身の "(with metric caveat)" が効いていました。
- **G3 は基準を通るが sheet の精度主張を否定**: 「4桁一致」に対し実測 **2.47 %** = 2桁。残差は片側（64³ が両観測量で高い）なので、32³ がわずかに解像不足。
- G4 は #369 で修復したミラー対（今回は両端とも反平行）で、**5桁一致**。

## 5. 逆戻り防止

`test/test_retracted_numbers_carry_their_replacement.jl`（fast tier）— **撤回した数値は、同じファイル内に置換値が無ければ書けない**。

撤回が無かったのではなく、**冒頭には書いてあった**のが #343 の実態です。200行下の表に同じ数字が再登場し、検索で飛んできた読者はそれを見ません。文書は節単位で読まれます。

初回実行で本物を1件検出: `docs/archive/klaus_quench_protocol_pivot_2026-05-26.md` が `0.468` を4回（自分の vintage 警告の中を含む）、置換値なしで引用。archive も**意図的に対象**です — FROZEN ヘッダは、途中から読む人がちょうど飛ばすものだから。

## 6. 実験手順への含意

experimentalist sheet に **RE-DERIVED ブロック**を追加し、生き残らない3点を名指ししました:

1. `0.468 ± 0.003` と「三領域 Ω 動作窓」表
2. step 5「初期スピン偏極と逆向きのカイラリティで」— 両向き同じ
3. 「回転支援」そのもの — 回転は不要

3 は**ラボの手順を実際に簡単にします**（回転する異方トラップが要らず、「シミュレーションの Ω → ラボの回転方向」の符号対応という注意書きごと消える）。

---

**Type**: §1 は A、R1/R2/対照は **B**（1シード・32³・`lhy: none` の物理一致。**C ではない**）。産出コミット `e8dafe8e`〜`3f7bcfe5`、CPU（`rotating_frame_omega + spinor + GPU` は #343 で CUDA 999）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
