### PR TITLE
feat(model): audit a Claim's control structurally — the half of "it must fail" that needs no run

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -208,7 +208,7 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 265 files
+- `FAST_TESTS` — 266 files
 - `CI_EXTRA` — 136 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files
@@ -275,7 +275,7 @@ as complete.
 | subtree | files cited | of |
 |---|---|---|
 | `src/hamiltonian/` | 13 | 63 |
-| `src/model/` | 3 | 15 |
+| `src/model/` | 3 | 16 |
 | `src/validation/` | 1 | 10 |
 | `src/manuscript/` | 1 | 17 |
 | `src/solvers/` | 2 | 46 |

--- a/src/model.jl
+++ b/src/model.jl
@@ -60,6 +60,7 @@ include("model/stage.jl")             # Stage: one computation over one Model
 include("model/identity.jl")          # code_tree_hash + artifact_id
 include("model/ref.jl")               # ref: the published number, re-measured
 include("model/claim.jl")             # Claim: the A/B/C taxonomy, enforced
+include("model/claim_audit.jl")       # ...and the half of "the control must fail" that needs no run
 include("model/complete.jl")          # the completion marker + the one admission decision
 # Separate from complete.jl on purpose: admission is a question about bytes on a
 # filesystem, this is a question about physics at a state. Merging them would

--- a/src/model/claim_audit.jl
+++ b/src/model/claim_audit.jl
@@ -1,0 +1,180 @@
+# --- Does the claim's CONTROL switch anything off? ---
+#
+# `Claim`'s constructor enforces that a `:B`/`:C` claim DECLARED a control, and
+# says so in its own comment: "The constructor cannot check that the control
+# actually fails; only running it can. It can insist one was declared." That
+# leaves a gap the constructor named and could not close, and this file closes
+# the half of it that does not need a run.
+#
+# The half that does: a control which differs from the evidence only in its
+# NUMERICS is not a control. `Claim`'s docstring already states the rule — "the
+# control is the physics switched off, not a tolerance loosened: a control that
+# differs from the evidence only in its numerics tests the plumbing, and a
+# bit-identical A/B has been read as physics in this repository before" — and
+# nothing read it. That failure is on the record twice, as
+# `mistake_bit_identical_ab_read_as_physics_2026_07_29` and as
+# `mistake_null_from_a_degenerate_knob_2026_07_31`, and in both cases the
+# declaration in front of the author already contained the evidence: the two
+# arms differed in a field that cannot move the observable.
+#
+# The half that does NOT: whether the control's number actually comes out wrong.
+# That needs both arms run and an observable, and `Claim` carries no predicate,
+# so `verify_claim` deliberately does not pretend to it. `checked_by_running =
+# false` is in the audit for exactly the reason `VerdictAudit.checked` is in that
+# one — "the instrument read zero" and "the instrument was not switched on" are
+# different results and a struct that conflates them is worse than no struct.
+#
+# WHY THE NUMERICS SET IS A LIST AND NOT A RULE. The obvious rule — "the physics
+# is in `Model`, the numerics are in `Stage`" — is wrong in this tree, and the
+# counterexample is the claim that motivated the layer. Klaus 2022's control is
+# the stir tilt taken to zero, and `evolve_stage` puts the stir protocol in
+# `Stage.params` because `Model` is spinor-shaped and the scalar eGPE path
+# cannot produce one. A gate built on that rule would have reddened on the one
+# well-formed control in the repository, and a gate that fires on correct work
+# gets switched off. So the discrimination is a NAMED LIST of param keys that
+# are unambiguously numerics, it is deliberately short, and being absent from it
+# is not an accusation — an unrecognised key counts as physics-bearing, i.e. the
+# list can only ever cause a PASS, never a failure. Adding a key to it is
+# therefore a decision to stop the gate seeing that key, and belongs in a diff
+# where a reviewer sees it.
+
+export ClaimAudit, verify_claim
+
+"""
+    ClaimAudit
+
+What could be established about a `Claim` WITHOUT running it.
+
+`ok` is a statement about the claim's *structure*, never about its result:
+`checked_by_running` is always `false` and is present so that no caller can read
+a structural pass as an experimental one. A claim can be perfectly well formed
+and still be false.
+
+`problems` is empty iff `ok`. `differences` maps each evidence stage's index to
+the dotted paths on which the control differs from it, so a failure names the
+fields rather than asserting a verdict.
+"""
+struct ClaimAudit
+    ok::Bool
+    checked_by_running::Bool
+    problems::Vector{String}
+    differences::Dict{Int, Vector{String}}
+end
+
+# Stage params that are unambiguously numerics. See the header: absence from
+# this list is not an accusation, so the list stays short and errs toward
+# omission — every key NOT here is treated as physics-bearing, which can only
+# make the gate quieter, never louder.
+const _NUMERICS_ONLY_PARAMS = Set{Symbol}([
+    :dt, :n_steps, :n_save, :save_every, :tol, :max_iters, :max_iterations,
+    :checkpoint_every, :verbose, :dtype, :seed,
+])
+
+_diff_paths(prefix::String, a, b) =
+    _speceq(a, b) ? String[] : [prefix]
+
+function _nt_diff_paths(prefix::String, a::NamedTuple, b::NamedTuple)
+    out = String[]
+    for k in union(keys(a), keys(b))
+        av = get(a, k, nothing)
+        bv = get(b, k, nothing)
+        _speceq(av, bv) || push!(out, "$prefix.$k")
+    end
+    sort!(out)
+    out
+end
+
+function _model_diff_paths(a::Model, b::Model)
+    out = String[]
+    for i in 1:fieldcount(Model)
+        _speceq(getfield(a, i), getfield(b, i)) ||
+            push!(out, "model.$(fieldname(Model, i))")
+    end
+    out
+end
+
+"""
+    stage_differences(a::Stage, b::Stage) -> Vector{String}
+
+The dotted paths on which two stages differ — `model.<field>`, `params.<key>`,
+`kind`, `method`, `backend`, `from`.
+
+`from` is compared as a whole rather than recursed: a control that branches from
+a different predecessor differs, and *which* ancestor field moved is a question
+about that ancestor's own claim.
+"""
+function stage_differences(a::Stage, b::Stage)
+    out = String[]
+    append!(out, _diff_paths("kind", a.kind, b.kind))
+    append!(out, _model_diff_paths(a.model, b.model))
+    append!(out, _diff_paths("method", a.method, b.method))
+    append!(out, _diff_paths("from", a.from, b.from))
+    append!(out, _nt_diff_paths("params", a.params, b.params))
+    append!(out, _diff_paths("backend", a.backend, b.backend))
+    out
+end
+
+# A path is physics-bearing unless it is one of the two numerics-only stage
+# fields or a param on the named list. `from` counts as physics-bearing: a
+# control seeded from a different state is a different experiment, and calling
+# that "numerics" would admit the case where the whole control IS the reseed.
+function _is_numerics_only(path::AbstractString)
+    path in ("method", "backend") && return true
+    startswith(path, "params.") || return false
+    Symbol(path[8:end]) in _NUMERICS_ONLY_PARAMS
+end
+
+"""
+    verify_claim(c::Claim) -> ClaimAudit
+
+Check what can be checked about a claim without running it.
+
+Three refusals, each one a failure this repository has actually shipped:
+
+1. **no evidence at all.** `Claim`'s constructor admits `evidence = Stage[]` on
+   purpose — its comment says the hole is "pinned as behaviour ... rather than
+   silently closed here, so that closing it is a decision someone makes with the
+   gap in front of them". This is that decision, made *here* rather than in the
+   constructor, so building a claim to hold a plan still works and only
+   *auditing* one insists the computation exists.
+2. **the control IS an evidence stage.** Nothing is switched off.
+3. **the control differs from an evidence stage only in numerics.** The
+   plumbing-vs-physics failure named in `Claim`'s own docstring.
+
+Returns rather than throws: an audit that throws on the first problem reports
+one of three, and the useful output is the whole list.
+
+`ok = true` says the claim is WELL FORMED. It does not say the claim is true —
+`checked_by_running` is `false` in every audit this function returns, because
+`Claim` carries no predicate and no observable to apply one to.
+
+```julia
+a = verify_claim(c)
+a.ok || foreach(println, a.problems)
+```
+"""
+function verify_claim(c::Claim)
+    problems = String[]
+    differences = Dict{Int, Vector{String}}()
+
+    isempty(c.evidence) && push!(problems,
+        "a :$(c.kind) claim with no evidence: `evidence` is empty, so nothing " *
+        "was computed for \"$(c.statement)\"")
+
+    if c.control !== nothing
+        for (i, e) in enumerate(c.evidence)
+            d = stage_differences(c.control, e)
+            differences[i] = d
+            if isempty(d)
+                push!(problems,
+                    "control is identical to evidence[$i]: nothing is switched off")
+            elseif all(_is_numerics_only, d)
+                push!(problems,
+                    "control differs from evidence[$i] only in numerics " *
+                    "($(join(d, ", "))): that tests the plumbing, not the physics")
+            end
+        end
+    end
+
+    ClaimAudit(isempty(problems), false, problems, differences)
+end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -173,6 +173,7 @@ const FAST_TESTS = [
     # not grow. `src/model.jl` said "still to come" with no number and no
     # consequence for months; this is the number (CLAUDE.md commitment 11).
     "model/test_model_adoption_ratchet.jl",
+    "model/test_claim_audit.jl",
     # `make_workspace(::Model)` must build the SAME workspace as the resolver
     # path. Without this the realisation layer would be a THIRD statement of the
     # physics rather than the inverse of the second one — and it caught two sign

--- a/test/model/test_claim_audit.jl
+++ b/test/model/test_claim_audit.jl
@@ -1,0 +1,173 @@
+# `verify_claim`: does the declared control switch anything off?
+#
+# `Claim`'s constructor insists a `:B`/`:C` claim DECLARED a control and says in
+# its own comment that it cannot check the control actually fails. This file
+# gates the half of that which needs no run — and, more importantly, gates the
+# ways the check itself could be WRONG:
+#
+#   - too loose: a control differing only in `backend` / `method` / `dt` / `seed`
+#     must be caught, because that is the bit-identical-A/B failure verbatim;
+#   - too TIGHT: a control differing in an unrecognised `params` key must PASS.
+#     That is not hypothetical politeness — it is the Klaus 2022 stir-tilt
+#     control, the one well-formed control in the tree, which lives in
+#     `Stage.params` because `Model` is spinor-shaped and the scalar eGPE path
+#     cannot produce one. A gate that reddened on it would be switched off.
+#
+# and the one thing the audit must never claim: `checked_by_running` is `false`
+# in every audit, so a structural pass can never be read as an experimental one.
+
+using Test
+using SpinorBEC
+using SpinorBEC: Claim, claim, ClaimAudit, verify_claim, stage_differences,
+    Stage, stage, Model, GridSpec, InteractionSpec, DDISpec, ATOM_REGISTRY, ref
+
+_m(; c1=-0.1, c_dd=1.0) = Model(;
+    grid=GridSpec(; ndim=3, n_points=(8, 8, 8), box=(6.0, 6.0, 6.0)),
+    atom=ATOM_REGISTRY[:Eu151],
+    interactions=InteractionSpec(; n_atoms=1000, omega_ref=691.15, c0=10.0, c1=c1),
+    ddi=DDISpec(; c_dd=c_dd))
+
+_st(m=_m(); method=:strang, backend=:cpu, params...) =
+    stage(:evolve; model=m, method=method, backend=backend, params...)
+
+@testset "verify_claim (structural: does the control switch anything off?)" begin
+    @testset "stage_differences names the paths, in both directions" begin
+        a = _st(; dt=0.001, theta=0.6)
+        @test isempty(stage_differences(a, a))
+        @test stage_differences(a, _st(; dt=0.002, theta=0.6)) == ["params.dt"]
+        @test stage_differences(a, _st(; dt=0.001, theta=0.0)) == ["params.theta"]
+        @test stage_differences(a, _st(; dt=0.001, theta=0.6, backend=:gpu)) ==
+            ["backend"]
+        @test stage_differences(a, _st(; dt=0.001, theta=0.6, method=:rk4ip)) ==
+            ["method"]
+        # a param present on one side only is a difference, not a silent match
+        @test stage_differences(a, _st(; dt=0.001)) == ["params.theta"]
+        # the model arm reports the FIELD, so a reader sees which physics moved
+        @test stage_differences(a, _st(_m(; c_dd=0.0); dt=0.001, theta=0.6)) ==
+            ["model.ddi"]
+    end
+
+    @testset "a well-formed control passes" begin
+        ev = _st(; dt=0.001, theta=0.6)
+        ct = _st(_m(; c_dd=0.0); dt=0.001, theta=0.6)   # DDI switched off
+        a = verify_claim(
+            claim("dipolar stripes need the DDI";
+                kind=:B, evidence=Stage[ev], control=ct),
+        )
+        @test a.ok
+        @test isempty(a.problems)
+        @test a.differences[1] == ["model.ddi"]
+    end
+
+    @testset "TOO TIGHT is the failure that matters: an unlisted param passes" begin
+        # The Klaus 2022 control. `theta` is not on `_NUMERICS_ONLY_PARAMS` and
+        # must therefore count as physics-bearing — unrecognised means physics,
+        # so the list can only ever quieten the gate, never redden it.
+        ev = _st(; dt=0.001, theta=0.6)
+        ct = _st(; dt=0.001, theta=0.0)
+        a = verify_claim(
+            claim("the stripe axis follows B"; kind=:B,
+                evidence=Stage[ev], control=ct),
+        )
+        @test a.ok
+        @test a.differences[1] == ["params.theta"]
+    end
+
+    @testset "numerics-only controls are refused" begin
+        ev = _st(; dt=0.001, theta=0.6)
+        for (label, ct) in [
+            ("backend", _st(; dt=0.001, theta=0.6, backend=:gpu)),
+            ("method", _st(; dt=0.001, theta=0.6, method=:rk4ip)),
+            ("dt", _st(; dt=0.002, theta=0.6)),
+            ("seed", _st(; dt=0.001, theta=0.6, seed=7)),
+            ("several at once", _st(; dt=0.002, theta=0.6, backend=:gpu)),
+        ]
+            a = verify_claim(claim("x"; kind=:B, evidence=Stage[ev], control=ct))
+            @test !a.ok
+            @test any(p -> occursin("only in numerics", p), a.problems)
+            @test !isempty(a.differences[1])   # it DID differ — just not in physics
+        end
+        # `seed` alone is the sharpest of these: a different realization is not a
+        # control, and it is the one a reader is most likely to defend.
+        a = verify_claim(
+            claim("x"; kind=:B, evidence=Stage[ev],
+                control=_st(; dt=0.001, theta=0.6, seed=7)),
+        )
+        @test occursin("params.seed", only(a.problems))
+    end
+
+    @testset "an identical control is refused, and says why" begin
+        ev = _st(; dt=0.001, theta=0.6)
+        a = verify_claim(claim("x"; kind=:B, evidence=Stage[ev], control=ev))
+        @test !a.ok
+        @test occursin("nothing is switched off", only(a.problems))
+        @test isempty(a.differences[1])
+    end
+
+    @testset "empty evidence is refused HERE, not in the constructor" begin
+        ct = _st(_m(; c_dd=0.0))
+        c = claim("nothing has been computed yet"; kind=:B,
+            evidence=Stage[], control=ct)   # constructs on purpose
+        @test c isa Claim
+        a = verify_claim(c)
+        @test !a.ok
+        @test occursin("no evidence", only(a.problems))
+    end
+
+    @testset "every evidence stage is audited, not just the first" begin
+        good = _st(_m(; c_dd=0.0); dt=0.001)
+        ev = Stage[_st(; dt=0.001), _st(_m(; c_dd=0.0); dt=0.002)]
+        a = verify_claim(claim("x"; kind=:B, evidence=ev, control=good))
+        @test !a.ok
+        @test length(a.problems) == 1          # only the second arm is degenerate
+        @test occursin("evidence[2]", only(a.problems))
+        @test a.differences[1] == ["model.ddi"]
+        @test a.differences[2] == ["params.dt"]
+    end
+
+    @testset ":A claims need no control, and are still audited for evidence" begin
+        a = verify_claim(claim("GPU == CPU"; kind=:A, evidence=Stage[_st()]))
+        @test a.ok
+        @test isempty(a.differences)           # no control ⇒ nothing to diff
+        @test !verify_claim(claim("GPU == CPU"; kind=:A, evidence=Stage[])).ok
+    end
+
+    @testset "a structural pass is never an experimental one" begin
+        ev = _st(; dt=0.001, theta=0.6)
+        ct = _st(; dt=0.001, theta=0.0)
+        for c in (claim("x"; kind=:A, evidence=Stage[ev]),
+            claim("y"; kind=:B, evidence=Stage[ev], control=ct),
+            claim("z"; kind=:B, evidence=Stage[], control=ct))
+            a = verify_claim(c)
+            @test a.checked_by_running === false
+            @test a.ok == isempty(a.problems)  # `ok` is derived, not settable
+        end
+    end
+
+    @testset "the two layers compose: Klaus cannot reach an audit at all" begin
+        # The real campaign, and the reason this testset is not a happy path.
+        # Every row in `refs/klaus2022.toml` is `read_off` — the paper publishes
+        # no re-measurable data record — so `arbitrates` is `false` for all of
+        # them and the CONSTRUCTOR refuses a `:C` claim before `verify_claim`
+        # ever sees one. Ω_c agreeing to 1.5 % is a real result and still not a
+        # deciding comparison, and the tree is built so that saying otherwise
+        # requires editing a fixture rather than writing a sentence.
+        t = ref(:klaus2022, :omega_c_over_omega_perp)
+        @test t.provenance === :read_off
+        @test !t.arbitrates
+        ev = _st(; dt=0.001, theta=0.6)
+        ct = _st(; dt=0.001, theta=0.0)
+        @test_throws ArgumentError claim("Omega_c reproduces Klaus et al. 2022";
+            kind=:C, evidence=Stage[ev], control=ct, target=t)
+
+        # The same evidence and control as a `:B` claim — physics agreement,
+        # no published number arbitrating — is well formed, and that is the
+        # honest kind for this campaign.
+        a = verify_claim(
+            claim("the stripe axis follows B and Omega_c is finite";
+                kind=:B, evidence=Stage[ev], control=ct),
+        )
+        @test a.ok
+        @test a.checked_by_running === false   # the 1.5 % is NOT established here
+    end
+end

--- a/test/validation/test_matsui2025_ref.jl
+++ b/test/validation/test_matsui2025_ref.jl
@@ -526,6 +526,15 @@ end
         # The control is also not required to DIFFER from the evidence, so an
         # arm that must fail may be an arm that must pass.
         @test Claim("x", :B, Stage[s], s, nothing).control == s
+
+        # ...and BOTH holes are now caught one layer out, by `verify_claim`.
+        # The division of labour is the point and is why the constructor was
+        # left alone: BUILDING a claim to hold a plan stays legal, AUDITING one
+        # insists the computation exists and that the control switches something
+        # off. Closing either in the constructor would still turn the two
+        # assertions above red, which is what that note asks for.
+        @test !verify_claim(vacuous).ok
+        @test !verify_claim(Claim("x", :B, Stage[s], s, nothing)).ok
     end
 end
 
@@ -603,6 +612,19 @@ end
         @test c.evidence[1].kind === :evolve
         @test c.control.kind === :evolve
         @test c.target.arbitrates
+
+        # The one real `Claim` in the tree, put through the structural audit —
+        # otherwise `verify_claim` is a layer with a test and no subject, which
+        # is the shape CLAUDE.md commitment 11 names as the defect. The control
+        # bites in the MODEL and through the ancestor it was seeded from, and
+        # naming both is the useful part: `evolve_stage` inherits `from.model`,
+        # so switching off the DDI at the ground state propagates.
+        a = verify_claim(c)
+        @test a.ok
+        @test "model.ddi" in a.differences[1]
+        @test "from" in a.differences[1]
+        # …and the audit still refuses to be read as a result.
+        @test a.checked_by_running === false
 
         # The refusals still bite on this exact claim, so `:C` is enforced and
         # not merely spelled: no control, and a target that does not arbitrate.


### PR DESCRIPTION
`Claim` のコンストラクタは「:B/:C の claim には control を**宣言**せよ」を強制しますが、自分のコメントで出来ないことを名指ししています — *"The constructor cannot check that the control actually fails; only running it can."* 実際にはその**両方**を誰もやっていませんでした。

`verify_claim` は**走らせなくても済む方**を閉じます。拒否するのは 3 つの形で、どれもこのリポジトリが実際に出荷した失敗です:

- **`evidence = Stage[]`** — `claim.jl` はこれを意図的に開けてあります（「gap を目の前に置いて誰かが決めるように」）。だから決定は**コンストラクタではなくここ**でしました。計画を保持する claim は今も作れて、**audit するとき**だけ計算の存在を要求します。
- **control が evidence と同一** — 何も切っていない。
- **control が numerics でしか違わない** — この規則は `Claim` の docstring に既に書いてあり（*"a control that differs from the evidence only in its numerics tests the plumbing"*）、**誰も読んでいませんでした**。記録には 2 回あります: `mistake_bit_identical_ab_read_as_physics` と `mistake_null_from_a_degenerate_knob`。

## 判別を「規則」でなく「名前つきリスト」にした理由

自然に見える規則「物理は `Model`、数値は `Stage`」は**このツリーでは偽**で、反例はこの層を作らせた当の claim です。Klaus 2022 の control は stir tilt を 0 にしたもので、`Stage.params` にいます — `Model` が spinor 形なのでスカラー eGPE 経路は `Model` を作れないからです。その規則で組んだゲートは**ツリー唯一のまともな control で赤くなり**、正しい仕事で光るゲートは切られます。

なので**未知のキーは physics-bearing 扱い**。リストは静かにする方向にしか効かず、赤くする方向には効きません。追加は reviewer が見る diff になります。

## しないこと

**走らせません。** `checked_by_running` は返る audit で常に `false` です（`VerdictAudit.checked` と同じ理由 — 「計器がゼロを読んだ」と「計器が入っていなかった」は別の結果）。`ok` は **well formed** の意味で、**真** の意味ではありません。

## テストの向き

一番効くのは**きつすぎる方向**（リストに無い param は PASS しなければならない）。最後の testset は happy path ではありません: `refs/klaus2022.toml` は全行 `read_off` ⇒ `arbitrates` は false ⇒ **コンストラクタが `:C` claim を `verify_claim` に届く前に拒否**します。Ω_c が 1.5 % で合っているのは本物の結果で、それでも**決着をつける比較ではない**。2 層が合成してその答えになるのが設計どおりで、テストがそれを留めています。

53 assertions。`test_matsui2025_ref.jl` (28) と `test_state_doc_is_current.jl` (42) も再確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
