### PR TITLE
docs(state): regenerate — main went red on a file neither PR changed

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -209,10 +209,10 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
 - `FAST_TESTS` — 265 files
-- `CI_EXTRA` — 137 files
+- `CI_EXTRA` — 138 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files
-- `ORACLE_TESTS` — 90 files
+- `ORACLE_TESTS` — 91 files
 - `INTEGRATION_TESTS` — 53 files
 
 ## Validation ladder — instruments present on disk


### PR DESCRIPTION

`main` is red at `test_state_doc_is_current.jl`, off by exactly one entry:
`CI_EXTRA` 137 -> 138 and `ORACLE_TESTS` 90 -> 91. That one is
`test/oracles/test_schema_guards_are_grounded.jl`, added by #388.

Nobody broke it. #388 regenerated STATE.md against the tree it was cut from, and
#391 merged afterwards carrying a STATE.md generated without #388's file. Git
took the later one — no conflict, because only #391 had touched those lines
relative to ITS base. The result is a committed copy that neither PR's tree
implies.

This is structural, not an accident of these two. `docs/STATE.md` is DERIVED and
COMMITTED, so every PR that adds a test regenerates it, and any two such PRs
landing close together produce exactly this: the second one's copy silently wins
and encodes a tree that does not exist. ci.yml's own concurrency comment already
names the general form — "a PR's checks run against the base it was cut from,
not the base it lands on, so the post-merge run on `main` is the only thing that
ever sees the merged tree" — and this is that, with the post-merge run doing its
job and catching it.

Regenerated from the merged tree, which is the only tree whose counts are real.

Assisted-by: Claude Code (model: claude-opus-5[1m])

🤖 Generated with [Claude Code](https://claude.com/claude-code)