### PR TITLE
test(oracles): dynamics schema の全物理キーが workspace に届くことをゲートする

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -208,11 +208,11 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 266 files
-- `CI_EXTRA` — 138 files
+- `FAST_TESTS` — 267 files
+- `CI_EXTRA` — 139 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files
-- `ORACLE_TESTS` — 91 files
+- `ORACLE_TESTS` — 92 files
 - `INTEGRATION_TESTS` — 53 files
 
 ## Validation ladder — instruments present on disk

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -663,6 +663,11 @@ const CI_EXTRA = [
     # dynamics step asking for the secular kernel silently got the full one,
     # which is the PATH-GAP class this campaign found to be the commonest.
     "oracles/test_dynamics_honours_kernel_ddi_knobs.jl",
+    # The BROAD version of the same question: one probe per DYNAMICS_SCHEMA key,
+    # checking only that the knob is not inert. The file above is the DEEP one
+    # for the DDI three. `ddi.secular` was found by reading; this is what finds
+    # the next sibling by running.
+    "oracles/test_dynamics_forwards_every_schema_knob.jl",
     # The same class one layer down: a physics kwarg a SOLVER accepts must reach
     # the workspace it builds. Behavioural (build twice, require a difference),
     # because the source-scan version of this question was a regex
@@ -1325,6 +1330,9 @@ const _COST = Dict{String, Float64}(
     # 384.9 s). Its remaining nine annotations, all from run 32237847445:
     "oracles/test_jz_conservation_ddi.jl" => 204.0,
     "oracles/test_dynamics_honours_kernel_ddi_knobs.jl" => 78.0,
+    # One two-step pipeline run per probe, 16 probes plus the control, at 8³.
+    # Measured 102 s.
+    "oracles/test_dynamics_forwards_every_schema_knob.jl" => 102.0,
     "oracles/test_solver_forwards_every_knob.jl" => 67.0,
     "oracles/test_term_consistency.jl" => 22.0,
     "oracles/test_flux_closure_ddi_identity.jl" => 20.0,

--- a/test/oracles/test_dynamics_forwards_every_schema_knob.jl
+++ b/test/oracles/test_dynamics_forwards_every_schema_knob.jl
@@ -1,0 +1,206 @@
+using Test
+using SpinorBEC
+using SpinorBEC:
+    DYNAMICS_SCHEMA, GroundStateStep, parse_pipeline, _run_step,
+    zeeman_at, zeeman_diagonal
+
+# Every physics-bearing key a `dynamics:` step ACCEPTS must reach the workspace
+# it builds.
+#
+# WHY
+#
+# `ddi.secular` did not. The handler re-resolved `trunc_radius` and `padded` and
+# not `secular` / `quasi_2d` / `l_z`, so a step declaring the secular kernel got
+# the full one — and `runs/eu_ham_only_conservation/eu_ham_only_24_sec.yaml`,
+# whose stated purpose is "Compare against 24_nonsec to isolate the impact of
+# off-diagonal DDI terms", ran both arms on the same kernel. Fixed 2026-08-19.
+#
+# That one was found by reading. This asks the same question of every key at
+# once, so the next sibling is found by running.
+#
+# `test_dynamics_honours_kernel_ddi_knobs.jl` is the DEEP version for the DDI
+# three — it compares Q tensors between two pipeline runs. This is the BROAD
+# version: one probe per schema key, checking only that the knob is not inert.
+# Cheap enough to cover the whole block.
+#
+# MEASURED BEFORE GATED (commitment 12). All 15 probeable keys reach the
+# workspace today. The 16th, `light_shift`, needs a trap fixture the handler
+# does not give it — disclosed below rather than dropped.
+#
+# THE SIGNATURE HAD A BLIND SPOT, and finding it is why this was measured first:
+# a first pass over the workspace's structural fields reported
+# `temperature_ratio` INERT. It is not — it adds a thermal seed to ψ, which no
+# Hamiltonian field carries. Had this been written as a gate straight away, that
+# would have read as a live defect in the handler. ψ is in the signature now.
+
+const _DFS_BASE = Dict{Any, Any}(
+    "pipeline" => [
+        Dict(
+            "ground_state" => Dict{Any, Any}(
+                "atom" => "Eu151",
+                "grid" => Dict("n" => [8, 8, 8], "box" => [6.0, 6.0, 6.0]),
+                "potential" => Dict("type" => "harmonic", "omega" => [1.0, 1.0, 1.0]),
+                "interactions" => Dict("N_atoms" => 1000, "omega_ref" => 600.0,
+                    "c1_ratio" => -0.05),
+                "ddi" => Dict("enabled" => true, "c_dd" => 0.2, "padded" => false),
+                "lhy" => Dict("kind" => "none"),
+                # `q` explicit: Eu can auto-derive it, but pinning it keeps the
+                # fixture independent of the geometry table.
+                "B" => Dict("Bz" => 0.01, "q" => 0.001),
+                "n_steps" => 2, "dt" => 0.002,
+            ),
+        ),
+        Dict(
+            "dynamics" => Dict{Any, Any}(
+                "duration" => 0.004, "dt" => 0.002,
+                "B" => Dict("Bz" => 0.01, "q" => 0.001),
+                "interactions" => Dict("N_atoms" => 1000, "omega_ref" => 600.0,
+                    "c1_ratio" => -0.05),
+                "ddi" => Dict("enabled" => true, "c_dd" => 0.2, "padded" => false),
+            ),
+        ),
+    ],
+)
+
+"""A signature of what the dynamics step BUILT.
+
+Includes ψ, not only the Hamiltonian fields: `temperature_ratio` seeds the state
+rather than an operator, and a structural-fields-only signature read it as inert
+on the first measurement."""
+function _dfs_signature(ws)
+    zd = zeeman_diagonal(zeeman_at(ws.zeeman, 0.0), ws.spin_matrices)
+    (
+        collect(zd),
+        copy(Array(ws.potential_values)),
+        sort(collect(ws.interactions.c)),
+        ws.interactions.c_lhy,
+        ws.ddi === nothing ? nothing :
+        (ws.ddi.C_dd, round.(Array(ws.ddi.Q_xz); digits=12)),
+        ws.ddi_padded === nothing,
+        ws.raman === nothing,
+        ws.loss === nothing,
+        ws.light_shift === nothing,
+        ws.magnetic_gradient === nothing,
+        ws.absorbing_mask === nothing,
+        ws.time_dep_interactions === nothing,
+        ws.lhy === nothing,
+        ws.sim_params.rotating_frame_omega,
+        ws.sim_params.dt,
+        ws.sim_params.n_steps,
+        round.(abs2.(Array(ws.state.psi)); digits=14),
+    )
+end
+
+"Run the two-step pipeline and return the DYNAMICS workspace's signature."
+function _dfs_run(cfg)
+    parsed = parse_pipeline(deepcopy(cfg))
+    psi, g, a, ws_gs, _ = _run_step(parsed.steps[1], nothing, nothing, nothing, nothing;
+        verbose=false)
+    _, _, _, ws, _ = _run_step(parsed.steps[2], psi, g, a, ws_gs; verbose=false)
+    _dfs_signature(ws)
+end
+
+"Set a (possibly nested) key on the dynamics step of a copy."
+function _dfs_with(cfg, path::Vector{String}, val)
+    c = deepcopy(cfg)
+    d = c["pipeline"][2]["dynamics"]
+    for k in path[1:(end - 1)]
+        haskey(d, k) || (d[k] = Dict{Any, Any}())
+        d = d[k]
+    end
+    d[path[end]] = val
+    c
+end
+
+# (label, path, perturbed value). A table of INPUTS: each says "this must make a
+# difference", never which field changes, so it cannot rot into agreeing with a
+# wrong handler.
+const _DFS_PROBES = [
+    ("ddi.secular", ["ddi", "secular"], true),
+    ("ddi.padded", ["ddi", "padded"], true),
+    ("ddi.c_dd", ["ddi", "c_dd"], 0.9),
+    ("ddi.enabled", ["ddi", "enabled"], false),
+    ("B.Bz", ["B", "Bz"], 0.05),
+    ("potential", ["potential"], Dict("type" => "harmonic", "omega" => [2.3, 1.1, 0.7])),
+    ("interactions.c1_ratio", ["interactions", "c1_ratio"], 0.2),
+    ("rotating_frame_omega", ["rotating_frame_omega"], 0.35),
+    ("loss", ["loss"], Dict("gamma_dr" => 0.05)),
+    ("magnetic_gradient", ["magnetic_gradient"],
+        Dict("gradient" => 0.2, "axis" => 1, "g_F" => 1.0)),
+    ("absorbing_boundary", ["absorbing_boundary"],
+        Dict("strength" => 0.5, "width" => 1.0)),
+    ("raman", ["raman"],
+        Dict("Omega_R" => 0.4, "delta" => 0.1, "k_eff" => [0.5, 0.0, 0.0])),
+    ("lhy", ["lhy"], Dict("kind" => "scalar", "c_lhy" => 0.3)),
+    ("temperature_ratio", ["temperature_ratio"], 0.4),
+    ("dt", ["dt"], 0.001),
+]
+
+"Physics keys NOT probed here, with why. Disclosed rather than left to look like
+coverage."
+const _DFS_NOT_PROBED = Dict(
+    "light_shift" => "eta_tensor needs a V_trap the handler passes as `nothing` \
+                      (pipeline_dispatch.jl:168); gated by its own analytic oracle",
+    "quasi_2d/l_z (ddi)" => "refused on a 3-D grid; the 2-D fixture lives in \
+                             test_solver_forwards_every_knob.jl",
+    "pulse_sequence" => "compiles INTO zeeman/raman/time_dep, which are probed",
+    "sgpe / twa / projected_gp / photon_scattering" => "select a different \
+        integrator rather than shaping this workspace",
+    "seed_mode / seed_amplitude / seed_k_cut / noise_seed / wigner_seed" => "shape the seed, gated where the seed is built",
+    "save / live_monitor / integrator / adaptive_dt / duration / hard_polarize \
+     / spin_step" => "runtime and output, not the Hamiltonian",
+    "kind / backend" => "select the solver path and the device — which workspace \
+                         is built, not what is in it",
+    "couplings / epsilon" => "read by the binary and rotating-basis handlers, \
+                              not by this one",
+    # The one this session spent an afternoon on. `B_direction` is provenance
+    # written by `apply_B_block_normalize!`; on the SPINOR path it is not read at
+    # all, and a ground_state step declaring a non-trivial one is now refused
+    # outright (`test_gs_refuses_dropped_physics.jl`). Probing it here would
+    # assert it is live, which is the opposite of true.
+    "B_direction" => "not read on this path; the ground_state half refuses it \
+                      rather than dropping it silently",
+)
+
+@testset "a dynamics step forwards every physics knob it accepts" begin
+    ref = _dfs_run(_DFS_BASE)
+
+    @testset "the signature distinguishes two workspaces" begin
+        # Negative control on the instrument: built twice from the same config it
+        # must compare equal, and against a different field it must not. Without
+        # this every assertion below could pass for the wrong reason.
+        @test _dfs_run(_DFS_BASE) == ref
+        @test _dfs_run(_dfs_with(_DFS_BASE, ["B", "Bz"], 0.07)) != ref
+    end
+
+    for (label, path, val) in _DFS_PROBES
+        @testset "$label reaches the workspace" begin
+            got = _dfs_run(_dfs_with(_DFS_BASE, path, val))
+            got == ref && @info "a dynamics schema key changed NOTHING in the built \
+                                 workspace — it is inert, i.e. not forwarded" key = label
+            @test got != ref
+        end
+    end
+
+    @testset "the un-probed list is a disclosure" begin
+        for (k, why) in _DFS_NOT_PROBED
+            @test !isempty(strip(why))
+        end
+        # The probe table plus the disclosure must together mention every key the
+        # dynamics schema declares, so a NEW schema key is red until classified.
+        declared = Set(keys(DYNAMICS_SCHEMA))
+        mentioned = Set{String}()
+        for (_, path, _) in _DFS_PROBES
+            push!(mentioned, path[1])
+        end
+        for k in keys(_DFS_NOT_PROBED), tok in split(k, r"[ /]+")
+            t = strip(String(tok))
+            isempty(t) || push!(mentioned, t)
+        end
+        missing_keys = sort(collect(setdiff(declared, mentioned)))
+        isempty(missing_keys) ||
+            @info "dynamics schema keys in neither the probe table nor the \
+                   disclosure" keys = missing_keys
+        @test isempty(missing_keys)
+    end
+end


### PR DESCRIPTION
`ddi.secular` が dynamics で落ちていた件（#390 で修正）は**読んで**見つけた。
同じ問いを **DYNAMICS_SCHEMA の全キーに一度に**投げ、次の兄弟は**走らせて**見つかるようにする。

## 測定結果

**15 の probe 可能キーすべてが workspace に到達**。つまり `secular` に兄弟はいなかった。
これは仮定ではなく数値として持つ価値があり、ゲートが保持するのはこの事実。

| | |
|---|---|
| `ddi.secular` / `padded` / `c_dd` / `enabled` | 到達 |
| `B.Bz` / `potential` / `interactions.c1_ratio` | 到達 |
| `rotating_frame_omega` / `loss` / `magnetic_gradient` | 到達 |
| `absorbing_boundary` / `raman` / `lhy` | 到達 |
| `temperature_ratio` / `dt` | 到達 |
| `light_shift` | fixture 都合で probe 不可（開示） |

## 既存ゲートとの関係

`test_dynamics_honours_kernel_ddi_knobs.jl` は DDI 3 キーの**深い**版（Q テンソルを
2回の pipeline 実行で比較）。これは**広い**版 — キーごとに1 probe、inert かどうかだけ見る。

相補的：深い版は16キーにスケールしないし、広い版は「secular が別の**誤った**カーネルに
なる」ケース（inert ではない）を捕まえられない。

## ゲート化の前に測った — また効いた

構造フィールドだけの signature は **`temperature_ratio` を INERT と報告**した。
実際は違う — ψ に熱シードを加えるので、ハミルトニアンのどのフィールドにも出ない。

**そのままゲートとして書いていたら、正しいコードを「実バグ」として直しに行っていた。**
ψ を signature に入れて解消。commitment 12 の順序がまた効いた。

## canary

`secular_ddi=` の転送を再度削ると赤になり、キー名を出す
（"a dynamics schema key changed NOTHING in the built workspace — it is inert"）。

**1回目の canary は EXIT 0 と出た** — `grep -A1` パイプがサマリを飲み込んでいた。
実行は正しく落ちていて、それを読む計器のほうが盲目だった。このキャンペーン中ずっと
同じクラスの失敗。パイプ無しで捕り直した。

## 開示リストは partition で守る

未 probe キーは理由つきで開示し、**probe 表 ∪ 開示リストが `DYNAMICS_SCHEMA` の
全キーを言及すること**を assert。新しい schema キーは分類されるまで赤。

初回実行で6キーが未分類と判明（`B_direction` / `backend` / `couplings` / `epsilon` /
`kind` / `wigner_seed`）— **ゲートが自分の穴を見つけた**。

## やらなかったこと（意図的）

`resolve_gs` に対応する **`resolve_dyn` の抽出はしていない**。

`resolve_gs` が抽出されたのは消費者が**2つ**あったから（runner と `yaml_to_model`）。
dynamics は1つなので、抽出は投機的な一般化になる。

そして抽出が解決するはずだった具体的欠陥 — **LHY の綴りが2つある**問題 — は
**存在しなかった**：`_resolve_lhy_block!` が書く `p["lhy_kind"]` は
`p["lhy"]["kind"]` と同じ文字列。仮定せず確認した。

## 検証

| | 結果 |
|---|---|
| `test_dynamics_forwards_every_schema_knob.jl`（新） | 27/27、canary 済み |
| `docs/STATE.md` | 再生成 |
| JuliaFormatter 2.5.0 | クリーン |

src/ への変更は**ゼロ**（ゲートのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
