### PR TITLE
docs(campaign): 効いている変数を直接掃いた — 窓は径方向で、1.3 nT には無い

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -208,7 +208,7 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 266 files
+- `FAST_TESTS` — 267 files
 - `CI_EXTRA` — 138 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -35,7 +35,10 @@ measurements, not tests).
 | 3b | Does the *rotation enhancement* survive the corrected field sign? | **No.** +15.8 % pre-fix vs **−0.45 %** post-fix, with the Ω knob proved live at both. `\|Ω\|/ω_⊥ = 0.468 ± 0.003` is not re-derivable as posed. §3.4 |
 | 7 | What replaces `\|Ω\|/ω_⊥ = 0.468 ± 0.003`? | **`\|Ω*\|/ω_⊥ = 0.68 ± 0.04`** at the anti-aligned preparation, +24.9 % over Ω=0. Two digits, not three. §9.1 |
 | 8 | Is the enhancement chirality-matched, as the sheet says? | **No.** The response is **even in Ω** to ≤ 0.124 %; Ω=0 is the minimum and both senses enhance equally. §9.2 |
-| 9 | Then what is the mechanism? | **Centrifugal, not Coriolis.** A *static* trap weakened to ω_eff = √(ω_⊥²−Ω²) reproduces the whole effect to **0.06–0.19 %**. **Rotation is not needed** — weaken the radial trap to ≈ 0.73 ω_⊥. §9.3 |
+| 9 | Then what is the mechanism? | **Centrifugal, not Coriolis.** A *static* trap weakened to ω_eff = √(ω_⊥²−Ω²) reproduces the whole effect to **0.06 %** across the range. **Rotation is not needed** — weaken the radial trap to **0.71 ω_⊥**. §9.3, §10.1 |
+| 10 | Is it density, or the radial confinement? | **Radial.** A density-matched weakening along **z** instead lands *below* the baseline (−36 % of the gain). Same ω̄, opposite sign. §10.4 |
+| 11 | Does the prescription hold at the other two fields? | **No, and differently.** 1.3 nT: **no window at all** (+1.8 %, flat) — the old `0.3 @ 1.3 nT` has no replacement. 5.2 nT: enhancement exists but is **unresolved** at 7 points (non-monotonic, dip at 0.650) — no optimum quoted. §10.2 |
+| 12 | How much of §9 is seed noise? | **None.** 5 seeds agree to 5 decimals, and the seed was *proved live* (state overlap 0.9999997, growing to 1.9e−5). The observable is deterministic here; grid/dt remain the real uncertainty (G3: 2.5 %). §10.3 |
 | 4 | Align the rotation-assisted EdH quench series to m=−F? | **No — and stop saying it in `m`.** The measured criterion is *aligned vs anti-aligned with B*. the EdH quench needs the **anti-aligned (Zeeman-highest)** state; under the project's +B_z that is m=+F. §4 |
 | 4b | Is `eu151_klaus_phi_phys` really "the one Eu arc on the other side"? | **No.** `p > 0` puts m=+F at the *bottom*, so it is aligned like everything else — and therefore on the wrong side for the EdH quench. #343 §2's premise was an m-label comparison across two field parameterisations. §4.2 |
 | 5 | Is the stored `(init m × Ω)` "mirror" pair still a mirror? | **No — `bce2068f` broke it.** Repaired here, and the repair is confirmed by measurement to 5 digits (§3.6 arm G). §5 |
@@ -606,6 +609,98 @@ under-resolves the cascade rather than scattering about it.
 **Cost note for whoever runs this next:** the 64³ arm took 3026 s against ~590 s
 at 32³ on the same core — 5.1×, not the 8× the cell count suggests, because the
 FFT work does not scale linearly and the run is partly memory-bound (3.0 GB RSS).
+
+---
+
+## 10. Scanning the variable that actually acts
+
+§9.3 said the operative variable is ω_⊥,eff, not Ω. So scan **that**, with a
+static trap and no rotation at all — which is also the correct re-posing of the
+two rows §6.1 deliberately did not re-derive. 34 arms, CPU, 32³, holdonly + 2 ms
+delay, anti-aligned.
+
+### 10.1 The static scan reproduces the rotating one
+
+At every ω_eff where the two scans sample the same point:
+
+| ω_eff | static trap, Ω = 0 | rotating, from \|Ω\| = √(1−ω_eff²) | rel |
+|---:|---:|---:|---:|
+| 1.000 | 0.52748 | 0.52748 (Ω=0.00) | **0.00 %** |
+| 0.750 | 0.65219 | 0.65258 (Ω=0.66) | **0.06 %** |
+| 0.714 | 0.65864 | 0.65905 (Ω=0.70) | **0.06 %** |
+| 0.600 | 0.61707 | 0.61730 (Ω=0.80) | **0.04 %** |
+
+**Worst 0.06 %.** Rotation is fully substitutable by a static radial trap of the
+same ω_eff, across the range — not just at the two points of §9.3.
+
+Static optimum at 2.6 nT: **ω_eff = 0.714, +24.9 % over ω_eff = 1**, which is the
+same optimum and the same enhancement the Ω scan gave.
+
+### 10.2 The optimum IS field-dependent — and one field has no window at all
+
+| field | best ω_eff | peak P_adj | enhancement | shape |
+|---|---:|---:|---:|---|
+| **1.3 nT** | 0.900 | 0.51386 | **+1.8 %** | flat: 0.505 → 0.514 over ω_eff ∈ [0.65, 1.0] |
+| **2.6 nT** | **0.714** | 0.65864 | **+24.9 %** | clean single peak |
+| **5.2 nT** | 0.550 | 0.51387 | +17.0 % | **non-monotonic**, with a dip at 0.650 |
+
+Three different answers, and only one of them is a number:
+
+- **1.3 nT — there is no operating window.** +1.8 % across a flat range is not an
+  optimum; it is the absence of one. The sheet's `|Ω|/ω_⊥ ≈ 0.3 at B = 1.3 nT`
+  therefore has **no replacement**, and that is the finding. Do not re-fit it.
+- **2.6 nT — ω_⊥,eff / ω_⊥ = 0.71.** This is the prescription.
+- **5.2 nT — unresolved at this sampling.** The best sampled point (0.550,
+  0.51387) is only 2.6 % above ω_eff = 0.800 (0.5007) and there is a dip between
+  them at 0.650. Seven points cannot distinguish one broad optimum from two
+  narrow ones, so **no optimum is quoted**; the sheet's `[0.5, 0.6] at 5.2 nT`
+  is neither confirmed nor replaced. Denser sampling would settle it.
+
+### 10.3 The seed is live, and the observable is deterministic anyway
+
+Five seeds at ω_eff = 1.000 and at 0.714 returned peak P_adj identical to five
+decimals (sd = 0.00000). That is exactly what a dead knob looks like, so it was
+checked rather than reported:
+
+| | overlap between seed 101 and seed 202 | max rel density diff |
+|---|---:|---:|
+| frame 1 (just after the seeded step) | 0.999999702 | 2.3e−7 |
+| frame 39 (end) | 0.999999881 | 1.9e−5 |
+
+**The seed reaches the state**, and its influence *grows* by two orders over the
+run — the cascade does amplify it — but it is still ~1e−5 at the end, far below
+anything that moves peak P_adj. The `noise_seed` knob was also initially wired to
+the wrong step (it is read only by the step carrying `seed_amplitude`), which
+produced the same all-identical table for a different and wrong reason; that was
+found and fixed before these numbers.
+
+**Consequence:** the one-seed values in §9 are not one sample of a distribution.
+On this protocol and duration the observable is deterministic, so the seed axis
+carries no uncertainty to quote. **The grid, dt and box axes still do** — G3
+measured 2.5 % between 32³ and 64³, which dwarfs everything here.
+
+### 10.4 Why a softer *radial* trap: not density
+
+Two candidates for the microscopic reason, and they are separable. Weaken **ω_z**
+instead, chosen to give the *same* mean trap frequency ω̄ = (ω_x ω_y ω_z)^⅓ —
+hence the same Thomas-Fermi density scaling — while leaving ω_⊥ at 1:
+
+| arm | trap | peak P_adj |
+|---|---|---:|
+| baseline | (1.000, 1.000, 1.1818) | 0.52748 |
+| radial | (0.714, 0.714, 1.1818) | **0.65864** |
+| **z-weakened, same ω̄** | (1.000, 1.000, 0.6026) | **0.48073** |
+
+The z-weakened arm does not merely fail to reproduce the gain — it lands
+**below** the baseline, recovering **−36 %** of it. Same mean trap frequency,
+same density scaling, opposite sign of effect.
+
+> **The variable is the radial confinement specifically, not the density.**
+
+That is consistent with the ℓ ≠ 0 orbital modes the spin flip must populate
+having their cost set by ω_⊥ — but that reading is still an interpretation. What
+is *measured* is that a density-matched change along z does not substitute for
+it, which is what rules the density explanation out.
 
 <!-- REDERIVE -->
 

--- a/docs/manuscript/klaus_protocol_sheet.md
+++ b/docs/manuscript/klaus_protocol_sheet.md
@@ -55,6 +55,23 @@
 > The upper bound also has a physical origin rather than a resonance: the cascade
 > collapses as |Ω| → ω_⊥, where the effective radial trap vanishes.
 >
+> **Scanned directly 2026-08-19 (§10 of the same document), 34 further arms:**
+>
+> 4. **The lab prescription at 2.6 nT is `ω_⊥,eff / ω_⊥ = 0.71`** — a static trap,
+>    no rotation. The static scan reproduces the rotating one to **0.06 %** at
+>    every matched point, so the substitution is not a coincidence of two points.
+> 5. **The other two field rows do not survive, and they fail differently.** At
+>    **1.3 nT there is no operating window at all** (+1.8 % across a flat range),
+>    so `|Ω|/ω_⊥ ≈ 0.3 at B = 1.3 nT` has **no replacement** — the effect is
+>    absent, not relocated. At **5.2 nT** an enhancement exists (+17 %) but the
+>    ω_eff dependence is non-monotonic at 7 points, so **no optimum is quoted**
+>    and `[0.5, 0.6] at 5.2 nT` is neither confirmed nor replaced.
+> 6. **It is the radial confinement, not the density.** A density-matched
+>    weakening along z instead lands *below* the baseline.
+>
+> Five seeds agree to five decimals with the seed proved live, so none of this is
+> seed noise; the live uncertainty is resolution (32³ ↔ 64³ = 2.5 %).
+>
 > **One of the 6 acceptance gates is now known to be un-re-runnable as written**
 > (2026-08-19, #343). The "(init m × Ω sign) reversal symmetry — 3-digit match" row in the
 > validation chain below compared `klaus_quench_omm0p5_keeprot` against


### PR DESCRIPTION
#392 の続き。「効いている変数を直接掃く」を 34 arm でやりました。

判定・全データ: **`docs/campaign/edh_quench_polarisation_decision.md` §10**（LIVE）

---

## 1. 静的スキャンが回転スキャンを再現 — 2点ではなく範囲全体で

#392 は ω_eff が一致する **2点**で 0.06–0.19 % の一致を見ました。今回は直接スキャンで全域を比較:

| ω_eff | 静的トラップ Ω=0 | 回転 \|Ω\|=√(1−ω_eff²) | 差 |
|---|---|---|---|
| 1.000 | 0.52748 | 0.52748 | **0.00 %** |
| 0.750 | 0.65219 | 0.65258 | **0.06 %** |
| 0.714 | 0.65864 | 0.65905 | **0.06 %** |
| 0.600 | 0.61707 | 0.61730 | **0.04 %** |

**最悪 0.06 %。** 2.6 nT の静的最適は **ω_⊥,eff/ω_⊥ = 0.714、+24.9 %** — Ω スキャンと同じ最適・同じ増強。

## 2. 最適は磁場依存で、3つとも「答えの種類」が違う

| 磁場 | 最適 ω_eff | 増強 | 形 |
|---|---|---|---|
| **1.3 nT** | — | **+1.8 %** | 平坦（ω_eff∈[0.65,1.0] で 0.505→0.514）⇒ **窓が無い** |
| **2.6 nT** | **0.714** | **+24.9 %** | 単峰 |
| **5.2 nT** | ? | +17.0 % | **非単調**（0.650 に凹み）⇒ 7点では未解決 |

- **1.3 nT**: sheet の `0.3 @ 1.3 nT` は**置換値が無い**。効果が移動したのではなく**消えている**。
- **5.2 nT**: 増強はあるが、最良点 0.550 は 0.800 より 2.6 % 高いだけで間に凹みがある。7点では「広い1峰」と「狭い2峰」を区別できないので**最適を出しません**。

どちらも数字ではなく「**再フィットするな**」として記録しました。数字はどちらの測定も支持しないからです。

## 3. 密度ではなく径方向（決定的）

同じ ω̄=(ωxωyωz)^⅓（＝同じ Thomas-Fermi 密度スケーリング）になるよう **z を弱める**:

| arm | trap | peak P_adj |
|---|---|---|
| baseline | (1.000, 1.000, 1.1818) | 0.52748 |
| 径方向 | (0.714, 0.714, 1.1818) | **0.65864** |
| **z 弱化（同 ω̄）** | (1.000, 1.000, 0.6026) | **0.48073** |

z 弱化は利得を再現しないどころか **baseline を下回り**、利得の **−36 %** を回収。同じ密度スケーリングで**符号が逆** ⇒ **密度説は棄却**。

## 4. シードは live、しかし観測量は決定論的

5 シードで peak P_adj が5桁一致（sd=0.00000）。これは **dead knob と見分けがつかない**ので、報告せず**確認**しました:

| | seed101 と seed202 の overlap | max rel density diff |
|---|---|---|
| frame 1（種を撒いた直後） | 0.999999702 | 2.3e−7 |
| frame 39（終端） | 0.999999881 | 1.9e−5 |

**シードは届いており、影響は2桁**成長します（カスケードは増幅する）— それでも peak P_adj を動かす水準に届かない。

⇒ §9 の1シード値は「分布の1標本」**ではない**。残る不確かさは**解像度**（G3: 32³↔64³ で 2.5 %）で、こちらが桁違いに大きい。

**途中で2つ結線を間違えました**: `noise_seed` は `seed_amplitude` を持つステップでしか読まれず（`run_step_dynamics.jl:305-315`）、最初 hold に付けたため**全く別の理由で同じ全一致表**が出ました。波動関数を見るまで区別できていません。

---

**Type**: すべて **B**（32³・`lhy: none` の物理一致。**C ではない**）。CPU（`rotating_frame_omega + spinor + GPU` は #343 で CUDA 999）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
