### PR TITLE
fix(lhy): tabulated n_max を宣言 seed に確定（cache-hit が solve と別テーブルだった／Model 23件解放）

### DIFF
--- a/src/workflow/experiments/pipeline/resolve_gs.jl
+++ b/src/workflow/experiments/pipeline/resolve_gs.jl
@@ -271,6 +271,62 @@ function _light_shift_spec(raw)
         polarization=NTuple{3, Float64}(Tuple(Float64.(get(raw, "polarization", [0, 0, 1])))))
 end
 
+"""
+    _resolve_lhy_n_max(opts, kind, grid, atom, p) -> LHYTableOpts
+
+Pin a tabulated LHY's `n_max` to the DECLARED SEED, once, instead of leaving it
+`NaN` for `make_workspace` to derive from whatever ψ it is handed.
+
+`_lhy_n_max(psi) = 3 × max|ψ|²` and the two GS entry points hand it different ψ:
+
+    fresh solve   `find_ground_state` builds the seed from `initial_state`
+    cache hit     `run_step_ground_state.jl:593` passes the CONVERGED ψ
+
+Measured on an Eu F=6 `fm_dipolar` fixture at 16³: the seed gives
+`n_max = 0.4466` and a converged-shaped ψ gives `0.7471` — the density grid the
+table is built on is **1.67× wider on a cache hit than in the solve that
+produced the cached state**. `V_LHY` agrees to 4e-5 where both tables cover, so
+this is a resolution difference rather than a different functional; it is still
+two tables for one config, and the energy reported from a cache hit is not the
+one the solve minimised.
+
+Pinning it here fixes that (both paths now read the same number) and is also
+what lets these configs have a `Model` at all: `LHYSpec` refuses a non-positive
+`n_max` precisely because a seed-derived one makes the functional depend on
+something the Model does not carry. Resolving it from the DECLARED seed makes it
+a function of the config, which is what a Model slot has to be.
+
+The seed is built by the SAME call `find_ground_state` uses
+(`solvers/ground_state.jl:211`) — `init_psi(grid, sys; state, init_kwargs...)`.
+Re-deriving the peak density analytically would be a second implementation of
+the state zoo, which is the defect class this file exists to close.
+
+Costs one `init_psi` per resolve, and only for a tabulated kind with no explicit
+`n_max`: every other shape returns `opts` untouched.
+"""
+function _resolve_lhy_n_max(opts::LHYTableOpts, kind, grid, atom, p::Dict{String, Any})
+    kind === nothing && return opts
+    k = kind::Symbol
+    (k === :none || k in LHY_CLOSED_SCALAR_KINDS) && return opts
+    isnan(opts.n_max) || return opts        # explicit `lhy: {n_max: …}` wins
+    seed = _declared_seed(grid, atom, p)
+    LHYTableOpts(; n_max=_lhy_n_max(seed), n_points=opts.n_points,
+        n_bins=opts.n_bins, n_atoms=opts.n_atoms)
+end
+
+"The ψ this step's `initial_state` declares, built the way the solver builds it."
+@noinline function _declared_seed(grid, atom, p::Dict{String, Any})
+    sys = SpinSystem(atom.F)
+    state = Symbol(get(p, "initial_state", "polar"))
+    isp = get(p, "init_state_params", nothing)
+    params = if isp isa AbstractDict
+        Dict{Symbol, Float64}(Symbol(k) => Float64(v) for (k, v) in isp)
+    else
+        Dict{Symbol, Float64}()
+    end
+    init_psi(grid, sys; state=state, pairs(params)...)
+end
+
 _is_trivial_direction(d) =
     !(d isa AbstractDict) ||
     all(k -> !haskey(d, k) || Float64(d[k]) == 0.0, ("theta", "phi"))
@@ -344,6 +400,7 @@ Idempotent in effect: `_resolve_derived_params!` guards `ddi["c_dd"]` with
     # "type stability boundaries": an Any-typed local reaching make_workspace
     # is what turns into a multi-minute JIT hang with no stack trace.
     gs_lhy_opts = get(p, "lhy_opts", LHYTableOpts())::LHYTableOpts
+    gs_lhy_opts = _resolve_lhy_n_max(gs_lhy_opts, spinor_lhy_mode, grid, atom, p)
     gs_rf_omega = Float64(get(p, "rotating_frame_omega", 0.0))
 
     # --- model-only reads, all of them here so `gs_model` touches no dict ---

--- a/test/model/test_corpus_resolves.jl
+++ b/test/model/test_corpus_resolves.jl
@@ -56,7 +56,9 @@ const CD_MU_0 = 1.25663706212e-6
 # ---------------------------------------------------------------------------
 # The configs `yaml_to_model` does NOT resolve, by name and reason.
 #
-# Measured 2026-08-02 over 429 YAML files under `runs/`; 351 resolve.
+# Measured 2026-08-19 over 488 YAML files under `runs/`; 432 resolve.
+# (2026-08-02: 351 of 429. The 23 `:lhy_n_max` exclusions closed together when
+#  `_resolve_lhy_n_max` landed; the rest of the growth is new configs.)
 #
 # Categories:
 #
@@ -95,68 +97,19 @@ const CD_MU_0 = 1.25663706212e-6
 # purpose — deriving them from the source that produces them would make this
 # gate agree with itself.
 const CORPUS_UNRESOLVED = [
-    # --- :lhy_n_max (23) ---
-    # Three arrived with origin/main (`#--`, the LHY-mode ablation). Refused for
-    # exactly the documented reason and not by this branch: a tabulated kind with
-    # no `n_max` resolves to `LHYTableOpts.n_max = NaN` ("3 x max|psi_init|^2"),
-    # which would make the table a function of WHICH psi built it, and `LHYSpec`
-    # refuses that. `LHY_none` and `LHY_scalar` in the same directory resolve,
-    # which is the control: the refusal tracks the LHY kind, not the directory.
-    (
-        "runs/lhy_mode_ablation_reconstructed/LHY_full_bdg.yaml",
-        :lhy_n_max,
-        "needs a resolved n_max",
-    ),
-    (
-        "runs/lhy_mode_ablation_reconstructed/LHY_polar_contact.yaml",
-        :lhy_n_max,
-        "needs a resolved n_max",
-    ),
-    (
-        "runs/lhy_mode_ablation_reconstructed/LHY_polar_dipolar.yaml",
-        :lhy_n_max,
-        "needs a resolved n_max",
-    ),
-    (
-        "runs/eu_gs_phase_c1_B_kappa/config_texture_bscan_lhy_full_bdg.yaml",
-        :lhy_n_max,
-        "needs a resolved n_max",
-    ),
-    (
-        "runs/eu_gs_phase_c1_B_kappa/config_texture_bscan_lhy_smoke.yaml",
-        :lhy_n_max,
-        "needs a resolved n_max",
-    ),
-    (
-        "runs/eu_gs_phase_c1_B_kappa/config_texture_quench_movie.yaml",
-        :lhy_n_max,
-        "needs a resolved n_max",
-    ),
-    (
-        "runs/eu_gs_phase_c1_B_kappa/config_texture_quench_movie_smoke.yaml",
-        :lhy_n_max,
-        "needs a resolved n_max",
-    ),
-    (
-        "runs/eu_gs_phase_c1_B_kappa/config_texture_stir_movie.yaml",
-        :lhy_n_max,
-        "needs a resolved n_max",
-    ),
-    ("runs/eu_k3_lhy/LHY_fm_dipolar.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_k3_lhy/LHY_full_bdg.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_k3_lhy/LHY_polar_contact.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_k3_lhy_control/LHY_fm_dipolar_K0.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_k3_lhy_control/LHY_full_bdg_K0.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_k3_lhy_control/LHY_polar_contact_K0.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_lhy_longtime/LHY_fm_dipolar_100ms.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_lhy_longtime/LHY_fm_dipolar_200ms.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_lhy_longtime/LHY_fm_dipolar_50ms.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_lhy_longtime/LHY_full_bdg_100ms.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_lhy_longtime/LHY_full_bdg_200ms.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_lhy_longtime/LHY_full_bdg_50ms.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_lhy_longtime/LHY_polar_contact_100ms.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_lhy_longtime/LHY_polar_contact_200ms.yaml", :lhy_n_max, "needs a resolved n_max"),
-    ("runs/eu_lhy_longtime/LHY_polar_contact_50ms.yaml", :lhy_n_max, "needs a resolved n_max"),
+    # --- :lhy_n_max — RESOLVED 2026-08-19, all 23 ---
+    #
+    # Refused because a tabulated kind with no `n_max` left
+    # `LHYTableOpts.n_max = NaN` ("3 x max|psi_init|^2"), making the table a
+    # function of WHICH psi built it. `resolve_gs` now pins it to the DECLARED
+    # seed (`_resolve_lhy_n_max`), so it is a function of the config and
+    # `LHYSpec` accepts it.
+    #
+    # The refusal was pointing at a live defect, not only a modelling gap: the
+    # two GS entry points hand `_lhy_n_max` different psi — the fresh solve the
+    # seed, the CACHE HIT the converged state — so a cache hit built a table
+    # 1.67x wider than the solve that produced the cached state (measured, Eu
+    # F=6 fm_dipolar at 16^3: n_max 0.4466 against 0.7471).
     # --- :no_N_atoms (16) — two copies of the same eight-config suite ---
     (
         "runs/spinorbec_verification_yamls/spinorbec_verification_yamls/yamls/00_scalar_free_uniform_stationary.yaml",
@@ -383,10 +336,16 @@ const CORPUS_UNRESOLVED = [
     ("runs/verification_suite/manifest.yaml", :yaml_unparseable, "invalid base 8 digit"),
 ]
 
-# Measured 2026-08-02. A floor, not an equality: adding a config that resolves
-# must not redden the suite, while a config that STOPS resolving is caught by the
-# census arm naming it.
-const CORPUS_RESOLVED_FLOOR = 351
+# A floor, not an equality: adding a config that resolves must not redden the
+# suite, while a config that STOPS resolving is caught by the census arm naming
+# it.
+#
+# 2026-08-02: 351 of 429.
+# 2026-08-19: raised to 432 after `_resolve_lhy_n_max` pinned a tabulated LHY's
+#   `n_max` to the declared seed, which is what the 23 `:lhy_n_max` exclusions
+#   were waiting for. Raised WITH the exclusions deleted in the same commit —
+#   a floor left low while the list shrinks is a gate that has stopped measuring.
+const CORPUS_RESOLVED_FLOOR = 432
 
 const NON_SPINOR_GS_KINDS = ("binary", "rotating_basis", "option_gamma")
 

--- a/test/model/test_gs_admission_axes.jl
+++ b/test/model/test_gs_admission_axes.jl
@@ -662,10 +662,25 @@ end
         # because calling `ax_id` here would register the warning outside the
         # logger and the arm below would measure zero for the wrong reason
         # (it did, on the first run of this file).
-        other = ax_base(; lhy=Dict{String, Any}("kind" => "full_bdg"))   # no n_max
+        # CHANGED 2026-08-19. This was `lhy: {kind: full_bdg}` with no `n_max`,
+        # which used to be a second reason and no longer is: `resolve_gs` pins a
+        # tabulated `n_max` to the declared seed, so that config now resolves.
+        #
+        # The replacement is `raman:` — declared by GS_SCHEMA, read by nothing on
+        # this path, and so in `GS_KEYS_DROPPED_PHYSICS`. Chosen by MEASURING
+        # which reasons are still live rather than by picking a plausible one:
+        # `B_direction` was tried first and gives `why == nothing` here, because
+        # it is written by `apply_B_block_normalize!` during `_run_yaml_prepare`
+        # and a hand-built step dict never goes through that.
+        other = ax_base(;
+            raman=Dict{String, Any}("Omega_R" => 0.3, "delta" => 0.0,
+                "k_eff" => [1.0, 0.0, 0.0]))
         why_other = ax_why(other)
         @test why_other !== nothing        # else `occursin` errors on `nothing`
-        @test why_other !== nothing && occursin("n_max", why_other)
+        @test why_other !== nothing && occursin("raman", why_other)
+        # …and it really is a DIFFERENT reason from `unresolvable()`'s, or the
+        # arm below would be measuring "warns once" against the same cause.
+        @test !occursin("raman", ax_why(unresolvable()))
         logger2 = Test.TestLogger(; min_level=Warn)
         with_logger(logger2) do
             ax_id(unresolvable())        # already warned: silent

--- a/test/model/test_yaml_to_model.jl
+++ b/test/model/test_yaml_to_model.jl
@@ -299,16 +299,41 @@ end
         @test occursin("omega_ref", msg)
     end
 
-    @testset "tabulated LHY with no resolved n_max" begin
+    @testset "tabulated LHY with no explicit n_max takes it from the seed" begin
+        # CHANGED 2026-08-19. This arm asserted that such a config is REFUSED,
+        # and `LHYSpec` still refuses a non-positive `n_max` — but the resolver
+        # no longer hands it one. `_resolve_lhy_n_max` pins it to the DECLARED
+        # seed, which is what makes it a function of the config rather than of
+        # whichever ψ `make_workspace` happens to hold.
+        #
+        # Measured before the change (Eu F=6 `fm_dipolar`, 16³): the fresh solve
+        # built the table from the seed at `n_max = 0.4466` and the CACHE-HIT
+        # path from the converged state at `0.7471`, 1.67× wider, for one config.
+        # `V_LHY` agreed to 4e-5 where both covered — a resolution difference,
+        # not a different functional, and still two tables where there should be
+        # one. 23 committed configs were in this state and none had a Model.
         p = ytm_write(
             "lhy.yaml",
             replace(YTM_BASE,
                 "      method: itp" => "      lhy: {kind: full_bdg}\n      method: itp"),
         )
-        msg = ytm_why(p)
-        @test msg !== nothing
-        @test occursin("n_max", msg)
-        # ... and giving it one resolves.
+        m0 = ytm_model(p)
+        @test m0.lhy.kind === :full_bdg
+        # A real, positive number, taken from the seed — not the `NaN` sentinel
+        # and not a default someone picked.
+        @test m0.lhy.n_max > 0
+        @test isfinite(m0.lhy.n_max)
+        # …and it IS the seed's `3·max|ψ|²`, not an arbitrary constant. Asserted
+        # against the value recomputed here from the same `init_psi` the solver
+        # calls (`solvers/ground_state.jl:211`), so the claim is the DERIVATION
+        # rather than "the number is positive".
+        let g = make_grid(GridConfig((8, 8, 8), (6.0, 6.0, 6.0))),
+            seed = SpinorBEC.init_psi(g, SpinorBEC.SpinSystem(Eu151.F); state=:polar)
+
+            @test m0.lhy.n_max ≈ 3.0 * maximum(sum(abs2, seed; dims=4))
+        end
+
+        # An EXPLICIT n_max still wins over the derived one.
         p2 = ytm_write(
             "lhy_ok.yaml",
             replace(YTM_BASE,


### PR DESCRIPTION
Model カバレッジの最大ブロッカー（23 config）を潰す。**その過程で実バグが1件出た。**

## 実バグ: cache-hit と solve が別の LHY テーブルを持つ

`_lhy_n_max(psi) = 3 × max|psi|²`、そして `n_max = NaN` は
「make_workspace が渡された ψ から導出せよ」を意味する。GS の2つの入口は**違う ψ を渡す**：

| | 渡す ψ |
|---|---|
| fresh solve | `find_ground_state` が `initial_state` から作る **seed** |
| **cache hit** | `run_step_ground_state.jl:593` が渡す **収束状態** |

実測（Eu F=6 `fm_dipolar`, 16³）:

```
seed から      : n_max = 0.4466
収束状態から   : n_max = 0.7471      ← 1.67 倍広い
```

**cache hit は、そのキャッシュを作った solve より 1.67 倍広いテーブルを組む。**

両方がカバーする密度での `V_LHY` は **4e-5 で一致**するので、これは functional の違いでなく
解像度の違い。それでも1つの config に2つのテーブルがあり、**cache hit が報告するエネルギーは
solve が最小化したものではない**。

## 修正

`resolve_gs` が `n_max` を**宣言された seed** から1回だけ確定する。両経路が同じ数を読む。

seed は**ソルバと同じ呼び出し**で作る（`init_psi(grid, sys; state, init_kwargs...)`、
`ground_state.jl:211`）。ピーク密度を解析的に再導出すれば state zoo の第二実装になる。

## それが 23 config を解放する

`LHYSpec` が非正の `n_max` を拒否するのは、seed 由来の値だと functional が
**Model の持たないもの**に依存するから。**宣言された** seed から解決すれば config の関数になり、
Model slot の要件を満たす。

```
corpus: 409 → 432 / 488
CORPUS_RESOLVED_FLOOR: 351 → 432   （同じコミットで）
```

床を低いまま除外リストだけ縮めるのは、**測るのをやめたゲート**になる。

## テストを書き換えた件（commitment 12 の手順で）

`test_yaml_to_model.jl` の該当 arm は「拒否される」と主張していた。書き換えたが、**測定の後**に。

新しい arm は「正の数である」ではなく**導出そのもの**を pin する —
同じ `init_psi` から再計算した `3×max|ψ_seed|²` と一致すること。

## 見つけたが直していない

**`init_sigma` は `GS_SCHEMA` にあり、range を持ち、units-block が長さとして変換するのに、
`src/` のどこからも読まれていない。** `GS_KEYS_DROPPED_PHYSICS` にも入っていないので、
設定しても既定の seed 幅が黙って使われる。

私の `_declared_seed` も同様に無視するので、**この PR はソルバと一貫している**。
ただし dropped リストに追加すると 23+ の committed config が実行を拒否されるため、
独自の影響範囲測定を伴う別判断。

## 検証

| | 結果 |
|---|---|
| `test_corpus_resolves.jl` | 95/95（432 resolve） |
| `test_realise_agrees_over_corpus.jl` | 7/7（無傷） |
| `test_yaml_to_model.jl` | 137/137 |
| STATE.md / formatter | 再生成・クリーン |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
