### PR TITLE
docs(#398): 68.4 µG は continuation が枝を見失う磁場であって、枝が終わる磁場ではない

### DIFF
--- a/docs/guides/eu_adiabatic_protocol.md
+++ b/docs/guides/eu_adiabatic_protocol.md
@@ -30,6 +30,19 @@
 > reading is not supported: the flower branch **ends at 68.4 ± 0.15 µG**, measured
 > statically; it merely takes longer than a ramp to fall once past its spinodal.
 >
+> **AMENDED 2026-08-20 (#398).** That last sentence is the part of this retraction
+> that does not hold. #383 measured three independent quantities at 68.25 µG and
+> none of them softens — the curvature's zero extrapolates to 78.2 µG, the escape
+> direction is **uphill** by +3.403, and the lowest ω is flat to 1.4 %. So 68.4 µG
+> is where a **warm-started continuation loses the branch**, which is not the same
+> as where the branch ends. If the flower minimum survives past it behind a
+> barrier, "flower survives to 100 µG" is back on the table and this document's
+> original rising-leg reading may have been right for the wrong stated reason.
+> The retraction's *other* half — that a B_z ramp conserves J_z, so no rate
+> converts between the two sectors — is untouched and is what actually closes the
+> hysteresis reading. See `eu_kappa_hysteresis_loop.md`'s HELD note; resolution
+> tracked as #399.
+>
 > What survives: the κ dependence, the static branch structure, and the protocol
 > machinery. What replaces the loop width as the deliverable: a discrete
 > Stern-Gerlach level count, 6–7 populated m_F at κ = 1.8 against 3–4 at κ = 0.9.

--- a/docs/guides/eu_in_place_nucleation.md
+++ b/docs/guides/eu_in_place_nucleation.md
@@ -89,9 +89,9 @@ rather than convenient:
   $\epsilon_{\rm cut} \approx 125$, $k_{\rm cut} \approx 16$ and a 192³ grid at 13
   components. Not for an ensemble, and saying so with a number is better than
   discovering it after a week of queue.
-- *below $f_{\rm sp}$, where the flower branch does not exist*, the condensate is
-  polarised because there is nothing else to be. That **is** the disordered side
-  of this transition, and it costs no thermal cloud to reach.
+- *below $f_{\rm sp}$, where the continuation cannot hold a flower state*, the
+  condensate is polarised because nothing else is reachable. That **is** the
+  disordered side of this transition, and it costs no thermal cloud to reach.
 
 ### Axes, and the settings held fixed
 
@@ -259,7 +259,7 @@ cell). Walking the flower branch **down** in condensate fraction:
 | $\langle F_\perp\rangle$ | 5.010 | 4.671 | 4.182 | 3.870 | **3.500** | **0.122** | 0.130 |
 | $J_z$ | −1.133 | −1.290 | −1.541 | −1.693 | **−1.860** | −2.197 | −2.357 |
 
-**The flower branch ceases to exist between $f = 0.271$ and $f = 0.320$** —
+**The continuation loses the flower branch between $f = 0.271$ and $f = 0.320$** —
 $N_0^\ast \approx 1.4$–$1.6\times10^4$ atoms. Below it the continuation has fallen
 onto the polarised branch ($\langle F_\perp\rangle \approx 0.12$ and falling
 smoothly to 0.23 at $f = 0.02$), which is what a branch ending looks like from a
@@ -267,7 +267,25 @@ warm continuation.
 
 This is the structural fact the rest of the campaign is about: **a condensate is
 born polarised**, not because it is preferred but because below $N_0^\ast$ the
-flower state does not exist to be selected.
+warm continuation cannot hold a flower state at all.
+
+**A caveat inherited from #398, and it is the same one.** "The continuation loses
+the branch" and "the branch ends" are different claims, and #383 showed the
+distinction has teeth on this very manifold: at #335's field-spinodal the
+curvature, the escape direction and the lowest ω all fail to soften, so 68.4 µG is
+where a warm-started L-BFGS stops staying on the branch and *not* demonstrably
+where the minimum ceases to exist. $f_{\rm sp}$ here is measured the same way and
+carries the same caveat: what is established is that **the continuation cannot
+follow a flower state below $f \approx 0.30$**, bracketed consistently at two
+grids and with the certification of criterion 6.
+
+Nothing in §5.9 depends on which reading is right. The selection statistic is
+measured by growing *through* the window and classifying the endpoint against the
+branch table, and the table is built from cells that converged — so a flower
+minimum surviving below $f_{\rm sp}$ behind a barrier would change the *story* of
+why a small condensate is polarised, not the measurement that the cold trajectories
+end polarised and the hot ones end flower. Settling it wants the same λ_min
+computation #399 tracks, run in $f$ rather than in $B$.
 
 **The polarised branch, by contrast, has no spinodal in $f$ at all.** Walked
 *upward* from $f = 0.02$ ($N_0 = 10^3$) to $f = 1$ it stays converged at the gate
@@ -298,7 +316,7 @@ So the structure at $(\kappa = 1.8, B = 20\ \mu$G$)$ is:
 
 | range | what exists | which is the ground state |
 |---|---|---|
-| $f < f_{\rm sp} \in (0.271, 0.320)$ | polarised only | polarised, by default |
+| $f < f_{\rm sp} \in (0.271, 0.320)$ | polarised only, as far as a continuation can reach | polarised, by default |
 | $f_{\rm sp} < f < f_{\rm eq} \approx 0.339$ | both | **polarised** — the flower is born *above* it |
 | $f > f_{\rm eq}$ | both | **flower**, and the gap grows without bound |
 
@@ -622,7 +640,7 @@ is a result in its own right.
 
 | | |
 |---|---|
-| **The flower texture has a minimum atom number.** | It ceases to exist below $f_{\rm sp} = 0.30 \pm 0.02$, $N_0^\ast \approx 1.5\times10^4$, bracketed consistently at 32³ and 64³. The polarised branch has no spinodal at all from $f = 0.02$ to 1. **A condensate is born polarised**, not because it is preferred but because nothing else exists. |
+| **The flower texture has a minimum atom number.** | A warm continuation cannot hold it below $f_{\rm sp} = 0.30 \pm 0.02$, $N_0^\ast \approx 1.5\times10^4$, bracketed consistently at 32³ and 64³, while the polarised branch is followable from $f = 0.02$ to 1. **A condensate is born polarised.** Whether the flower minimum *ceases to exist* there or merely becomes unreachable is the #398/#399 distinction and is not settled — see §5.2. |
 | **The choice is made in a narrow window, not at the target.** | The branches are 663 $k_BT$ apart at $f = 1$ and 8–15 at the bifurcation; they cross at $f_{\rm eq} = 0.343$. Asking the question at $f = 1$, which is what "cool at the target point" reads as, returns zero by arithmetic. |
 | **The full SPGPE cannot be used for a growth problem here.** | Its projected scattering step loses number at 1.25× the growth rate — 11.5 % in 60 ms with the growth drive at exactly zero. Growth-only (Rooney Eq. 20) is the sub-theory that answers this, and it carries the $M_z$-changing exchange that makes nucleation possible where $J_z$ conservation blocks transport. |
 

--- a/docs/guides/eu_kappa_hysteresis_loop.md
+++ b/docs/guides/eu_kappa_hysteresis_loop.md
@@ -18,6 +18,40 @@
 > survive.
 >
 > **Read §6 first if you want the number to hand the experiment.**
+>
+> ## ⚠ HELD 2026-08-20: "68.4 µG is a spinodal" is not established
+>
+> §5.1 calls 68.4 µG a **mean-field spinodal** and draws a consequence from it —
+> *"a rising ramp must convert by then at any rate."* #383
+> (`docs/guides/eu_spinodal_spectrum.md`) measured three independent quantities on
+> those same cells and **none of them softens**: the branch-tangent curvature
+> `R = ⟨t,At⟩` is linear in `R²` to rms 0.4 % with its zero at **78.2 µG**, the
+> escape direction `⟨d,Ad⟩` from the 68.25 → 68.50 µG pair is **+3.403** (uphill
+> along the way it actually falls, i.e. a barrier), and the lowest resolvable ω is
+> flat to 1.4 %. A saddle-node takes all three to zero.
+>
+> **What the continuation measured is where a warm-started L-BFGS stops being able
+> to stay on the branch — not that the branch stops existing.** Those are different
+> claims and this document conflated them. Everything downstream that only needs
+> "the continuation loses the branch at 68.4 ± 0.15 µG" stands, including the grid
+> agreement of §5.8.
+>
+> **What is weakened**: the *at any rate* clause. If the flower minimum survives
+> past 68.4 µG behind a barrier, a fast enough rising ramp carries it further — and
+> that is exactly what the predecessor observed (flower surviving to > 100 µG at
+> every rate). §5.5b's hold experiment reads the same either way: a state 1.75 µG
+> past a spinodal moves slowly *because the growth rate vanishes there*, and a
+> state behind a barrier moves slowly *because there is a barrier*.
+>
+> **What is untouched**: §5.7's Stern-Gerlach level count, the deliverable — 6–7
+> populated m_F at κ = 1.8 against 3–4 at κ = 0.9, disjoint at all five rates. It
+> does not rest on the spinodal reading at all.
+>
+> Settling it needs a resolved λ_min at 68.25 µG, which neither solver reached in
+> #383. #395's preconditioner reaches λ_min ≤ 7.6e-8, so it is now answerable —
+> tracked as #399. Until then the honest phrasing is **"the field at which the
+> continuation loses the flower branch"**, and this document's own use of
+> "spinodal" should be read with that substitution throughout §5.1.
 
 ## 1. What is being delivered, and why it is worth the compute
 


### PR DESCRIPTION
#398 の指定作業です。`docs/` 3件のみ、コードとテストは触っていません。

## 何が食い違っていたか

#335 §5.1 は 68.4 µG を **mean-field spinodal** と呼び、そこから「**上昇ランプはどのレートでも**そこまでに変換する」を導いています。

#383 が同じセルで3つの独立な量を測り、**どれも柔化しません**:

| 観測量 | 測定 | saddle-node なら |
|---|---|---|
| 枝接線の曲率 `R = ⟨t,At⟩` | R² が rms 0.4 % で線形、零点 **78.2 µG** | 0 へ |
| 逃げる方向 `⟨d,Ad⟩`（68.25 → 68.50） | **+3.403**（実際に落ちる向きが**上り**）| 0 へ |
| 最低の解像可能 ω | 1.4 % 以内でフラット | 0 へ |

**「continuation が枝を見失う磁場」と「枝が存在しなくなる磁場」は別の主張**で、#335 はこれを混同していました。

## 直したもの

両文書とも FROZEN なので、#352 の撤回コミットに倣い**本文は書き換えず冒頭に注記**を置いています。

**`eu_kappa_hysteresis_loop.md`** — HELD 注記。弱くなるのは *at any rate* 節だけで、成果物である **Stern-Gerlach 準位数（κ=1.8 で 6–7、κ=0.9 で 3–4）は spinodal 読解に依存しない**ので無傷です。§5.5b の hold 実験がどちらとも同じくらい読めることも書きました。

**`eu_adiabatic_protocol.md`** — こちらは単なる伝播ではありません。この文書の「flower survives to 100 µG は支持されない」という**撤回そのものが** spinodal 論法で書かれています。障壁つきで flower 極小が 68.4 µG より上まで生きるなら、元の読みが（述べた理由は違っても）正しかった可能性が戻ります。撤回のもう半分 — `B_z F_z` が `J_z` と可換なのでどのレートでもセクター間を変換しない — は無傷で、hysteresis 読解を実際に閉じているのはそちらです。

**`eu_in_place_nucleation.md`**（#334、本日マージ）— 同じ混同を f 軸で継いでいました。「flower 枝が f_sp 以下で **ceases to exist**」と書きましたが、測ったのは warm continuation が追えなくなる f です。5箇所を訂正し、**§5.9 の選択統計はどちらの読みでも変わらない**ことを明記しました（終端は収束したセルに対して分類されるため）。

## 決着

λ_min が resolved なら直接答えが出ます。#395 の前処理で λ_min ≤ 7.6e-8 まで降りられるようになったので、いまなら測れます → **#399**。f 軸でも同じ計算が要ります。

それまでの正しい言い方は「**continuation が枝を見失う磁場（/凝縮体割合）**」です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
