### PR TITLE
fix: 共鳴仮説は反証、観測量に欠陥、rotating_basis の GPU 経路が死んでいた

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -124,7 +124,7 @@ checking either.
 
 - admits: `src/workflow/experiment.jl:253`
 - admits: `src/workflow/experiments/pipeline/run_registry.jl:601`
-- admits: `src/workflow/experiments/pipeline/run_registry.jl:840`
+- admits: `src/workflow/experiments/pipeline/run_registry.jl:854`
 - admits: `src/workflow/experiments/pipeline/run_step_ground_state.jl:549`
 - **verifies**: `src/workflow/experiments/pipeline/run_step_ground_state.jl:606`
 
@@ -208,7 +208,7 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 267 files
+- `FAST_TESTS` — 268 files
 - `CI_EXTRA` — 139 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -38,6 +38,10 @@ measurements, not tests).
 | 9 | Then what is the mechanism? | **Centrifugal, not Coriolis.** A *static* trap weakened to ω_eff = √(ω_⊥²−Ω²) reproduces the whole effect to **0.06 %** across the range. **Rotation is not needed** — weaken the radial trap to **0.71 ω_⊥**. §9.3, §10.1 |
 | 10 | Is it density, or the radial confinement? | **Radial.** A density-matched weakening along **z** instead lands *below* the baseline (−36 % of the gain). Same ω̄, opposite sign. §10.4 |
 | 11 | Does the prescription hold at the other two fields? | **No, and differently.** 1.3 nT: **no window at all** (+1.8 %, flat) — the old `0.3 @ 1.3 nT` has no replacement. 5.2 nT: **two branches**, resolved in §11. §10.2 |
+| 14 | Is the 5.2 nT dip a resonance? | **No — the prediction was made and failed.** ω_eff,dip ∝ B predicts a dip near 0.325 at 2.6 nT; the measured tail rises monotonically through it. §11.4 withdrawn; the second branch has no mechanism. §12.3 |
+| 15 | Was the observable right? | **Not at 10.4 nT.** The peak must be taken *inside the hold*; over the whole trajectory it read the pre-hold transient and 7 of 10 arms were blind. Re-extracted: **0.00 % change at 1.3 / 2.6 / 5.2 nT**, so §9–§11 stand. §12.1 |
+| 16 | Does it survive LHY? | **Yes.** `full_bdg` moves the baseline +0.07 % and the optimum +2.18 %; the enhancement goes +24.9 % → **+27.5 %**. §12.4 |
+| 17 | Does the static substitution hold at long time? | **Only on the peak.** At 145 ms static and rotating differ by 3.2 % at the peak (vs 0.06 % short) but by **2.25× at the endpoint** — rotation gives a transient, the static trap a *sustained* transfer. §13 |
 | 13 | 5.2 nT, resolved at 20 points + 64³ | **Two branches**, global max at ω_eff ≈ 0.55 (+17.0 %), secondary at ≈ 0.77, dip at ≈ 0.65 that **survives 64³** with 93 % of its depth. No single optimum quoted (criterion D1). The old `[0.5, 0.6]` maps to ω_eff ∈ [0.80, 0.87] — a declining shoulder below both maxima, so it is **refuted**, not merely unresolved. §11 |
 | 12 | How much of §9 is seed noise? | **None.** 5 seeds agree to 5 decimals, and the seed was *proved live* (state overlap 0.9999997, growing to 1.9e−5). The observable is deterministic here; grid/dt remain the real uncertainty (G3: 2.5 %). §10.3 |
 | 4 | Align the rotation-assisted EdH quench series to m=−F? | **No — and stop saying it in `m`.** The measured criterion is *aligned vs anti-aligned with B*. the EdH quench needs the **anti-aligned (Zeeman-highest)** state; under the project's +B_z that is m=+F. §4 |
@@ -776,7 +780,139 @@ peak with no dip; doubling the field introduces one. That is what a resonance
 entering the sampled window looks like — plausibly between the Zeeman splitting
 and the radial mode spacing, both of which the field and ω_⊥,eff set. The test
 is one more field: if the dip is a resonance, its ω_eff position must move again
-at 10.4 nT. **Not measured here.**
+at 10.4 nT.
+
+> **WITHDRAWN 2026-08-20 — the prediction was made and it failed.** §12.3. The
+> informative half was 2.6 nT, where a dip was predicted near ω_eff ≈ 0.325 and
+> the measured curve rises monotonically through it. The second branch at 5.2 nT
+> is a measured structure **without** a mechanism; this paragraph is kept struck
+> rather than deleted because a discarded hypothesis that was actually tested is
+> worth more to the next reader than a clean page.
+
+---
+
+## 12. The resonance prediction fails, and the observable needed fixing first
+
+### 12.1 An instrument correction that changed one field and no others
+
+Every peak up to here was taken over the **whole** streamed trajectory. At 10.4 nT
+four arms differing *only in the hold* returned peak P_adj = 0.26050 to five
+decimals — impossible unless the maximum lies before the hold. It does: argmax at
+frame 29, hold starts at frame 32.
+
+So the observable was reading the pre-hold transient, and "no dip at 10.4 nT"
+would have been a confirmed prediction read off a blind instrument. **The claim is
+always about the hold, so the peak must be taken inside it.**
+
+Re-extracted from cache — no recompute — across every arm measured so far:
+
+| scan | arms | peak moved? |
+|---|---:|---|
+| 1.3 nT (§10.2) | 7 | **0.00 % on all** |
+| 2.6 nT (§10.1, §11 tail) | 16 | **0.00 % on all** |
+| 5.2 nT (§10.2, §11) | 20 | **0.00 % on all** |
+| **10.4 nT** | 10 | **7 of 10 moved, by up to −23 %** |
+
+**§9, §10 and §11 are unaffected** — that is measured, not assumed. Only 10.4 nT
+is contaminated, and for a physical reason: it is the Zeeman-re-pinning regime the
+sheet warns about, so the hold suppresses the cascade and the transient wins.
+
+### 12.2 10.4 nT, read correctly: a clean single peak
+
+| ω_eff | peak in hold | ω_eff | peak in hold |
+|---:|---:|---:|---:|
+| 1.000 | 0.20139 | 0.650 | **0.30101** |
+| 0.900 | 0.22628 | 0.600 | 0.29316 |
+| 0.800 | 0.24117 | 0.550 | 0.25721 |
+| 0.750 | 0.25204 | 0.500 | 0.22104 |
+| 0.700 | 0.27828 | 0.450 | 0.20178 |
+
+Single maximum at **ω_eff = 0.650**, **+49.5 %** over ω_eff = 1 — the *largest
+relative* enhancement of any field measured, on the *smallest absolute* transfer
+(0.30 against 0.66 at 2.6 nT). Zeeman re-pinning is real — it costs a factor 2 in
+absolute transfer — but it does not close the channel, and weakening the trap
+helps proportionally more when it is nearly closed.
+
+### 12.3 The resonance reading is refuted
+
+§11.4 proposed that the 5.2 nT dip is a resonance, predicting ω_eff,dip ∝ B, and
+that prediction was written down before the runs:
+
+| field | predicted | observed | |
+|---|---|---|---|
+| 10.4 nT | dip at ω_eff ≈ 1.30 ⇒ none in range | no dip | consistent, but weakly — "no dip" is the easy half |
+| **2.6 nT** | **dip near ω_eff ≈ 0.325** | **0.250→0.375 rises monotonically: 0.45976, 0.46412, 0.46681, 0.47068, 0.47682** | **FAILS** |
+
+The informative arm fails. **The resonance reading is refuted** and §11.4 is
+withdrawn. What produces the second branch at 5.2 nT is now unexplained — and the
+honest position is that it is a measured structure without a mechanism, not a
+mechanism awaiting confirmation.
+
+Field dependence of the optimum, with everything read in the hold:
+
+| field | optimum ω_eff | enhancement | shape |
+|---|---:|---:|---|
+| 1.3 nT | — | +1.8 % | flat, no window |
+| 2.6 nT | 0.714 | +24.9 % | single peak |
+| 5.2 nT | 0.55 | +17.0 % | **two branches** |
+| 10.4 nT | 0.650 | **+49.5 %** | single peak |
+
+Non-monotonic in every column. There is no one-line prescription across field.
+
+### 12.4 LHY: the conclusion survives
+
+Everything above is `lhy: none`. Repeated at 2.6 nT with `full_bdg` (the
+general-spinor path; the closed forms assume an ansatz this state does not have):
+
+| | ω_eff = 1.000 | ω_eff = 0.714 | enhancement |
+|---|---:|---:|---:|
+| `lhy: none` | 0.52748 | 0.65864 | **+24.9 %** |
+| `lhy: full_bdg` | 0.52786 | 0.67297 | **+27.5 %** |
+
+LHY moves the baseline by **+0.07 %** and the optimum by **+2.18 %**. The
+enhancement does not merely survive, it grows slightly. **The `lhy: none` caveat
+is discharged for this conclusion** — though not for absolute values at other
+fields or densities, which were not re-run.
+
+---
+
+## 13. Long time (145 ms): the substitution is a short-time statement
+
+`runs/klaus_quench_long_time/` was **missed by the corpus retarget** — it was
+still `m_minus_F` at B_z > 0, i.e. aligned, until this branch. Retargeted (9
+configs, seed-agreement gate green), then three arms at hold = 100 ω_ref⁻¹
+(≈ 145 ms), 32³, CPU, peak taken inside the hold per §12.1:
+
+| arm | hold-peak P_adj | hold-peak P_exc | **P_adj at the END** |
+|---|---:|---:|---:|
+| baseline (ω_eff = 1.000, Ω = 0) | 0.38532 | 0.79035 | 0.23127 |
+| **static (ω_eff = 0.714, Ω = 0)** | 0.50790 (+31.8 %) | **0.88794** | **0.47517** |
+| **rotating (Ω = −0.70, full trap)** | 0.52475 (+36.2 %) | 0.84341 | 0.21093 |
+
+Two findings, and they point opposite ways.
+
+**On the peak, the substitution degrades but survives.** Static and rotating
+differ by **3.21 %** here against **0.06 %** on the short protocol. 3.21 % is
+comparable to the 32³↔64³ resolution uncertainty (2.5 %, G3), so this is
+*suggestive of divergence, not established* — it wants a 64³ point before anyone
+leans on it.
+
+**On the endpoint, they are qualitatively different, and that is not marginal.**
+The rotating arm peaks and then collapses back to 0.21093 — *below* the baseline's
+0.23127 — while the static arm holds 0.47517, i.e. **2.25×** the rotating one.
+Rotation produces a transient; the weakened static trap produces a *sustained*
+transfer.
+
+So the §9.3 substitution ("rotation is fully replaceable by a static weakened
+trap") is a **short-time statement**. At 145 ms the two agree on how high the
+cascade climbs and disagree completely on whether it stays there — and the static
+prescription is the better one on the observable an experiment would actually
+integrate.
+
+The sheet's long-time rows (`P_exc(end) = 0.958 at 145 ms`) are not directly
+comparable — different cell (`keep_rot`, Ω = −0.5, aligned corpus) — and are not
+re-derived here. What is established is the *ordering*, which is the load-bearing
+part: static > rotating > baseline on sustained transfer.
 
 <!-- REDERIVE -->
 

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -41,6 +41,7 @@ measurements, not tests).
 | 14 | Is the 5.2 nT dip a resonance? | **No — the prediction was made and failed.** ω_eff,dip ∝ B predicts a dip near 0.325 at 2.6 nT; the measured tail rises monotonically through it. §11.4 withdrawn; the second branch has no mechanism. §12.3 |
 | 15 | Was the observable right? | **Not at 10.4 nT.** The peak must be taken *inside the hold*; over the whole trajectory it read the pre-hold transient and 7 of 10 arms were blind. Re-extracted: **0.00 % change at 1.3 / 2.6 / 5.2 nT**, so §9–§11 stand. §12.1 |
 | 16 | Does it survive LHY? | **Yes.** `full_bdg` moves the baseline +0.07 % and the optimum +2.18 %; the enhancement goes +24.9 % → **+27.5 %**. §12.4 |
+| 18 | The field-rotation branch (`eu151_klaus_phi_phys`) | **Two code defects, no physics.** Its GPU path was dead (`spin_density_vector` allocated host arrays → scalar-indexing error); and it reported **`conv = true` having never been asked**, because the rotating-basis GS returns no convergence flag and the writer defaulted it to `true` — so every such run satisfied CAMPAIGN guard 7 by construction. Both fixed and gated. §14 |
 | 17 | Does the static substitution hold at long time? | **Only on the peak.** At 145 ms static and rotating differ by 3.2 % at the peak (vs 0.06 % short) but by **2.25× at the endpoint** — rotation gives a transient, the static trap a *sustained* transfer. §13 |
 | 13 | 5.2 nT, resolved at 20 points + 64³ | **Two branches**, global max at ω_eff ≈ 0.55 (+17.0 %), secondary at ≈ 0.77, dip at ≈ 0.65 that **survives 64³** with 93 % of its depth. No single optimum quoted (criterion D1). The old `[0.5, 0.6]` maps to ω_eff ∈ [0.80, 0.87] — a declining shoulder below both maxima, so it is **refuted**, not merely unresolved. §11 |
 | 12 | How much of §9 is seed noise? | **None.** 5 seeds agree to 5 decimals, and the seed was *proved live* (state overlap 0.9999997, growing to 1.9e−5). The observable is deterministic here; grid/dt remain the real uncertainty (G3: 2.5 %). §10.3 |
@@ -913,6 +914,73 @@ The sheet's long-time rows (`P_exc(end) = 0.958 at 145 ms`) are not directly
 comparable — different cell (`keep_rot`, Ω = −0.5, aligned corpus) — and are not
 re-derived here. What is established is the *ordering*, which is the load-bearing
 part: static > rotating > baseline on sustained transfer.
+
+---
+
+## 14. The field-rotation branch: two code defects, no physics yet
+
+`runs/eu151_klaus_phi_phys/` — the field-rotation branch, 32×32×16 rotating-basis
+on GPU, 1 s steady stir × 8 scan points — had never been *run* since its seed was
+corrected to the anti-aligned end (§4.2). Smoking it before committing GPU hours
+(CLAUDE.md: render every path in ≈2 min first) found two defects and no physics.
+
+### 14.1 The rotating-basis GPU path was dead
+
+```
+ERROR: Scalar indexing is disallowed.
+  spin_density_vector → _compute_spin_density!
+  run_step_rotating/dynamics.jl:252
+```
+
+`spin_density_vector` allocated its three outputs as `zeros(Float64, n_pts)` —
+unconditionally **host**. On GPU that is a host destination with a device source,
+so the `@.` writes fall to the CPU broadcast kernel and **error**. Not a slow
+path: the whole rotating-basis dynamics path was unusable on GPU.
+
+Fixed with `similar(psi, Float64, n_pts)`, which is correct for any backend and
+leaves nothing to remember. The smoke then completes.
+
+### 14.2 `E = NaN` with `conv = true` — and the second half is the serious one
+
+The completed smoke reports `E=NaN conv=true`, with **ψ entirely finite**
+(212992/212992). Discriminated across four arms — seed `init_m_idx` ∈ {1, 13} ×
+ITP ∈ {100, 1500} — **all four give E = NaN with finite ψ**, so this is neither
+the anti-aligned seed (§4.2 is exonerated) nor an under-converged smoke.
+
+The cause is an absent key read through a default. The rotating-basis ground
+state returns `mu` and **no** energy and **no** convergence flag, and
+`run_registry.jl` read them as
+
+```julia
+energy    = get(result, :ground_state_energy,    NaN)
+converged = get(result, :ground_state_converged, true)   # <-- 
+```
+
+`NaN` for a missing energy is at least loud. **`true` for a missing convergence
+flag is not.** It collapses three states into one — converged, did-not-converge,
+and *nobody checked* — and the third is real: `:ground_state_converged` is
+already the discriminator for "did a ground state run at all"
+(`model/complete.jl:222`).
+
+> **Every rotating-basis run has been writing `converged = true` having never
+> been asked, and satisfying CAMPAIGN.md §4 guard 7 ("`conv == false` ⇒
+> disqualified") by construction.**
+
+Fixed by writing nothing when there is nothing to report — every consumer already
+handles absence — and gated by
+`test/workflow/test_converged_absent_is_not_a_pass.jl`, which counts the writes
+and the guarded writes and requires them equal, so a new unguarded write fails.
+
+**The rotating-basis GS still reports no energy.** That is left open and named
+rather than papered over: it needs the GS step to compute one, which is a change
+to that solver, not to the writer.
+
+### 14.3 Status
+
+No physics from this branch. What it produced is two defects, one of which was
+silently satisfying a campaign guard. The 8-point production scan is **not**
+launched — it would now run, but on a path whose ground state reports no energy,
+so there would be nothing to check the result against.
 
 <!-- REDERIVE -->
 

--- a/runs/klaus_quench_long_time/klaus_long_om0p0_holdonly_t350.yaml
+++ b/runs/klaus_quench_long_time/klaus_long_om0p0_holdonly_t350.yaml
@@ -6,6 +6,12 @@
 #   Ω/ω_⊥ during hold     : 0.0
 #   hold duration         : 350.0 ω_ref⁻¹  ≈ 506.4 ms
 #   Prasad references     : t=100 surface, t=350 vortex entry, t=5000 lattice
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -25,7 +31,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench_long_time/klaus_long_omm0p3_holdonly_t100.yaml
+++ b/runs/klaus_quench_long_time/klaus_long_omm0p3_holdonly_t100.yaml
@@ -3,6 +3,12 @@
 #   Ω/ω_⊥ = -0.3
 #   hold = 100.0 ω_ref⁻¹  ≈ 144.7 ms
 #   hold-only protocol (no pre-rotation).
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench_long_time/klaus_long_omm0p42_holdonly_t100.yaml
+++ b/runs/klaus_quench_long_time/klaus_long_omm0p42_holdonly_t100.yaml
@@ -3,6 +3,12 @@
 #   Ω/ω_⊥ = -0.42
 #   hold = 100.0 ω_ref⁻¹  ≈ 144.7 ms
 #   hold-only protocol (no pre-rotation).
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench_long_time/klaus_long_omm0p5_holdonly_t100.yaml
+++ b/runs/klaus_quench_long_time/klaus_long_omm0p5_holdonly_t100.yaml
@@ -6,6 +6,12 @@
 #   Ω/ω_⊥ during hold     : -0.5
 #   hold duration         : 100.0 ω_ref⁻¹  ≈ 144.7 ms
 #   Prasad references     : t=100 surface, t=350 vortex entry, t=5000 lattice
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -25,7 +31,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench_long_time/klaus_long_omm0p5_holdonly_t350.yaml
+++ b/runs/klaus_quench_long_time/klaus_long_omm0p5_holdonly_t350.yaml
@@ -6,6 +6,12 @@
 #   Ω/ω_⊥ during hold     : -0.5
 #   hold duration         : 350.0 ω_ref⁻¹  ≈ 506.4 ms
 #   Prasad references     : t=100 surface, t=350 vortex entry, t=5000 lattice
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -25,7 +31,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench_long_time/klaus_long_omm0p7_holdonly_t100.yaml
+++ b/runs/klaus_quench_long_time/klaus_long_omm0p7_holdonly_t100.yaml
@@ -3,6 +3,12 @@
 #   Ω/ω_⊥ = -0.7
 #   hold = 100.0 ω_ref⁻¹  ≈ 144.7 ms
 #   hold-only protocol (no pre-rotation).
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -22,7 +28,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench_long_time/klaus_long_omm0p85_holdonly_t100.yaml
+++ b/runs/klaus_quench_long_time/klaus_long_omm0p85_holdonly_t100.yaml
@@ -1,6 +1,12 @@
 # Klaus long-time Ω large scan @ t=100 ω⊥⁻¹.
 # Source: scripts/validation/klaus_long_omega_large_gen.jl
 #   Ω/ω_⊥ = -0.85  (near centrifugal limit Ω/ω_⊥ = 1)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -20,7 +26,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench_long_time/klaus_long_omm1p0_holdonly_t100.yaml
+++ b/runs/klaus_quench_long_time/klaus_long_omm1p0_holdonly_t100.yaml
@@ -1,6 +1,12 @@
 # Klaus long-time Ω large scan @ t=100 ω⊥⁻¹.
 # Source: scripts/validation/klaus_long_omega_large_gen.jl
 #   Ω/ω_⊥ = -1.0  (near centrifugal limit Ω/ω_⊥ = 1)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -20,7 +26,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/runs/klaus_quench_long_time/klaus_long_omm1p15_holdonly_t100.yaml
+++ b/runs/klaus_quench_long_time/klaus_long_omm1p15_holdonly_t100.yaml
@@ -1,6 +1,12 @@
 # Klaus long-time Ω large scan @ t=100 ω⊥⁻¹.
 # Source: scripts/validation/klaus_long_omega_large_gen.jl
 #   Ω/ω_⊥ = -1.15  (near centrifugal limit Ω/ω_⊥ = 1)
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned, and peak P_adj 0.53 against 0.24. This is the
+#   standard Einstein-de Haas preparation (Kawaguchi-Saito-Ueda PRL 96, 080405).
+#   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults:
   kind: spinor
@@ -20,7 +26,7 @@ pipeline:
       lhy: {kind: none}
       B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
       gauge_fix: false
-      initial_state: m_minus_F
+      initial_state: m_plus_F
       init_sigma: 1.5
       dt: 0.005
       n_steps: 3000

--- a/src/analysis/observables/density_spin.jl
+++ b/src/analysis/observables/density_spin.jl
@@ -91,7 +91,17 @@ end
 
 """
 Local spin density vector (Fx, Fy, Fz) at each spatial point.
-Returns a tuple of 3 arrays.
+Returns a tuple of 3 arrays, on the SAME DEVICE as `psi`.
+
+The outputs used to be `zeros(Float64, n_pts)` — unconditionally host. On the GPU
+that gives a host destination and a device source, so the `@.` writes in
+`_compute_spin_density!` fall back to the CPU broadcast kernel and die with
+"Scalar indexing is disallowed". It is not a slow path, it is an error, and it
+took out the whole rotating-basis dynamics path on GPU
+(`run_step_rotating/dynamics.jl:252`) — found 2026-08-20 by smoking
+`runs/eu151_klaus_phi_phys/` before committing GPU hours to it.
+
+`similar` keeps this correct for any future backend without anything to remember.
 """
 function spin_density_vector(
     psi::AbstractArray{<:Complex},
@@ -100,9 +110,9 @@ function spin_density_vector(
 ) where {D}
     n_pts = ntuple(d -> size(psi, d), ndim)
 
-    fx = zeros(Float64, n_pts)
-    fy = zeros(Float64, n_pts)
-    fz = zeros(Float64, n_pts)
+    fx = fill!(similar(psi, Float64, n_pts), 0)
+    fy = fill!(similar(psi, Float64, n_pts), 0)
+    fz = fill!(similar(psi, Float64, n_pts), 0)
 
     _compute_spin_density!(fx, fy, fz, psi, sm, Val(D), ndim, n_pts)
 

--- a/src/workflow/experiments/pipeline/run_registry.jl
+++ b/src/workflow/experiments/pipeline/run_registry.jl
@@ -646,7 +646,21 @@ function _run_yaml_scan(data::Dict, scan::OverrideScan, run_dir, env; verbose=tr
 
             psi_host = _to_host(result.psi)
             energy = get(result, :ground_state_energy, NaN)
-            converged = get(result, :ground_state_converged, true)
+            # ABSENT, not `true`. `:ground_state_converged` is already the discriminator
+            # for "did a ground state run at all" (`model/complete.jl:222`), so
+            # defaulting it to `true` here collapsed three different states into one:
+            # converged, did-not-converge, and NOBODY CHECKED. The third is real — a
+            # dynamics-only pipeline has no GS, and the rotating-basis GS
+            # (`run_step_rotating/ground_state.jl`) reports `mu` and no convergence flag
+            # at all — so every rotating-basis run was writing `converged = true` having
+            # never been asked, and walking through CAMPAIGN.md guard 7 ("conv == false
+            # => disqualified") by construction.
+            #
+            # Writing nothing is the minimal honest fix: every consumer already handles
+            # the key being missing (`haskey` in html_report.jl / run_summary.jl,
+            # `_gslib_get(..., -1)` in gs_library.jl, the optional-key list in
+            # open_result.jl), and absence cannot be mistaken for a pass.
+            converged = get(result, :ground_state_converged, nothing)
             grad_norm = get(result, :ground_state_grad_norm, NaN)
 
             # Mz measurement
@@ -681,7 +695,7 @@ function _run_yaml_scan(data::Dict, scan::OverrideScan, run_dir, env; verbose=tr
                     f["finished_at"] = finished_at
                     f["duration_seconds"] = duration
                     f["energy"] = energy
-                    f["converged"] = converged
+                    converged === nothing || (f["converged"] = converged)
                     f["grad_norm"] = grad_norm
                     f["mz_actual"] = mz_actual
                     # Provenance. `gs_ref` already carries this value but only
@@ -860,7 +874,21 @@ function _run_yaml_single(data::Dict, run_dir, env, index, run_name; verbose=tru
 
     psi_host = _to_host(result.psi)
     energy = get(result, :ground_state_energy, NaN)
-    converged = get(result, :ground_state_converged, true)
+    # ABSENT, not `true`. `:ground_state_converged` is already the discriminator
+    # for "did a ground state run at all" (`model/complete.jl:222`), so
+    # defaulting it to `true` here collapsed three different states into one:
+    # converged, did-not-converge, and NOBODY CHECKED. The third is real — a
+    # dynamics-only pipeline has no GS, and the rotating-basis GS
+    # (`run_step_rotating/ground_state.jl`) reports `mu` and no convergence flag
+    # at all — so every rotating-basis run was writing `converged = true` having
+    # never been asked, and walking through CAMPAIGN.md guard 7 ("conv == false
+    # => disqualified") by construction.
+    #
+    # Writing nothing is the minimal honest fix: every consumer already handles
+    # the key being missing (`haskey` in html_report.jl / run_summary.jl,
+    # `_gslib_get(..., -1)` in gs_library.jl, the optional-key list in
+    # open_result.jl), and absence cannot be mistaken for a pass.
+    converged = get(result, :ground_state_converged, nothing)
 
     tmp_file = _scratch_tmp_path(psi_file)
     jld_kwargs = _snapshot_compression_kwargs(result)
@@ -874,7 +902,7 @@ function _run_yaml_single(data::Dict, run_dir, env, index, run_name; verbose=tru
             f["finished_at"] = finished_at
             f["duration_seconds"] = duration
             f["energy"] = energy
-            f["converged"] = converged
+            converged === nothing || (f["converged"] = converged)
             # Provenance — see the scan path for why this is a separate key from
             # `gs_ref`, and for the step-3 rename.
             gs_artifact_id = get(result, :gs_stage_ref, nothing)

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -34,6 +34,10 @@ const FAST_TESTS = [
     # `0.468` survived weeks in an experimentalist sheet that carried its own
     # retraction at the top — documents are read by section, not from the top.
     "test_retracted_numbers_carry_their_replacement.jl",
+    # "Nobody checked" must not be written as "converged". The rotating-basis GS
+    # reports no convergence flag, so every such run satisfied CAMPAIGN guard 7
+    # by default, having never been asked.
+    "workflow/test_converged_absent_is_not_a_pass.jl",
     # A declared mirror pair must flip EVERY axial quantity (Omega, m AND B_z).
     # bce2068f repaired two configs correctly one at a time and broke the mirror
     # relationship between them; nothing recorded that they were a pair (#343).

--- a/test/workflow/test_converged_absent_is_not_a_pass.jl
+++ b/test/workflow/test_converged_absent_is_not_a_pass.jl
@@ -1,0 +1,63 @@
+# "Nobody checked" must not be written as "converged".
+#
+# `run_registry.jl` read the convergence flag as
+#
+#     converged = get(result, :ground_state_converged, true)
+#
+# and wrote the result unconditionally. That default collapsed three distinct
+# states into one:
+#
+#   converged            the solver ran and reached its tolerance
+#   did not converge     the solver ran and did not
+#   NOBODY CHECKED       there is no convergence information at all
+#
+# The third is not hypothetical. `:ground_state_converged` is already the
+# discriminator for "did a ground state run at all" (`model/complete.jl:222`), so
+# a dynamics-only pipeline has none — and the rotating-basis ground state
+# (`run_step_rotating/ground_state.jl`) returns `mu` and no convergence flag
+# either. Every rotating-basis run therefore wrote `converged = true` having
+# never been asked, and satisfied CAMPAIGN.md guard 7 ("conv == false =>
+# disqualified") by construction.
+#
+# Found 2026-08-20 by smoking `runs/eu151_klaus_phi_phys/` before spending GPU
+# hours on it: the run came back `E=NaN conv=true`, and the energy was NaN for
+# the same reason — an absent key read through a default.
+#
+# The fix is to write nothing when there is nothing to report. Every consumer
+# already handles absence (`haskey` in html_report.jl and run_summary.jl,
+# `_gslib_get(..., -1)` in gs_library.jl, the optional-key list in
+# open_result.jl), and absence cannot be mistaken for a pass.
+
+using SpinorBEC
+using Test
+
+const _REPO = normpath(joinpath(@__DIR__, "..", ".."))
+const _REG = joinpath(_REPO, "src", "workflow", "experiments",
+    "pipeline", "run_registry.jl")
+
+@testset "an absent convergence flag is never written as a pass" begin
+    src = read(_REG, String)
+
+    # 1. The defaulting-to-true read is gone, at every site.
+    @test !occursin(":ground_state_converged, true)", src)
+
+    # 2. …and the replacement reads absence AS absence.
+    @test occursin(":ground_state_converged, nothing)", src)
+    @test count(", nothing)", src) >= 1
+
+    # 3. Every write of the key is guarded, so `nothing` never reaches the file.
+    #    Count writes and guarded writes and require them equal — a new
+    #    unguarded write anywhere in this file fails here.
+    writes = length(collect(eachmatch(r"f\[\"converged\"\]\s*=", src)))
+    guarded = length(
+        collect(eachmatch(
+            r"converged\s*===\s*nothing\s*\|\|\s*\(f\[\"converged\"\]\s*=", src)),
+    )
+    @test writes >= 2                 # the scan-point path and the single-run path
+    @test guarded == writes
+
+    # POSITIVE CONTROL. Arms 1-3 are all satisfied by a file that never mentions
+    # `converged`, so pin that the thing being guarded is actually present.
+    @test occursin("ground_state_converged", src)
+    @test occursin("f[\"converged\"]", src)
+end


### PR DESCRIPTION
#403 の続き。残っていた4項目（共鳴仮説・LHY・長時間分枝・field-rotation 分枝）を全部やりました。

判定・全データ: **`docs/campaign/edh_quench_polarisation_decision.md` §12–§14**（LIVE）

---

## 0. まず観測量に欠陥がありました

10.4 nT で **hold しか違わない4本が peak P_adj = 0.26050 で完全一致**。hold しか違わない腕が同値になるのは、最大値が **hold より前**にあるときだけです。実際 argmax は frame 29、hold は 32 から。

つまり観測量が hold 前の過渡を読んでいました。**「10.4 nT に谷なし」は盲目な計器から読んだ確認済み予言になるところでした。**

主張は常に hold についてなので、ピークは hold 内で取ります。全キャッシュを再抽出（再計算なし）:

| 磁場 | 腕数 | 変化 |
|---|---|---|
| 1.3 / 2.6 / 5.2 nT | 43 | **全点 0.00 %** |
| **10.4 nT** | 10 | **10本中7本が最大 −23 %** |

⇒ **§9–§11 は無傷**（測って確認、仮定ではなく）。汚染は Zeeman 再ピン留め領域だけ。

## 1. 共鳴仮説 — 予言して、外れました

§11.4 は 5.2 nT の谷を共鳴と読み、**ω_eff,dip ∝ B** を予言しました。実行前に明文化:

| 磁場 | 予言 | 実測 | |
|---|---|---|---|
| 10.4 nT | 谷は 1.30（範囲外）⇒ 谷なし | 谷なし | 整合（ただし弱い半分） |
| **2.6 nT** | **0.325 付近に谷** | **0.250→0.375 単調増加**（0.45976, 0.46412, 0.46681, 0.47068, 0.47682） | **失敗** |

情報量のある方が外れたので **共鳴解釈は反証**、§11.4 は取り消し（削除せず打ち消し線）。5.2 nT の第二枝は**機構のない測定事実**になりました。

10.4 nT を正しく読むと **ω_eff=0.650 の単峰、+49.5 %** — 相対増強は全磁場中最大、絶対量は最小（0.30 vs 2.6 nT の 0.66）。Zeeman 再ピン留めは因子2を奪うが**チャネルを閉じない**。

磁場に対する最適は全列で非単調で、**一行の処方は存在しません**:

| 1.3 nT | 窓なし | +1.8 % |
| 2.6 nT | 0.714 | +24.9 % | 単峰 |
| 5.2 nT | 0.55 | +17.0 % | 二枝 |
| 10.4 nT | 0.650 | +49.5 % | 単峰 |

## 2. LHY — 生き残りました

2.6 nT を `full_bdg` で再実行: baseline **+0.07 %**、最適 **+2.18 %**、増強は +24.9 % → **+27.5 %**。`lhy: none` の但し書きはこの結論については解除。

## 3. 長時間 145 ms — 置換が割れました

`runs/klaus_quench_long_time/` は最初の retarget が**取りこぼし**ており、まだ平行のままでした。9本を修正（ゲート緑）。

| | hold ピーク | **終端** |
|---|---|---|
| baseline | 0.38532 | 0.23127 |
| **静的** ω_eff=0.714 | 0.50790 | **0.47517** |
| **回転** Ω=−0.70 | 0.52475 | **0.21093** |

ピークでは 3.21 % 差（短時間 0.06 %）— 解像度不確かさ 2.5 % と同程度なので**示唆どまり**（64³ 確認を実行中）。

しかし**終端では質的に違います**: 回転はピーク後に **0.21093 まで崩れ**（baseline の 0.23127 を**下回る**）、静的は **0.47517 を保持** = **2.25 倍**。⇒ 回転は過渡的、静的は**持続的**。置換は**短時間の主張**です。

## 4. field-rotation 分枝 — 物理は出ず、欠陥が2つ

GPU 投入前の smoke（2分）で:

**(a) GPU 経路が死んでいた** — `spin_density_vector` が `zeros(Float64, n_pts)`（無条件ホスト）を確保 ⇒ device ソース×host 宛先で **"Scalar indexing is disallowed" エラー**。遅いのではなく死ぬ。`similar(psi, ...)` で修正。

**(b) こちらが重い** — 完走後 `E=NaN conv=true`、**ψ は全成分有限**（212992/212992）。seed {1,13} × ITP {100,1500} の4本すべて同じ ⇒ 反平行種も smoke の切り詰めも無罪。

原因は欠落キーを既定値で読むこと:
```julia
energy    = get(result, :ground_state_energy,    NaN)
converged = get(result, :ground_state_converged, true)   # ←
```
`NaN` は騒がしい。**`true` は静かです。**「収束した / しなかった / **誰も確認していない**」を潰します。rotating_basis GS は `mu` だけ返し収束フラグを返しません。

> **rotating_basis の全 run が `converged = true` を聞かれずに書き、CAMPAIGN.md guard 7 を構造的に通過していました。**

無いときは**書かない**よう修正。gate は「書き込み数 == ガード付き書き込み数」を数えます。

**未解決として明記**: rotating_basis GS は依然 energy を報告しません（ソルバ変更が要る）。**8点の本番スキャンは投げていません** — 走りはしますが照合するものが無いためです。

---

**Type**: §12/§13 は **B**、§14 は **A**（コード正しさ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
