### PR TITLE
docs(campaign): 長時間の順序を撤回 — 32³ はこの分枝を解像していない

### DIFF
--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -533,3 +533,36 @@ doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "4.2"
 pr = 392
 note = "Named rather than left implicit. It is a 32×32×16 GPU rotating-basis 8-point scan with no result being quoted, so it was deferred rather than fixed — but a deferral with no row is indistinguishable from an oversight."
+
+[[claim]]
+id = "edh-longtime-static-sustains"
+claim = "At 145 ms the rotating arm peaks and collapses back below the baseline while the static weakened trap holds 2.25× it, so rotation gives a transient and the static trap a SUSTAINED transfer."
+status = "refuted"
+type = "B"
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, 2.6 nT, hold = 100 ω_ref⁻¹, three arms."
+retired_literal = ["2.25×", "2.25x", "sustained transfer", "a transient"]
+uncertainty = "The claim was stated with its own key number (3.21 % static-vs-rotating at the peak) INSIDE the resolution systematic (2.5 %), and said so. That overlap is what made the 64³ run the obvious next step."
+uncertainty_basis = "grid"
+evidence = ["32³: baseline 0.38532/0.23127, static 0.50790/0.47517, rotating 0.52475/0.21093 (hold-peak/end)"]
+evidence_status = "absent"
+commit = "97ec124e"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "13"
+pr = 410
+note = """REFUTED 2026-08-20 by the 64³ re-run, with NO replacement ordering — see `edh-longtime-not-converged-at-32`. Both orderings invert: static-vs-rotating at the peak goes -3.2 % to +21.6 %, and at the endpoint 2.25× to 0.68×. Per-arm the endpoints move -42.6 % (static) and +91.3 % (rotating). This is not a 3 % divergence being resolved, it is 32³ failing to resolve the branch."""
+
+[[claim]]
+id = "edh-longtime-not-converged-at-32"
+claim = "At a 100 ω_ref⁻¹ hold, 32³ is not resolution-converged: refining to 64³ inverts both the peak and the endpoint ordering of static vs rotating, so NEITHER resolution establishes the long-time ordering."
+status = "live"
+type = "B"
+scope = "2.6 nT, anti-aligned, CPU, one seed. TWO arms at 64³ (static ω_eff=0.714 and rotating Ω=−0.70); the 64³ BASELINE was not run."
+uncertainty = "unbounded: n = 1 at each 64³ point and no 64³ baseline, so this bounds what 32³ CANNOT support without establishing what is true. A third arm and a second seed at 64³ are the missing measurements."
+uncertainty_basis = "grid"
+evidence = ["64³: static 0.49081/0.27262, rotating 0.40358/0.40358 (hold-peak/end) against 32³ 0.50790/0.47517 and 0.52475/0.21093"]
+evidence_status = "absent"
+commit = "32aa5e50"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "15"
+pr = 0
+note = """The part that generalises: grid adequacy is a property of the grid AND the integration time. Under the same 32³→64³ refinement the SHORT protocol (14.5 ω⁻¹) moved by a uniform +2.3 % and the 5.2 nT dip kept 93 % of its depth — shape preserved — while the long one moves -3.4/-23.1/-42.6/+91.3 % and orderings invert. So sections 9-12 are unaffected and only the long-time branch is out of reach at 32³. A convergence check at one duration does not transfer to another."""

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -885,6 +885,11 @@ fields or densities, which were not re-run.
 
 ## 13. Long time (145 ms): the substitution is a short-time statement
 
+> **RETRACTED 2026-08-20 — every ordering below flips sign at 64³. See §15.**
+> The section is kept because the 32³ numbers are real and the retraction is
+> about what they support, not about whether they were measured. Do not quote
+> the endpoint comparison or the "sustained vs transient" reading.
+
 `runs/klaus_quench_long_time/` was **missed by the corpus retarget** — it was
 still `m_minus_F` at B_z > 0, i.e. aligned, until this branch. Retargeted (9
 configs, seed-agreement gate green), then three arms at hold = 100 ω_ref⁻¹
@@ -906,20 +911,26 @@ leans on it.
 
 **On the endpoint, they are qualitatively different, and that is not marginal.**
 The rotating arm peaks and then collapses back to 0.21093 — *below* the baseline's
-0.23127 — while the static arm holds 0.47517, i.e. **2.25×** the rotating one.
-Rotation produces a transient; the weakened static trap produces a *sustained*
-transfer.
+0.23127 — while the static arm holds 0.47517, i.e. ~~**2.25×**~~ the rotating one.
+Rotation produces ~~a transient~~; the weakened static trap produces a
+~~sustained transfer~~.
+<!-- REFUTED 2026-08-20 (§15, claim `edh-longtime-static-sustains`): at 64³ the
+     ratio is 0.68× and the arms swap roles. No replacement ordering exists. -->
+
+> **REFUTED — §15.** At 64³ this ordering inverts: static ÷ rotating at the end is
+> **0.68×**, and it is the *static* arm that decays while the rotating one is
+> still climbing. Neither resolution establishes the long-time ordering.
 
 So the §9.3 substitution ("rotation is fully replaceable by a static weakened
 trap") is a **short-time statement**. At 145 ms the two agree on how high the
 cascade climbs and disagree completely on whether it stays there — and the static
 prescription is the better one on the observable an experiment would actually
-integrate.
+integrate. *(That last clause is **refuted**; see §15.)*
 
 The sheet's long-time rows (`P_exc(end) = 0.958 at 145 ms`) are not directly
 comparable — different cell (`keep_rot`, Ω = −0.5, aligned corpus) — and are not
-re-derived here. What is established is the *ordering*, which is the load-bearing
-part: static > rotating > baseline on sustained transfer.
+re-derived here. The *ordering* was claimed here as the load-bearing part —
+~~static > rotating > baseline on sustained transfer~~ — and is **REFUTED** by §15.
 
 ---
 
@@ -987,6 +998,69 @@ No physics from this branch. What it produced is two defects, one of which was
 silently satisfying a campaign guard. The 8-point production scan is **not**
 launched — it would now run, but on a path whose ground state reports no energy,
 so there would be nothing to check the result against.
+
+---
+
+## 15. RETRACTION — 32³ is not converged for the long-time branch
+
+§13 was published in PR #410 on the strength of three 32³ arms. The two arms its
+conclusion rests on were then re-run at 64³, and **both orderings reverse**.
+
+| | 32³ | 64³ |
+|---|---:|---:|
+| **hold-peak** static (ω_eff = 0.714) | 0.50790 | 0.49081 |
+| **hold-peak** rotating (Ω = −0.70) | 0.52475 | 0.40358 |
+| static vs rotating | **−3.2 %** | **+21.6 %** |
+| **endpoint** static | 0.47517 | 0.27262 |
+| **endpoint** rotating | 0.21093 | 0.40358 |
+| static ÷ rotating at the end (the **refuted** 32³ figure vs 64³) | **2.25×** | **0.68×** |
+
+Per-arm, 32³ → 64³: static peak −3.4 %, rotating peak −23.1 %, static endpoint
+**−42.6 %**, rotating endpoint **+91.3 %**.
+
+### 15.1 What is withdrawn
+
+- **REFUTED — "Rotation gives a transient, the static trap a sustained transfer."**
+  At 64³ it is the *static* arm that decays (0.49081 → 0.27262) and the
+  *rotating* one that is still climbing at 145 ms (peak = end = 0.40358).
+- **"The static prescription is the better one on the observable an experiment
+  would integrate."** Withdrawn — at 64³ the rotating arm ends higher.
+- **"Static and rotating differ by 3.21 %, suggestive of divergence."**
+  Withdrawn. The correct reading is not a 3 % divergence but that **32³ does not
+  resolve this branch at all.**
+
+### 15.2 What replaces it
+
+Only this, and it is deliberately thin:
+
+> **At 145 ms, 32³ is not resolution-converged. Nothing about the long-time
+> ordering of static vs rotating is established at either resolution**, because
+> 64³ has n = 1 per point and its baseline arm was **not** run — so 64³ shows the
+> 32³ answer is wrong without establishing the right one.
+
+### 15.3 The part that generalises: resolution adequacy is duration-dependent
+
+The short protocol and the long one behave completely differently under the same
+refinement:
+
+| | shift under 32³ → 64³ |
+|---|---|
+| short (14.5 ω⁻¹), §11.2 | a **uniform** +2.3 %; the 5.2 nT dip kept **93 %** of its depth, so the *shape* survived |
+| long (100 ω⁻¹), here | **−3.4 / −23.1 / −42.6 / +91.3 %** — not uniform, and orderings invert |
+
+**So §9–§12 are unaffected** — their conclusions rest on shapes and orderings at
+14.5 ω⁻¹, where the refinement was measured to be a uniform offset. It is only the
+long-time branch that 32³ cannot carry. Grid adequacy is not a property of the
+grid alone; it is a property of the grid *and the integration time*, and a
+convergence check done at one duration does not transfer to another.
+
+### 15.4 Why this was caught
+
+Because §13 said its own key number sat inside the resolution uncertainty
+(3.21 % against 2.5 %) and named the missing measurement instead of rounding it
+away. The 64³ run was then the obvious next thing rather than something nobody
+thought to do. **A stated uncertainty that overlaps the claim is a work item, and
+writing it down is what makes it one.**
 
 <!-- REDERIVE -->
 


### PR DESCRIPTION
**#410 で出した長時間（145 ms）の結論を撤回します。** 64³ で順序が両方とも反転しました。

判定: **`docs/campaign/edh_quench_polarisation_decision.md` §15**（LIVE）

---

## 何が起きたか

#410 は 32³ 3本に基づき、**自分の本文で**「主要な数字（ピークでの静的↔回転 3.21 %）は解像度系統誤差 2.5 % と同程度なので示唆どまり」と書いていました。その2本を 64³ で回したところ:

| | 32³ | 64³ |
|---|---|---|
| hold ピーク 静的 (ω_eff=0.714) | 0.50790 | 0.49081 |
| hold ピーク 回転 (Ω=−0.70) | 0.52475 | 0.40358 |
| 静的 vs 回転 | **−3.2 %** | **+21.6 %** |
| 終端 静的 | 0.47517 | 0.27262 |
| 終端 回転 | 0.21093 | 0.40358 |
| 終端の比 | **2.25×** | **0.68×** |

腕ごとの 32³→64³: 静的ピーク −3.4 %、回転ピーク −23.1 %、**静的終端 −42.6 %**、**回転終端 +91.3 %**。

## 撤回するもの

- 「回転は過渡的、静的は**持続的**」— 64³ では**静的の方が減衰**し、回転は 145 ms でまだ上昇中
- 「実験が積分する量では静的の方が良い」
- 「3.21 % は乖離の示唆」— 正しくは**32³ がこの分枝を解像できていない**

## 置き換え（意図的に薄い）

> 145 ms では **32³ は解像度収束していない**。そして **どちらの解像度も長時間の順序を確立していません** — 64³ は各点 n=1 で、**baseline 腕を走らせていない**ので、32³ の答えが誤りであることは示しても正しい答えは示していません。

ledger には **`refuted`（置換なし）** として記録しました。「反証されたが置き換えが無い」は実在する結果で、スキーマがそれを表現できるのはそのためです。

## 一般化する部分

同じ 32³→64³ の細分化で、**短時間と長時間の振る舞いが全く違います**:

| | 32³→64³ の変化 |
|---|---|
| 短（14.5 ω⁻¹、§11.2） | **一様** +2.3 %。5.2 nT の谷は深さ **93 % を保持** ⇒ **形は生き残る** |
| 長（100 ω⁻¹、今回） | **−3.4 / −23.1 / −42.6 / +91.3 %** — 一様でなく、順序が反転 |

⇒ **格子の妥当性は格子だけの性質ではなく、格子と積分時間の性質**です。ある継続時間での収束確認は別の継続時間に移りません。したがって **§9–§12 は無傷**（これも測って確認）。

## なぜ捕まったか

#410 が**自分の主張と重なる不確かさを丸めずに書いた**からです。だから 64³ が「誰も思いつかなかったこと」ではなく「次にやる明らかなこと」になりました。**主張と重なる不確かさは作業項目**で、書き下すことがそれを作業項目にします。

## ゲートが自分の変更を捕まえた

point-of-use ゲートが本 PR 内の**未マークの6箇所**を検出しました — **撤回セクション自身が撤回した数字を再掲している箇所を含めて**。全て行単位でマーク済み。

---

**Type**: **B**（32³/64³、CPU、`lhy: none`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
