### PR TITLE
fix(campaign): close the long-time branch at 64³, and the gate that was hiding it

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -149,7 +149,7 @@ to their own default), and that qualification is judgement, not derived.
 | knob | `find_ground_state` | `find_ground_state_lbfgs` | YAML fallback |
 |---|---|---|---|
 | `n_steps` | 10000 | 1000 | method === :lbfgs ? 500 : 100000 / 1000 / 100000 / 4000 / use_from_jld2 ? 0 : 200 (schema `100000`) |
-| `tol` | 1e-10 | 1e-8 | 1e-8 / 1e-6 (schema `1.0e-8`) |
+| `tol` | 1e-10 | 1e-8 | 1e-8 / 1e-6 / 1.0e-9 (schema `1.0e-8`) |
 | `m_lbfgs` | 20 | 20 | 10 (schema `10`) |
 
 **`m_lbfgs` is the live trap.** Both Julia entries default to 20 and

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -566,3 +566,35 @@ doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "15"
 pr = 0
 note = """The part that generalises: grid adequacy is a property of the grid AND the integration time. Under the same 32³→64³ refinement the SHORT protocol (14.5 ω⁻¹) moved by a uniform +2.3 % and the 5.2 nT dip kept 93 % of its depth — shape preserved — while the long one moves -3.4/-23.1/-42.6/+91.3 % and orderings invert. So sections 9-12 are unaffected and only the long-time branch is out of reach at 32³. A convergence check at one duration does not transfer to another."""
+
+[[claim]]
+id = "edh-phi-phys-anti-aligned-needs-field-reversal"
+claim = "The anti-aligned preparation cannot be produced by ITP on the fast-Larmor rotating-basis path: at p = 26700 the Zeeman-shifted factor for the highest m is exp(-12·p·dt) = exp(-1602), which underflows in ONE step and returns ψ identically zero. It needs the state relaxed at the OPPOSITE field sign and the field reversed for the dynamics — a pipeline change, not a config key."
+status = "live"
+type = "A"
+scope = "`runs/eu151_klaus_phi_phys/config.yaml`, p = 26700, dt = 0.005, F = 6. Quantitative, so it does NOT generalise: the klaus_quench spinor corpus has p ≈ 148, per-step factor exp(-8.9), renormalised every step and never underflowing."
+uncertainty = "Four control arms — init_m_idx in {1, 13} x ITP in {100, 1500} — separate the candidate causes: both init_m_idx=13 arms give 0 of 212992 non-zero entries and ‖ψ‖² = 0.0, both init_m_idx=1 arms give ‖ψ‖² = 4.096 and E = -160177.6. The seed, not the ITP length, is what decides it."
+uncertainty_basis = "control"
+evidence = ["runs/eu151_klaus_phi_phys/config.yaml", "src/workflow/experiments/pipeline/run_step_rotating/ground_state.jl"]
+evidence_status = "in_tree"
+commit = "e11b0291"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "16.3"
+pr = 0
+note = """SUPERSEDES the deferral in `edh-phi-phys-config-anti-alignment`, which proposed `init_m_idx: 13` as the repair. That was set on 2026-08-19 and reverted on 2026-08-20 once the energy was reported at all — the run had been completing on ψ ≡ 0 with E = 0.0 and saying nothing. The underflow is now a hard error naming the mechanism and the remedy. The repair is not implemented."""
+
+[[claim]]
+id = "rotating-basis-result-writer-omitted-energy"
+claim = "`save_rotating_basis_result!` — the writer that owns result.jld2 for BOTH `kind: rotating_basis` and `kind: spinor`-with-dynamics — wrote neither `energy` nor `converged`, so both keys were ABSENT from every dynamics run's result file."
+status = "live"
+type = "A"
+scope = "All runs written through `save_rotating_basis_result!` (runner.jl:294), which is every pipeline carrying a dynamics history."
+uncertainty = "unbounded: this is a code-shape claim, not a measured quantity — the writer either emits the key or it does not, and it did not. What is NOT bounded is how many stored runs are affected, because runs/ is untracked."
+uncertainty_basis = "none"
+evidence = ["src/workflow/io/save_rotating_result.jl"]
+evidence_status = "in_tree"
+commit = "e11b0291"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "16.1"
+pr = 0
+note = """CORRECTS section 14.2, which attributed the missing energy to `run_registry.jl` reading absent keys through defaults. That writer is never reached on this path. The `conv = true` default was real and printed to stdout, but was never STORED — so a guard reading the file finds nothing, which is unknown rather than a pass, and section 14.2's guard-7 claim overstated. The #410 default fix stands on its own path; this is a third writer nobody had checked."""

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -482,7 +482,9 @@ commit = "b2d746cc"
 doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "10.3"
 pr = 392
-note = "Consequence: the seed axis carries no uncertainty to quote for this family, so every `uncertainty` field above is bounded by grid/dt instead. The `noise_seed` knob was initially wired to the wrong step and produced the same all-identical table for a wrong reason; that was found and fixed before these numbers."
+note = """Consequence: the seed axis carries no uncertainty to quote for this family, so every `uncertainty` field above is bounded by grid/dt instead. The `noise_seed` knob was initially wired to the wrong step and produced the same all-identical table for a wrong reason; that was found and fixed before these numbers.
+
+CAVEAT NOW MEASURED, 2026-08-20. The scope's warning about longer holds was not hypothetical: at 100 ω_ref⁻¹ and 64³ a second seed moves the static arm's ENDPOINT by 34.2 % (0.27262 → 0.17952) while leaving its PEAK identical to five decimals (0.49081 both). So the determinism is a property of the peak, and the endpoint at long time carries a seed uncertainty large enough to swallow an 18.8 % arm separation — see `edh-longtime-endpoint-ordering-unresolved`. Rows bounded by grid/dt above remain correct for the short protocol; a long-hold endpoint must quote a seed bound."""
 
 [[claim]]
 id = "edh-corpus-is-one-seed-32cubed-lhy-none"
@@ -556,8 +558,8 @@ id = "edh-longtime-not-converged-at-32"
 claim = "At a 100 ω_ref⁻¹ hold, 32³ is not resolution-converged: refining to 64³ inverts both the peak and the endpoint ordering of static vs rotating, so NEITHER resolution establishes the long-time ordering."
 status = "live"
 type = "B"
-scope = "2.6 nT, anti-aligned, CPU, one seed. TWO arms at 64³ (static ω_eff=0.714 and rotating Ω=−0.70); the 64³ BASELINE was not run."
-uncertainty = "unbounded: n = 1 at each 64³ point and no 64³ baseline, so this bounds what 32³ CANNOT support without establishing what is true. A third arm and a second seed at 64³ are the missing measurements."
+scope = "2.6 nT, anti-aligned, CPU. THREE arms at 64³ (baseline, static ω_eff=0.714, rotating Ω=−0.70), two seeds on the static and rotating arms."
+uncertainty = "Bounds what 32³ cannot support; it does not by itself establish the 64³ answer. The two measurements it named as missing — a baseline arm and a second seed — were run on 2026-08-20 and are `edh-longtime-peak-ordering-at-64` (established) and `edh-longtime-endpoint-ordering-unresolved` (still not)."
 uncertainty_basis = "grid"
 evidence = ["64³: static 0.49081/0.27262, rotating 0.40358/0.40358 (hold-peak/end) against 32³ 0.50790/0.47517 and 0.52475/0.21093"]
 evidence_status = "absent"
@@ -566,6 +568,38 @@ doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "15"
 pr = 0
 note = """The part that generalises: grid adequacy is a property of the grid AND the integration time. Under the same 32³→64³ refinement the SHORT protocol (14.5 ω⁻¹) moved by a uniform +2.3 % and the 5.2 nT dip kept 93 % of its depth — shape preserved — while the long one moves -3.4/-23.1/-42.6/+91.3 % and orderings invert. So sections 9-12 are unaffected and only the long-time branch is out of reach at 32³. A convergence check at one duration does not transfer to another."""
+
+[[claim]]
+id = "edh-longtime-peak-ordering-at-64"
+claim = "At a 100 ω_ref⁻¹ hold and 64³ the hold-peak ordering is static (0.49081) > rotating (0.40102) > baseline (0.37973): the statically weakened trap beats no-intervention by +29.3 % and beats rotation by +22.4 %."
+status = "live"
+type = "B"
+scope = "2.6 nT, anti-aligned, CPU, `lhy: none`, 64³, 100 ω_ref⁻¹ hold. The PEAK only — the endpoint ordering at the same duration is a separate and unresolved row."
+uncertainty = "The static peak is seed-independent to five decimals (0.49081 at two seeds) and the rotating peak moves 0.63 %, so the 22.4 % and 29.3 % gaps are 35-100x the seed scatter. Not grid-bounded: this IS the refined grid, and 32³ gave the opposite static-vs-rotating sign, so no statement is carried over from there."
+uncertainty_basis = "seed"
+evidence = ["64³ hold-peak P_adj: baseline 0.37973, static 0.49081, rotating 0.40102; static seed 101 vs default both 0.49081"]
+evidence_status = "absent"
+commit = "6bb97bb2"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "17.2"
+pr = 0
+note = """Replaces the ordering `edh-longtime-static-sustains` asserted and `edh-longtime-not-converged-at-32` refused to restate — but only for the peak, and with the opposite reading of what the two arms do. The original claim was that the static arm SUSTAINS and the rotating one decays; at 64³ the rotating arm is the persistent one (peak ~= endpoint, still climbing at 145 ms) and the static one falls from 0.49081 to 0.17952. Larger cascade and more persistent cascade are different questions and 32³ answered neither."""
+
+[[claim]]
+id = "edh-longtime-endpoint-ordering-unresolved"
+claim = "At 100 ω_ref⁻¹ and 64³ the endpoint separates rotating (0.40013) from static (0.17952) by 2.23x, which is safe, but does NOT separate static from baseline (0.17952 vs 0.15112, +18.8 %) because the static endpoint moves 34.2 % between two seeds."
+status = "open"
+type = "B"
+scope = "2.6 nT, anti-aligned, CPU, `lhy: none`, 64³. The endpoint at long hold only; the peak at the same points IS resolved (`edh-longtime-peak-ordering-at-64`)."
+uncertainty = "unbounded on the static-vs-baseline row: n = 2 seeds gives a spread (34.2 %) but no distribution, so 18.8 % is inside it and no confidence can be attached. Closing it needs an ensemble on both arms, not a finer grid — the grid is already the refined one."
+uncertainty_basis = "seed"
+evidence = ["64³ endpoint P_adj: baseline 0.15112, static 0.17952 (seed 101) / 0.27262 (default), rotating 0.40013 / 0.40358"]
+evidence_status = "absent"
+commit = "6bb97bb2"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "17.2"
+pr = 0
+note = """Recorded as `open` rather than left out, because the absence of a statement here is exactly what a reader would otherwise supply from the peak row. The rotating-vs-static factor of 2.23 IS outside the scatter and is safe to quote; the static-vs-baseline one is not. Same shape as `edh-longtime-not-converged-at-32`: a quantity measured on one axis (peak) does not transfer to another (endpoint), just as one duration did not transfer to another."""
 
 [[claim]]
 id = "edh-phi-phys-anti-aligned-needs-field-reversal"

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -32,8 +32,8 @@ measurements, not tests).
 | 1 | Is `bce2068f` in the ancestor gate? | **Yes**, as `eu-config-field-sign`, and the gate now **executes** (`cli.jl campaign-gate`) instead of being prose |
 | 2 | How many stored runs does the new row disqualify? | **0 marginally.** All 200 gateable runs were already disqualified by older refs; 3 more have no producing commit at all |
 | 3 | Does the field sign move the load-bearing observables? | **Yes, by ×2.2 to ×5.0.** Peak P_{−5,−4} 0.244 → 0.530; peak \|L_z\| 0.020 → 0.101. Nothing depending on either is quotable without re-derivation. §3 |
-| 3b | Does the *rotation enhancement* survive the corrected field sign? | **No.** +15.8 % pre-fix vs **−0.45 %** post-fix, with the Ω knob proved live at both. `\|Ω\|/ω_⊥ = 0.468 ± 0.003` is not re-derivable as posed. §3.4 |
-| 7 | What replaces `\|Ω\|/ω_⊥ = 0.468 ± 0.003`? | **`\|Ω*\|/ω_⊥ = 0.68 ± 0.04`** at the anti-aligned preparation, +24.9 % over Ω=0. Two digits, not three. §9.1 |
+| 3b | Does the *rotation enhancement* survive the corrected field sign? | **No.** +15.8 % pre-fix vs **−0.45 %** post-fix, with the Ω knob proved live at both. `\|Ω\|/ω_⊥ = 0.468 ± 0.003` is **superseded** — not re-derivable as posed. §3.4 |
+| 7 | What replaces the **superseded** `\|Ω\|/ω_⊥ = 0.468 ± 0.003`? | **`\|Ω*\|/ω_⊥ = 0.68 ± 0.04`** at the anti-aligned preparation, +24.9 % over Ω=0. Two digits, not three. §9.1 |
 | 8 | Is the enhancement chirality-matched, as the sheet says? | **No.** The response is **even in Ω** to ≤ 0.124 %; Ω=0 is the minimum and both senses enhance equally. §9.2 |
 | 9 | Then what is the mechanism? | **Centrifugal, not Coriolis.** A *static* trap weakened to ω_eff = √(ω_⊥²−Ω²) reproduces the whole effect to **0.06 %** across the range. **Rotation is not needed** — weaken the radial trap to **0.71 ω_⊥**. §9.3, §10.1 |
 | 10 | Is it density, or the radial confinement? | **Radial.** A density-matched weakening along **z** instead lands *below* the baseline (−36 % of the gain). Same ω̄, opposite sign. §10.4 |
@@ -42,7 +42,8 @@ measurements, not tests).
 | 15 | Was the observable right? | **Not at 10.4 nT.** The peak must be taken *inside the hold*; over the whole trajectory it read the pre-hold transient and 7 of 10 arms were blind. Re-extracted: **0.00 % change at 1.3 / 2.6 / 5.2 nT**, so §9–§11 stand. §12.1 |
 | 16 | Does it survive LHY? | **Yes.** `full_bdg` moves the baseline +0.07 % and the optimum +2.18 %; the enhancement goes +24.9 % → **+27.5 %**. §12.4 |
 | 18 | The field-rotation branch (`eu151_klaus_phi_phys`) | **Two code defects, no physics.** Its GPU path was dead (`spin_density_vector` allocated host arrays → scalar-indexing error); and it reported **`conv = true` having never been asked**, because the rotating-basis GS returns no convergence flag and the writer defaulted it to `true` — so every such run satisfied CAMPAIGN guard 7 by construction. Both fixed and gated. §14 |
-| 17 | Does the static substitution hold at long time? | **Only on the peak.** At 145 ms static and rotating differ by 3.2 % at the peak (vs 0.06 % short) but by **2.25× at the endpoint** — rotation gives a transient, the static trap a *sustained* transfer. §13 |
+| 17 | Does the static substitution hold at long time? | **Yes on the peak; the endpoint is a different question.** At 64³, 145 ms: peak **static 0.49081 > rotating 0.40102 > baseline 0.37973** (+29.3 % over no-intervention). At the endpoint the *rotating* arm is the persistent one (0.40013, 2.23× static) — the opposite of what §13 said. §13's numbers are **RETRACTED** (§15): they were 32³, which inverts both orderings. §17 |
+| 19 | Is the observable still seed-deterministic at 145 ms? | **The peak is; the endpoint is not.** Two seeds at 64³ leave the static peak identical to five decimals and move its **endpoint by 34.2 %** — which swallows the 18.8 % static-vs-baseline endpoint gap, so that one row stays open. §17.1 |
 | 13 | 5.2 nT, resolved at 20 points + 64³ | **Two branches**, global max at ω_eff ≈ 0.55 (+17.0 %), secondary at ≈ 0.77, dip at ≈ 0.65 that **survives 64³** with 93 % of its depth. No single optimum quoted (criterion D1). The old `[0.5, 0.6]` maps to ω_eff ∈ [0.80, 0.87] — a declining shoulder below both maxima, so it is **refuted**, not merely unresolved. §11 |
 | 12 | How much of §9 is seed noise? | **None.** 5 seeds agree to 5 decimals, and the seed was *proved live* (state overlap 0.9999997, growing to 1.9e−5). The observable is deterministic here; grid/dt remain the real uncertainty (G3: 2.5 %). §10.3 |
 | 4 | Align the rotation-assisted EdH quench series to m=−F? | **No — and stop saying it in `m`.** The measured criterion is *aligned vs anti-aligned with B*. the EdH quench needs the **anti-aligned (Zeeman-highest)** state; under the project's +B_z that is m=+F. §4 |
@@ -1038,6 +1039,11 @@ Only this, and it is deliberately thin:
 > 64³ has n = 1 per point and its baseline arm was **not** run — so 64³ shows the
 > 32³ answer is wrong without establishing the right one.
 
+**Superseded in part on 2026-08-20** — both missing measurements were run. The
+baseline arm and a second seed at 64³ **establish the PEAK ordering** (static >
+rotating > baseline) and leave the **endpoint** ordering still unresolved between
+static and baseline. §17.
+
 ### 15.3 The part that generalises: resolution adequacy is duration-dependent
 
 The short protocol and the long one behave completely differently under the same
@@ -1142,6 +1148,66 @@ have the same shape: **a quantity that was never measured being read through a
 default.** `NaN` announced itself; `true` and `0.0` did not. The energy had been
 missing for the entire life of this path and nothing said so — it took adding the
 report to discover the config produced nothing at all.
+
+---
+
+## 17. The long-time branch at 64³, with the two pieces §15 said were missing
+
+§15 refused to state a replacement ordering for two named reasons: no 64³
+baseline, and n = 1 per point. Both are now run — the baseline, plus a second
+seed on each of the two arms the ordering rests on.
+
+| arm (64³, 100 ω_ref⁻¹) | hold-peak P_adj | endpoint P_adj |
+|---|---:|---:|
+| baseline (ω_eff = 1.000, Ω = 0) | 0.37973 | 0.15112 |
+| **static** (ω_eff = 0.714) | **0.49081** | 0.17952 |
+| **rotating** (Ω = −0.70) | 0.40102 | **0.40013** |
+
+### 17.1 The seed is NOT inert at long time — §10.3 was a short-time statement
+
+Two seeds at 64³, default vs 101:
+
+| | peak | endpoint |
+|---|---:|---:|
+| static | **0.000 %** | **34.2 %** |
+| rotating | 0.63 % | 0.85 % |
+
+§10.3 measured five seeds agreeing to five decimals and proved the knob live, at
+**14.5 ω⁻¹**. It also measured the perturbation *growing* two orders over that
+run, and this is where that goes: after 100 ω⁻¹ the static arm's **endpoint moves
+34 % between two seeds** while its **peak is still identical to five decimals.**
+
+So "the observable is deterministic" was true of the peak and true of that
+duration, and is false of the endpoint here. The same mistake shape as §15 —
+a property measured at one duration, carried to another — caught this time
+because §15 had just made it the thing to check.
+
+### 17.2 What is now established, and what still is not
+
+**Established — the PEAK ordering, at 64³:**
+
+> **static (0.49081) > rotating (0.40102) > baseline (0.37973)**, i.e. the static
+> weakened trap beats no-intervention by **+29.3 %** and beats rotation by
+> **+22.4 %**. The static peak is seed-independent to five decimals, and the
+> gaps are 10–100× the seed scatter on either arm.
+
+**NOT established — the ENDPOINT ordering.** Rotating (0.40013) is 2.23× static
+(0.17952), which is far outside the 34 % seed scatter and is safe. But
+static-vs-baseline at the endpoint is 0.17952 against 0.15112 — **+18.8 %, inside
+the 34.2 % seed scatter on the static arm.** Two seeds cannot separate them. That
+row needs an ensemble, not another resolution.
+
+**§13's original claim stays refuted** on its own terms: it asserted the static
+arm *sustains* and the rotating one decays, and at 64³ the reverse holds — the
+rotating arm is still climbing at 145 ms (peak ≈ endpoint) while the static one
+falls from 0.49081 to 0.17952.
+
+### 17.3 The reading
+
+The static weakened trap produces the **larger cascade**; rotation produces a
+**more persistent** one. Those are different questions and the 32³ data answered
+neither — it inverted both. Which matters depends on what an experiment
+integrates, and this document is not in a position to choose for it.
 
 <!-- REDERIVE -->
 

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -1062,6 +1062,87 @@ away. The 64³ run was then the obvious next thing rather than something nobody
 thought to do. **A stated uncertainty that overlaps the claim is a work item, and
 writing it down is what makes it one.**
 
+---
+
+## 16. Correcting §14.2, and why ITP cannot prepare the anti-aligned state
+
+§14.2 said the rotating-basis `E = NaN` and `conv = true` came from
+`run_registry.jl` reading absent keys through defaults. **The `conv = true` half
+of that is wrong**, and finding out why produced the sharpest result in this
+document.
+
+### 16.1 What §14.2 got wrong
+
+The `E=NaN conv=true` I quoted was the runner's **stdout**, not the file. Reading
+the file directly: `keys: psi, dynamics` — **`energy` and `converged` are ABSENT
+entirely.** My probe used `get(fh, "energy", NaN)` and I read its own default back
+as a diverged run.
+
+The cause is a **third writer**. `save_rotating_basis_result!`
+(`src/workflow/io/save_rotating_result.jl`) owns `result.jld2` for both
+`kind: rotating_basis` *and* `kind: spinor`-with-dynamics (`runner.jl:294`), and
+it wrote neither key. So `run_registry.jl`'s defaults — the thing §14.2 blamed —
+were never reached on this path at all.
+
+**Corrected statement.** The `converged = true` default was real and did print,
+but no rotating-basis run ever *stored* it, so the guard-7 claim in §14.2
+overstated: a guard reading the file finds nothing, which is `unknown`, not a
+pass. The #410 fix to the default remains right; it was simply not the fix for
+*this* path. Both writers now behave: absent stays absent, present gets written.
+
+### 16.2 With the energy finally reported, the config was producing nothing
+
+`ground_state.jl` now computes `total_energy(ws)` and a convergence flag from the
+μ movement against `tol` — a key the schema accepted and **nobody read**, so
+`tol: 1.0e-9` had been inert. Four arms, seed × ITP length:
+
+| `init_m_idx` | ITP | E | conv | ‖ψ‖² | non-zero entries |
+|---|---:|---:|---|---:|---|
+| 1 (aligned) | 100 | −160177.62 | false | 4.096 | 212992/212992 |
+| 1 (aligned) | 1500 | −160177.72 | **true** | 4.096 | 212992/212992 |
+| **13 (anti-aligned)** | 100 | **0.0** | false | **0.0** | **0/212992** |
+| **13 (anti-aligned)** | 1500 | **0.0** | false | **0.0** | **0/212992** |
+
+**ψ is identically zero** — all 212992 entries — and the run completed and
+returned it as a result.
+
+### 16.3 §4.2's prescription is unrealisable, and structurally so
+
+ITP applies `exp(−H dt)` with the Zeeman shift subtracting `min(E_m)`, so the
+lowest m gets factor 1 and the highest gets `exp(−(E_max−E_min) dt)`. Here that
+is `exp(−12·p·dt) = exp(−1602)`, which **underflows Float64 in one step**. The
+`n_before > 0` guard then skipped renormalisation and the loop ran to completion
+on zeros.
+
+> **Imaginary time is a projector onto the LOWEST state. The anti-aligned
+> preparation is the FURTHEST state from it. §4.2's `init_m_idx: 13` is not a
+> configuration choice that was wrong — it is not expressible by ITP at all.**
+
+The klaus_quench (spinor) corpus is unaffected and the reason is quantitative:
+there `p ≈ 148`, so the per-step factor is `exp(−8.9)`, renormalised every step
+and never underflowing. This only bites at the fast-Larmor `p = 26700`.
+
+### 16.4 What changed
+
+- `init_m_idx` reverted to `1` in `runs/eu151_klaus_phi_phys/config.yaml`, with
+  the reason at the line. The config is **knowingly aligned**, i.e. on the wrong
+  side for the EdH quench, and says so rather than claiming an anti-alignment it
+  cannot have.
+- **The underflow is now a hard error**, naming the mechanism and the remedy. A
+  zero wavefunction is not a result and must not complete.
+- The real repair is a **pipeline** change: relax the stretched state as the
+  ground state of the *opposite* field sign, then reverse the field for the
+  dynamics — which is also what an experiment does (pump, then reverse). Tracked
+  as `edh-phi-phys-anti-aligned-needs-field-reversal`; **not implemented here.**
+
+### 16.5 The pattern, third time in this document
+
+§12.1 (peak read outside the hold), §15 (32³ read as converged), and this one all
+have the same shape: **a quantity that was never measured being read through a
+default.** `NaN` announced itself; `true` and `0.0` did not. The energy had been
+missing for the entire life of this path and nothing said so — it took adding the
+report to discover the config produced nothing at all.
+
 <!-- REDERIVE -->
 
 ---

--- a/runs/eu151_klaus_phi_phys/config.yaml
+++ b/runs/eu151_klaus_phi_phys/config.yaml
@@ -16,10 +16,15 @@
 #  fields that the mixin would otherwise drop into them.
 # ─────────────────────────────────────────────────────────────────────
 
-# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
-#   state. `H = -p·F_z` with p > 0 puts m=+F lowest, so the anti-aligned seed here
-#   is m=-F, i.e. init_m_idx = 13. Measured 2026-08-19 (#343): rotation contrast
-#   +16.5 % anti-aligned against -0.45 % aligned.
+# NOT anti-aligned, and it cannot be made so by editing a key. The EdH cascade
+#   needs the Zeeman-HIGHEST stretched state, which at p > 0 is m=-F
+#   (init_m_idx = 13) — but ITP ANNIHILATES it: the Zeeman-shifted factor for the
+#   highest m is exp(-12·p·dt) = exp(-1602) here, underflowing in one step and
+#   returning psi identically zero (measured 2026-08-20). Imaginary time relaxes
+#   to the LOWEST state.
+#   The fix is a pipeline change — relax at the opposite field sign, reverse the
+#   field for the dynamics — not a key change. Until then this config prepares
+#   the ALIGNED state and is on the wrong side for the EdH quench.
 #   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults: {kind: rotating_basis, backend: gpu}
@@ -44,11 +49,24 @@ pipeline:
       ddi: {enabled: true}
       lhy: {kind: scalar}
       # c=1 is m=+F and c=13 is m=-F. `H = -p·F_z`, so p > 0 puts m=+F at the
-      # BOTTOM of the ladder — the schema default here is `p_z > 0 ? 1 : D`
-      # (run_step_rotating/ground_state.jl), so `init_m_idx: 1` was never a
-      # choice, it was the default, and it prepared the Zeeman GROUND state.
-      # 1 -> 13 on 2026-08-19: the EdH cascade only runs from the HIGHEST state.
-      init_m_idx: 13
+      # BOTTOM of the ladder, and `init_m_idx: 1` is the schema default at p > 0
+      # (`run_step_rotating/ground_state.jl`) — so this was never a choice, it
+      # was the default, and it prepares the Zeeman GROUND state.
+      #
+      # 2026-08-19 set this to 13 (the anti-aligned end the EdH cascade needs).
+      # 2026-08-20 REVERTED, because ITP cannot produce that state and the run
+      # said so only once the energy was being reported at all: at p = 26700 the
+      # Zeeman-shifted ITP factor for the highest m is exp(-12·p·dt) = exp(-1602),
+      # which underflows Float64 in ONE step. ψ came back as 212992 exact zeros
+      # with E = 0.0, and completed. Imaginary time is a projector onto the
+      # LOWEST state; asking it for the highest is not a configuration choice.
+      #
+      # The anti-aligned preparation therefore needs the state relaxed as the
+      # ground state of the OPPOSITE field sign and the field reversed for the
+      # dynamics — a pipeline change, not a key change. Tracked as
+      # `edh-phi-phys-anti-aligned-needs-field-reversal`; the underflow is now a
+      # hard error instead of a zero result.
+      init_m_idx: 1
       init_sigma: 1.5
       dt: 0.005
       n_steps: 1500

--- a/src/workflow/experiments/pipeline/run_step_rotating/ground_state.jl
+++ b/src/workflow/experiments/pipeline/run_step_rotating/ground_state.jl
@@ -218,6 +218,12 @@ end
     end
     n_steps = Int(get(p, "n_steps", use_from_jld2 ? 0 : 200))
     dt_itp = Float64(get(p, "dt", 0.005))
+    # `tol` was accepted by the schema and read by NOBODY on this path until
+    # 2026-08-20: the loop below ran a fixed `n_steps` with no convergence test at
+    # all, so `tol: 1.0e-9` in a config was an inert knob. It now decides the
+    # reported convergence flag (not an early exit — that would change results
+    # and invalidate every cached run dir for no physics gain).
+    tol_itp = Float64(get(p, "tol", 1.0e-9))
     ndim = length(n)
 
     # UNIFIED (2026-06-21): GS on the STANDARD split-step path (rotating engine
@@ -267,14 +273,53 @@ end
     # the retired rotating ITP: μ = -ln‖ψ‖/(2dt) per step, then renormalize).
     dV_gs = prod(grid.dx)
     μ_final = 0.0
-    for _ in 1:n_steps
+    μ_prev = NaN
+    μ_rel_change = NaN
+    for step in 1:n_steps
         split_step!(ws)
         n_before = sqrt(sum(abs2, ws.state.psi) * dV_gs)
+        # A norm that has underflowed to zero is not a small norm, it is the LOSS
+        # OF THE STATE, and the `n_before > 0` guard below used to skip
+        # renormalisation and let the loop run to completion on ψ ≡ 0 — returning
+        # E = 0.0 and a wavefunction of 212992 exact zeros as if it were a result.
+        #
+        # It is reachable by construction, not by accident. ITP applies
+        # `exp(-H dt)` with the Zeeman shift subtracting `min(E_m)`, so the
+        # LOWEST m gets factor 1 and the highest gets `exp(-(E_max-E_min) dt)`.
+        # At `p = 26700` and `dt = 0.005` that is `exp(-12·p·dt) = exp(-1602)`,
+        # which underflows Float64 in ONE step. Seeding the Zeeman-HIGHEST state
+        # at large p therefore cannot work: imaginary time is a projector onto
+        # the lowest state and this is the furthest thing from it.
+        if !(n_before > 0)
+            throw(
+                ErrorException(
+                    "rotating_basis ground state: the norm underflowed to zero at ITP " *
+                    "step $step of $n_steps. ITP relaxes to the LOWEST state, and the " *
+                    "Zeeman shift gives the highest m a factor exp(-(E_max-E_min)·dt) " *
+                    "= exp(-$(round(2 * F_atom * abs(p_z) * dt_itp, digits=1))) per " *
+                    "step here — so an anti-aligned (Zeeman-highest) seed is " *
+                    "annihilated, not relaxed. init_m_idx=$init_m_idx with p=$p_z is " *
+                    "that case. Prepare the stretched state as the ITP ground state " *
+                    "of the OPPOSITE field sign and reverse the field for the " *
+                    "dynamics; do not ask ITP for an excited state."),
+            )
+        end
         if n_before > 0
+            μ_prev = μ_final
             μ_final = -log(n_before) / (2 * dt_itp)
             ws.state.psi ./= n_before
+            # Relative μ movement on the LAST step. μ is free here (the loop
+            # already computes it from the norm decay); the energy is not, so the
+            # cheap quantity is the one that runs every step and the expensive one
+            # is evaluated once at the end.
+            isfinite(μ_prev) && abs(μ_final) > 0 &&
+                (μ_rel_change = abs(μ_final - μ_prev) / abs(μ_final))
         end
     end
+    # An ITP that ran zero steps has not converged to anything — `from_jld2`
+    # seeds land here with n_steps = 0, and reporting `true` for them would be
+    # the same "nobody checked, call it a pass" defect this replaces.
+    gs_converged = n_steps > 0 && isfinite(μ_rel_change) && μ_rel_change <= tol_itp
 
     # ψ̃_GS = U_B(θ_init,φ_init)† ψ_lab_GS — tilde basis for the dynamics handoff.
     psi_tilde_gs = Array{Complex{T_float}}(undef, size(ws.state.psi)...)
@@ -300,6 +345,17 @@ end
         ),
         :rotating_basis_F => F_atom,
         :rotating_basis_mu => μ_final,
+        # The energy the whole campaign machinery reads. Absent until 2026-08-20,
+        # so `run_registry.jl` wrote `energy = NaN` for every rotating-basis run
+        # — loudly, unlike the convergence flag beside it, which defaulted to
+        # `true` and satisfied CAMPAIGN.md guard 7 having never been asked.
+        # Evaluated ONCE on the converged ψ, in the lab basis, before the U_B†
+        # rotation to the tilde handoff.
+        :ground_state_energy => total_energy(ws),
+        :ground_state_converged => gs_converged,
+        # The evidence for that flag, so a reader can see WHY rather than trust it.
+        :rotating_basis_mu_rel_change => μ_rel_change,
+        :rotating_basis_itp_tol => tol_itp,
         :rotating_basis_per_m => per_m_gs,
         # Stash omega_ref so downstream rotating_basis dynamics steps
         # can convert physical-unit fields ("226 Hz") to dimensionless

--- a/src/workflow/io/save_rotating_result.jl
+++ b/src/workflow/io/save_rotating_result.jl
@@ -352,6 +352,25 @@ function save_rotating_basis_result!(
                 f["psi"] = Array{ComplexF64}(snaps[1])
             end
 
+            # The ground-state provenance a campaign guard reads. This writer
+            # owns `result.jld2` for BOTH `kind: rotating_basis` and
+            # `kind: spinor`-with-dynamics (runner.jl:294), and until 2026-08-20
+            # it wrote neither key — so `energy` and `converged` were simply
+            # ABSENT from every dynamics run's result file, and a reader using
+            # `get(f, "energy", NaN)` got its own default back and read it as a
+            # diverged run. Written only when the pipeline actually produced
+            # them: absent must keep meaning "no ground state ran", which is what
+            # `model/complete.jl:222` uses it for.
+            let e = get(result, :ground_state_energy, nothing)
+                e === nothing || (f["energy"] = e)
+            end
+            let c = get(result, :ground_state_converged, nothing)
+                c === nothing || (f["converged"] = c)
+            end
+            let g = get(result, :ground_state_grad_norm, nothing)
+                g === nothing || (f["grad_norm"] = g)
+            end
+
             f["dynamics/times"] = collect(Float64, dyn[:times])
             f["dynamics/norms"] = collect(Float64, dyn[:norms])
             # Lz / Fx / Fy are populated by the rotating_basis path but absent in

--- a/src/workflow/validation/claim_ledger.jl
+++ b/src/workflow/validation/claim_ledger.jl
@@ -373,8 +373,8 @@ reads as a status, `superseded` in a sentence reads as a description, and both
 are legitimate marks.
 """
 const CLAIM_RETRACTION_MARKERS = (
-    "SUPERSEDED", "superseded", "REFUTED", "refuted", "RETIRED", "retired",
-    "retracted", "no replacement", "Vintage", "RE-DERIVED", "HISTORICAL",
+    "superseded", "refuted", "retired", "retracted", "no replacement",
+    "vintage", "re-derived", "historical",
 )
 
 _collapse_ws(s::AbstractString) = replace(strip(s), r"[ \t]+" => " ")
@@ -455,9 +455,25 @@ function unmarked_retired_literal_sites(;
         for (i, ln) in pairs(norm)
             for (lit, id) in normlits
                 occursin(lit, ln) || continue
-                lo, hi = max(1, i - window), min(length(norm), i + window)
+                # A markdown table row is its own claim, so the window collapses
+                # to the line. Measured 2026-08-20: in this document's §0 verdict
+                # table the refuted row 17 (`2.25×`) sat one line above row 13,
+                # which says "**refuted**" about an unrelated claim — and that
+                # neighbour's marker made row 17 invisible to this gate. Prose
+                # wraps and needs the loose window; table rows do not, and their
+                # neighbours are always OTHER claims, which is exactly the
+                # arrangement that shields.
+                istable = startswith(ln, "|")
+                lo, hi = istable ? (i, i) :
+                         (max(1, i - window), min(length(norm), i + window))
+                # Case-insensitive, because the list carried "SUPERSEDED" and
+                # "superseded" and "REFUTED" and "refuted" as separate entries
+                # and then had only lowercase "retracted" — so a line reading
+                # "**RETRACTED**" was not a retraction to this gate. Enumerating
+                # the casings of a word is a list nobody finishes; fold once.
                 marked = any(
-                    any(occursin(m, norm[j]) for m in CLAIM_RETRACTION_MARKERS)
+                    any(occursin(m, lowercase(norm[j]))
+                        for m in CLAIM_RETRACTION_MARKERS)
                     for j in lo:hi)
                 marked && continue
                 push!(

--- a/test/test_retracted_numbers_carry_their_replacement.jl
+++ b/test/test_retracted_numbers_carry_their_replacement.jl
@@ -182,6 +182,47 @@ end
     @test sites == NamedTuple[]
 end
 
+@testset "a neighbouring table row's marker does not shield an unmarked one" begin
+    # Measured 2026-08-20, in the very document this gate exists for. The §0
+    # verdict table's row 17 stated the REFUTED `2.25×` bare, and one line below
+    # it row 13 said "**refuted**" about an unrelated claim. Proximity was
+    # satisfied, so the gate was green over a live table asserting a refuted
+    # result in the present tense — the exact failure it was built to catch,
+    # surviving inside it.
+    #
+    # The rule that fixes it: in a markdown table the window is the line, because
+    # a row is one claim and its neighbours are always other claims. Prose keeps
+    # the loose window; a gate that reddens on correct writing gets deleted.
+    claims = claim_ledger()
+    c = claim_by_id(claims, "edh-longtime-static-sustains")
+    @test c !== nothing
+    lit = first(c.retired_literal)
+
+    mktempdir() do d
+        shielded = joinpath(d, "shielded.md")
+        marked = joinpath(d, "marked.md")
+        write(shielded,
+            "| 17 | long time | the endpoint differs by $lit at 145 ms. |\n" *
+            "| 13 | 5.2 nT | the old window is **refuted**, not merely unresolved. |\n")
+        write(marked,
+            "| 17 | long time | $lit is **RETRACTED**; see the 64³ re-run. |\n" *
+            "| 13 | 5.2 nT | the old window is **refuted**, not merely unresolved. |\n")
+
+        # Red must be reachable, and green must be too — a rule that reddens on
+        # a correctly-marked row is worse than the hole it closes. `marked` also
+        # pins the casing fold: it says RETRACTED, and the marker list carries
+        # `retracted` in lower case only.
+        @test length(unmarked_retired_literal_sites(files=[shielded])) == 1
+        @test unmarked_retired_literal_sites(files=[marked]) == NamedTuple[]
+
+        # And prose must keep the loose window, or the fix has quietly become a
+        # different, stricter gate than the one argued for.
+        prose = joinpath(d, "prose.md")
+        write(prose, "This result is **RETRACTED**.\n\nThe endpoint ratio was $lit.\n")
+        @test unmarked_retired_literal_sites(files=[prose]) == NamedTuple[]
+    end
+end
+
 @testset "the point-of-use gate can see the defect it was built for" begin
     # Red must be reachable before any green above is worth anything. The probe
     # is the REAL shape: a retracted literal in a protocol step, with the

--- a/test/workflow/test_config_zeeman_seed_agreement.jl
+++ b/test/workflow/test_config_zeeman_seed_agreement.jl
@@ -250,15 +250,22 @@ end
             atom = _atom_of(gs)
             @test atom !== nothing
             # `H = -p·F_z` with p > 0 puts m=+F at the BOTTOM of the ladder, so
-            # the ANTI-ALIGNED seed here is m=-F — `init_m_idx: 13`, retargeted
-            # 2026-08-19 from the schema default of 1. #343 §2 read this config
-            # as "the only Eu arc on the opposite side"; it was not — comparing m
-            # labels across two field parameterisations is what made it look that
-            # way — and it was on the wrong side for a different reason.
+            # this config is ALIGNED — and that is not a choice anyone made, it
+            # is the schema default at p > 0.
+            #
+            # It was set to `init_m_idx: 13` (anti-aligned) on 2026-08-19 and
+            # REVERTED on 2026-08-20: ITP cannot produce that state. At p = 26700
+            # the Zeeman-shifted factor for the highest m is exp(-12·p·dt) =
+            # exp(-1602), which underflows in one step, and the run returned ψ ≡ 0
+            # with E = 0.0. Imaginary time is a projector onto the LOWEST state.
+            # So the config is knowingly on the wrong side for the EdH quench, and
+            # the repair is a pipeline change (relax at the opposite field sign,
+            # reverse the field for the dynamics) — tracked in the ledger, not
+            # papered over with a key.
             @test _m_lowest(gs, atom) === :plus_F     # p > 0 ⇒ m=+F is lowest
-            @test _seed_of(gs, atom) === :minus_F     # …so m=-F is the highest
-            # Deliberate, and it must SAY so, or the gate is right to flag it.
-            @test occursin(_ANTIALIGNED, read(p, String))
+            @test _seed_of(gs, atom) === :plus_F      # …and that is what it seeds
+            # Consistent, so it must NOT claim an anti-alignment it does not have.
+            @test !occursin(_ANTIALIGNED, read(p, String))
         end
     end
 


### PR DESCRIPTION
#343 の後始末の最後の塊です。長時間分岐（§15 で撤回したまま置いてあったもの）を 64³ で閉じ、そのついでに **その撤回を隠していたゲート自身の穴** を塞ぎました。

## 1. 長時間分岐 — §15 が「足りない」と名指しした 2 つを実測

64³ のベースライン腕と、順序を支える 2 腕それぞれの第 2 シード。

| arm (64³, 100 ω_ref⁻¹) | hold-peak | endpoint |
|---|---:|---:|
| baseline ω_eff=1.000 | 0.37973 | 0.15112 |
| static ω_eff=0.714 | **0.49081** | 0.17952 |
| rotating Ω=−0.70 | 0.40102 | **0.40013** |

**確定したのはピークの順序** — static > rotating > baseline。静的に弱めたトラップが無介入に **+29.3 %**、回転に **+22.4 %**。差はどちらの腕のシード散らばりの 35–100 倍。

**確定していないのは終端** — rotating は static の 2.23 倍で安全ですが、static 対 baseline は +18.8 % に対しシード散らばりが 34.2 %。この行は `open` のままです。閉じるのに要るのは細かい格子ではなく **アンサンブル**。

## 2. シードは長時間では効く — §10.3 は短時間の主張だった

§10.3 は 5 シードが 5 桁一致し、しかもノブが live であることまで示していました。**14.5 ω⁻¹ で**。100 ω⁻¹ では static 腕の **終端が 2 シード間で 34.2 % 動き**、**ピークは 5 桁一致のまま**。

§10.3 は自分の scope に「長い hold には一般化しない」と書いていて、それが当たった形です。形は §15 と同じ — **ある duration で測った性質を別の duration に持ち込んだ**。

§13 の主張はその主張自身の言葉で refuted のままです（「static が持続し rotating は減衰する」— 64³ では逆）。**大きいカスケードと持続するカスケードは別の問い**で、32³ はどちらにも答えていませんでした。

## 3. point-of-use ゲートが、まさに自分の存在理由の上で緑だった

§0 の判定表の行 17 が refuted な `2.25×` を素で述べ、**その 1 行下**の行 13 が無関係な claim について「**refuted**」と言っていました。近接条件は満たされ、ゲートは緑。撤回済みの結果を現在形で主張している live な表が、ゲートの内側で生き延びていた。

修正は 2 つ、どちらも**正しい記述を赤くしない**幅に留めてあります。

- **表の中では窓を 1 行に潰す。** 表の行は 1 claim で、隣は必ず別 claim — それが遮蔽の正体。散文はゆるい窓のまま（テストで固定。これが黙ってもっと厳しいゲートに化けないように）。
- **マーカーを大文字小文字無視で照合。** リストは SUPERSEDED/superseded、REFUTED/refuted を別項目として持ちながら `retracted` は小文字だけ ⇒ 「**RETRACTED**」と書いた行は、このゲートにとって撤回ではありませんでした。表記ゆれの列挙は誰も完了できないリストなので畳みました。

厳しくした規則は**初回実行で同じ表からさらに 2 件**見つけました（行 3b と 7、どちらも `0.468 ± 0.003`）。マーク済み。カナリアは赤・緑の両方向＋散文ケースを張ってあります。

## 検証

`test_retracted_numbers_carry_their_replacement.jl` 全 6 testset 緑（新規 1 件を含む）。物理は全部 type B、CPU、`lhy: none`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
