### PR TITLE
docs(#398): 68.4 µG の読解を台帳へ — 使われている場所に印を打つ

### DIFF
--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -566,3 +566,55 @@ doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "15"
 pr = 0
 note = """The part that generalises: grid adequacy is a property of the grid AND the integration time. Under the same 32³→64³ refinement the SHORT protocol (14.5 ω⁻¹) moved by a uniform +2.3 % and the 5.2 nT dip kept 93 % of its depth — shape preserved — while the long one moves -3.4/-23.1/-42.6/+91.3 % and orderings invert. So sections 9-12 are unaffected and only the long-time branch is out of reach at 32³. A convergence check at one duration does not transfer to another."""
+
+# --- eu335 / #383 / #398: the 68.4 µG reading ---------------------------------
+#
+# The SECOND document poured in, and it was chosen for a shape the EdH rows do not
+# have: a claim retracted not because its NUMBER moved but because its READING did.
+# 68.4 ± 0.15 µG is the same measurement before and after; what changed is whether
+# it is a property of the energy landscape or a property of the solver walking it.
+
+[[claim]]
+id = "eu335-68p4-is-a-mean-field-spinodal"
+claim = "68.4 ± 0.15 µG is the flower branch's mean-field spinodal at κ = 1.8 — the branch stops existing there — so a rising B_z ramp must convert by then at ANY rate."
+status = "superseded"
+type = "B"
+scope = "¹⁵¹Eu F = 6, κ = ω_z/ω_⊥ = 1.8, 32³ (64³ bracket [68.0, 68.5] µG), flower branch reached by warm-started L-BFGS continuation in B_z."
+retired_literal = [
+    "spinodal at 68.4 µG",
+    "flower-branch spinodal at κ = 1.8",
+    "flower branch stops existing",
+    "ends at 68.4 ± 0.15 µG",
+]
+replacement_literal = [
+    "loses the flower branch",
+    "continuation loses the branch",
+    "warm-started continuation loses the branch",
+]
+superseded_by = "eu335-68p4-is-where-continuation-loses-the-branch"
+uncertainty = "±0.15 µG at 32³ and [68.0, 68.5] µG at 64³, 0.2 % apart. That bound is on the FIELD at which the continuation stops and was read as a bound on where the branch ends; the reading itself carried no uncertainty at all, which is how it survived."
+uncertainty_basis = "grid"
+evidence = ["docs/guides/eu_spinodal_spectrum.md", "docs/guides/eu_kappa_hysteresis_loop.md"]
+evidence_status = "in_tree"
+commit = "bace6f12"
+doc = "docs/guides/eu_kappa_hysteresis_loop.md"
+section = "5.1"
+pr = 409
+note = """SUPERSEDED 2026-08-20 (#398) by #383's three-quantity test, and the reason it is `superseded` rather than `refuted` is that the number did not move — only what it is a number OF. A saddle-node takes the branch-tangent curvature, the escape direction and the lowest ω to zero together; #383 measured all three on the same cells and none softens (R² linear to rms 0.4 % with its zero at 78.2 µG, ⟨d,Ad⟩ = +3.403 uphill, ω flat to 1.4 %). What is NOT established either way is that the branch survives: λ_min at 68.25 µG is unresolved by both solvers, tracked as #399. The generalisable part: "the continuation loses the branch" and "the branch ends" are different claims about different objects — one about a solver's basin, one about the energy landscape — and a continuation instrument can only ever measure the first."""
+
+[[claim]]
+id = "eu335-68p4-is-where-continuation-loses-the-branch"
+claim = "68.4 ± 0.15 µG is the field at which a warm-started L-BFGS continuation loses the flower branch at κ = 1.8, agreeing to 0.2 % between 32³ and 64³. Nothing in the campaign establishes that the branch ENDS there."
+status = "live"
+type = "B"
+scope = "Same cells as the superseded row: ¹⁵¹Eu F = 6, κ = 1.8, 32³ and 64³, warm-started continuation in B_z. Says nothing about any other κ, and nothing about the polarised branch."
+supersedes = "eu335-68p4-is-a-mean-field-spinodal"
+uncertainty = "±0.15 µG at 32³, bracket [68.0, 68.5] µG at 64³ — 0.2 % apart. This is a bound on a solver-dependent field, so a different warm-start schedule may move it; the grid agreement bounds the discretisation, not the algorithm."
+uncertainty_basis = "grid"
+evidence = ["docs/guides/eu_kappa_hysteresis_loop.md", "docs/guides/eu_spinodal_spectrum.md"]
+evidence_status = "in_tree"
+commit = "bace6f12"
+doc = "docs/guides/eu_spinodal_spectrum.md"
+section = "5.1"
+pr = 409
+note = """Everything #335 delivers that needs only this weaker reading stands unchanged, including the 32³↔64³ agreement of §5.8 and the deliverable itself — the Stern-Gerlach level count (6-7 populated m_F at κ = 1.8 against 3-4 at κ = 0.9, disjoint at all five rates), which never rested on the landscape reading. What is lost is the *at any rate* clause: behind a barrier a fast enough rising ramp carries the flower past 68.4 µG, which is what the predecessor campaign actually observed."""

--- a/docs/guides/eu_adiabatic_protocol.md
+++ b/docs/guides/eu_adiabatic_protocol.md
@@ -30,8 +30,9 @@
 > reading is not supported: the flower branch **ends at 68.4 ± 0.15 µG**, measured
 > statically; it merely takes longer than a ramp to fall once past its spinodal.
 >
-> **AMENDED 2026-08-20 (#398).** That last sentence is the part of this retraction
-> that does not hold. #383 measured three independent quantities at 68.25 µG and
+> **AMENDED 2026-08-20 (#398) — the struck sentence is SUPERSEDED**, ledger row
+> `eu335-68p4-is-a-mean-field-spinodal`. That last sentence is the part of this
+> retraction that does not hold. #383 measured three independent quantities at 68.25 µG and
 > none of them softens — the curvature's zero extrapolates to 78.2 µG, the escape
 > direction is **uphill** by +3.403, and the lowest ω is flat to 1.4 %. So 68.4 µG
 > is where a **warm-started continuation loses the branch**, which is not the same

--- a/docs/guides/eu_kappa_hysteresis_loop.md
+++ b/docs/guides/eu_kappa_hysteresis_loop.md
@@ -247,9 +247,20 @@ Its 20 µG energy, 10.863612, reproduces the independently converged reference
 reached two ways.
 
 **So the loop at κ = 1.8 is one-sided, and this is the campaign's main structural
-finding.** The rising edge is a genuine mean-field **spinodal at 68.4 µG**: the
+finding.** The rising edge is a genuine mean-field ~~**spinodal at 68.4 µG**: the
 flower branch stops existing there, so a rising ramp must convert by then at *any*
-rate. The falling edge is **not** a spinodal — the polarised branch is still a
+rate~~.
+
+> **SUPERSEDED 2026-08-20 (#398, ledger `eu335-68p4-is-a-mean-field-spinodal`).**
+> The struck sentence is the landscape reading, and #383 measured three quantities
+> a saddle-node must take to zero — none of them softens. What survives is the
+> measurement: **68.4 ± 0.15 µG is where the warm-started continuation loses the
+> flower branch.** The *at any rate* consequence does not follow from it. The rest
+> of this paragraph — the falling edge not being a spinodal — is unaffected,
+> because it rests on the polarised branch still being a stationary state, which
+> was checked directly.
+
+The falling edge is **not** a spinodal — the polarised branch is still a
 stationary state at 27.4 µG where the predecessor's falling leg converted, and
 indeed everywhere down to 5 µG. A conversion there is barrier crossing driven by
 whatever excitation the ramp delivered, which means it moves with rate and does
@@ -522,7 +533,7 @@ What the campaign delivers instead, all of it new and all of it falsifiable:
 
 | deliverable | value | where |
 |---|---|---|
-| flower-branch spinodal at κ = 1.8 | **68.4 ± 0.15 µG** at 32³, **[68.0, 68.5] µG** at 64³ — 0.2 % apart | §5.1, §5.8 |
+| ~~flower-branch spinodal at κ = 1.8~~ **SUPERSEDED (#398)** → the field at which the warm-started continuation **loses the flower branch** | **68.4 ± 0.15 µG** at 32³, **[68.0, 68.5] µG** at 64³ — 0.2 % apart. The number is unchanged; what it is a number *of* is not the landscape | §5.1, §5.8 |
 | polarised branch's lower spinodal | **none above 5 µG** — it is a stable minimum throughout | §5.5b |
 | static branch separation at 20 µG | δ⟨F⊥⟩ = **5.06** (5.137 vs 0.075) | §5.1 |
 | κ = 0.9: number of branches | **one** — two continuations from opposite ends agree to 6–7 digits in E | §5.3 |

--- a/docs/guides/eu_spinodal_spectrum.md
+++ b/docs/guides/eu_spinodal_spectrum.md
@@ -237,7 +237,9 @@ resolvable excitation does not notice the branch end at all.
 
 ## 6. Answer
 
-**The spectrum does not see a spinodal at 68.4 µG.** Three measurements, none of
+**The spectrum does not see a spinodal at 68.4 µG.** This section is what
+SUPERSEDED the landscape reading — ledger row `eu335-68p4-is-a-mean-field-spinodal`
+→ `eu335-68p4-is-where-continuation-loses-the-branch`. Three measurements, none of
 which needed a converged eigenvalue:
 
 1. the curvature along the branch, 2.62 → 2.12 over 61→67 µG, extrapolating to


### PR DESCRIPTION
#398 のチェックボックスは PR #409 で全部満たされている。**満たされていないのは、その訂正が「節単位で読まれること」に耐えるかどうか**だった。

`docs/guides/eu_kappa_hysteresis_loop.md` は 22 行目に HELD 注記を持ちながら、250 行目で 68.4 µG を *"genuine mean-field **spinodal at 68.4 µG**"* と書き、525 行目の成果物テーブルで *"flower-branch spinodal at κ = 1.8"* として出荷していた。撤回から使用点まで **275 行**。これは `klaus_protocol_sheet.md` と同じ形で、まさに台帳が開かれた理由そのもの。

## やったこと

**1. 台帳に 2 行（`docs/campaign/claims.toml`）**

| id | status |
|---|---|
| `eu335-68p4-is-a-mean-field-spinodal` | `superseded` |
| `eu335-68p4-is-where-continuation-loses-the-branch` | `live` |

`refuted` ではなく `superseded` なのは、**数字が動いていない**から。68.4 ± 0.15 µG は前も後も同じ測定で、変わったのは*それが何の数字か* — エネルギー地形の性質か、ソルバの basin の性質か。#383 は saddle-node が 3 つとも 0 にするはずの量（接線曲率・逃げ方向・最低 ω）を測って、どれも柔化しないことを示した。枝が 68.4 µG より上まで生き延びるかは**まだ未決着**で、それが #399。

これは EdH の行が持っていない形の追加でもある: **数字ではなく読解が撤回された行**。

**2. 使用点に印**

`doc` フィールドは frozen 文書もゲート対象に引き込むので、追加した時点で `eu_kappa_hysteresis_loop.md` と `eu_spinodal_spectrum.md` が corpus に入る。2 つの使用点に `SUPERSEDED` を行内に置き、撤回された節に取り消し線。`eu_spinodal_spectrum.md` §6 と `eu_adiabatic_protocol.md` の amendment 注記は台帳 id を指す。

## 検証

`test_retracted_numbers_carry_their_replacement.jl`（fast tier）が両ゲートを見る。手元では Julia を回さない規範なので、CI が権威。事前に python で両ゲートを再実装して 0 件（corpus 29 文書）、**陽性対照つき** — 撤回文が 40 行上にある合成ファイルは必ず flag され、行内に印のあるものは flag されないことを assert してから 0 を読んでいる。

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)