### PR TITLE
feat(pipeline): 全 dynamics 経路が進捗と ETA を出す (#408)

### DIFF
--- a/docs/reference/dynamics.md
+++ b/docs/reference/dynamics.md
@@ -66,6 +66,29 @@ All five live inside one `save:` mapping (`SAVE_SCHEMA`). The flat spellings
 
 Snapshots land at `dynamics/psi_snapshots_streamed/frame_NNNNN`. Set `SPINORBEC_SCRATCH_DIR` to redirect the scratch `.tmp`.
 
+## Progress and ETA (#408)
+
+Every dynamics path — standard, `binary`, `rotating_basis`, `scalar_egpe` —
+prints a wall-clock-throttled progress line, **on by default**:
+
+```
+[scalar_egpe]  t = 0.44/1.10 (40.0 %)  step 176000/440000  elapsed 44m01s  left 1h06m  ETA 18:32:07
+```
+
+| variable | default | meaning |
+|---|---|---|
+| `SPINORBEC_PROGRESS` | on | set to `quiet` / `off` / `0` / `false` / `no` / `none` to silence. Any other value leaves it on |
+| `SPINORBEC_PROGRESS_INTERVAL` | `60` | seconds between lines. A malformed or non-positive value falls back to 60 rather than throwing |
+
+Three things about it are deliberate. The cadence is **wall-clock, not step
+count** — a step cadence floods at 32³ and goes silent at 128³, and 128³ is
+where the silence costs something. The ETA is a **clock time**, because `h_rt`
+is a clock time and "66 minutes left" has to be added to now by hand before the
+two can be compared. And it is **not** a YAML key and not tied to
+`live_monitor:`: `live_monitor` is documented as the thing batch runs switch
+off, which is exactly the hand-submitted `qsub` job that ran 110 minutes in
+silence and then died on `h_rt`.
+
 ## Hamiltonian overrides (per phase)
 
 Each of these falls back to the previous step's value if omitted:

--- a/src/workflow/experiments.jl
+++ b/src/workflow/experiments.jl
@@ -36,6 +36,7 @@ include("experiments/analyzers.jl")
 include("experiments/pipeline/pipeline_analyzers.jl")
 include("experiments/pipeline/pipeline_dispatch.jl")
 include("experiments/pipeline/pipeline_callbacks.jl")
+include("experiments/pipeline/progress_reporter.jl")
 include("experiments/pipeline/runner.jl")
 include("experiments/pipeline/resolve_gs.jl")   # ONE resolution of a ground_state: block
 include("experiments/pipeline/run_step_ground_state.jl")

--- a/src/workflow/experiments/pipeline/pipeline_callbacks.jl
+++ b/src/workflow/experiments/pipeline/pipeline_callbacks.jl
@@ -216,7 +216,7 @@ end
 statically dispatched. The previous closure-based form captured a
 `Vector{Any}` of callbacks and incurred dynamic dispatch on every
 step × every callback (a measurable cost in long Eu151 runs)."""
-struct ComposedCallbacks{T <: Tuple}
+struct ComposedCallbacks{T <: Tuple} <: Function
     cbs::T
 end
 

--- a/src/workflow/experiments/pipeline/progress_reporter.jl
+++ b/src/workflow/experiments/pipeline/progress_reporter.jl
@@ -1,0 +1,210 @@
+# --- Wall-clock progress for long dynamics runs ---
+#
+# WHY THIS EXISTS
+#
+# On 2026-08-20 three 128³ jobs were killed by `execd enforced h_rt limit` at
+# 7195 s having produced one line of output each: `Step 2/2:
+# ScalarEGPEDynamicsStep`. The `h_rt` was set too short — that was a human
+# error — but the cost of the error was two hours per job, and it was two hours
+# only because **"90 % done" and "stuck at 10 %" printed the same thing.**
+#
+# The three consequences, in the order they bit:
+#
+#   1. no ETA, so the decision "this will not finish, kill it now" could not be
+#      made at all. Two estimates were given in that session and one was
+#      withdrawn;
+#   2. no way to tell a slow run from a hung one;
+#   3. `h_rt` adequacy observable only through "finished" vs "killed", which is
+#      the most expensive possible instrument.
+#
+# WHAT THIS IS NOT
+#
+# It is not the liveness file. `_emit_live_status` writes `_live_status.json`
+# for the autopilot's divergence reaper, and #408 proposed riding on it because
+# it already reaches all three dynamics paths. That is the right SHAPE and the
+# wrong COUPLING: the liveness callback is built from `live_monitor:`, whose own
+# documentation tells batch users to switch it OFF —
+#
+#     # live_monitor defaults ON (every=50). Disable explicitly with
+#     # `live_monitor: false` for batch / TSUBAME / no-dashboard runs.
+#
+# — so a progress line hung off it would be absent from exactly the hand-submitted
+# `qsub` job the issue was opened about. What is borrowed instead is the property
+# that made the liveness fix stick: ONE reporter, constructed the same way on
+# every dynamics path, with a gate that reddens when a path is added without it
+# (`test/workflow/test_every_dynamics_path_reports_progress.jl`).
+#
+# The knob is an environment variable and not a YAML key, deliberately. A YAML
+# key is a per-config decision, and "this config is long enough to want progress"
+# is a decision nobody makes correctly in advance — that is the whole content of
+# the incident. The variable silences it for the one caller who genuinely wants
+# silence (a test), which is the same shape as `SPINORBEC_TEST_TIMING=quiet`.
+
+export ProgressReporter, progress_enabled, PROGRESS_OFF_VALUES
+
+"""
+    ProgressReporter(label, n_steps, t_end; interval_s, io)
+
+Wall-clock-throttled progress line for one dynamics phase.
+
+Call it on every step; it prints at most once per `interval_s` seconds. The
+throttle is on TIME and not on step count on purpose — a step-count cadence is a
+flood at 32³ and silence at 128³, which is the resolution where the silence
+actually costs something.
+
+Reports, in the form [`feedback_report_eta_as_completion_time`](@ref) asks for:
+elapsed, remaining, **and the wall-clock time it expects to finish at**, because
+"66 minutes left" has to be added to the current time by hand before it can be
+compared with an `h_rt`.
+
+    [dynamics]  t = 0.44/1.10 (40.0 %)  step 176000/440000  elapsed 44m01s  left 1h06m  ETA 18:32:07
+
+Progress is measured on PHYSICAL time `t / t_end` rather than on the step index,
+so a path whose callback receives a save index rather than a step index still
+reports a true fraction. `n_steps` is displayed, never divided by.
+"""
+struct ProgressReporter{IOT <: IO} <: Function
+    label::String
+    n_steps::Int
+    t_end::Float64
+    interval_s::Float64
+    started::Base.RefValue{Float64}
+    last::Base.RefValue{Float64}
+    io::IOT
+end
+
+# Parameterised on the IO type rather than declaring `io::IO`. The reporter is
+# reached from `SimulationCallbacks{typeof(on_step)}`, i.e. it becomes a
+# Workspace-path type parameter, and an abstractly-typed field there is the
+# boxing that `pitfall_partial_type_params_in_struct_fields` is about.
+function ProgressReporter(label::AbstractString, n_steps::Integer, t_end::Real;
+    interval_s::Real=_progress_interval(), io::IO=stdout)
+    now = time()
+    ProgressReporter(String(label), Int(n_steps), Float64(t_end),
+        Float64(interval_s), Ref(now), Ref(now), io)
+end
+
+"""
+    PROGRESS_OFF_VALUES
+
+What `SPINORBEC_PROGRESS` may be set to in order to silence progress lines.
+Closed set, and every member means the same thing — a free-text comparison here
+would make `SPINORBEC_PROGRESS=false` and `SPINORBEC_PROGRESS=off` behave
+differently for no reason a user could predict.
+"""
+const PROGRESS_OFF_VALUES = ("quiet", "off", "0", "false", "no", "none")
+
+"""
+    progress_enabled() -> Bool
+
+Progress is ON unless `SPINORBEC_PROGRESS` names one of
+[`PROGRESS_OFF_VALUES`](@ref). Default-on is the whole point: #408 is an issue
+about a run that was silent, and an opt-in fix would have been opted out of by
+the same person who set the wrong `h_rt`.
+"""
+progress_enabled() =
+    !(lowercase(strip(get(ENV, "SPINORBEC_PROGRESS", ""))) in PROGRESS_OFF_VALUES)
+
+"""
+    _progress_interval() -> Float64
+
+Seconds between progress lines, from `SPINORBEC_PROGRESS_INTERVAL` (default 60).
+A non-positive or unparseable value falls back to the default rather than
+throwing: a malformed environment variable must not be able to kill a job that
+had already started, which is the failure this file exists to reduce.
+"""
+function _progress_interval()
+    raw = get(ENV, "SPINORBEC_PROGRESS_INTERVAL", "")
+    v = tryparse(Float64, strip(raw))
+    (v === nothing || !(v > 0)) ? 60.0 : v
+end
+
+"""
+    _build_progress_reporter(label, n_steps, t_end) -> Union{Nothing,ProgressReporter}
+
+`nothing` when progress is disabled, so the result composes into
+[`_compose_callbacks`](@ref) and into the `cb === nothing || cb(...)` guards the
+hand-written loops already use for liveness.
+"""
+_build_progress_reporter(label::AbstractString, n_steps::Integer, t_end::Real) =
+    progress_enabled() ? ProgressReporter(label, n_steps, t_end) : nothing
+
+"Human duration: `44m01s`, `1h06m`, `2d03h`. Never a bare float of seconds."
+function _fmt_duration(s::Real)
+    (isfinite(s) && s >= 0) || return "--"
+    x = round(Int, s)
+    x < 60 && return string(x, "s")
+    x < 3600 && return string(x ÷ 60, "m", lpad(x % 60, 2, '0'), "s")
+    x < 86400 && return string(x ÷ 3600, "h", lpad((x % 3600) ÷ 60, 2, '0'), "m")
+    string(x ÷ 86400, "d", lpad((x % 86400) ÷ 3600, 2, '0'), "h")
+end
+
+"""
+    _progress_line(pr, step, t, now) -> String
+
+The line, as a pure function of the reporter's state and the clock. Split out
+from the printing so a test can assert the CONTENT — that the ETA is a clock
+time and that the percentage tracks `t / t_end` — without capturing stdout or
+waiting a minute for a throttle to open.
+"""
+function _progress_line(pr::ProgressReporter, step::Integer, t::Real, now::Float64)
+    elapsed = now - pr.started[]
+    frac = if pr.t_end > 0
+        clamp(Float64(t) / pr.t_end, 0.0, 1.0)
+    else
+        (pr.n_steps > 0 ? clamp(step / pr.n_steps, 0.0, 1.0) : 0.0)
+    end
+    # Below ~0.1 % the extrapolation is division by noise and would print an ETA
+    # of days that moves by hours on the next line. `--` is the honest output:
+    # nothing has been measured yet.
+    remaining = frac > 1e-3 ? elapsed * (1 - frac) / frac : NaN
+    eta = if isfinite(remaining)
+        Dates.format(Dates.now() + Dates.Second(round(Int, remaining)), "HH:MM:SS")
+    else
+        "--"
+    end
+    string("[", pr.label, "]  t = ", round(Float64(t); digits=4), "/",
+        round(pr.t_end; digits=4), " (", round(100 * frac; digits=1), " %)",
+        "  step ", step, "/", pr.n_steps,
+        "  elapsed ", _fmt_duration(elapsed),
+        "  left ", _fmt_duration(remaining),
+        "  ETA ", eta)
+end
+
+"""
+    _progress!(pr, step, t) -> Bool
+
+Print if the throttle has opened; `true` when a line was emitted.
+
+`flush` is not optional here. Julia fully buffers a non-TTY stdout, so a
+backgrounded job without it writes a zero-byte log until it exits — which is
+indistinguishable from the silence this file was written to remove.
+"""
+function _progress!(pr::ProgressReporter, step::Integer, t::Real)
+    now = time()
+    (now - pr.last[]) < pr.interval_s && return false
+    pr.last[] = now
+    println(pr.io, _progress_line(pr, step, t, now))
+    flush(pr.io)
+    true
+end
+
+_progress!(::Nothing, ::Integer, ::Real) = false
+
+# The spinor path composes its callbacks and hands the result to
+# `SimulationCallbacks(; on_step=…)`, so the reporter has to BE the callback
+# there. The three hand-written loops (rotating / scalar eGPE / binary) call
+# `_progress!` directly, because they have the step and the time in hand and a
+# wrapper closure would be one more type on a Workspace path for nothing.
+#
+# `<: Function` on the struct is load-bearing and was not cosmetic:
+# `_run_dynamics_with_optional_streaming!` types its hook
+# `extra_on_step::Union{Nothing, Function}`, so a plain callable struct is a
+# MethodError at that kwarg. `ComposedCallbacks` had the same defect latent —
+# it only ever reached that kwarg when two callbacks were active at once, which
+# needed `live_monitor` on (so, a `run_yaml` with a run directory) AND an
+# `sgpe:` / `projected_gp:` / `photon_scattering:` block. Making progress
+# default-on would have made two callbacks the NORMAL case and turned a latent
+# defect into every standard dynamics run.
+@inline (pr::ProgressReporter)(ws, step, times, energies) =
+    (_progress!(pr, step, Float64(ws.state.t)); nothing)

--- a/src/workflow/experiments/pipeline/run_step_binary.jl
+++ b/src/workflow/experiments/pipeline/run_step_binary.jl
@@ -154,8 +154,13 @@ end
     dV_bin = prod(grid.dx)
     cb_live = _build_binary_live_callback(get(p, "live_monitor", true),
         live_status_path, dV_bin)
+    # Progress + ETA (#408). Not conditional on `save_psi` and not on
+    # `live_monitor:`, for the same reason liveness is not: a knob about output
+    # must not be able to switch off the thing that tells you the run is alive.
+    cb_progress = _build_progress_reporter(
+        "binary", max(1, round(Int, duration / dt)), duration)
     n_saves = Ref(0)
-    on_save = if (save_psi || cb_live !== nothing)
+    on_save = if (save_psi || cb_live !== nothing || cb_progress !== nothing)
         function _on(s)
             n_saves[] += 1
             if save_psi
@@ -164,6 +169,7 @@ end
                 push!(psi_B_snaps, copy(s.psi_B))
             end
             cb_live === nothing || cb_live(s, n_saves[])
+            _progress!(cb_progress, s.step, s.t)
             return nothing
         end
     else

--- a/src/workflow/experiments/pipeline/run_step_dynamics.jl
+++ b/src/workflow/experiments/pipeline/run_step_dynamics.jl
@@ -397,7 +397,11 @@ LHY. Give the dynamics step an `interactions: {N_atoms: …, omega_ref: …}` (t
     # live_monitor defaults ON (every=50). Disable explicitly with
     # `live_monitor: false` for batch / TSUBAME / no-dashboard runs.
     cb_live = _build_live_callback(get(p, "live_monitor", true), live_status_path)
-    extra_cb = _compose_callbacks(cb_sgpe, cb_pgp, cb_photon, cb_live)
+    # Progress + ETA (#408). Deliberately NOT hung off `live_monitor:`, which the
+    # comment two lines up tells batch users to switch off — that is precisely
+    # the job that ran silent for 110 minutes. Env-gated, default on.
+    cb_progress = _build_progress_reporter("dynamics", n_steps, duration)
+    extra_cb = _compose_callbacks(cb_sgpe, cb_pgp, cb_photon, cb_live, cb_progress)
 
     # `spin_step:` picks how the V half-step realizes its spin rotations.
     # Scoped to this step and restored afterwards, so one dynamics phase

--- a/src/workflow/experiments/pipeline/run_step_rotating/dynamics.jl
+++ b/src/workflow/experiments/pipeline/run_step_rotating/dynamics.jl
@@ -216,9 +216,13 @@ const _ROTATING_ACTUAL_INTEGRATOR = "strang"
     # writer as the standard path (`_emit_live_status`), so the keys cannot drift
     # apart again.
     cb_live = _build_live_callback(get(p, "live_monitor", true), live_status_path)
+    # Progress + ETA (#408). Separate from `live_monitor:` on purpose — see
+    # `progress_reporter.jl`.
+    cb_progress = _build_progress_reporter("rotating_basis", n_steps, n_steps * dt_rtp)
     _record =
         (step, t) -> begin
             cb_live === nothing || cb_live(ws, step, times_arr, Float64[])
+            _progress!(cb_progress, step, t)
             if step == 1 || step % save_every == 0
                 push!(times_arr, t)
                 push!(norms_arr, sqrt(sum(abs2, ws.state.psi) * dV))

--- a/src/workflow/experiments/pipeline/run_step_scalar_egpe.jl
+++ b/src/workflow/experiments/pipeline/run_step_scalar_egpe.jl
@@ -269,9 +269,16 @@ end
 
     B_func = t -> stir_axis(stir, t)
     t = 0.0
+    # Progress + ETA (#408). This is the path whose silence cost 2 h × 3 jobs on
+    # 2026-08-20: it printed `Step 2/2: ScalarEGPEDynamicsStep` and then nothing
+    # for 110 minutes. Its own `verbose` line below fires every `save_every*10`
+    # steps, which at 128³ is once per many minutes and carries neither a
+    # fraction nor an ETA.
+    cb_progress = _build_progress_reporter("scalar_egpe", n_steps, duration)
     for step_i in 1:n_steps
         split_step_scalar!(ws, dt, t, B_func)
         t += dt
+        _progress!(cb_progress, step_i, t)
         if step_i % save_every == 0 || step_i == n_steps
             record!(t)
             isfinite(norms[end]) || throw(ErrorException(

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -112,6 +112,7 @@ const FAST_TESTS = [
     "workflow/test_full_bdg_advisory_fires.jl",
     "workflow/test_no_second_atom_F_table.jl",
     "workflow/test_every_dynamics_path_reports_liveness.jl",
+    "workflow/test_every_dynamics_path_reports_progress.jl",
     "workflow/test_oom_reaches_resource_permanent.jl",
     "workflow/test_preflight_can_fail.jl",
     "workflow/test_slack_alerts_report_delivery.jl",

--- a/test/workflow/test_every_dynamics_path_reports_progress.jl
+++ b/test/workflow/test_every_dynamics_path_reports_progress.jl
@@ -1,0 +1,235 @@
+using Test
+using SpinorBEC
+
+include(joinpath(@__DIR__, "..", "helpers", "calibrated_scan.jl"))
+
+# A long dynamics run must say how far along it is — on every path.
+#
+# On 2026-08-20 three 128³ jobs were killed by `execd enforced h_rt limit` after
+# 7195 s, each having printed exactly one line: `Step 2/2:
+# ScalarEGPEDynamicsStep`. Nothing in the log distinguished "90 % done" from
+# "stuck at 10 %", so the runs could not be abandoned early and the `h_rt`
+# mistake cost its full two hours three times over.
+#
+# TWO GATES, because the unit test alone would have passed while three of the
+# four paths stayed silent:
+#
+#   1. TOTALITY — every `XDynamicsStep` branch in `_step_dispatch!` maps to a
+#      progress label, and every label is actually constructed in the pipeline
+#      source. Both directions, so neither a new unreported path nor a stale
+#      label survives.
+#
+#   2. BEHAVIOUR — the reporter throttles on wall-clock, reports an ETA as a
+#      CLOCK TIME, and goes quiet when asked. Asserted on `_progress_line`,
+#      which is a pure function of (state, clock) precisely so this does not
+#      need a minute of real time or a captured stdout.
+#
+# The liveness gate next door (`test_every_dynamics_path_reports_liveness.jl`)
+# is the model, and the lesson taken from it is in its own comments: `_NO_LIVENESS`
+# was introduced to DECLARE a gap and the gap was closed the next day, which is
+# the argument for making the totality assertion first and the wiring second.
+
+const _PIPELINE_DIR = normpath(
+    joinpath(@__DIR__, "..", "..", "src", "workflow", "experiments", "pipeline"))
+const _RUNNER_SRC = joinpath(_PIPELINE_DIR, "runner.jl")
+
+# Step kind → the `label` its progress lines carry. This is the declaration; the
+# gates below check it against the dispatcher on one side and the source on the
+# other, so it cannot quietly become a description of only what is wired.
+const _PROGRESS_LABELS = Dict{String, String}(
+    "DynamicsStep" => "dynamics",
+    "BinaryDynamicsStep" => "binary",
+    "RotatingBasisDynamicsStep" => "rotating_basis",
+    "ScalarEGPEDynamicsStep" => "scalar_egpe",
+)
+
+"Every `step isa XDynamicsStep` dispatch branch in `_step_dispatch!`."
+function _dispatch_dynamics_kinds()
+    src = read(_RUNNER_SRC, String)
+    i = findfirst("function _step_dispatch!", src)
+    i === nothing && return String[]
+    tail = src[first(i):end]
+    j = findfirst("\nend\n", tail)
+    body = j === nothing ? tail : tail[1:first(j)]
+    out = String[]
+    for p in split(body, r"elseif step isa ")
+        m = match(r"^([A-Za-z]*DynamicsStep)\b", p)
+        m === nothing && continue
+        branch = first(split(p, r"\n\s*elseif|\n\s*else\b"))
+        # Same discriminator the liveness gate uses: a DISPATCH branch calls
+        # `_run_step`. `_step_dispatch!` carries a second if-chain over the same
+        # step types for results collection, and counting it once made a wired
+        # path report as unwired.
+        occursin("_run_step(", branch) || continue
+        push!(out, m.captures[1])
+    end
+    unique(out)
+end
+
+"Every `_build_progress_reporter(\"label\", …)` call under `pipeline/`."
+function _constructed_progress_labels()
+    labels = String[]
+    for (dir, _, files) in walkdir(_PIPELINE_DIR), f in files
+        endswith(f, ".jl") || continue
+        for m in eachmatch(r"_build_progress_reporter\(\s*\"([a-z_]+)\"",
+            read(joinpath(dir, f), String))
+            push!(labels, m.captures[1])
+        end
+    end
+    labels
+end
+
+@testset "every dynamics path reports progress" begin
+    @testset "the dispatcher and the source are both being read" begin
+        # CALIBRATION. Two extractors, and an empty result from either would
+        # make every assertion below vacuously true — the exact shape
+        # `calibrated_scan` exists to refuse.
+        kinds = _dispatch_dynamics_kinds()
+        @test length(kinds) >= 4
+        @test "DynamicsStep" in kinds
+        @test "ScalarEGPEDynamicsStep" in kinds
+
+        # And the label extractor must be able to say "none". Prove it on
+        # synthetic text rather than on the tree, so the control does not die the
+        # moment the tree is correct.
+        probe(src) = [m.captures[1] for m in
+                           eachmatch(r"_build_progress_reporter\(\s*\"([a-z_]+)\"", src)]
+        @test probe("cb = _build_progress_reporter(\"fake_path\", n, d)") == ["fake_path"]
+        @test isempty(probe("cb = _build_live_callback(node, path)"))
+    end
+
+    @testset "totality: dispatcher ⊆ labels ⊆ constructed" begin
+        kinds = _dispatch_dynamics_kinds()
+        constructed = _constructed_progress_labels()
+
+        undeclared = [k for k in kinds if !haskey(_PROGRESS_LABELS, k)]
+        if !isempty(undeclared)
+            println("\nDynamics step kinds with no progress label declared:")
+            foreach(k -> println("  ", k), undeclared)
+            println("\nA long run on that path prints nothing between its opening")
+            println("line and its exit. Add the kind to `_PROGRESS_LABELS` and")
+            println("build a `ProgressReporter` in its handler.")
+        end
+        @test isempty(undeclared)
+
+        # Stale entries are the other direction: a label for a kind the
+        # dispatcher no longer has would make this file assert coverage of
+        # something that does not run.
+        @test all(k -> k in kinds, keys(_PROGRESS_LABELS))
+
+        missing_ctor = [l for l in values(_PROGRESS_LABELS) if !(l in constructed)]
+        if !isempty(missing_ctor)
+            println("\nDeclared progress labels never constructed in `pipeline/`:")
+            foreach(l -> println("  ", l), missing_ctor)
+        end
+        @test isempty(missing_ctor)
+
+        # No orphans: every constructed label belongs to a declared kind. A
+        # reporter built for a path nobody dispatches is a line nobody sees.
+        @test all(l -> l in values(_PROGRESS_LABELS), constructed)
+    end
+end
+
+@testset "a composed on_step hook is accepted where it is installed" begin
+    # `_run_dynamics_with_optional_streaming!` declares
+    # `extra_on_step::Union{Nothing, Function}`, so anything `_compose_callbacks`
+    # can return must be `<: Function`. `ComposedCallbacks` was NOT, and the
+    # defect stayed latent because two simultaneously-active callbacks needed
+    # `live_monitor` on (a `run_yaml` with a run directory) AND an `sgpe:` /
+    # `projected_gp:` / `photon_scattering:` block. Default-on progress makes two
+    # callbacks the ordinary case, so this is pinned rather than rediscovered.
+    f = (ws, step, times, energies) -> nothing
+    g = (ws, step, times, energies) -> nothing
+    @test SpinorBEC._compose_callbacks(nothing, nothing) === nothing
+    @test SpinorBEC._compose_callbacks(f, nothing) isa Function
+    @test SpinorBEC._compose_callbacks(f, g) isa Function
+    @test SpinorBEC._compose_callbacks(f, g, ProgressReporter("p", 10, 1.0)) isa Function
+    # The reporter alone is what `_compose_callbacks` returns when it is the only
+    # live callback — the batch case, i.e. `live_monitor: false`.
+    @test ProgressReporter("p", 10, 1.0) isa Function
+    @test SpinorBEC._compose_callbacks(nothing, ProgressReporter("p", 10, 1.0)) isa Function
+end
+
+@testset "ProgressReporter behaviour" begin
+    io = IOBuffer()
+
+    @testset "throttles on wall-clock, not on step count" begin
+        pr = ProgressReporter("dyn", 1000, 10.0; interval_s=1e6, io=io)
+        # A million-second throttle: no step count may open it.
+        @test !SpinorBEC._progress!(pr, 1, 0.01)
+        @test !SpinorBEC._progress!(pr, 999, 9.99)
+        @test isempty(String(take!(io)))
+
+        open_now = ProgressReporter("dyn", 1000, 10.0; interval_s=0.0, io=io)
+        @test SpinorBEC._progress!(open_now, 500, 5.0)
+        @test occursin("[dyn]", String(take!(io)))
+    end
+
+    @testset "the line carries a fraction, a step count and a CLOCK ETA" begin
+        pr = ProgressReporter("dyn", 1000, 10.0; interval_s=60.0, io=io)
+        # 40 s of wall clock have passed at 40 % of the physical duration, so
+        # the run has ~60 s left. Drive the clock explicitly rather than sleeping.
+        now = pr.started[] + 40.0
+        line = SpinorBEC._progress_line(pr, 400, 4.0, now)
+        @test occursin("40.0 %", line)
+        @test occursin("step 400/1000", line)
+        @test occursin("elapsed 40s", line)
+        @test occursin("left 1m00s", line)
+        # ETA is a clock time — HH:MM:SS — because `h_rt` is compared against a
+        # clock and "60 s left" has to be added to now() by hand first.
+        @test occursin(r"ETA \d\d:\d\d:\d\d", line)
+    end
+
+    @testset "an unmeasurable ETA prints `--` rather than a fiction" begin
+        pr = ProgressReporter("dyn", 10^6, 100.0; interval_s=60.0, io=io)
+        line = SpinorBEC._progress_line(pr, 1, 1e-9, pr.started[] + 5.0)
+        @test occursin("left --", line)
+        @test occursin("ETA --", line)
+    end
+
+    @testset "progress is ON by default and silenced only by the env var" begin
+        # The default matters more than the knob: #408 is about a run that was
+        # silent, and an opt-in fix would have been opted out of by the same
+        # person who set the wrong h_rt.
+        withenv("SPINORBEC_PROGRESS" => nothing) do
+            @test progress_enabled()
+            @test SpinorBEC._build_progress_reporter("dyn", 10, 1.0) !== nothing
+        end
+        for off in PROGRESS_OFF_VALUES
+            withenv("SPINORBEC_PROGRESS" => off) do
+                @test !progress_enabled()
+                @test SpinorBEC._build_progress_reporter("dyn", 10, 1.0) === nothing
+            end
+        end
+        withenv("SPINORBEC_PROGRESS" => "QUIET") do
+            @test !progress_enabled()   # case-insensitive
+        end
+        # A value that is not a recognised "off" leaves progress on rather than
+        # silently disabling it — the failure this file exists to prevent is
+        # silence, so an unparseable knob must fall to the loud side.
+        withenv("SPINORBEC_PROGRESS" => "yes-please") do
+            @test progress_enabled()
+        end
+    end
+
+    @testset "a malformed interval falls back instead of throwing" begin
+        # A job that has already started must not die because an env var was
+        # mistyped; that trades a silent run for no run at all.
+        for bad in ("", "abc", "-5", "0")
+            withenv("SPINORBEC_PROGRESS_INTERVAL" => bad) do
+                @test SpinorBEC._progress_interval() == 60.0
+            end
+        end
+        withenv("SPINORBEC_PROGRESS_INTERVAL" => "5") do
+            @test SpinorBEC._progress_interval() == 5.0
+        end
+    end
+
+    @testset "durations are human, never a bare float of seconds" begin
+        @test SpinorBEC._fmt_duration(42) == "42s"
+        @test SpinorBEC._fmt_duration(90) == "1m30s"
+        @test SpinorBEC._fmt_duration(3960) == "1h06m"
+        @test SpinorBEC._fmt_duration(97200) == "1d03h"
+        @test SpinorBEC._fmt_duration(NaN) == "--"
+    end
+end


### PR DESCRIPTION
2026-08-20 に 128³ のジョブ 3 本が `execd enforced h_rt limit` で 7195 s に殺された。各ジョブが出力していた行は **1 行だけ** — `Step 2/2: ScalarEGPEDynamicsStep`。h_rt を短く切ったのは人為ミスだが、そのミスが 1 本あたり 2 時間になったのは、**「9 割終わっている」と「10 % で詰まっている」が同じ見え方をしたから**。

```
[scalar_egpe]  t = 0.44/1.10 (40.0 %)  step 176000/440000  elapsed 44m01s  left 1h06m  ETA 18:32:07
```

## 設計で意図的にしていること

**1. 節ではなく時計で throttle。** ステップ基準の間隔は 32³ で洪水、128³ で無音になる — そして 128³ こそ無音が高くつく解像度。既定 60 秒、`SPINORBEC_PROGRESS_INTERVAL` で変更可。

**2. ETA は時刻。** `h_rt` は時刻の量なので、「残り 66 分」は手で now に足さないと比較できない（`feedback_report_eta_as_completion_time`）。

**3. `_emit_live_status` には相乗り *しない*。** issue の提案はそちらで、全 3 経路に届くという理由は正しい。しかし結合先が間違っている: liveness callback は `live_monitor:` から作られ、その真上のコメントが **「batch / TSUBAME / no-dashboard runs では `live_monitor: false` にせよ」** と書いている。つまりそこにぶら下げた進捗行は、**issue が題材にしている手投げ qsub ジョブにだけ存在しない**。借りたのは liveness の修正が定着した理由のほう — **1 つの reporter を全経路で同じ形で作り、経路が増えたら赤くなる総覧ゲートを置く**。

**4. YAML キーではなく環境変数。** 「この config は進捗が要るほど長いか」は事前に誰も正しく判断できない、というのが事案の中身そのもの。既定 ON、`SPINORBEC_PROGRESS=quiet|off|0|false|no|none` で黙る。認識できない値は **ON 側に倒す**（この機構が防ぎたい失敗は沈黙なので）。壊れた `INTERVAL` は 60 に fallback して投げない — 走り始めたジョブを env の打ち間違いで殺すのは、沈黙をノーランに変えるだけ。

## 途中で見つかった別の欠陥

`ComposedCallbacks` が **`<: Function` ではなかった**。唯一の消費者は hook を `extra_on_step::Union{Nothing, Function}` と型付けしている。潜在だったのは、同時に 2 つの callback が生きるには `live_monitor` ON（= run dir 付きの `run_yaml`）**かつ** `sgpe:` / `projected_gp:` / `photon_scattering:` ブロックが要ったから。進捗を既定 ON にすると **2 つが普通の場合**になるので、これは全ての標準 dynamics ラン を壊していた。修正して testset で pin。

## ゲート

`test/workflow/test_every_dynamics_path_reports_progress.jl`（fast tier）。2 段:

- **総覧性** — `_step_dispatch!` の全 `XDynamicsStep` 分岐 ↔ 進捗ラベル ↔ `pipeline/` 内の実際の構築、を**両方向**で。抽出器 2 つとも陽性・陰性対照つき（空リストを返す抽出器は全 assert を空虚に真にする）。
- **挙動** — throttle が時計基準であること、行に割合・step・**時刻の ETA** が載ること、測れない ETA は数字を捏造せず `--` を出すこと、既定 ON で env でのみ黙ること。`_progress_line` を (状態, 時計) の純関数に切り出してあるので、stdout を捕まえず 1 分待たずに中身を assert できる。

Julia はローカルで回さない規範なので、権威は CI。

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)
