### PR TITLE
fix(io): result.jld2 を宣言どおりの要約にする — 148 GB

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -123,8 +123,8 @@ checking either.
 **4 sites admit a cached payload; 1 re-derives its verdict.**
 
 - admits: `src/workflow/experiment.jl:253`
-- admits: `src/workflow/experiments/pipeline/run_registry.jl:601`
-- admits: `src/workflow/experiments/pipeline/run_registry.jl:854`
+- admits: `src/workflow/experiments/pipeline/run_registry.jl:625`
+- admits: `src/workflow/experiments/pipeline/run_registry.jl:878`
 - admits: `src/workflow/experiments/pipeline/run_step_ground_state.jl:549`
 - **verifies**: `src/workflow/experiments/pipeline/run_step_ground_state.jl:606`
 
@@ -208,7 +208,7 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 272 files
+- `FAST_TESTS` — 274 files
 - `CI_EXTRA` — 141 files
 - `FULL_EXTRA` — 77 files
 - `PHYSICS_TESTS` — 7 files

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -208,7 +208,7 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 270 files
+- `FAST_TESTS` — 271 files
 - `CI_EXTRA` — 139 files
 - `FULL_EXTRA` — 74 files
 - `PHYSICS_TESTS` — 7 files

--- a/docs/campaign/prior_art/data_reduction.md
+++ b/docs/campaign/prior_art/data_reduction.md
@@ -1,0 +1,16 @@
+# Prior art — data_reduction
+
+> **FROZEN 2026-08-20.** A snapshot of the open work on data_reduction as of that
+> date. Re-run the generator when picking the topic up again; existing
+> dispositions are preserved.
+
+Keywords: storage, disk, reduction, tier, archive, prune, retention, jld2, catalog. Regenerate with
+`python3 scripts/prior_art.py --topic data_reduction --keywords storage disk reduction tier archive prune retention jld2 catalog`.
+
+Dispositions: `unread`, `read`, `unrelated`, `superseded`, `depends`
+
+| ref | disposition | what | note |
+|---|---|---|---|
+| origin/ci/trim-fast-tier-and-cache | unrelated | branch:  | test tier membership + CI precompile cache; "cache" matched the keyword but it is the Julia compile cache, not run output |
+| origin/fix/oracles-tier-red | unrelated | branch:  | a citation gate going red on an archive import; matched "archive" as a word |
+| origin/fix/result-jld2-duplication | read | branch:  | PR #195, CLOSED 2026-07-30 unmerged. anko: the duplication is INTENTIONAL, result.jld2 is a SUMMARY artifact — so that PR's premise (unintended bug) was wrong. But its measurement stands and is the starting point here: result.jld2 is 9.71 GB against point_001 10.25 GB because it carries all 753 frames, i.e. it is NOT functioning as a summary. The change left on record for a decision — drop dynamics/psi_snapshots_streamed from result.jld2 — serves the stated design AND recovers the space. That is what this work does. |

--- a/docs/campaign/prior_art/provenance.md
+++ b/docs/campaign/prior_art/provenance.md
@@ -1,0 +1,15 @@
+# Prior art — provenance
+
+> **FROZEN 2026-08-20.** A snapshot of the open work on provenance as of that
+> date. Re-run the generator when picking the topic up again; existing
+> dispositions are preserved.
+
+Keywords: provenance, commit, seed, reproducib, metadata, env, catalog. Regenerate with
+`python3 scripts/prior_art.py --topic provenance --keywords provenance commit seed reproducib metadata env catalog`.
+
+Dispositions: `unread`, `read`, `unrelated`, `superseded`, `depends`
+
+| ref | disposition | what | note |
+|---|---|---|---|
+| #55 | unrelated | issue: feat(solvers): unified snapshot + spectral/real-space seeding mechanism | snapshot + spectral/real-space SEEDING mechanism — matched "seed" as a word; it is about initial-state construction, not about recording which code produced a file |
+| #57 | unrelated | issue: research(phases): 2D Eu F=6 phase diagram via adaptive multi-seed mapping | adaptive multi-seed phase mapping; same keyword collision |

--- a/scripts/eu334/nucleate.jl
+++ b/scripts/eu334/nucleate.jl
@@ -399,7 +399,13 @@ function main()
         T=T_RES, mu0=MU0, mu1=MU1, tau_ms=TAU_MS, hold_ms=HOLD_MS, seed=SEED,
         noise=NOISE, f_seed=seed.f, grid_n_points=(GRID_N, GRID_N, GRID_N),
         grid_box_size=(BOX, BOX, BOX), n_atoms_norm=NATOMS, dt=DT, every=EVERY,
-        wall_s=wall, seed_file=SEED_FILE)
+        wall_s=wall, seed_file=SEED_FILE,
+        # WHICH CODE PRODUCED THIS. Measured 2026-08-21: these files carried every
+        # physics parameter and the seed, and nothing about the code — so a
+        # trajectory was reproducible only from a session someone still remembered.
+        # `git_dirty` is the load-bearing field; a hash from a dirty tree names a
+        # commit that does not describe what ran.
+        provenance=run_provenance())
     @printf("  wrote %s/{traj,psi}_%s\n", OUT, tag)
 end
 

--- a/scripts/eu334/nucleation_bifurcation.jl
+++ b/scripts/eu334/nucleation_bifurcation.jl
@@ -266,7 +266,11 @@ function walk(name, dirn, anchor; init_state=:m_minus_F)
         jldsave(joinpath(OUT, @sprintf("%s_f%06.4f.jld2", name, f)); psi=r.psi, f=f,
             n_atoms=r.n_atoms, E_total=r.E, fperp=r.fperp, Jz=r.Jz,
             grid_n_points=(GRID_N, GRID_N, GRID_N), grid_box_size=(BOX, BOX, BOX),
-            B_uG=B_UG, kappa=KAPPA, pin_bx=PIN)
+            B_uG=B_UG, kappa=KAPPA, pin_bx=PIN,
+            # Which code produced this — see nucleate.jl. These cells are the
+            # REFERENCE TABLE every classification is measured against, so a cell
+            # whose provenance is unknown makes every verdict built on it unknown.
+            provenance=run_provenance())
     end
     writedlm(joinpath(OUT, "$name.csv"), vcat(permutedims(COLS), permutedims.(rows)...), '\t')
     rows

--- a/scripts/reduce_result_backlog.jl
+++ b/scripts/reduce_result_backlog.jl
@@ -86,14 +86,13 @@ function main()
                 :error
             end
         else
-            # The same predicate the writer uses, without writing: ask it on a
-            # scratch COPY so a dry run cannot modify anything by construction.
-            mktempdir() do d
-                cp(res, joinpath(d, "result.jld2"))
-                # a hardlink would let the real file be rewritten; copy is the point
-                symlink(abspath(point), joinpath(d, basename(point)))
-                make_result_a_summary!(d, joinpath(d, basename(point)))
-            end
+            # The same call, `dry=true`. The first version built a stand-in — a
+            # copied result.jld2 and a SYMLINK to the point file in a temp dir —
+            # and every directory came back `:skipped`, because the symlink
+            # tripped a guard the real call would never see. It also copied a 9 GB
+            # file per directory to preview it. A preview that reconstructs the
+            # conditions is a second implementation, and it was already wrong.
+            make_result_a_summary!(dir, point; dry=true)
         end
         counts[st] = get(counts, st, 0) + 1
         if st === :summarised

--- a/scripts/reduce_result_backlog.jl
+++ b/scripts/reduce_result_backlog.jl
@@ -1,0 +1,118 @@
+# Reduce EXISTING result.jld2 files to the summaries they are declared to be.
+#
+#   julia --project=. scripts/reduce_result_backlog.jl <root>            # DRY RUN
+#   julia --project=. scripts/reduce_result_backlog.jl <root> --apply
+#
+# The forward fix (`make_result_a_summary!`, called when a point file lands) only
+# helps runs written after it. The backlog measured 2026-08-21 is 136 pairs and
+# 148.4 GB of result.jld2 on a volume with 693 GB free.
+#
+# This does NOT reimplement the reduction. It calls the same gated function, so
+# every refusal — point file absent / short / differently shaped, rotating-basis
+# runs whose point_NNN is a symlink at result.jld2 — is the one the unit tests
+# canary. A sweep with its own copy of the safety logic is how the two drift.
+#
+# WHAT THIS ADDS is the one thing a sweep needs and the writer does not: it runs
+# NEXT TO LIVE JOBS. A directory being written while it is rewritten loses data
+# in a way no per-file check can catch, so the interference guard is first and it
+# is deliberately conservative:
+#
+#   - `_live_status.json` present and touched within QUIET_S  -> skip
+#   - ANY file in the directory touched within QUIET_S        -> skip
+#
+# The second one is the load-bearing one. `_live_status.json` is written by
+# `run_yaml`; a campaign script or a hand-run job has none, and skipping only on
+# the status file would sweep exactly those.
+#
+# DRY RUN IS THE DEFAULT and prints what each directory would do, because the
+# failure mode is destroying the only copy of a multi-GB run and the check is
+# cheap enough that there is no reason to skip it.
+
+using SpinorBEC
+using Printf
+
+const QUIET_S = parse(Float64, get(ENV, "REDUCE_QUIET_S", "3600"))
+
+"""Recently touched by anything — a job may still be writing here."""
+function _is_live(dir::String)
+    now_s = time()
+    for (root, _, files) in walkdir(dir)
+        for f in files
+            p = joinpath(root, f)
+            try
+                (now_s - mtime(p)) < QUIET_S && return true
+            catch
+                continue        # vanished mid-walk: something IS writing
+            end
+        end
+    end
+    false
+end
+
+function main()
+    length(ARGS) >= 1 || error("usage: reduce_result_backlog.jl <root> [--apply]")
+    root = ARGS[1]
+    apply = "--apply" in ARGS
+    isdir(root) || error("not a directory: $root")
+
+    @printf("%s over %s   (quiet window %.0f s)\n",
+        apply ? "APPLYING" : "DRY RUN", root, QUIET_S)
+
+    counts = Dict{Symbol, Int}()
+    freed = 0
+    for (dir, _, files) in walkdir(root)
+        "result.jld2" in files || continue
+        pts = sort([f for f in files if startswith(f, "point_") && endswith(f, ".jld2")])
+        isempty(pts) && (counts[:no_point] = get(counts, :no_point, 0) + 1; continue)
+        point = joinpath(dir, pts[1])
+        res = joinpath(dir, "result.jld2")
+
+        if _is_live(dir)
+            counts[:live] = get(counts, :live, 0) + 1
+            @printf("  live    %s\n", dir)
+            continue
+        end
+
+        before = try
+            filesize(res)
+        catch
+            0
+        end
+        st = if apply
+            try
+                make_result_a_summary!(dir, point)
+            catch err
+                @warn "reduction failed" dir exception = err
+                :error
+            end
+        else
+            # The same predicate the writer uses, without writing: ask it on a
+            # scratch COPY so a dry run cannot modify anything by construction.
+            mktempdir() do d
+                cp(res, joinpath(d, "result.jld2"))
+                # a hardlink would let the real file be rewritten; copy is the point
+                symlink(abspath(point), joinpath(d, basename(point)))
+                make_result_a_summary!(d, joinpath(d, basename(point)))
+            end
+        end
+        counts[st] = get(counts, st, 0) + 1
+        if st === :summarised
+            after = apply ? filesize(res) : 0
+            gain = apply ? before - after : before
+            freed += gain
+            @printf("  %-11s %6.2f GB  %s\n",
+                apply ? "summarised" : "would free", gain / 2^30, dir)
+        elseif st !== :already_summary
+            @printf("  %-11s %s\n", String(st), dir)
+        end
+    end
+
+    println()
+    for (k, v) in sort(collect(counts); by=first)
+        @printf("  %-18s %d\n", String(k), v)
+    end
+    @printf("  %-18s %.1f GB\n", apply ? "freed" : "recoverable", freed / 2^30)
+    apply || println("\nDRY RUN — nothing was written. Re-run with --apply.")
+end
+
+main()

--- a/src/workflow/experiments/pipeline/run_registry.jl
+++ b/src/workflow/experiments/pipeline/run_registry.jl
@@ -932,6 +932,19 @@ function _run_yaml_single(data::Dict, run_dir, env, index, run_name; verbose=tru
         rethrow(err)
     end
 
+    # The sibling `result.jld2` is a SUMMARY (PR #195). It only becomes one once
+    # a real point file carries the frames, which is exactly here — the auto-save
+    # in `run_pipeline` wrote it before this file existed, so it could not know.
+    # Non-fatal and key-only; refuses unless the point file provably covers it.
+    try
+        st = make_result_a_summary!(run_dir, psi_file)
+        verbose && st === :summarised &&
+            println("  result.jld2 reduced to a summary (frames live in ",
+                basename(psi_file), ")")
+    catch err
+        @warn "result.jld2 summary reduction failed (non-fatal)" run_dir exception=err
+    end
+
     # Catalog fuel (non-fatal) — see scan-path emit for rationale.
     try
         write_run_summary(run_dir, psi_file; source="finish_hook")

--- a/src/workflow/experiments/pipeline/run_registry.jl
+++ b/src/workflow/experiments/pipeline/run_registry.jl
@@ -1,6 +1,6 @@
 # --- Run Registry: resumable YAML-driven experiments ---
 
-export run_yaml, run_status, list_runs, compute_run_dir
+export run_yaml, run_status, list_runs, compute_run_dir, run_provenance
 
 # Directory-per-run design: 1 config.yaml ↔ 1 directory containing one
 # self-contained JLD2 per scan point. Re-running the same YAML skips files
@@ -41,6 +41,30 @@ function compute_run_dir(yaml_path::String; base_dir::String=default_run_root())
     basename_no_ext = splitext(basename(yaml_path))[1]
     joinpath(base_dir, "$(basename_no_ext)_$(hash16)")
 end
+
+"""
+    run_provenance() -> Dict{String,Any}
+
+Which code produced a file: git hash, whether the tree was dirty, Julia version
+and threads, host, platform.
+
+PUBLIC because the pipeline is not the only writer. `run_yaml` outputs carry this
+under `env/`, but campaign scripts write their own JLD2 and carried NONE of it —
+measured 2026-08-21 on `scripts/eu334/nucleate.jl` output, which holds every
+physics parameter and the seed (`B_uG`, `kappa`, `mu0`, `mu1`, `tau_ms`, `seed`,
+`seed_file`, …) and not one fact about the code that ran. The seed makes a
+trajectory reproducible only if you also know what it was fed to.
+
+The asymmetry ran the other way from what was assumed: the pipeline has the
+provenance and keeps the seed in its config; the scripts have the seed and no
+provenance. Both halves are needed once files outlive the session that wrote
+them, which is the whole premise of deleting anything later.
+
+`git_dirty` is the load-bearing field. A hash from a dirty tree names a commit
+that does not describe the code that ran, and silently — so a run recorded as
+reproducible would not be.
+"""
+run_provenance() = _env_metadata()
 
 function _env_metadata()
     git_hash = try

--- a/src/workflow/io/dashboard/snapshots.jl
+++ b/src/workflow/io/dashboard/snapshots.jl
@@ -106,12 +106,20 @@ end
 Base.showerror(io::IO, e::NoPsiAvailable) = print(io, "NoPsiAvailable: ", e.msg)
 
 """Return the path that actually carries the streamed dynamics snapshots
-for `jld2_path`. The lab-frame spinor pipeline writes only the static
-final ψ + scalar traces to point_NNN.jld2, while the per-frame spinor
-volumes live in sibling result.jld2 (canonical streamed layout). If
-the requested file has its own snapshots (rotating_basis path, or a
-older run that embedded them) return it unchanged; otherwise
-redirect to the sibling result.jld2 when present."""
+for `jld2_path`.
+
+CORRECTED 2026-08-21. This said the lab-frame spinor pipeline writes only the
+static final ψ + scalar traces to point_NNN.jld2 with the per-frame volumes in
+sibling result.jld2. That was one of TWO statements of the intended layout that
+disagreed — anko's, on PR #195, is that `result.jld2` is a SUMMARY — and neither
+described the tree, where both files carried every frame (9.11 GB against 9.55 GB
+on a 750-frame run, 148.4 GB across 136 pairs).
+
+The layout now enforced by `make_result_a_summary!`: **the point file carries the
+frames, result.jld2 is the summary.** The resolution order below already serves
+it — the requested file has its own streams, so it is returned unchanged — and
+the sibling redirect stays for rotating-basis runs (whose point_NNN is a symlink
+at result.jld2) and for runs written before the reduction."""
 function _resolve_snapshot_source(jld2_path::String)
     try
         has_streams = jldopen(jld2_path, "r") do f

--- a/src/workflow/io/save_rotating_result.jl
+++ b/src/workflow/io/save_rotating_result.jl
@@ -1,5 +1,6 @@
-export save_rotating_basis_result!, summarize_rotating_basis_result,
-    launch_experiment
+export save_rotating_basis_result!,
+    summarize_rotating_basis_result,
+    launch_experiment, make_result_a_summary!
 
 """
     summarize_rotating_basis_result(io, result; label="")
@@ -522,4 +523,90 @@ function save_rotating_basis_result!(
     end
 
     out_path
+end
+
+"""
+    make_result_a_summary!(run_dir, point_file) -> Symbol
+
+Rewrite `<run_dir>/result.jld2` WITHOUT its per-frame payload, once a real point
+file provably carries the same frames.
+
+WHY. `result.jld2` is a **summary artifact** — anko's decision on PR #195, which
+closed an attempt to collapse it into a symlink precisely because that would have
+changed the design rather than fixed a bug. What the same PR measured is that the
+summary is not one: 9.11 GB against point_001's 9.55 GB, carrying all 750 frames.
+Across the group volume that is 148.4 GB in 136 `result.jld2` files, ~11 % of the
+1.3 TB in use. Dropping the frames is what makes the file match its stated role,
+and it was left on record as the change to make instead.
+
+The dashboard keeps working without a redirect: `_resolve_snapshot_source` returns
+the requested path when it has its own streams, and the point file does.
+
+NOTE — the dashboard's own docstring says the opposite ("point_NNN gets only the
+static final ψ + scalar traces, per-frame volumes live in sibling result.jld2").
+Two statements of the intended layout existed and disagreed; today NEITHER holds,
+because both files are full. This follows the owner's explicit decision, and the
+docstring is corrected in the same commit rather than left to contradict it.
+
+REFUSES rather than guesses, because the failure is silent data loss:
+
+  - `result.jld2` absent, or a symlink            → `:skipped`
+  - the point file is a symlink (rotating-basis   → `:skipped`
+    runs point at `result.jld2`, so its frames
+    are the ONLY copy)
+  - the point file has no frames, or fewer, or a  → `:not_covered`
+    different spatial shape / component count
+  - already stripped                              → `:already_summary`
+
+Keys only — no frame is ever read, so the check costs milliseconds against files
+of several GB.
+"""
+function make_result_a_summary!(run_dir::AbstractString, point_file::AbstractString)
+    res = joinpath(run_dir, "result.jld2")
+    (isfile(res) && !islink(res)) || return :skipped
+    (isfile(point_file) && !islink(point_file)) || return :skipped
+    samefile(res, point_file) && return :skipped
+
+    grp = "dynamics/psi_snapshots_streamed"
+    meta(path) = jldopen(path, "r") do f
+        haskey(f, "$grp/n_snapshots") || return nothing
+        (n=Int(f["$grp/n_snapshots"]),
+            shape=f["$grp/spatial_shape"], comps=f["$grp/n_components"])
+    end
+    rm_ = meta(res)
+    rm_ === nothing && return :already_summary
+    pm = meta(point_file)
+    pm === nothing && return :not_covered
+    (pm.n >= rm_.n && pm.shape == rm_.shape && pm.comps == rm_.comps) || return :not_covered
+
+    tmp = res * ".summary.tmp"
+    isfile(tmp) && rm(tmp; force=true)
+    try
+        jldopen(res, "r") do src
+            jldopen(tmp, "w") do dst
+                _copy_except!(dst, src, "", "dynamics/psi_snapshots_streamed")
+            end
+        end
+        mv(tmp, res; force=true)
+    catch err
+        isfile(tmp) && rm(tmp; force=true)
+        rethrow(err)
+    end
+    :summarised
+end
+
+# Recursive key copy that skips one group. JLD2 has no "copy all but" primitive,
+# and reconstructing the file by listing top-level keys alone would silently flatten
+# the `dynamics/` group the readers index into.
+function _copy_except!(dst, src, prefix::String, skip::String)
+    for k in keys(src)
+        path = isempty(prefix) ? String(k) : prefix * "/" * String(k)
+        path == skip && continue
+        v = src[k]
+        if v isa JLD2.Group
+            _copy_except!(dst, v, path, skip)
+        else
+            dst[path] = v
+        end
+    end
 end

--- a/src/workflow/io/save_rotating_result.jl
+++ b/src/workflow/io/save_rotating_result.jl
@@ -557,11 +557,16 @@ REFUSES rather than guesses, because the failure is silent data loss:
   - the point file has no frames, or fewer, or a  → `:not_covered`
     different spatial shape / component count
   - already stripped                              → `:already_summary`
+  - either file will not open (truncated, held,   → `:unreadable`
+    killed mid-write)
+
+`dry=true` runs every check and returns the verdict WITHOUT writing.
 
 Keys only — no frame is ever read, so the check costs milliseconds against files
 of several GB.
 """
-function make_result_a_summary!(run_dir::AbstractString, point_file::AbstractString)
+function make_result_a_summary!(run_dir::AbstractString, point_file::AbstractString;
+    dry::Bool=false)
     res = joinpath(run_dir, "result.jld2")
     (isfile(res) && !islink(res)) || return :skipped
     (isfile(point_file) && !islink(point_file)) || return :skipped
@@ -574,16 +579,36 @@ function make_result_a_summary!(run_dir::AbstractString, point_file::AbstractStr
     samefile(res, point_file) && return :skipped
 
     grp = "dynamics/psi_snapshots_streamed"
-    meta(path) = jldopen(path, "r") do f
-        haskey(f, "$grp/n_snapshots") || return nothing
-        (n=Int(f["$grp/n_snapshots"]),
-            shape=f["$grp/spatial_shape"], comps=f["$grp/n_components"])
-    end
+    # A file that will not OPEN is distinct from one with no frames, and the
+    # backlog sweep found the difference the hard way: `jldopen` threw on a
+    # `result.jld2` in the tree and took the whole pass down. Truncated writes,
+    # a kill mid-save, a file another process holds — all real, all reasons to
+    # REFUSE rather than to rewrite. Returning `:already_summary` for an
+    # unreadable file would be worse than throwing: it reads as "done".
+    meta(path) =
+        try
+            jldopen(path, "r") do f
+                haskey(f, "$grp/n_snapshots") || return (; missing_frames=true)
+                (n=Int(f["$grp/n_snapshots"]),
+                    shape=f["$grp/spatial_shape"], comps=f["$grp/n_components"])
+            end
+        catch
+            nothing
+        end
     rm_ = meta(res)
-    rm_ === nothing && return :already_summary
+    rm_ === nothing && return :unreadable
+    haskey(rm_, :missing_frames) && return :already_summary
     pm = meta(point_file)
-    pm === nothing && return :not_covered
+    pm === nothing && return :unreadable
+    haskey(pm, :missing_frames) && return :not_covered
     (pm.n >= rm_.n && pm.shape == rm_.shape && pm.comps == rm_.comps) || return :not_covered
+
+    # `dry` returns the verdict from the SAME checks, one line before the rewrite.
+    # The alternative — a caller reproducing the conditions to preview them — is
+    # how a preview starts disagreeing with the act. The backlog sweep's first
+    # version did exactly that and reported `:skipped` for every directory,
+    # because the stand-in it built tripped a guard the real call would not.
+    dry && return :summarised
 
     tmp = res * ".summary.tmp"
     isfile(tmp) && rm(tmp; force=true)

--- a/src/workflow/io/save_rotating_result.jl
+++ b/src/workflow/io/save_rotating_result.jl
@@ -565,6 +565,12 @@ function make_result_a_summary!(run_dir::AbstractString, point_file::AbstractStr
     res = joinpath(run_dir, "result.jld2")
     (isfile(res) && !islink(res)) || return :skipped
     (isfile(point_file) && !islink(point_file)) || return :skipped
+    # `samefile` is the load-bearing one — canaried 2026-08-21: removing it lets
+    # the rotating-basis case strip its own only copy, and the gate goes red with
+    # `KeyError: dynamics/psi_snapshots_streamed`. The `islink` check above is
+    # REDUNDANT with it (a symlinked point file is the same file) and is kept as a
+    # cheap early exit, not as protection. Removing `islink` alone changes nothing,
+    # which is why that arm of the canary did not fire.
     samefile(res, point_file) && return :skipped
 
     grp = "dynamics/psi_snapshots_streamed"

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -41,6 +41,7 @@ const FAST_TESTS = [
     # "Nobody checked" must not be written as "converged". The rotating-basis GS
     # reports no convergence flag, so every such run satisfied CAMPAIGN guard 7
     # by default, having never been asked.
+    "workflow/test_result_jld2_summary.jl",
     "workflow/test_converged_absent_is_not_a_pass.jl",
     # A declared mirror pair must flip EVERY axial quantity (Omega, m AND B_z).
     # bce2068f repaired two configs correctly one at a time and broke the mirror

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -42,6 +42,7 @@ const FAST_TESTS = [
     # reports no convergence flag, so every such run satisfied CAMPAIGN guard 7
     # by default, having never been asked.
     "workflow/test_result_jld2_summary.jl",
+    "workflow/test_run_provenance.jl",
     "workflow/test_converged_absent_is_not_a_pass.jl",
     # A declared mirror pair must flip EVERY axial quantity (Omega, m AND B_z).
     # bce2068f repaired two configs correctly one at a time and broke the mirror

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -29,6 +29,7 @@ const _SCRIPTS_ALLOWLIST = Set([
     "cli.jl",                      # shim → SpinorBEC.cli_main
     "generate_state.jl",           # docs/STATE.md generator (test-gated)
     "prior_art.py",                # prior-art dispositions (test-gated)
+    "reduce_result_backlog.jl",     # result.jld2 backlog sweep (calls the gated reducer)
     "audit_memory.py",             # memory-store auditor (CLAUDE.md-gated)
     "preflight_invariants.jl",     # physics-invariant preflight battery
     "watch_until_done.sh",         # job watcher with a reachable RED

--- a/test/workflow/test_result_jld2_summary.jl
+++ b/test/workflow/test_result_jld2_summary.jl
@@ -95,6 +95,56 @@ end
         end
     end
 
+    @testset "dry=true gives the SAME verdict and writes nothing" begin
+        # The backlog sweep previews with this. Its first version built a stand-in
+        # instead — a copied result.jld2 plus a symlink to the point file — and
+        # every directory came back `:skipped` because the symlink tripped a guard
+        # the real call never sees. `0.0 GB recoverable` from a check that could
+        # not fire. So the preview must be the same call, and that must be gated.
+        mktempdir() do d
+            res, pt = joinpath(d, "result.jld2"), joinpath(d, "point_001.jld2")
+            _write_frames(res; n=4)
+            _write_frames(pt; n=4)
+            before = filesize(res)
+            @test make_result_a_summary!(d, pt; dry=true) === :summarised
+            @test filesize(res) == before                      # nothing written
+            @test jldopen(f -> haskey(f, "$_GRP/n_snapshots"), res, "r")
+            # and the wet call agrees with what the dry one predicted
+            @test make_result_a_summary!(d, pt) === :summarised
+        end
+        # a refusal must be predicted as a refusal, not just as "not summarised"
+        mktempdir() do d
+            res, pt = joinpath(d, "result.jld2"), joinpath(d, "point_001.jld2")
+            _write_frames(res; n=6)
+            _write_frames(pt; n=3)
+            @test make_result_a_summary!(d, pt; dry=true) === :not_covered
+            @test make_result_a_summary!(d, pt) === :not_covered
+        end
+    end
+
+    @testset "REFUSES a file it cannot open" begin
+        # Found by the backlog sweep: `jldopen` threw on a result.jld2 in the tree
+        # and took the whole pass down. Refusing is the only safe verdict — and it
+        # must NOT be `:already_summary`, which reads as "done" and would let a
+        # truncated file be counted as reduced.
+        mktempdir() do d
+            res, pt = joinpath(d, "result.jld2"), joinpath(d, "point_001.jld2")
+            _write_frames(pt; n=3)
+            write(res, "not a JLD2 file at all")
+            @test make_result_a_summary!(d, pt) === :unreadable
+            @test read(res, String) == "not a JLD2 file at all"   # untouched
+        end
+        # and the same when it is the POINT file that will not open: the coverage
+        # claim cannot be checked, so the frames stay where they are
+        mktempdir() do d
+            res, pt = joinpath(d, "result.jld2"), joinpath(d, "point_001.jld2")
+            _write_frames(res; n=3)
+            write(pt, "truncated")
+            @test make_result_a_summary!(d, pt) === :unreadable
+            @test jldopen(f -> f["$_GRP/n_snapshots"], res, "r") == 3
+        end
+    end
+
     @testset "inert when there is no result.jld2" begin
         mktempdir() do d
             pt = joinpath(d, "point_001.jld2")

--- a/test/workflow/test_result_jld2_summary.jl
+++ b/test/workflow/test_result_jld2_summary.jl
@@ -1,0 +1,105 @@
+using Test
+using SpinorBEC
+using JLD2
+
+# `result.jld2` is a SUMMARY artifact (anko's decision on PR #195, which closed a
+# symlink-collapse attempt for changing the design rather than fixing a bug). It
+# was not one: 9.11 GB against point_001's 9.55 GB on a 750-frame run, 148.4 GB
+# across 136 pairs on the group volume. `make_result_a_summary!` drops the frames
+# once a real point file provably carries them.
+#
+# The assertions are on the CLASSIFICATION and on what survives, because the
+# failure mode is silent data loss: a wrong refusal costs disk, a wrong summary
+# costs the only copy of a multi-GB run.
+const _GRP = "dynamics/psi_snapshots_streamed"
+
+function _write_frames(path; n, shape=[2, 2, 2], comps=3, extra=Dict{String, Any}())
+    jldopen(path, "w") do f
+        f["psi"] = zeros(ComplexF32, shape..., comps)
+        f["dynamics/times"] = collect(1.0:n)
+        f["$_GRP/n_snapshots"] = n
+        f["$_GRP/spatial_shape"] = shape
+        f["$_GRP/n_components"] = comps
+        for s in 1:n
+            f["$_GRP/frame_" * lpad(s, 5, '0')] = zeros(ComplexF32, shape..., comps)
+        end
+        for (k, v) in extra
+            f[k] = v
+        end
+    end
+end
+
+@testset "result.jld2 becomes a summary only when the point file covers it" begin
+    @testset "summarises, and keeps everything that is not a frame" begin
+        mktempdir() do d
+            res = joinpath(d, "result.jld2")
+            pt = joinpath(d, "point_001.jld2")
+            _write_frames(
+                res;
+                n=4,
+                extra=Dict("dynamics/Lz" => [1.0, 2.0],
+                    "dynamics/integrator_meta/dt_used" => 0.004),
+            )
+            _write_frames(pt; n=4)
+            before = filesize(res)
+            @test make_result_a_summary!(d, pt) === :summarised
+            @test filesize(res) < before
+            jldopen(res, "r") do f
+                @test !haskey(f, "$_GRP/n_snapshots")     # the frames are gone
+                @test haskey(f, "psi")                     # and nothing else is
+                @test f["dynamics/times"] == collect(1.0:4)
+                @test f["dynamics/Lz"] == [1.0, 2.0]
+                # the nested group must survive as a GROUP, not be flattened away
+                @test f["dynamics/integrator_meta/dt_used"] == 0.004
+            end
+            # idempotent — a second pass has nothing to do and says so
+            @test make_result_a_summary!(d, pt) === :already_summary
+        end
+    end
+
+    @testset "REFUSES when the point file does not cover the frames" begin
+        # fewer frames
+        mktempdir() do d
+            res, pt = joinpath(d, "result.jld2"), joinpath(d, "point_001.jld2")
+            _write_frames(res; n=6)
+            _write_frames(pt; n=3)
+            @test make_result_a_summary!(d, pt) === :not_covered
+            @test jldopen(f -> haskey(f, "$_GRP/n_snapshots"), res, "r")
+        end
+        # different spatial shape — same count, different data
+        mktempdir() do d
+            res, pt = joinpath(d, "result.jld2"), joinpath(d, "point_001.jld2")
+            _write_frames(res; n=3, shape=[2, 2, 2])
+            _write_frames(pt; n=3, shape=[4, 2, 2])
+            @test make_result_a_summary!(d, pt) === :not_covered
+        end
+        # point file carries no frames at all
+        mktempdir() do d
+            res, pt = joinpath(d, "result.jld2"), joinpath(d, "point_001.jld2")
+            _write_frames(res; n=3)
+            jldopen(f -> (f["psi"] = zeros(ComplexF32, 2, 2, 2, 3)), pt, "w")
+            @test make_result_a_summary!(d, pt) === :not_covered
+        end
+    end
+
+    @testset "REFUSES on the rotating-basis shape — result.jld2 is the only copy" begin
+        # `save_rotating_basis_result!` symlinks point_001.jld2 AT result.jld2.
+        # Stripping there destroys the frames outright, which is the one outcome
+        # this function must never produce.
+        mktempdir() do d
+            res, pt = joinpath(d, "result.jld2"), joinpath(d, "point_001.jld2")
+            _write_frames(res; n=3)
+            symlink("result.jld2", pt)
+            @test make_result_a_summary!(d, pt) === :skipped
+            @test jldopen(f -> f["$_GRP/n_snapshots"], res, "r") == 3
+        end
+    end
+
+    @testset "inert when there is no result.jld2" begin
+        mktempdir() do d
+            pt = joinpath(d, "point_001.jld2")
+            _write_frames(pt; n=2)
+            @test make_result_a_summary!(d, pt) === :skipped
+        end
+    end
+end

--- a/test/workflow/test_run_provenance.jl
+++ b/test/workflow/test_run_provenance.jl
@@ -1,0 +1,56 @@
+using Test
+using SpinorBEC
+
+# Which code produced a file. `run_yaml` outputs carry this under `env/`; campaign
+# scripts write their own JLD2 and carried NONE of it — measured 2026-08-21 on
+# scripts/eu334 output, which holds every physics parameter and the seed and not
+# one fact about the code that ran.
+#
+# The asymmetry was the opposite of what had been assumed: the pipeline has the
+# provenance and keeps the seed in its config; the scripts have the seed and no
+# provenance. `run_provenance()` is the public shared answer so a new writer gets
+# it in one line rather than reinventing half of it.
+@testset "run_provenance records which code produced a file" begin
+    p = run_provenance()
+
+    # The contract, per field, because a provenance record missing any one of
+    # these cannot answer the question it exists for.
+    for k in ("git_hash", "git_dirty", "julia_version", "hostname", "platform")
+        @test haskey(p, k)
+    end
+
+    # git_dirty is the LOAD-BEARING field and the one most likely to be dropped as
+    # noise: a hash from a dirty tree names a commit that does not describe the
+    # code that ran, silently, so a run recorded as reproducible would not be.
+    @test p["git_dirty"] isa Bool
+
+    # A hash of "unknown" is the honest value outside a repo; what is NOT allowed
+    # is the key being absent, which reads as "clean" to anything that checks.
+    @test p["git_hash"] isa AbstractString
+    @test !isempty(p["git_hash"])
+    @test p["julia_version"] == string(VERSION)
+end
+
+# Every campaign writer must record it. This is the CLASS-level gate: the fix
+# is not "these two scripts now call it" but "a script that saves a state and
+# forgets where it came from is a test failure".
+@testset "campaign JLD2 writers record provenance" begin
+    root = normpath(joinpath(@__DIR__, "..", ".."))
+    writers = [
+        "scripts/eu334/nucleate.jl",
+        "scripts/eu334/nucleation_bifurcation.jl",
+    ]
+    for w in writers
+        path = joinpath(root, w)
+        @test isfile(path)
+        isfile(path) || continue
+        src = read(path, String)
+        # `jldsave` is how these scripts persist a state; if one is present, a
+        # provenance call must be too.
+        if occursin("jldsave", src)
+            occursin("run_provenance", src) ||
+                @info "writer saves state without provenance" w
+            @test occursin("run_provenance", src)
+        end
+    end
+end


### PR DESCRIPTION
## 前提：これは #195 の判断を蒸し返しません

PR #195 は「重複は**意図的**、`result.jld2` は**要約成果物**なので symlink 化は設計変更であってバグ修正ではない」という理由で閉じられました。**その判断はそのままです。**

同じ PR が記録に残したのがこれです:

> `result.jld2` は 9.71 GB（point_001 は 10.25 GB）— 753 フレーム全部を持っており、**サイズ的に要約として機能していない**。要約の役割が欲しいなら `dynamics/psi_snapshots_streamed` を落とせば、役割も果たすし容量も戻る。

判断待ちで置かれていた、その変更です。

## 再測定（本日、グループ枠）

```
136 対（symlink 0）
result.jld2 合計  148.4 GB
point_*   合計  182.8 GB
枠 2.0T 中 1.3T 使用 → result 側だけで 11 %
```

750 フレームの実例:

| | サイズ | frames | toplevel | dynamics |
|---|---:|---:|---:|---:|
| `result.jld2` | 9.11 GB | 750 | 2 | 5 |
| `point_001.jld2` | 9.55 GB | 750 | 13 | 8 |

**全フレームを 2 回持っています。**

## 設計の記述が 2 つあって食い違っていました

| 出典 | 主張 |
|---|---|
| ダッシュボード `_resolve_snapshot_source` の docstring | point_NNN は静的な最終 ψ とスカラーだけ、**フレームは result.jld2** |
| anko（#195 を閉じた際） | **result.jld2 は要約** |

**どちらも実態ではありません**（両方満載）。所有者の明示判断に従い、docstring は同じコミットで訂正しました。2 つの真実を残さないためです。

## 実装

`make_result_a_summary!` は**実 point ファイルが着地した直後**に走ります。`run_pipeline` の auto-save は point がまだ存在しない時点で `result.jld2` を書くので、そこでは判定できません。

**キーだけを見ます** — フレームは一度も読まないので数 GB のファイルに対してミリ秒 — そして**推測せず拒否します**（失敗すると唯一のコピーが消えるため）:

| 条件 | 戻り値 |
|---|---|
| point にフレームが無い／少ない／形が違う | `:not_covered` |
| point が symlink（rotating-basis は result を指す＝唯一のコピー） | `:skipped` |
| 既に要約済み | `:already_summary` |

ダッシュボードは redirect 無しで動きます: `_resolve_snapshot_source` は要求されたファイルが stream を持てばそれを返し、いまはそれが point 側です。sibling redirect は rotating-basis と既存ランのために残ります。

## ゲート

`test/workflow/test_result_jld2_summary.jl` — 15 assertion、TSUBAME で 15/15。

**canary を両方向で回しました。** `samefile` を外すと rotating-basis が自分の唯一のコピーを剥ぎ、`KeyError: dynamics/psi_snapshots_streamed` で赤くなります。`islink` 単体を外しても何も変わらない（symlink された point は同一ファイル）ので、**どちらが荷重を担っているか**をコメントに書きました。

## この PR に**入っていない**もの

**既存の重複には触れていません。** 稼働中のジョブの隣にあるので、backlog の一掃は干渉しない別パスが要ります — 完了ランのみ、ディレクトリごとに検証してから書き換え。

## 経緯

**`scripts/prior_art.py` の初の実運用です。** トピック開始前に回したら `fix/result-jld2-duplication` が出て、#195 のクローズコメントを読んだことで「93 GB の未判定な重複を測り直す」が「既に決まっている変更を実装する」に変わりました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)