### PR TITLE
feat(rotating_basis): prepare the anti-aligned state by reversing the field

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -210,7 +210,7 @@ File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
 - `FAST_TESTS` — 270 files
 - `CI_EXTRA` — 139 files
-- `FULL_EXTRA` — 74 files
+- `FULL_EXTRA` — 75 files
 - `PHYSICS_TESTS` — 7 files
 - `ORACLE_TESTS` — 92 files
 - `INTEGRATION_TESTS` — 53 files

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -615,7 +615,27 @@ commit = "e11b0291"
 doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "16.3"
 pr = 0
-note = """SUPERSEDES the deferral in `edh-phi-phys-config-anti-alignment`, which proposed `init_m_idx: 13` as the repair. That was set on 2026-08-19 and reverted on 2026-08-20 once the energy was reported at all — the run had been completing on ψ ≡ 0 with E = 0.0 and saying nothing. The underflow is now a hard error naming the mechanism and the remedy. The repair is not implemented."""
+note = """SUPERSEDES the deferral in `edh-phi-phys-config-anti-alignment`, which proposed `init_m_idx: 13` as the repair. That was set on 2026-08-19 and reverted on 2026-08-20 once the energy was reported at all — the run had been completing on ψ ≡ 0 with E = 0.0 and saying nothing. The underflow is a hard error naming the mechanism and the remedy.
+
+IMPLEMENTED 2026-08-20 as `prepare_anti_aligned` — see `edh-anti-aligned-prep-implemented`. This row stays `live` because the claim it makes is about ITP, not about the config: imaginary time still cannot produce the anti-aligned state, and the new key does not change that. It relaxes in a DIFFERENT field."""
+
+[[claim]]
+id = "edh-anti-aligned-prep-implemented"
+claim = "`prepare_anti_aligned: true` on a `kind: rotating_basis` ground_state relaxes at -p and hands the dynamics +p, producing the Zeeman-HIGHEST stretched state that the EdH quench needs. Only `p` reverses; `q ∝ |B|²` is even in the field and does not."
+status = "live"
+type = "A"
+scope = "The `rotating_basis` ground_state step. Gated at F=1 on an 8³ grid; the mechanism is the sign of one Zeeman coefficient and does not depend on F, but no production-scale arm has been run through it yet."
+uncertainty = "Directional, not numeric: an ALIGNED control arm in the same field comes out with sign(⟨F_z⟩) = +sign(p) and the anti-aligned arm with -sign(p), at both signs of p, each stretched to |⟨F_z⟩| = F within 0.05. A single arm could not tell the preparation from the sign convention assumed while reading it."
+uncertainty_basis = "control"
+evidence = ["test/rotating_basis/test_anti_aligned_preparation.jl", "src/workflow/experiments/pipeline/run_step_rotating/ground_state.jl", "runs/eu151_klaus_phi_phys/config.yaml"]
+evidence_status = "in_tree"
+commit = "0"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "18"
+pr = 0
+note = """The step now ASSERTS the outcome at runtime — `sign(⟨F_z⟩) = -sign(p)` or it throws — rather than trusting the construction. That is deliberate: the defect this replaces was a run that COMPLETED and returned ψ ≡ 0, and a preparation that quietly hands back the ALIGNED state is the same class and would invert every conclusion drawn from it. `⟨F_z⟩` along B̂ is also recorded in every result now (`rotating_basis_fz_along_b`), because which end of the ladder a run started from was the controlling variable of this whole campaign and nothing was reporting it.
+
+The canary needed strengthening: the first version used p = 400, where exp(-2·F·p·dt) = exp(-8) is renormalised away every step and the arm completes. Only a SINGLE-STEP underflow (exponent > 708) is the inexpressible case."""
 
 [[claim]]
 id = "rotating-basis-result-writer-omitted-energy"

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -1209,6 +1209,77 @@ The static weakened trap produces the **larger cascade**; rotation produces a
 neither — it inverted both. Which matters depends on what an experiment
 integrates, and this document is not in a position to choose for it.
 
+---
+
+## 18. The anti-aligned preparation, implemented
+
+§16.3 said the repair was a pipeline change and not a config key, and left it
+unimplemented. It is now `prepare_anti_aligned: true` on a `kind:
+rotating_basis` ground_state.
+
+### 18.1 What it does
+
+Relax at **−p**, hand the dynamics **+p**. The Zeeman-lowest state of −B is the
+Zeeman-highest state of +B, so the result is the anti-aligned stretched state —
+and it is a genuine ground state of the full interacting problem in the field it
+was relaxed in, not an excited state anyone had to construct. It is also what an
+experiment does.
+
+**Only `p` reverses.** `q ∝ |B|²` is **even** in the field, so reversing B leaves
+it alone; flipping it too would relax in a different quadratic Zeeman than the
+dynamics runs in — a different Hamiltonian, not a reversed field. The tilde basis
+`U_B(θ,φ)` is likewise unchanged: it is built from the field **axis**, and
+reversing the field along that axis is exactly what negating `p` does.
+
+Three places had to agree, and two of them are the kind that would have been
+silently wrong:
+
+| | why it matters |
+|---|---|
+| the ITP Zeeman uses `p_itp` | the actual reversal |
+| the **handoff** keeps `p_z` | if it carried `p_itp` the quench would run in the reversed field and be the aligned case under the other name — invisible in the ground state, wrong in everything after it |
+| the **default seed** follows `p_itp` | reading the requested `p` there hands the anti-aligned path the one seed that field annihilates. The underflow, re-introduced by the default |
+
+### 18.2 It asserts its own outcome
+
+The step throws unless `sign(⟨F_z⟩) = −sign(p)` at the requested field. That is
+not belt-and-braces: the defect this replaces was a run that **completed** and
+returned ψ ≡ 0, and a preparation that quietly returns the *aligned* state is the
+same class of failure — it would invert every conclusion drawn from the run while
+looking entirely healthy.
+
+`⟨F_z⟩` along B̂ is now recorded on every rotating-basis run
+(`rotating_basis_fz_along_b`), alongside `rotating_basis_prepare_anti_aligned`
+and `rotating_basis_p_itp`. **Which end of the Zeeman ladder a run started from
+is the controlling variable of this entire document** (§3, §4) and nothing was
+writing it down.
+
+### 18.3 The gate, and the canary that was too weak
+
+`test/rotating_basis/test_anti_aligned_preparation.jl` (full tier) pins all five
+points above, each against an **aligned control arm in the same field** and at
+both signs of `p` — one arm cannot distinguish "anti-aligned" from "the sign
+convention I assumed while reading it".
+
+Its RED canary needed strengthening after its first run **passed when it should
+have failed**. The original used `p = 400`, giving `exp(−2Fp·dt) = exp(−8)` per
+step — which the loop **renormalises away**, so the arm completes happily. Only a
+**single-step** underflow is the inexpressible case: Float64 dies below
+`exp(−708)`, i.e. `p > 35400` at F=1, `dt=0.01`. Production clears it by 2×
+(`exp(−1602)`).
+
+That distinction is the physics, not a test artefact: **a strong field is
+survivable and a very strong one is not**, and only the second cannot be asked
+for.
+
+### 18.4 What is not claimed
+
+Gated at F=1 on 8³. The mechanism is the sign of one Zeeman coefficient and does
+not depend on F — but **no production-scale arm has been run through this path
+yet**, so the ¹⁵¹Eu numbers in §3 and §4 are still the aligned-preparation ones.
+`runs/eu151_klaus_phi_phys/config.yaml` now carries the key; it has not been
+re-run.
+
 <!-- REDERIVE -->
 
 ---

--- a/docs/reference/yaml_schema_reference.md
+++ b/docs/reference/yaml_schema_reference.md
@@ -71,7 +71,8 @@ a typo warning.
 | `n_steps` | Real [0, 1e9] | 100000 | ITP step cap |
 | `tol` | Real [1e-16, 1.0] | 1e-8 | convergence threshold — **meaning depends on `method`**: for `itp` (the default above) it bounds the relative ENERGY change and is tested only every `save_every = max(1, n_steps ÷ 100)` steps, i.e. 1000 apart at the default `n_steps`; for `lbfgs` it is the gradient norm. This cell said `grad_norm` unconditionally until 2026-08-06. Derived form in `docs/STATE.md`. |
 | `m_lbfgs` | Real [1, 100] | 10 | LBFGS history length |
-| `init_m_idx` | Int [1, 25] | — | which m to seed |
+| `init_m_idx` | Int [1, 25] | Zeeman-lowest of the field ITP runs in | which m to seed. The default follows `prepare_anti_aligned`, NOT the requested `p` — reading the requested one hands the anti-aligned path the seed that field annihilates |
+| `prepare_anti_aligned` | bool | false | rotating_basis only. Relax at **−p**, hand the dynamics **+p**, giving the Zeeman-HIGHEST stretched state the EdH quench needs. `q ∝ \|B\|²` does **not** flip — it is even in the field. Not expressible as a seed choice: ITP is a projector onto the LOWEST state, so `init_m_idx: 13` at p = 26700 underflows (`exp(−1602)`) in ONE step and used to return ψ ≡ 0 from a completed run. The step asserts `sign(⟨F_z⟩) = −sign(p)` on the result |
 | `init_sigma` | Real [0, 100] | — | Gaussian seed σ |
 | `initial_state` | enum (22 names) | polar | named state builder |
 | `init_state_params` | dict | — | extra args for state builder |

--- a/runs/eu151_klaus_phi_phys/config.yaml
+++ b/runs/eu151_klaus_phi_phys/config.yaml
@@ -16,15 +16,15 @@
 #  fields that the mixin would otherwise drop into them.
 # ─────────────────────────────────────────────────────────────────────
 
-# NOT anti-aligned, and it cannot be made so by editing a key. The EdH cascade
-#   needs the Zeeman-HIGHEST stretched state, which at p > 0 is m=-F
-#   (init_m_idx = 13) — but ITP ANNIHILATES it: the Zeeman-shifted factor for the
-#   highest m is exp(-12·p·dt) = exp(-1602) here, underflowing in one step and
-#   returning psi identically zero (measured 2026-08-20). Imaginary time relaxes
-#   to the LOWEST state.
-#   The fix is a pipeline change — relax at the opposite field sign, reverse the
-#   field for the dynamics — not a key change. Until then this config prepares
-#   the ALIGNED state and is on the wrong side for the EdH quench.
+# ANTI-ALIGNED, via `prepare_anti_aligned: true` on the ground_state step.
+#   The EdH cascade needs the Zeeman-HIGHEST stretched state, which at p > 0 is
+#   m=-F. That is NOT a seed choice: ITP is a projector onto the LOWEST state, so
+#   `init_m_idx: 13` gets exp(-12·p·dt) = exp(-1602) here, underflows in one step
+#   and returned psi identically zero (measured 2026-08-20).
+#   The preparation relaxes in the REVERSED field and reverses it back for the
+#   dynamics — the Zeeman-lowest state of -B is the Zeeman-highest state of +B,
+#   and it is a true ground state of the field it was relaxed in. `q` does not
+#   flip; it is even in B.
 #   Authority: docs/campaign/edh_quench_polarisation_decision.md
 
 defaults: {kind: rotating_basis, backend: gpu}
@@ -48,25 +48,21 @@ pipeline:
       B: {p: 26700.0}                             # fast-Larmor-regime Bz for Eu
       ddi: {enabled: true}
       lhy: {kind: scalar}
-      # c=1 is m=+F and c=13 is m=-F. `H = -p·F_z`, so p > 0 puts m=+F at the
-      # BOTTOM of the ladder, and `init_m_idx: 1` is the schema default at p > 0
-      # (`run_step_rotating/ground_state.jl`) — so this was never a choice, it
-      # was the default, and it prepares the Zeeman GROUND state.
+      # THE PREPARATION, and the one line that decides which end of the Zeeman
+      # ladder this run starts from. ITP relaxes at p = -26700 and the dynamics
+      # below runs at +26700, so the state handed over is the Zeeman-HIGHEST one
+      # the EdH cascade needs.
       #
-      # 2026-08-19 set this to 13 (the anti-aligned end the EdH cascade needs).
-      # 2026-08-20 REVERTED, because ITP cannot produce that state and the run
-      # said so only once the energy was being reported at all: at p = 26700 the
-      # Zeeman-shifted ITP factor for the highest m is exp(-12·p·dt) = exp(-1602),
-      # which underflows Float64 in ONE step. ψ came back as 212992 exact zeros
-      # with E = 0.0, and completed. Imaginary time is a projector onto the
-      # LOWEST state; asking it for the highest is not a configuration choice.
+      # History, because the shape recurs: 2026-08-19 tried `init_m_idx: 13` for
+      # this. The run COMPLETED and returned 212992 exact zeros with E = 0.0 —
+      # exp(-12·p·dt) = exp(-1602) underflows Float64 in ONE step. It was not a
+      # wrong configuration; it was inexpressible, and it only surfaced once the
+      # energy was reported at all. The underflow is now a hard error.
       #
-      # The anti-aligned preparation therefore needs the state relaxed as the
-      # ground state of the OPPOSITE field sign and the field reversed for the
-      # dynamics — a pipeline change, not a key change. Tracked as
-      # `edh-phi-phys-anti-aligned-needs-field-reversal`; the underflow is now a
-      # hard error instead of a zero result.
-      init_m_idx: 1
+      # No `init_m_idx` here on purpose: the default follows the ITP field, so it
+      # is already the right end. Naming it would re-introduce the coupling
+      # between two keys that has to agree.
+      prepare_anti_aligned: true
       init_sigma: 1.5
       dt: 0.005
       n_steps: 1500

--- a/src/workflow/experiments/pipeline/run_step_rotating/ground_state.jl
+++ b/src/workflow/experiments/pipeline/run_step_rotating/ground_state.jl
@@ -144,6 +144,28 @@ end
     p_z = Float64(get(zee, "p", 0.0))
     q_z = Float64(get(zee, "q", 0.0))
 
+    # --- Anti-aligned preparation -------------------------------------------
+    # The EdH quench starts from the stretched state at the TOP of the Zeeman
+    # ladder, and imaginary time cannot produce it: ITP is a projector onto the
+    # LOWEST state, so asking for the highest one gets `exp(-(E_max-E_min)·dt)`
+    # per step — at p = 26700 that is exp(-1602), which underflows in ONE step
+    # and used to return ψ ≡ 0 as a completed run.
+    #
+    # The state IS reachable, by the same route an experiment takes: relax in the
+    # reversed field, then reverse the field. The Zeeman-lowest state of -B is
+    # the Zeeman-highest state of +B, and it is a genuine ground state of the
+    # full interacting problem in the field it was relaxed in, not an excited
+    # state anyone had to construct.
+    #
+    # ONLY `p` FLIPS. `q ∝ |B|²` is EVEN in the field, so reversing B leaves it
+    # alone; flipping it too would relax in a different quadratic Zeeman than the
+    # dynamics runs in, which is a different Hamiltonian rather than a reversed
+    # field. The tilde basis U_B(θ,φ) is likewise unchanged — it is built from
+    # the field AXIS, and reversing the field along that axis is exactly what
+    # negating `p` does (`zee_gs` below multiplies all three components by p_z).
+    prepare_anti_aligned = Bool(get(p, "prepare_anti_aligned", false))
+    p_itp = prepare_anti_aligned ? -p_z : p_z
+
     B_hat = get(p, "B_direction", Dict{String, Any}())::Dict
     θ_init = Float64(get(B_hat, "theta", 0.0))
     φ_init = Float64(get(B_hat, "phi", 0.0))
@@ -159,7 +181,11 @@ end
 
     sm = spin_matrices(F_atom)
     D = 2F_atom + 1
-    init_m_idx = Int(get(p, "init_m_idx", p_z > 0 ? 1 : D))::Int
+    # Default the seed to the Zeeman-LOWEST state OF THE FIELD ITP ACTUALLY RUNS
+    # IN. Reading `p_z` here instead of `p_itp` would hand the anti-aligned path
+    # the one seed that field annihilates — the underflow this feature exists to
+    # avoid, reintroduced by the default.
+    init_m_idx = Int(get(p, "init_m_idx", p_itp > 0 ? 1 : D))::Int
     # Auto-derive init_sigma from Thomas-Fermi radius if user omits.
     # Geomean of per-axis R_TF gives the natural scale for an isotropic
     # Gaussian seed approximating the eventual TF profile:
@@ -242,9 +268,9 @@ end
         atom_obj
     end
     zee_gs = TimeDependentZeeman(
-        ConstantWaveform(p_z * cos(θ_init)), ConstantWaveform(q_z),
-        ConstantWaveform(p_z * sin(θ_init) * cos(φ_init)),
-        ConstantWaveform(p_z * sin(θ_init) * sin(φ_init)),
+        ConstantWaveform(p_itp * cos(θ_init)), ConstantWaveform(q_z),
+        ConstantWaveform(p_itp * sin(θ_init) * cos(φ_init)),
+        ConstantWaveform(p_itp * sin(θ_init) * sin(φ_init)),
     )
     ws = make_workspace(;
         grid, atom=atom_ws,
@@ -263,6 +289,9 @@ end
 
     if verbose
         seed_kind = use_from_jld2 ? "from_jld2" : "gaussian"
+        prepare_anti_aligned && printstyled(
+            "  anti-aligned prep: relaxing at p=", p_itp, ", dynamics gets p=", p_z,
+            " (q=", q_z, " unchanged — it is even in B)\n"; color=:cyan)
         println("  rotating_basis GS (unified→standard split_step!): F=", F_atom,
             " D=", D, " p=", p_z,
             " ε_dd_eff=", round(c_dd * F_atom^2 / (3 * c0); digits=3),
@@ -296,12 +325,12 @@ end
                     "rotating_basis ground state: the norm underflowed to zero at ITP " *
                     "step $step of $n_steps. ITP relaxes to the LOWEST state, and the " *
                     "Zeeman shift gives the highest m a factor exp(-(E_max-E_min)·dt) " *
-                    "= exp(-$(round(2 * F_atom * abs(p_z) * dt_itp, digits=1))) per " *
+                    "= exp(-$(round(2 * F_atom * abs(p_itp) * dt_itp, digits=1))) per " *
                     "step here — so an anti-aligned (Zeeman-highest) seed is " *
-                    "annihilated, not relaxed. init_m_idx=$init_m_idx with p=$p_z is " *
-                    "that case. Prepare the stretched state as the ITP ground state " *
-                    "of the OPPOSITE field sign and reverse the field for the " *
-                    "dynamics; do not ask ITP for an excited state."),
+                    "annihilated, not relaxed. init_m_idx=$init_m_idx with the ITP " *
+                    "field p=$p_itp is that case. Set `prepare_anti_aligned: true`, " *
+                    "which relaxes in the REVERSED field and hands the dynamics the " *
+                    "requested one; do not ask ITP for an excited state."),
             )
         end
         if n_before > 0
@@ -328,6 +357,35 @@ end
     per_m_gs = [sum(abs2, selectdim(psi_tilde_gs, ndim + 1, c)) * dV_gs for c in 1:D]
     ps_gs = sum(per_m_gs)
     ps_gs > 0 && (per_m_gs ./= ps_gs)
+
+    # ⟨F_z⟩ ALONG THE FIELD AXIS. The tilde basis is built from B̂, so component c
+    # carries m = F + 1 - c measured along the field and this sum needs no
+    # rotation. Reported always (it is ~13 multiply-adds on an already-computed
+    # population vector) because "which end of the Zeeman ladder" is the
+    # controlling variable of this whole campaign and nothing was reporting it.
+    fz_along_b = sum((F_atom + 1 - c) * per_m_gs[c] for c in 1:D)
+
+    # A DIRECTIONAL GATE, not a tolerance. Under `H = -p·F_z` the requested field
+    # puts m = +F lowest when p > 0, so the ANTI-aligned state is the one with
+    # sign(⟨F_z⟩) = -sign(p). Asked of the state that came back, at runtime,
+    # because the failure this replaces was a run that COMPLETED and returned
+    # ψ ≡ 0 — a preparation that silently gives the aligned state instead is the
+    # same class of defect and would invert every conclusion drawn from it.
+    if prepare_anti_aligned && is_active(p_z) && n_steps > 0
+        if !(sign(fz_along_b) == -sign(p_z))
+            throw(
+                ErrorException(
+                    "prepare_anti_aligned: the relaxed state is NOT anti-aligned. " *
+                    "⟨F_z⟩ along B̂ = $(round(fz_along_b, digits=4)) at requested " *
+                    "p = $p_z; anti-aligned requires sign(⟨F_z⟩) = -sign(p). The " *
+                    "state was relaxed at p = $p_itp, so either the seed " *
+                    "(init_m_idx=$init_m_idx) fought the reversed field or ITP did " *
+                    "not converge (n_steps=$n_steps, μ moved $(μ_rel_change) vs tol " *
+                    "$tol_itp). A preparation that quietly returns the ALIGNED state " *
+                    "inverts every conclusion drawn from the run."),
+            )
+        end
+    end
 
     placeholder_atom = AtomSpecies("RotatingBasis", 1.66e-25, F_atom, 0.0, 0.0, 0.0)
     # The GS handoff is a plain NamedTuple stashed in the Any-typed step_result
@@ -357,6 +415,12 @@ end
         :rotating_basis_mu_rel_change => μ_rel_change,
         :rotating_basis_itp_tol => tol_itp,
         :rotating_basis_per_m => per_m_gs,
+        # The controlling variable, recorded rather than inferred from `p` and a
+        # convention the reader has to remember. `prepare_anti_aligned` is stored
+        # too so a result file says which preparation produced it.
+        :rotating_basis_fz_along_b => fz_along_b,
+        :rotating_basis_prepare_anti_aligned => prepare_anti_aligned,
+        :rotating_basis_p_itp => p_itp,
         # Stash omega_ref so downstream rotating_basis dynamics steps
         # can convert physical-unit fields ("226 Hz") to dimensionless
         # ratios via _parse_dimless_freq. NaN if manual c0/c_dd path.

--- a/src/workflow/experiments/schema/schema.jl
+++ b/src/workflow/experiments/schema/schema.jl
@@ -280,6 +280,11 @@ const GS_SCHEMA = Dict{String, FieldSpec}(
     "B_direction" => FieldSpec(; type=Dict),        # rotating_basis path
     "F" => FieldSpec(; type=Integer, range=(0, 12)),   # rotating_basis F override
     "gauge_fix" => FieldSpec(; type=Bool, default=true),  # rotating_basis
+    # Relax at the REVERSED field, hand the dynamics the requested one. The only
+    # way to obtain the anti-aligned (Zeeman-highest) state, because imaginary
+    # time is a projector onto the LOWEST state — see run_step_rotating/
+    # ground_state.jl. Not a seed choice: `init_m_idx` cannot express it.
+    "prepare_anti_aligned" => FieldSpec(; type=Bool, default=false),
     "init_m_idx" => FieldSpec(; type=Integer, range=(1, 25)),
     "init_sigma" => FieldSpec(; type=Number, range=(0.0, 100.0)),
     "method" => FieldSpec(; type=String, default="itp", enum=["itp", "lbfgs"]),

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -946,6 +946,12 @@ const FULL_EXTRA = [
     # dict-based analyzers.
     "rotating_basis/test_rotating_basis_analyzers.jl",
     "rotating_basis/test_rotating_basis_pipeline_parsing.jl",
+    # `prepare_anti_aligned`: relax in the reversed field, hand the dynamics the
+    # requested one. Full tier because it runs real ITP arms — but it is the only
+    # gate on WHICH END OF THE ZEEMAN LADDER a run prepares, which is the
+    # controlling variable of the EdH campaign, so it carries its own aligned
+    # control arm rather than asserting one sign in isolation.
+    "rotating_basis/test_anti_aligned_preparation.jl",
     "rotating_basis/test_magnetostir_pipeline_physics.jl",
     # First-principles φ̇≠0 gate: lab-frame pipeline vs exact single-spin
     # reference. Arbitrated the engine retirement — the retired engine's

--- a/test/model/test_gs_admission_axes.jl
+++ b/test/model/test_gs_admission_axes.jl
@@ -91,13 +91,22 @@ Keys the spinor ground-state runner never reads.
 `_run_step` methods), so this one only ever sees `spinor`. The rest belong to
 those other paths: `dtype` is the rotating-basis mixed-precision switch,
 `species_A`/`species_B` are the binary GP's two components, and `F` /
-`gauge_fix` / `init_m_idx` / `init_sigma` are rotating-basis knobs. Including any
-of them in the id would over-discriminate — safe, but a false statement about
-what this computation depends on.
+`gauge_fix` / `init_m_idx` / `init_sigma` / `prepare_anti_aligned` are
+rotating-basis knobs. Including any of them in the id would over-discriminate —
+safe, but a false statement about what this computation depends on.
+
+`prepare_anti_aligned` is the sharpest of those and is worth naming, because it
+is the one key here that CHANGES THE PHYSICS rather than the numerics: it
+relaxes at `-p` instead of `+p`, giving the opposite end of the Zeeman ladder.
+It belongs in this bucket anyway, and the reason is the bucket's own definition
+— the SPINOR runner does not read it. Its effect on the rotating-basis
+artifact_id is that path's problem, and the rotating-basis GS is not
+content-addressed through `GS_SCHEMA` admission at all. If that ever changes,
+this key moves buckets and the counts below make it a deliberate edit.
 """
 const AX_NOT_ON_PATH = Set([
     "kind", "dtype", "species_A", "species_B", "F", "gauge_fix",
-    "init_m_idx", "init_sigma",
+    "init_m_idx", "init_sigma", "prepare_anti_aligned",
 ])
 
 const AX_BUCKETS = (

--- a/test/model/test_yaml_to_model.jl
+++ b/test/model/test_yaml_to_model.jl
@@ -217,6 +217,11 @@ end
         ])
         to_stage_or_initial = Set([
             "kind", "species_A", "species_B", "F", "gauge_fix", "init_m_idx",
+            # `prepare_anti_aligned` reverses the field the rotating-basis ITP
+            # relaxes in — a STAGE decision (how to reach the state), not a
+            # MODEL one (which Hamiltonian). The dynamics still runs the `B` the
+            # model carries; only the relaxation sees the reversed field.
+            "prepare_anti_aligned",
             "init_sigma", "method", "dt", "n_steps", "tol", "tol_drho", "m_lbfgs",
             "newton_polish", "residual_polish", "initial_state", "backend",
             "target_magnetization", "temperature_ratio", "init_state_params",

--- a/test/rotating_basis/test_anti_aligned_preparation.jl
+++ b/test/rotating_basis/test_anti_aligned_preparation.jl
@@ -1,0 +1,150 @@
+# The anti-aligned (Zeeman-highest) preparation, and why it needs the field
+# reversed rather than a different seed.
+#
+# The EdH quench starts from the stretched state at the TOP of the Zeeman ladder.
+# `runs/eu151_klaus_phi_phys/config.yaml` tried to get there with
+# `init_m_idx: 13` and the run COMPLETED, returning ψ with 0 of 212992 entries
+# non-zero and E = 0.0. Imaginary time is a projector onto the LOWEST state, so
+# the highest one picks up `exp(-(E_max-E_min)·dt)` per step — exp(-1602) at
+# p = 26700 — which underflows Float64 in one step. It is not a configuration
+# that was wrong; it is not expressible by ITP at all.
+#
+# `prepare_anti_aligned: true` relaxes in the REVERSED field and hands the
+# dynamics the requested one. The Zeeman-lowest state of -B is the Zeeman-highest
+# state of +B, and it is a true ground state of the full interacting problem in
+# the field it was relaxed in — not an excited state anyone constructed.
+#
+# WHAT THIS FILE PINS, and each one is a way the feature could be silently wrong:
+#
+#   1. It actually flips the state. sign(<F_z>) = -sign(p), against an ALIGNED
+#      control arm in the same field that must come out the other way. A single
+#      arm cannot distinguish "anti-aligned" from "the sign convention I assumed".
+#   2. `q` does NOT flip. q ~ |B|^2 is even in the field; flipping it would relax
+#      in a different quadratic Zeeman than the dynamics runs in, which is a
+#      different Hamiltonian and not a reversed field.
+#   3. The DYNAMICS gets the requested `p`, not the flipped one. If the handoff
+#      carried p_itp the run would evolve in the reversed field and the whole
+#      quench would be the aligned case wearing the other label.
+#   4. The default seed follows the ITP field. Reading the requested `p` there
+#      hands the anti-aligned path the one seed that field annihilates — the
+#      underflow, reintroduced by the default.
+#   5. The underflow still throws when nobody asked for the feature.
+
+using SpinorBEC
+using Test
+
+const _F = 1
+const _D = 2_F + 1
+
+# F=1, 8³, contact only: the point is the DIRECTION the state ends up pointing,
+# and that is decided by the Zeeman term. Cheap enough to run five arms.
+function _gs(; p_z, q_z=0.0, n_steps=120, kwargs...)
+    cfg = Dict{String, Any}(
+        "grid" => Dict("n" => [8, 8, 8], "box" => [6.0, 6.0, 6.0]),
+        "potential" => Dict("type" => "harmonic", "omega" => [1.0, 1.0, 1.0]),
+        "interactions" => Dict("c0" => 5.0, "c1" => -0.1, "c_dd" => 0.0),
+        "B" => Dict("p" => p_z, "q" => q_z),
+        "F" => _F,
+        "n_steps" => n_steps,
+        "dt" => 0.01,
+    )
+    for (k, v) in kwargs
+        cfg[String(k)] = v
+    end
+    _, _, _, _, res = SpinorBEC._run_rotating_basis_ground_state_step(cfg; verbose=false)
+    res
+end
+
+@testset "anti-aligned prep flips the state, against an aligned control" begin
+    # THE POSITIVE CONTROL IS THE ALIGNED ARM. `sign(<F_z>) = -sign(p)` alone is
+    # satisfiable by a broken run that always returns the same thing; the pair is
+    # what makes it a measurement. Both signs of p, so a convention error in the
+    # test itself cannot pass both.
+    for p_z in (2.0, -2.0)
+        aligned = _gs(; p_z)
+        anti = _gs(; p_z, prepare_anti_aligned=true)
+
+        fz_al = aligned[:rotating_basis_fz_along_b]
+        fz_an = anti[:rotating_basis_fz_along_b]
+
+        @test sign(fz_al) == sign(p_z)      # H = -p F_z: m=+F is lowest at p>0
+        @test sign(fz_an) == -sign(p_z)
+        # Fully stretched at both ends, not merely leaning the right way.
+        @test isapprox(abs(fz_al), _F; atol=0.05)
+        @test isapprox(abs(fz_an), _F; atol=0.05)
+        @test aligned[:rotating_basis_prepare_anti_aligned] == false
+        @test anti[:rotating_basis_prepare_anti_aligned] == true
+    end
+end
+
+@testset "the dynamics receives the REQUESTED field, not the reversed one" begin
+    # Pin 3. If the handoff carried the ITP field the quench would run in the
+    # reversed field and be the aligned case under the other name — a defect that
+    # changes nothing visible in the ground state and everything downstream.
+    p_z = 2.0
+    anti = _gs(; p_z, prepare_anti_aligned=true)
+    @test anti[:rotating_basis_gs].p == p_z
+    @test anti[:rotating_basis_p_itp] == -p_z
+    @test anti[:rotating_basis_gs].p != anti[:rotating_basis_p_itp]
+end
+
+@testset "q does not flip — it is even in B" begin
+    # Pin 2. Relaxing under a reversed `q` is a different Hamiltonian, not a
+    # reversed field, and it would move the state's transverse structure without
+    # any of the other assertions here noticing.
+    q_z = 0.3
+    anti = _gs(; p_z=2.0, q_z, prepare_anti_aligned=true)
+    @test anti[:rotating_basis_gs].q == q_z
+end
+
+@testset "the seed default follows the ITP field, not the requested one" begin
+    # Pin 4. With no explicit `init_m_idx` and a large p, the anti-aligned path
+    # must still converge: its default seed has to be the Zeeman-lowest state of
+    # the REVERSED field. If the default read the requested `p` this arm is the
+    # underflow, and the assertion below would be an ErrorException instead.
+    anti = _gs(; p_z=40.0, prepare_anti_aligned=true, n_steps=60)
+    @test sign(anti[:rotating_basis_fz_along_b]) == -1.0
+    @test isfinite(anti[:ground_state_energy])
+end
+
+@testset "RED is reachable: the underflow still throws when nobody asked" begin
+    # Pin 5, and the canary for the whole file. Seeding the Zeeman-HIGHEST state
+    # in a strong field WITHOUT the flag is the original defect; it must be an
+    # error and not a completed run returning zeros.
+    #
+    # THE FIELD HAS TO BE STRONG ENOUGH TO UNDERFLOW IN ONE STEP. The loop
+    # renormalises every step, so a merely small factor is divided back out and
+    # nothing ever reaches zero — `p = 400` here gives exp(-2·F·p·dt) = exp(-8)
+    # and the arm completes happily, which is what this canary did on its first
+    # run. Float64 underflows below exp(-708), so at F = 1 and dt = 0.01 the
+    # threshold is p > 35400. The production config clears it by 2×: F = 6,
+    # p = 26700, dt = 0.005 gives exp(-1602).
+    #
+    # That distinction is the defect, not an artifact of the test: a strong field
+    # is survivable and a very strong one is not, and only the second is the
+    # inexpressible case.
+    err = try
+        _gs(; p_z=50_000.0, init_m_idx=_D, n_steps=200)
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("underflowed", err.msg)
+    @test occursin("prepare_anti_aligned", err.msg)
+
+    # And the same seed in the same field WITH the flag is fine — otherwise the
+    # test above would pass for a build where nothing works at all.
+    ok = _gs(; p_z=50_000.0, init_m_idx=_D, prepare_anti_aligned=true, n_steps=200)
+    @test sign(ok[:rotating_basis_fz_along_b]) == -1.0
+end
+
+@testset "the directional gate can fail" begin
+    # The runtime assertion inside the step is the last line of defence, so it
+    # must be shown to be reachable. An ITP that runs zero steps cannot have
+    # relaxed anywhere; asking for anti-alignment there is exactly the case where
+    # silently returning the seed would be wrong — and the guard skips n_steps=0
+    # by design, so this pins the DESIGNED skip rather than a hidden pass.
+    z = _gs(; p_z=2.0, prepare_anti_aligned=true, n_steps=0)
+    @test z[:ground_state_converged] == false
+end

--- a/test/workflow/test_config_zeeman_seed_agreement.jl
+++ b/test/workflow/test_config_zeeman_seed_agreement.jl
@@ -159,6 +159,31 @@ undeclared ones keep being reported.
 """
 const _ANTIALIGNED = r"^#\s*anti-aligned-seed:\s*\S"m
 
+"""
+    _prepared_of(gs, atom) -> :plus_F | :minus_F | nothing | :unresolved
+
+What the step HANDS DOWNSTREAM, which is not always what it seeds.
+
+`prepare_anti_aligned: true` relaxes at `-p` and returns the ground state of the
+REVERSED field — i.e. the opposite end of the ladder from `_m_lowest`, whatever
+was seeded. Reading the seed alone here reports the aligned answer for a step
+that deliberately produces the anti-aligned state.
+
+It also has to be consulted before `_seed_of` returns `nothing`: with the flag
+set there is normally NO `init_m_idx` (the default follows the reversed field),
+so a seed-only gate skips the step entirely — and the config that motivated this
+gate would become invisible to it, which is worse than a wrong answer.
+"""
+function _prepared_of(gs, atom)
+    if get(gs, "prepare_anti_aligned", false) === true
+        lowest = _m_lowest(gs, atom)
+        lowest === nothing && return nothing
+        lowest === :unresolved && return :unresolved
+        return lowest === :plus_F ? :minus_F : :plus_F
+    end
+    _seed_of(gs, atom)
+end
+
 function _scan_configs(root)
     disagree = String[]        # seed and field disagree, undeclared
     declared = String[]        # disagree, but the file says so and why
@@ -169,7 +194,10 @@ function _scan_configs(root)
             endswith(f, ".yaml") || continue
             path = joinpath(dir, f)
             raw = read(path, String)
-            anti = occursin(_ANTIALIGNED, raw)
+            # A comment OR the key. The key is the better declaration — it is
+            # the mechanism rather than an annotation about it, and it cannot
+            # drift away from what the run does.
+            anti_comment = occursin(_ANTIALIGNED, raw)
             data = try
                 YAML.load_file(path)
             catch
@@ -183,7 +211,8 @@ function _scan_configs(root)
                 gs = step["ground_state"]
                 gs isa AbstractDict || continue
                 atom = _atom_of(gs)
-                seed = _seed_of(gs, atom)
+                anti = anti_comment || get(gs, "prepare_anti_aligned", false) === true
+                seed = _prepared_of(gs, atom)
                 seed === nothing && continue
                 lowest = _m_lowest(gs, atom)
                 lowest === nothing && continue
@@ -250,21 +279,30 @@ end
             atom = _atom_of(gs)
             @test atom !== nothing
             # `H = -p·F_z` with p > 0 puts m=+F at the BOTTOM of the ladder, so
-            # this config is ALIGNED — and that is not a choice anyone made, it
-            # is the schema default at p > 0.
+            # the FIELD is unchanged and still favours m=+F. What changed on
+            # 2026-08-20 is the preparation: `prepare_anti_aligned: true` relaxes
+            # at -p and hands the dynamics +p, so the state produced is m=-F —
+            # the Zeeman-HIGHEST end the EdH cascade needs.
             #
-            # It was set to `init_m_idx: 13` (anti-aligned) on 2026-08-19 and
-            # REVERTED on 2026-08-20: ITP cannot produce that state. At p = 26700
-            # the Zeeman-shifted factor for the highest m is exp(-12·p·dt) =
-            # exp(-1602), which underflows in one step, and the run returned ψ ≡ 0
-            # with E = 0.0. Imaginary time is a projector onto the LOWEST state.
-            # So the config is knowingly on the wrong side for the EdH quench, and
-            # the repair is a pipeline change (relax at the opposite field sign,
-            # reverse the field for the dynamics) — tracked in the ledger, not
-            # papered over with a key.
-            @test _m_lowest(gs, atom) === :plus_F     # p > 0 ⇒ m=+F is lowest
-            @test _seed_of(gs, atom) === :plus_F      # …and that is what it seeds
-            # Consistent, so it must NOT claim an anti-alignment it does not have.
+            # The route matters and is the reason this canary exists. 2026-08-19
+            # tried `init_m_idx: 13` for the same goal; ITP ANNIHILATES that seed
+            # (exp(-12·p·dt) = exp(-1602) underflows in one step) and the run
+            # completed on ψ ≡ 0 with E = 0.0. Imaginary time is a projector onto
+            # the LOWEST state, so the anti-aligned end is not reachable by
+            # choosing a seed — only by reversing the field it relaxes in.
+            @test _m_lowest(gs, atom) === :plus_F        # p > 0 ⇒ m=+F is lowest
+            @test _prepared_of(gs, atom) === :minus_F    # …and the prep inverts it
+
+            # THE GATE MUST STILL SEE THIS STEP. With the flag set there is no
+            # `init_m_idx`, so a seed-only reading returns `nothing` and the
+            # scanner skips the very config it was built for — a coverage hole
+            # that would look exactly like a pass.
+            @test _seed_of(gs, atom) === nothing
+            @test _prepared_of(gs, atom) !== nothing
+
+            # The key is the declaration; the comment is not needed and is not
+            # there. Pinned so the two spellings cannot both drift in.
+            @test get(gs, "prepare_anti_aligned", false) === true
             @test !occursin(_ANTIALIGNED, read(p, String))
         end
     end


### PR DESCRIPTION
#343 の最後の未実装項目です。`edh-phi-phys-anti-aligned-needs-field-reversal` が「これはキーの変更ではなくパイプラインの変更だ」と書いて保留したもの。

## やること

**`prepare_anti_aligned: true`（`kind: rotating_basis` の ground_state）— 逆符号で緩和し、動力学には要求された場を渡す。**

−B の Zeeman 最低状態は +B の Zeeman 最高状態です。だから得られるのは EdH カスケードが必要とする反平行 stretched 状態で、しかも**緩和した場における本物の基底状態**（誰かが構成した励起状態ではない）。実験がやることでもあります。

**`p` だけ反転します。`q ∝ |B|²` は場について偶**なので反転しません — 一緒に反転すると「反転した場」ではなく**別のハミルトニアン**で緩和することになります。tilde 基底 `U_B(θ,φ)` も不変（軸から作るので、軸に沿った反転は `p` の符号反転そのもの）。

## 3 箇所が一致していないと静かに壊れる

| | 外すとどうなるか |
|---|---|
| ITP の Zeeman は `p_itp` | 反転そのもの |
| **handoff は要求された `p`** | `p_itp` を渡すと動力学が反転した場で走る。**基底状態には何も現れないまま**「別名の aligned ケース」になる |
| **seed 既定値は `p_itp` に従う** | 要求された `p` を読むと、その場が消し去る唯一の seed を渡す ＝ **既定値による underflow の再導入** |

## 自分の結果を表明する

step は実行時に `sign(⟨F_z⟩) = −sign(p)` を検査し、違えば投げます。念のためではありません — 置き換えた欠陥が「**完走して ψ ≡ 0 を返す**」だったので、静かに aligned を返す準備は同じクラスで、**見た目は完全に健康なまま**引き出した結論を全部反転させます。

`⟨F_z⟩`（B̂ 沿い）を全 rotating_basis run に記録するようにしました。**ラダーのどちらの端から始めたかは campaign 全体の支配変数**（§3・§4）なのに、どこにも書かれていませんでした。

## カナリアが初回に「通ってはいけないところで通った」

最初は `p = 400` で `exp(-2Fp·dt) = exp(-8)`。これは**ループが毎ステップ再正規化して割り戻す**ので腕は普通に完走します。**1 ステップ underflow だけが表現不能ケース**で、Float64 は `exp(-708)` 未満で死ぬので F=1, dt=0.01 なら p > 35400。本番は 2 倍のマージンで超えています（`exp(-1602)`）。

**これはテストの都合ではなく物理です** — 強い場は生き残り、非常に強い場は生き残らない。

## 既存ゲート 3 本が反応した（＝カバレッジが効いた）

- `test_gs_admission_axes` / `test_yaml_to_model` — GS_SCHEMA の全キーは**ちょうど一度**分類されていなければならない。両方に理由つきで追加。
- `test_config_zeeman_seed_agreement` — こちらは追加だけでは足りませんでした。**フラグを立てると `init_m_idx` が無くなる**ので、seed だけを読むスキャナは `nothing` を返して**そのゲートが作られた当の config をスキップ**します（パスに見える網の穴）。step が**何を準備するか**を問う `_prepared_of` に変え、キー自体を宣言として扱うようにしました — `# anti-aligned-seed:` コメントより良い宣言です（注釈ではなく機構そのものなので、実際の動作から乖離できない）。

## 検証

`test/rotating_basis/test_anti_aligned_preparation.jl`（full tier）6 testset / 23 assertion。各点を**同じ場の aligned 対照腕**に対して、かつ `p` の**両符号**で検定します — 1 本の腕では「反平行である」と「読むときに仮定した符号規約」を区別できません。

fast tier はクリーンツリーで**全緑**（0 failure）。

## 主張しないこと

F=1・8³ でのゲートです。機構は Zeeman 係数 1 個の符号なので F に依存しませんが、**本番規模の腕はまだ通していません**。`runs/eu151_klaus_phi_phys/config.yaml` はキーを載せましたが**再実行していない**ので、§3・§4 の ¹⁵¹Eu の数値は aligned 準備のままです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
