### PR TITLE
feat(runs): the 64³ endpoint ensemble, sized and criteria-fixed, deliberately not run

### DIFF
--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -593,13 +593,19 @@ type = "B"
 scope = "2.6 nT, anti-aligned, CPU, `lhy: none`, 64³. The endpoint at long hold only; the peak at the same points IS resolved (`edh-longtime-peak-ordering-at-64`)."
 uncertainty = "unbounded on the static-vs-baseline row: n = 2 seeds gives a spread (34.2 %) but no distribution, so 18.8 % is inside it and no confidence can be attached. Closing it needs an ensemble on both arms, not a finer grid — the grid is already the refined one."
 uncertainty_basis = "seed"
-evidence = ["64³ endpoint P_adj: baseline 0.15112, static 0.17952 (seed 101) / 0.27262 (default), rotating 0.40013 / 0.40358"]
-evidence_status = "absent"
+evidence = ["64³ endpoint P_adj: baseline 0.15112, static 0.17952 (seed 101) / 0.27262 (default), rotating 0.40013 / 0.40358", "runs/klaus_quench_long_time_ensemble/", "scripts/submit_lt64_endpoint_ensemble.sh"]
+evidence_status = "partial"
 commit = "6bb97bb2"
 doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "17.2"
 pr = 0
-note = """Recorded as `open` rather than left out, because the absence of a statement here is exactly what a reader would otherwise supply from the peak row. The rotating-vs-static factor of 2.23 IS outside the scatter and is safe to quote; the static-vs-baseline one is not. Same shape as `edh-longtime-not-converged-at-32`: a quantity measured on one axis (peak) does not transfer to another (endpoint), just as one duration did not transfer to another."""
+note = """Recorded as `open` rather than left out, because the absence of a statement here is exactly what a reader would otherwise supply from the peak row. The rotating-vs-static factor of 2.23 IS outside the scatter and is safe to quote; the static-vs-baseline one is not. Same shape as `edh-longtime-not-converged-at-32`: a quantity measured on one axis (peak) does not transfer to another (endpoint), just as one duration did not transfer to another.
+
+THE RUN THAT WOULD CLOSE IT IS PREPARED AND NOT SPENT (2026-08-21). 20 committed configs (8 baseline + 8 static + 4 rotating, seeds 1001-1008) and an array submit script. Sizing fixed BEFORE launch: sd = 0.0658 at n = 2, difference of means 0.0750, SE_diff = sd*sqrt(2/n), so n = 7 reaches 2 sigma and n = 8 is what is committed; fewer than 7 cannot answer the question at all. Rejection criterion also fixed before launch and written into `runs/klaus_quench_long_time_ensemble/README.md`: ESTABLISHED only if the difference of means is at least 2*SE_diff using the sd POOLED FROM THOSE RUNS, and if the pooled sd comes back much larger than 0.0658 the answer is "n = 8 does not reach 2 sigma, it would need N", not a re-fitted criterion.
+
+NOT LAUNCHED because it is ~5.2 points of a 19.24 group balance (~27 %) with another session spending concurrently, and this is a secondary row — the peak ordering it might be confused with is already established and unaffected. anko made that call; the numbers are in the README so the next person does not re-derive the decision.
+
+Two API facts were established the expensive way and are recorded so the next author does not invent them again: `cli.jl launch` takes `[<batch>] <run_name>` and has NO `--smoke`, and `run_yaml` has NO point selection. The second is why this is 20 single-arm configs rather than 3 seed-scans — a `scan:` cannot be split across array tasks."""
 
 [[claim]]
 id = "edh-phi-phys-anti-aligned-needs-field-reversal"

--- a/runs/klaus_quench_long_time_ensemble/README.md
+++ b/runs/klaus_quench_long_time_ensemble/README.md
@@ -1,0 +1,105 @@
+# 64³ long-time endpoint ensemble
+
+**Status: NOT RUN.** Configs and submit script are committed; the compute was
+deliberately not spent on 2026-08-21 (see *Cost*). Nothing in this directory has
+produced a number yet.
+
+## The one question these arms answer
+
+At a 100 ω_ref⁻¹ hold, does the statically weakened trap beat no-intervention
+**at the endpoint**?
+
+The **peak** ordering is already established and nothing here can move it:
+
+| arm (64³, 100 ω_ref⁻¹) | hold-peak P_adj | endpoint P_adj |
+|---|---:|---:|
+| baseline ω_eff = 1.000 | 0.37973 | 0.15112 |
+| static ω_eff = 0.714 | **0.49081** | 0.17952 / 0.27262 |
+| rotating Ω = −0.70 | 0.40102 | **0.40013** |
+
+Static beats baseline by **+29.3 %** at the peak, with gaps 35–100× the seed
+scatter. That is the result. The endpoint is a separate row and is `open`.
+
+## Why an ensemble and not a finer grid
+
+**64³ is already the refined grid.** The 32³ → 64³ refinement inverted both
+orderings, which is why §15 retracted the long-time claim — but refining again
+answers a question nobody asked. What is missing is **n**.
+
+The static arm's **endpoint moves 34.2 %** between two seeds (0.27262 → 0.17952)
+while its **peak stays identical to five decimals** (0.49081 both). §10.3
+measured five seeds agreeing to five decimals *and proved the knob live* — at
+**14.5 ω⁻¹**. That result does not reach 100 ω⁻¹, and its own `scope` field said
+so before this was measured.
+
+So the seed is the axis carrying the uncertainty here, and it is the axis to
+sample.
+
+## Sizing — fixed before launch
+
+| | |
+|---|---|
+| measured static endpoint sd | **0.0658** (n = 2, so one degree of freedom) |
+| difference of means vs the single baseline point | **0.0750** |
+| SE_diff | sd · √(2/n) |
+| **n = 7 per arm** | 2.13 σ ← threshold |
+| **n = 8 per arm** | 2.28 σ ← what is committed here |
+
+**Fewer than 7 per arm cannot answer the question.** A cheaper version of this
+run is not a cheaper answer, it is no answer.
+
+`rotating` gets 4 rather than 8: its endpoint is 2.23× static and already far
+outside the scatter, so these seeds check that its own scatter stays small
+(0.85 % at n = 2) instead of assuming it.
+
+## Rejection criterion — fixed before launch
+
+> **ESTABLISHED** if `|mean(static) − mean(baseline)| ≥ 2 · SE_diff`, using the
+> standard deviation **pooled from these runs** — not the n = 2 estimate above.
+>
+> **NOT ESTABLISHED** otherwise. The ledger row `edh-longtime-endpoint-ordering-
+> unresolved` stays `open`, and the measured SE is reported.
+>
+> If the pooled sd comes back much larger than 0.0658, **n = 8 does not reach
+> 2 σ**: say so and quote the n it would need. **Do not re-fit the criterion to
+> whatever landed**, and do not report a difference without the SE beside it.
+
+Written down here because a run that finishes and *then* has its interpretation
+chosen is not a measurement.
+
+## Cost, and why it was not spent
+
+20 arms × `cpu_16` × ~5 h actual / 8 h reserved:
+
+```
+0.060 × 20 × (0.7×5 + 0.1×8) ≈ 5.2 points
+```
+
+On 2026-08-21 the group balance was **19.24** — about **27 %** of it — with
+another session spending concurrently on the ω_eff third-field scan. anko chose
+not to spend it then. Check `t4-user-info group point` before submitting.
+
+## Running it
+
+```bash
+# from the TSUBAME worktree root
+qsub -g tga-kozuma-kouhi -t 1-20 scripts/submit_lt64_endpoint_ensemble.sh
+```
+
+Task → config mapping is in the submit script: 1–8 baseline, 9–16 static, 17–20
+rotating.
+
+**There is no `--smoke` flag and no `--only-point` flag.** Both were written into
+a first draft of the submit script from memory and neither exists: `cli.jl
+launch` takes `[<batch>] <run_name>`, and `run_yaml` has no point selection. To
+smoke one arm, submit `-t 1-1` with a short `h_rt` and expect it to be **killed**
+— that proves the config compiles, the 64³ grid allocates and the first
+snapshots land. It does **not** prove an arm finishes; the local 64³ arms ran
+3.8–4.9 h.
+
+## Collecting
+
+Each arm writes its own run directory (content-addressed on the config bytes).
+The hold-peak must be taken **inside the hold**, not over the whole trajectory —
+a whole-trajectory argmax reads the pre-hold transient and at 10.4 nT blinded 7
+of 10 arms (§12.1).

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1001.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1001.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `baseline`, seed 1001.
+#
+# omega_perp = 1.0, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1001
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1002.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1002.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `baseline`, seed 1002.
+#
+# omega_perp = 1.0, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1002
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1003.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1003.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `baseline`, seed 1003.
+#
+# omega_perp = 1.0, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1003
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1004.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1004.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `baseline`, seed 1004.
+#
+# omega_perp = 1.0, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1004
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1005.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1005.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `baseline`, seed 1005.
+#
+# omega_perp = 1.0, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1005
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1006.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1006.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `baseline`, seed 1006.
+#
+# omega_perp = 1.0, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1006
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1007.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1007.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `baseline`, seed 1007.
+#
+# omega_perp = 1.0, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1007
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1008.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_baseline_s1008.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `baseline`, seed 1008.
+#
+# omega_perp = 1.0, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1008
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_rotating_s1001.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_rotating_s1001.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `rotating`, seed 1001.
+#
+# omega_perp = 1.0, Omega = -0.7 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1001
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: -0.7
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_rotating_s1002.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_rotating_s1002.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `rotating`, seed 1002.
+#
+# omega_perp = 1.0, Omega = -0.7 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1002
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: -0.7
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_rotating_s1003.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_rotating_s1003.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `rotating`, seed 1003.
+#
+# omega_perp = 1.0, Omega = -0.7 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1003
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: -0.7
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_rotating_s1004.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_rotating_s1004.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `rotating`, seed 1004.
+#
+# omega_perp = 1.0, Omega = -0.7 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1004
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: -0.7
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1001.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1001.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `static`, seed 1001.
+#
+# omega_perp = 0.714, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1001
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 0.714
+      - 0.714
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1002.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1002.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `static`, seed 1002.
+#
+# omega_perp = 0.714, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1002
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 0.714
+      - 0.714
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1003.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1003.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `static`, seed 1003.
+#
+# omega_perp = 0.714, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1003
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 0.714
+      - 0.714
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1004.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1004.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `static`, seed 1004.
+#
+# omega_perp = 0.714, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1004
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 0.714
+      - 0.714
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1005.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1005.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `static`, seed 1005.
+#
+# omega_perp = 0.714, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1005
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 0.714
+      - 0.714
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1006.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1006.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `static`, seed 1006.
+#
+# omega_perp = 0.714, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1006
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 0.714
+      - 0.714
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1007.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1007.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `static`, seed 1007.
+#
+# omega_perp = 0.714, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1007
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 0.714
+      - 0.714
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1008.yaml
+++ b/runs/klaus_quench_long_time_ensemble/lt64_ens_static_s1008.yaml
@@ -1,0 +1,131 @@
+# 64^3 long-time endpoint ensemble -- arm `static`, seed 1008.
+#
+# omega_perp = 0.714, Omega = 0.0 during the 100 omega_ref^-1 hold, grid 64^3.
+#
+# ONE ARM PER FILE, on purpose. `run_yaml` has no point selection -- it runs a
+# whole `scan:` and skips points already on disk -- so a `scan:` over seeds
+# cannot be split across array tasks, and a walltime kill mid-scan would leave
+# the tail unrun. Sequentially, 8 arms x ~4.5 h exceeds any walltime.
+#
+# `noise_seed` is on pipeline[1], the step carrying `seed_amplitude`. IT IS READ
+# NOWHERE ELSE: on the hold it is inert and every seed returns bit-identical
+# numbers, which looks exactly like a deterministic observable. Measured
+# 2026-08-19.
+#
+# WHY, SIZING and the REJECTION CRITERION: see README.md in this directory. The
+# criterion is fixed BEFORE launch and must not be re-fitted to what lands.
+#
+# anti-aligned-seed: inherited from the base cell -- the EdH cascade only runs
+#   from the Zeeman-HIGHEST stretched state (Kawaguchi-Saito-Ueda PRL 96,
+#   080405). Authority: docs/campaign/edh_quench_polarisation_decision.md
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions:
+    N_atoms: 10000
+    omega_ref: 691.1504
+pipeline:
+- ground_state:
+    atom: Eu151
+    grid:
+      n:
+      - 64
+      - 64
+      - 64
+      box:
+      - 12.0
+      - 12.0
+      - 12.0
+    potential:
+      type: harmonic
+      omega:
+      - 1.0
+      - 1.0
+      - 1.181818
+    interactions:
+      N_atoms: 10000
+      omega_ref: 691.1504
+      c1_ratio: 0.02778
+    ddi:
+      enabled: true
+      secular: true
+    lhy:
+      kind: none
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    gauge_fix: false
+    initial_state: m_plus_F
+    init_sigma: 1.5
+    dt: 0.005
+    n_steps: 3000
+    tol: 1.0e-09
+- dynamics:
+    duration: 6.9115
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 0.01 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    seed_amplitude: 1.0e-06
+    seed_k_cut: 2.5
+    save:
+      every: 200
+      psi: true
+      precision: f64
+    noise_seed: 1008
+- dynamics:
+    duration: 0.69115
+    dt: 0.001
+    rotating_frame_omega: 0.0
+    B:
+      Bz:
+        from: 0.01
+        to: 2.6e-05
+        duration: 0.6911504
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 50
+      psi: true
+      precision: f64
+- dynamics:
+    duration: 100.0
+    dt: 0.005
+    rotating_frame_omega: 0.0
+    B:
+      Bz: 2.6e-5 Gauss
+      theta: 0.0
+      phi: 0.0
+    ddi:
+      enabled: true
+      secular: false
+    lhy:
+      kind: none
+    save:
+      every: 1000
+      psi: true
+      precision: f64
+    potential:
+      type: harmonic
+      omega:
+      - 0.714
+      - 0.714
+      - 1.181818
+- analyze:
+  - phase_classify: {}
+  - winding_map: {}
+  - energy_decomposition: {}

--- a/scripts/submit_lt64_endpoint_ensemble.sh
+++ b/scripts/submit_lt64_endpoint_ensemble.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# 64^3 long-time ENDPOINT ensemble — closes `edh-longtime-endpoint-ordering-unresolved`.
+#
+# WHAT IT ANSWERS, and nothing else: at a 100 omega_ref^-1 hold, does the static
+# weakened trap beat no-intervention AT THE ENDPOINT? The PEAK ordering is already
+# established (static 0.49081 > rotating 0.40102 > baseline 0.37973, gaps 35-100x
+# the seed scatter) and no result here can move it.
+#
+# WHY AN ENSEMBLE AND NOT A FINER GRID. 64^3 IS the refined grid. What is missing
+# is n: the static arm's endpoint moves 34.2 % between two seeds while its peak
+# stays identical to five decimals. A third resolution would answer a question
+# nobody asked.
+#
+# SIZING, fixed before launch (do not re-fit it afterwards):
+#   measured static endpoint sd = 0.0658 (n = 2, one degree of freedom)
+#   difference of means vs the single baseline point = 0.0750
+#   SE_diff = sd * sqrt(2/n)  =>  n = 7 reaches 2 sigma, n = 8 gives margin
+#   FEWER THAN 7 PER ARM CANNOT ANSWER THE QUESTION. Do not run a cheaper version.
+#
+# REJECTION CRITERION, fixed before launch:
+#   ESTABLISHED      |mean(static) - mean(baseline)| >= 2 * SE_diff, with the sd
+#                    POOLED FROM THESE RUNS, not the n = 2 estimate above.
+#   NOT ESTABLISHED  otherwise. The ledger row stays `open`, the measured SE is
+#                    reported, and if the pooled sd is much larger than 0.0658 we
+#                    say what n it would need instead of quietly declaring a
+#                    trend.
+#
+# COST, so nobody launches this without seeing it: 20 arms x cpu_16 x ~5 h actual
+# / 8 h reserved = 0.060 * 20 * (0.7*5 + 0.1*8) = ~5.2 points. On 2026-08-21 the
+# group balance was 19.24, i.e. this is ~27 % of it, with another session
+# spending concurrently. It was NOT launched on that date for exactly that
+# reason. Check `t4-user-info group point` before submitting.
+#
+# ONE ARM PER TASK. A shard that dies on walltime must not take completed
+# neighbours with it, and `run_yaml` already skips finished points on re-run, so
+# a resubmit costs only what actually failed.
+#
+# Submit (from the TSUBAME worktree root):
+#   qsub -g tga-kozuma-kouhi -t 1-20 scripts/submit_lt64_endpoint_ensemble.sh
+# Smoke first — ONE arm, short wall, and EXPECT IT TO BE KILLED at 20 min:
+#   qsub -g tga-kozuma-kouhi -t 1-1 -l h_rt=0:20:00 \
+#        scripts/submit_lt64_endpoint_ensemble.sh
+#   There is no --smoke flag. `cli.jl launch` takes [<batch>] <run_name> and
+#   `run_yaml` takes no point selection; a first draft of this script invoked
+#   both with flags that do not exist. A short-wall kill is the smoke: it proves
+#   the config compiles, the 64^3 grid allocates and the first snapshots land. It
+#   does NOT prove an arm finishes — the local 64^3 arms ran 3.8-4.9 h.
+#
+#$ -cwd
+#$ -N lt64_ens
+#$ -l cpu_16=1
+#$ -l h_rt=8:00:00
+#$ -j y
+#$ -o logs/tsubame/lt64_ens.$TASK_ID.log
+set -euo pipefail
+
+REPO="${SPINORBEC_TSUBAME_PROJECT_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/BEC-simulation}"
+JULIA="${SPINORBEC_TSUBAME_JULIA:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia}"
+export JULIA_DEPOT_PATH="${SPINORBEC_TSUBAME_DEPOT:-/gs/fs/tga-kozuma-kouhi/shared/.julia}"
+
+# TSUBAME 4 HAS NO `julia` MODULEFILE. `module load julia` fails and
+# `tsubame_setup.sh` swallows it, so point at the binary and check it exists here
+# rather than discovering the absence three hours into a job array.
+[ -x "$JULIA" ] || { echo "no julia at $JULIA"; exit 1; }
+cd "$REPO"
+
+# TASK_ID -> ONE config. 8 baseline + 8 static + 4 rotating = 20.
+# One arm per file because `run_yaml` has no point selection: it runs a whole
+# `scan:` and skips points already on disk, so a seed scan cannot be split
+# across array tasks.
+T="${SGE_TASK_ID:-1}"
+DIR=runs/klaus_quench_long_time_ensemble
+# Built group by group. `ls a* b* c*` sorts ALL matches together, which would
+# put `rotating` before `static` alphabetically and silently contradict the
+# 1-8 / 9-16 / 17-20 mapping documented above. Every arm still runs either way —
+# but a log line naming the wrong arm is how a result gets attributed to the
+# wrong one.
+CFGS=()
+for arm in baseline static rotating; do
+    for f in "$DIR"/lt64_ens_${arm}_s*.yaml; do CFGS+=("$f"); done
+done
+
+# The count is asserted, not assumed. A glob that matched 19 files would run a
+# silently smaller ensemble and n < 7 cannot answer the question at all.
+[ "${#CFGS[@]}" -eq 20 ] || { echo "expected 20 configs, found ${#CFGS[@]}"; exit 1; }
+[ "$T" -ge 1 ] && [ "$T" -le 20 ] || { echo "task $T is outside 1-20"; exit 1; }
+
+CFG_PATH="${CFGS[$((T - 1))]}"
+echo "task $T -> $CFG_PATH   ($(date -Is))"
+mkdir -p logs/tsubame
+
+# `run_yaml` is resumable: it skips any point already on disk, so resubmitting
+# after a walltime kill re-runs only what did not finish. There is no --smoke and
+# no --only-point; see README.md in the config directory.
+set +e
+"$JULIA" --project=. -e 'using SpinorBEC; run_yaml(ARGS[1])' "$CFG_PATH"
+RC=$?
+set -e
+echo "task $T rc=$RC   ($(date -Is))"
+exit $RC

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -53,6 +53,7 @@ const _SCRIPTS_ALLOWLIST = Set([
     "submit_mutation_sweep.sh",
     "submit_kz_exponent.sh",
     "submit_eu_bscan.sh",
+    "submit_lt64_endpoint_ensemble.sh",
     "tsubame/_preamble.sh",
     "tsubame/preflight.sh",
     "tsubame/submit_gpu_smoke.sh",


### PR DESCRIPTION
`edh-longtime-endpoint-ordering-unresolved` を閉じるための 20 本を **config としてコミット**しました。**投げていません** — 予算判断は anko のものなので、算術を README に残して判断できる状態にしてあります。

## なぜアンサンブルで、なぜ格子ではないか

**64³ が既に refined grid** です。足りないのは **n**。static 腕は**終端が 2 seed 間で 34.2 % 動き、ピークは 5 桁一致のまま**。3 つ目の解像度は誰も訊いていない問いに答えます。

## 打つ前に固定したこと（後から決められない部分）

```
sd = 0.0658（n=2、自由度 1）
平均差 vs 単一 baseline = 0.0750
SE_diff = sd·√(2/n)  ⇒  n=7 で 2σ、n=8 をコミット
```

**1 腕あたり 7 本未満ではこの問いに答えられません。**安く済ませた版は安い答えではなく、答えなしです。

**棄却基準**: `|mean(static) − mean(baseline)| ≥ 2·SE_diff`（sd は**その run から pool したもの**）。pooled sd が 0.0658 より大きく出たら、答えは「n=8 では 2σ に届かない、必要なのは N」であって、**基準を後から合わせ直すことではありません**。差を SE 抜きで引用することもしません。

## 自分の書き方の訂正

§17.2 で終端差を「**+18.8 %**」と書きましたが、これは **static の低い方の seed** と単一 baseline の比較です。2 seed の**平均**に対しては **+49.6 %**。どちらも別の量についての真です。sizing は平均を使っており、**この行が `open` である理由がまさにこれ**です。

## 高くついて分かった API 事実 2 件（再発明されないよう記録）

submit スクリプトの初稿は `cli.jl launch --only-point N --smoke` を呼んでいました。**どちらのフラグも存在しません** — `launch` は `[<batch>] <run_name>`（パスではなく**名前**）を取り、`run_yaml` には**点選択が一切ありません**。

後者が「3 本の seed スキャン」ではなく「20 本の単一腕 config」にした理由です: `scan:` は丸ごと走って完了点だけスキップするので**配列タスクに分割できず**、8 腕 × 約 4.5 h の逐次実行はどの walltime も超えます。

## シェルが黙っていた欠陥 1 件

`ls a* b* c*` は**全マッチをまとめてソート**するので、`rotating` が `static` より前に来て、**20 本すべて走るのにログの腕名が全部ずれる**ところでした。グループごとに構築し、**本数を仮定せず表明**するようにしました（19 本しかマッチしなければ、何も答えられない n で静かに走ってしまう）。

## コスト（投げなかった理由）

20 腕 × cpu_16 × 約 5 h = **約 5.2 ポイント**。2026-08-21 時点の group balance は **19.24**（約 27 %）で、別セッションが ω_eff 第三磁場スキャンを同時に走らせていました。しかもこれは**副次的な行**で、隣の見出し結果（ピーク順序 static > rotating > baseline、+29.3 %）は既に確定していて**この run では動きません**。

## 検証

20 config は Zeeman/seed 一致ゲート・`scripts/` allowlist ゲート・ledger ゲートを通過。`run_yaml` は resumable なので、walltime kill のコストは**終わらなかった腕の分だけ**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
