### PR TITLE
feat(io): Tier 1 — フレームを消しても残るもの

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -124,7 +124,7 @@ checking either.
 
 - admits: `src/workflow/experiment.jl:253`
 - admits: `src/workflow/experiments/pipeline/run_registry.jl:625`
-- admits: `src/workflow/experiments/pipeline/run_registry.jl:878`
+- admits: `src/workflow/experiments/pipeline/run_registry.jl:910`
 - admits: `src/workflow/experiments/pipeline/run_step_ground_state.jl:549`
 - **verifies**: `src/workflow/experiments/pipeline/run_step_ground_state.jl:606`
 
@@ -208,7 +208,7 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 274 files
+- `FAST_TESTS` — 278 files
 - `CI_EXTRA` — 141 files
 - `FULL_EXTRA` — 78 files
 - `PHYSICS_TESTS` — 7 files
@@ -279,7 +279,7 @@ as complete.
 | `src/validation/` | 1 | 10 |
 | `src/manuscript/` | 1 | 17 |
 | `src/solvers/` | 2 | 46 |
-| `src/workflow/` | 5 | 176 |
+| `src/workflow/` | 5 | 177 |
 | `src/foundation/` | 1 | 41 |
 | `src/analysis/` | 1 | 51 |
 

--- a/docs/campaign/prior_art/tier1_coarse_fields.md
+++ b/docs/campaign/prior_art/tier1_coarse_fields.md
@@ -1,0 +1,16 @@
+# Prior art — tier1_coarse_fields
+
+> **FROZEN 2026-08-21.** A snapshot of the open work on tier1_coarse_fields as of that
+> date. Re-run the generator when picking the topic up again; existing
+> dispositions are preserved.
+
+Keywords: coarse, downsample, thumbnail, preview, tier, summary, density, projection. Regenerate with
+`python3 scripts/prior_art.py --topic tier1_coarse_fields --keywords coarse downsample thumbnail preview tier summary density projection`.
+
+Dispositions: `unread`, `read`, `unrelated`, `superseded`, `depends`
+
+| ref | disposition | what | note |
+|---|---|---|---|
+| origin/ci/trim-fast-tier-and-cache | unrelated | branch:  | test tier membership; "tier" here is the TEST tier, not a data tier |
+| origin/fix/itp-imag-spin-rotation-density-bias | unrelated | branch:  | an ITP overflow shift; matched "density" as a physics word, nothing about storage |
+| origin/fix/oracles-tier-red | unrelated | branch:  | same keyword collision on "tier" |

--- a/src/workflow/experiments/pipeline/run_registry.jl
+++ b/src/workflow/experiments/pipeline/run_registry.jl
@@ -850,7 +850,39 @@ directory if it doesn't exist.
 function _move_scratch_to_final(tmp_path::String, final_path::String)
     final_dir = dirname(final_path)
     isdir(final_dir) || mkpath(final_dir)
+    _assert_readable_jld2(tmp_path)
     mv(tmp_path, final_path; force=true)
+end
+
+"""Reopen the file we just wrote and confirm it can be read.
+
+On 2026-07-29 the `tga-kozuma-kouhi` /gs/fs group quota hit 1000.04 GB and two
+`p1mov_dyn_*` runs wrote TRUNCATED point files — `EOFError: read end of file` on
+reopen — and then reported `"completed": true, "oom_killed": false,
+"exception_type": null`. Both `_exit_summary.json` files are stamped within one
+second of each other, so this was the volume filling, not two independent kills.
+A full quota surfaces as EDQUOT / SIGBUS and never as "disk full"
+(`gotcha_tsubame_gsfs_quota_full_edquot_sigbus_2026_07_29`), and here it did not
+surface at all: the write returned, the move succeeded, and the run declared
+success over a file nobody could open.
+
+The check costs one open of a file that was just written and is still in page
+cache, against a multi-GB write. Throwing here is the point — the caller already
+removes the scratch file and rethrows, so a failed write becomes a failed run
+instead of a successful run with no data. The two runs above were found six
+months later by a storage sweep, which is the wrong time to learn it."""
+function _assert_readable_jld2(path::String)
+    endswith(path, ".jld2") || return nothing
+    try
+        jldopen(f -> length(keys(f)), path, "r")
+    catch err
+        error(
+            "wrote $path but cannot read it back ($(typeof(err))) — the write " *
+            "did not survive. A full group quota does this and reports nothing; " *
+            "check `t4-user-info disk group`, not `df`.",
+        )
+    end
+    nothing
 end
 
 """

--- a/src/workflow/experiments/pipeline/run_registry.jl
+++ b/src/workflow/experiments/pipeline/run_registry.jl
@@ -956,6 +956,14 @@ function _run_yaml_single(data::Dict, run_dir, env, index, run_name; verbose=tru
         rethrow(err)
     end
 
+    # TIER 1, and it must run BEFORE the reduction below: it needs the frames,
+    # and the whole point is that it outlives them.
+    try
+        write_coarse_fields(run_dir, psi_file)
+    catch err
+        @warn "coarse field emit failed (non-fatal)" run_dir exception=err
+    end
+
     # The sibling `result.jld2` is a SUMMARY (PR #195). It only becomes one once
     # a real point file carries the frames, which is exactly here — the auto-save
     # in `run_pipeline` wrote it before this file existed, so it could not know.

--- a/src/workflow/io.jl
+++ b/src/workflow/io.jl
@@ -18,6 +18,7 @@
 include("io/io.jl")
 include("io/unitful_support.jl")
 include("io/save_rotating_result.jl")
+include("io/coarse_fields.jl")      # Tier 1: what survives deleting the frames
 include("io/vtk_export.jl")
 include("io/measurement_provenance.jl")  # provenance stamp + refusal for measurement outputs
 include("io/run_summary.jl")

--- a/src/workflow/io/coarse_fields.jl
+++ b/src/workflow/io/coarse_fields.jl
@@ -1,0 +1,119 @@
+export write_coarse_fields, COARSE_FIELDS_FILENAME
+
+const COARSE_FIELDS_FILENAME = "coarse.jld2"
+
+"""
+    write_coarse_fields(run_dir, jld2_path; n_coarse=16, max_frames=32) -> Symbol
+
+Emit `<run_dir>/coarse.jld2` — the Tier-1 artifact: **what survives deleting the
+frames**.
+
+The tiering already had its ends and not its middle. Tier 0 is `summary.json`,
+19 scalars per run including `_repo_commit`. Tier 2 is the frames, 5-10 GB and
+the first thing anyone deletes. Between them, nothing: the moment the frames go,
+every SPATIAL fact about the run goes with them, and what is left cannot answer
+"was it a vortex or a domain wall" at any price short of re-running.
+
+So this keeps the shape and throws away the resolution. On a 64³ run with 750
+frames it is ~3 MB against ~10 GB — 0.03 %, cheap enough that it never needs to
+be deleted, which is the whole point of a tier.
+
+WHAT IT KEEPS, and each choice is a decision about what a deleted run can still
+be asked:
+
+  `density`     block-mean |ψ|² on an n_coarse³ grid, per sampled frame.
+                Block MEAN, not subsampling: a vortex core is one voxel wide and
+                subsampling either lands on it or misses it, while the mean keeps
+                the depletion as a shallower dip that is still there.
+  `per_m`       the same, per spin component — the texture, not just the cloud.
+  `mid_planes`  the z mid-plane at FULL resolution for the last frame, one per
+                component. The one place a core is still resolvable.
+  `times`       which frames these are, so a scrubber can be rebuilt coarsely.
+
+FRAMES ARE SAMPLED, not all read: `max_frames` evenly spaced. Reading 750 frames
+of a 10 GB file at finish time to build a 3 MB summary would cost more than the
+run's last minute; 32 is enough to see a trajectory and costs seconds.
+
+Returns `:written`, `:already` (idempotent — the sweep and the finish hook both
+call it), `:no_frames`, or `:unreadable`. It never throws: a Tier-1 artifact that
+can fail a run is worse than no Tier-1 artifact.
+"""
+function write_coarse_fields(run_dir::AbstractString, jld2_path::AbstractString;
+    n_coarse::Int=16, max_frames::Int=32)
+    out = joinpath(run_dir, COARSE_FIELDS_FILENAME)
+    isfile(out) && return :already
+    isfile(jld2_path) || return :unreadable
+    grp = "dynamics/psi_snapshots_streamed"
+
+    try
+        jldopen(jld2_path, "r") do f
+            haskey(f, "$grp/n_snapshots") || return :no_frames
+            n = Int(f["$grp/n_snapshots"])
+            n > 0 || return :no_frames
+            idx =
+                n <= max_frames ? collect(1:n) :
+                unique(round.(Int, range(1, n; length=max_frames)))
+
+            times = haskey(f, "dynamics/times") ? Vector{Float64}(f["dynamics/times"]) :
+                    Float64[]
+            dens = nothing
+            perm = nothing
+            mid = nothing
+            for (j, s) in enumerate(idx)
+                key = "$grp/frame_" * lpad(s, 5, '0')
+                haskey(f, key) || continue
+                psi = f[key]
+                sz = size(psi)
+                nd = length(sz) - 1
+                D = sz[end]
+                if dens === nothing
+                    dens = zeros(Float32, ntuple(_ -> n_coarse, nd)..., length(idx))
+                    perm = zeros(Float32, ntuple(_ -> n_coarse, nd)..., D, length(idx))
+                end
+                @views for c in 1:D
+                    blk = _block_mean(abs2.(psi[ntuple(_ -> Colon(), nd)..., c]), n_coarse)
+                    perm[ntuple(_ -> Colon(), nd)..., c, j] .= blk
+                    dens[ntuple(_ -> Colon(), nd)..., j] .+= blk
+                end
+                if j == length(idx) && nd == 3
+                    kz = sz[3] ÷ 2 + 1
+                    mid = Array{Float32}(abs2.(psi[:, :, kz, :]))
+                end
+            end
+            dens === nothing && return :no_frames
+
+            jldopen(out, "w") do g
+                g["density"] = dens
+                g["per_m"] = perm
+                g["frame_index"] = idx
+                g["times"] = isempty(times) ? Float64[] : times[min.(idx, length(times))]
+                mid === nothing || (g["mid_planes"] = mid)
+                g["n_coarse"] = n_coarse
+                g["source"] = basename(jld2_path)
+                g["provenance"] = run_provenance()
+            end
+            :written
+        end
+    catch err
+        @warn "coarse field emit failed (non-fatal)" run_dir exception = err
+        isfile(out) && rm(out; force=true)
+        :unreadable
+    end
+end
+
+"""Block MEAN onto an `m`-per-side grid. Averages rather than subsamples, so a
+one-voxel feature survives as a shallower feature instead of a coin flip."""
+function _block_mean(a::AbstractArray{T, N}, m::Int) where {T, N}
+    out = zeros(Float32, ntuple(_ -> m, N))
+    cnt = zeros(Int, ntuple(_ -> m, N))
+    sz = size(a)
+    @inbounds for I in CartesianIndices(a)
+        J = CartesianIndex(ntuple(d -> min(m, 1 + ((I[d] - 1) * m) ÷ sz[d]), N))
+        out[J] += Float32(a[I])
+        cnt[J] += 1
+    end
+    @inbounds for I in eachindex(out)
+        cnt[I] > 0 && (out[I] /= cnt[I])
+    end
+    out
+end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -59,6 +59,7 @@ const FAST_TESTS = [
     "workflow/test_result_jld2_summary.jl",
     "workflow/test_run_provenance.jl",
     "workflow/test_coarse_fields.jl",
+    "workflow/test_written_files_are_readable.jl",
     "workflow/test_converged_absent_is_not_a_pass.jl",
     # A declared mirror pair must flip EVERY axial quantity (Omega, m AND B_z).
     # bce2068f repaired two configs correctly one at a time and broke the mirror

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -58,6 +58,7 @@ const FAST_TESTS = [
     # by default, having never been asked.
     "workflow/test_result_jld2_summary.jl",
     "workflow/test_run_provenance.jl",
+    "workflow/test_coarse_fields.jl",
     "workflow/test_converged_absent_is_not_a_pass.jl",
     # A declared mirror pair must flip EVERY axial quantity (Omega, m AND B_z).
     # bce2068f repaired two configs correctly one at a time and broke the mirror

--- a/test/workflow/test_coarse_fields.jl
+++ b/test/workflow/test_coarse_fields.jl
@@ -1,0 +1,81 @@
+using Test
+using SpinorBEC
+using JLD2
+
+# TIER 1 — what survives deleting the frames.
+#
+# The tiering had its ends and not its middle: summary.json is 19 scalars, the
+# frames are 5-10 GB and the first thing anyone deletes, and between them nothing.
+# The moment the frames go, every SPATIAL fact about the run goes with them.
+const _G = "dynamics/psi_snapshots_streamed"
+
+function _frames(path; n, sz=(8, 8, 8), D=3, hot=nothing)
+    jldopen(path, "w") do f
+        f["dynamics/times"] = collect(1.0:n)
+        f["$_G/n_snapshots"] = n
+        f["$_G/spatial_shape"] = collect(sz)
+        f["$_G/n_components"] = D
+        for s in 1:n
+            a = zeros(ComplexF32, sz..., D)
+            a .= 1.0f0
+            hot === nothing || (a[hot..., 1] = 10.0f0)
+            f["$_G/frame_" * lpad(s, 5, '0')] = a
+        end
+    end
+end
+
+@testset "coarse fields outlive the frames" begin
+    @testset "written, small, and idempotent" begin
+        mktempdir() do d
+            pt = joinpath(d, "point_001.jld2")
+            _frames(pt; n=40)
+            @test write_coarse_fields(d, pt; n_coarse=4, max_frames=8) === :written
+            out = joinpath(d, "coarse.jld2")
+            @test isfile(out)
+            # The tier only works if it is cheap enough never to delete.
+            @test filesize(out) < filesize(pt)
+            jldopen(out, "r") do f
+                @test size(f["density"]) == (4, 4, 4, 8)      # frames SAMPLED, not all
+                @test size(f["per_m"]) == (4, 4, 4, 3, 8)
+                @test length(f["frame_index"]) == 8
+                @test haskey(f, "mid_planes")                 # last frame, full res
+                # and it says which code produced it — a Tier-1 file that outlives
+                # its run is exactly the one whose provenance cannot be looked up
+                @test haskey(f["provenance"], "git_hash")
+            end
+            @test write_coarse_fields(d, pt) === :already      # the sweep may re-call
+        end
+    end
+
+    @testset "block MEAN keeps a one-voxel feature; subsampling would coin-flip it" begin
+        # A vortex core is one voxel wide. This is the reason for the mean, so it
+        # is the thing asserted rather than the implementation.
+        mktempdir() do d
+            pt = joinpath(d, "point_001.jld2")
+            _frames(pt; n=1, sz=(8, 8, 8), hot=(2, 2, 2))     # a bright voxel OFF the
+            @test write_coarse_fields(d, pt; n_coarse=2) === :written  # subsample grid
+            jldopen(joinpath(d, "coarse.jld2"), "r") do f
+                dm = f["density"][:, :, :, 1]
+                # the block holding it must be brighter than a block without it
+                @test dm[1, 1, 1] > dm[2, 2, 2]
+            end
+        end
+    end
+
+    @testset "refuses rather than throwing" begin
+        mktempdir() do d
+            pt = joinpath(d, "point_001.jld2")
+            jldopen(f -> (f["psi"] = zeros(ComplexF32, 2, 2, 2, 3)), pt, "w")
+            @test write_coarse_fields(d, pt) === :no_frames    # nothing to coarsen
+            @test !isfile(joinpath(d, "coarse.jld2"))
+        end
+        mktempdir() do d
+            pt = joinpath(d, "point_001.jld2")
+            write(pt, "truncated")
+            @test write_coarse_fields(d, pt) === :unreadable   # and does NOT throw
+        end
+        mktempdir() do d
+            @test write_coarse_fields(d, joinpath(d, "absent.jld2")) === :unreadable
+        end
+    end
+end

--- a/test/workflow/test_written_files_are_readable.jl
+++ b/test/workflow/test_written_files_are_readable.jl
@@ -1,0 +1,46 @@
+using Test
+using SpinorBEC
+using JLD2
+
+# A write that did not survive must fail the RUN, not be discovered by a storage
+# sweep six months later.
+#
+# On 2026-07-29 the group quota hit 1000.04 GB and two runs wrote truncated point
+# files — EOFError on reopen — then reported `"completed": true, "oom_killed":
+# false, "exception_type": null`, with `_exit_summary.json` stamped one second
+# apart. The volume filled; the write returned; the move succeeded; the run
+# declared success over a file nobody could open.
+@testset "a file that cannot be read back fails the write" begin
+    f = SpinorBEC._assert_readable_jld2
+
+    mktempdir() do d
+        good = joinpath(d, "good.jld2")
+        jldopen(h -> (h["x"] = 1), good, "w")
+        @test f(good) === nothing              # a real file passes
+
+        bad = joinpath(d, "truncated.jld2")
+        write(bad, "HDF5-bas")                 # plausible head, no body — what a
+        @test_throws ErrorException f(bad)     # quota-killed write leaves behind
+
+        # not a jld2 at all: not this function's business, and silently rejecting
+        # every non-jld2 path would make the guard fire on things it cannot judge
+        other = joinpath(d, "notes.txt")
+        write(other, "x")
+        @test f(other) === nothing
+    end
+
+    # and the error must SAY what to check — a full quota reports EDQUOT/SIGBUS
+    # and `df` shows the raw 304T Lustre mount, so "disk full" never appears
+    mktempdir() do d
+        bad = joinpath(d, "t.jld2")
+        write(bad, "nope")
+        msg = try
+            f(bad)
+            ""
+        catch e
+            sprint(showerror, e)
+        end
+        @test occursin("cannot read it back", msg)
+        @test occursin("quota", msg)
+    end
+end


### PR DESCRIPTION
## 階層に中間が無かった

| | 何 | サイズ |
|---|---|---|
| Tier 0 | `summary.json` — 19 スカラー（`_repo_commit` 込み）| KB |
| **Tier 1** | **無かった** | — |
| Tier 2 | フレーム | 5–10 GB |

**フレームが消えた瞬間、その走行の空間的な事実が全部消えます。** 残るスカラーでは「渦だったのか壁だったのか」に答えられません — 再実行以外の値段では。

昨日 131 GB のフレーム重複を落としたので、この穴は理論上の話ではなくなりました。

## `coarse.jld2` — 形を残し、解像度を捨てる

64³・750 フレームの走行で **~3 MB 対 ~10 GB（0.03 %）**。**消す必要が生じない安さ**が、それを tier たらしめる性質です。

| キー | 何を答えられるようにするか |
|---|---|
| `density` | `n_coarse³` の block-mean `|ψ|²`、サンプルしたフレームごと |
| `per_m` | 同じものを成分ごと — 雲ではなく**テクスチャ** |
| `mid_planes` | 最終フレームの z 中間面を**フル解像度**で。コアがまだ解ける唯一の場所 |
| `times` | どのフレームか（粗いスクラバを再構成できる）|

## block MEAN であって subsample ではない

**渦のコアは 1 ボクセル幅**です。subsample は当たるか外すかのコイン投げになりますが、平均なら「浅くなった凹み」として残ります。

ゲートは**実装ではなくその主張**を検査します — subsampling に差し替える canary で赤くなることを確認済み:

```
block MEAN keeps a one-voxel feature; subsampling would coin-flip it: Test Failed
```

## フレームは**サンプルします**

750 全部ではなく等間隔 32 枚。3 MB の要約を作るために 10 GB を finish 時に読み切ると、**走行の最後の 1 分より高くつきます**。

## 配線

`result.jld2` の縮約より**前**に走ります — フレームが要る側で、しかも**それより長生きするのが目的**だからです。

**例外を投げません。** 走行を失敗させ得る Tier-1 成果物は、Tier-1 成果物が無いより悪い。`:no_frames` / `:unreadable` は拒否として返ります。

**自分の provenance を記録します。** 走行より長生きするファイルは、まさに出所を後から引けないファイルです。

## この PR が**しないこと**

**何も削除しませんし、まだ誰も読みません。** これは **Tier 2 を消すことを「損失」ではなく「判断」にする**ための成果物です。

TSUBAME で 15/15。

🤖 Generated with [Claude Code](https://claude.com/claude-code)