### PR TITLE
chore(scripts): 削除した worktree を指していた submit の既定を直す

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -208,7 +208,7 @@ of these fails `test/test_docs_examples_avoid_removed_keys.jl`.
 
 File counts from `test/_tiers.jl`. Membership is explicit — no auto-discovery.
 
-- `FAST_TESTS` — 274 files
+- `FAST_TESTS` — 276 files
 - `CI_EXTRA` — 141 files
 - `FULL_EXTRA` — 78 files
 - `PHYSICS_TESTS` — 7 files

--- a/scripts/klaus2022/submit_ar_sensitivity.sh
+++ b/scripts/klaus2022/submit_ar_sensitivity.sh
@@ -11,9 +11,12 @@
 #$ -l h_rt=2:00:00
 #$ -j y
 #$ -o logs/tsubame/
-ROOT="${AS_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/iss408}"
+# The long-lived klaus2022 campaign worktree, not the scratch one #406 was run
+# from — that one was removed after the campaign and a default pointing at it
+# would `cd` into nothing.
+ROOT="${AS_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/klaus2022}"
 export EU335_ROOT="$ROOT"
-export EU335_OUT="${AS_RUNS:-/gs/fs/tga-kozuma-kouhi/uk07267/runs/iss408}"
+export EU335_OUT="${AS_RUNS:-/gs/fs/tga-kozuma-kouhi/uk07267/runs/klaus2022}"
 source "$ROOT/scripts/eu_hysteresis/_preamble.sh"
 
 export AS_OUT="${AS_OUT:-$EU335_OUT/ar_sensitivity}"

--- a/scripts/klaus2022/submit_fftw_probe.sh
+++ b/scripts/klaus2022/submit_fftw_probe.sh
@@ -14,7 +14,9 @@
 #$ -o logs/tsubame/
 set -euo pipefail
 
-ROOT="${FP_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/iss408}"
+# The long-lived klaus2022 campaign worktree, not the scratch one #407 was run
+# from — that one was removed after the campaign.
+ROOT="${FP_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/klaus2022}"
 export SPINORBEC_TSUBAME_JULIA="${SPINORBEC_TSUBAME_JULIA:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia}"
 JULIA="$SPINORBEC_TSUBAME_JULIA"
 export JULIA_DEPOT_PATH="${T4_TMPDIR:-/tmp}/.julia:/gs/fs/tga-kozuma-kouhi/shared/.julia"


### PR DESCRIPTION
#406 / #407 のドライバは `ROOT` の既定を、その campaign を走らせた**スクラッチの worktree**（`iss408`）にしていました。片付けでそれを消したので、素の `qsub scripts/klaus2022/submit_*.sh` は存在しないディレクトリに `cd` します。**片付けが作った rot** であって片付けが捕まえた rot ではないので、同じ turn で直します。

長命な `klaus2022` campaign worktree（兄弟の `submit_stripes.sh` と同じ先）へ repoint。env での上書きは維持。`grep -rn iss408 scripts/ docs/ CLAUDE.md` は 0 件。

## STATE.md について（**訂正**）

この PR は一時 `docs/STATE.md` の再導出も含んでいました。main `0b0a0605` の push CI が `docs/STATE.md is current` で赤く、原因は **#420 と #419 がどちらも自分の分岐元に対して STATE を再生成し、テキストのマージは衝突しなかったのに生成器とは一致しなくなった**ことでした（274 対 276）。

**その後 #430 がマージされ、main は自力で緑に戻りました**（run 32449861679、`68458215`）。#430 が載せた 278 は、マージ後のツリーでの導出と一致します — TSUBAME job 8457158 でこの PR のマージコミット `e23c6522` に対して再導出し、**差分ゼロ**を確認済み。

つまり私の STATE コミットは結果的に不要で、**この PR の main に対する正味の差分はシェルスクリプト 2 本だけ**です。赤かった窓は 1 コミット分でした。

残る一般論（この PR では直しません）: 派生物を各 PR が自分の base で再生成し、衝突なくマージされると、どちらでもない値が main に載り得ます。今回は次のマージがたまたま正しい値を載せて塞がりましたが、それは幸運であって仕組みではありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)