### PR TITLE
fix(eu334): #418 — F=6 を無罪にする probe

### DIFF
--- a/scripts/eu334/ed_growth_probe.jl
+++ b/scripts/eu334/ed_growth_probe.jl
@@ -37,8 +37,24 @@ const MU, T_RES, GAMMA, DT = 3.0, 1.0, 0.1, 0.002
 const K_CUT = sqrt(2 * (MU + T_RES))
 const NSTEP = parse(Int, get(ENV, "ED_NSTEP", "25000"))
 
+# `ED_ATOM=eu151` runs the SAME probe at F = 6, 13 components, DDI off.
+#
+# #418: the full theory stalls on #334's ramp (N_C flat at f = 0.065 where
+# growth-only reaches 0.37) and three explanations are already excluded by
+# measurement — the projector's number loss (common-mode across the arms), the
+# moving cutoff (pinning changes N_C by 5 parts in 3271), and energy damping in
+# general (this probe, scalar, condenses at BOTH values of M: 0.586 vs 0.543 of
+# N_TF). What is left is specific to that configuration: F = 6, the DDI, or the
+# ramp itself.
+#
+# This separates the first from the other two. Everything is held at the scalar
+# probe's values except the spin: same grid, same trap, same reservoir, DDI OFF,
+# only c0 in the interactions. If the stall reproduces here it is the spinor; if
+# it does not, F = 6 is exonerated and the DDI or the ramp carries it.
+const ATOM = get(ENV, "ED_ATOM", "rb87") == "eu151" ? Eu151 : Rb87
+
 function ground_mode(grid, dV, n_tf)
-    gs = find_ground_state(; grid, atom=Rb87,
+    gs = find_ground_state(; grid, atom=ATOM,
         interactions=InteractionParams(Dict{Int, Float64}(0 => C0 * n_tf)),
         potential=HarmonicTrap{3}((OMEGA, OMEGA, OMEGA)), dt=0.002, n_steps=3000,
         tol=1e-10, initial_state=:m_minus_F, verbose=false)
@@ -49,7 +65,7 @@ function ground_mode(grid, dV, n_tf)
 end
 
 function arm(grid, dV, phi, d, energy_damping::Bool)
-    ws = make_workspace(; grid, atom=Rb87,
+    ws = make_workspace(; grid, atom=ATOM,
         interactions=InteractionParams(Dict{Int, Float64}(0 => C0)),
         potential=HarmonicTrap{3}((OMEGA, OMEGA, OMEGA)),
         sim_params=SimParams(; dt=DT, n_steps=1, imaginary_time=false,
@@ -85,7 +101,8 @@ function main()
     π / minimum(grid.dx) > K_CUT || error("grid does not resolve the C region")
     (phi, d) = ground_mode(grid, dV, n_tf)
 
-    @printf("N_TF = %.1f   steps = %d   M = physical vs 0\n", n_tf, NSTEP)
+    @printf("atom = %s (D = %d)   N_TF = %.1f   steps = %d   M = physical vs 0\n",
+        ATOM === Rb87 ? "Rb87" : "Eu151", Int(2 * ATOM.F + 1), n_tf, NSTEP)
     for (name, ed) in (("growth-only (M=0)", false), ("full (M != 0)", true))
         a = arm(grid, dV, phi, d, ed)
         @printf("  %-18s N0 = %8.1f (%.3f N_TF)  N_C = %8.1f  out = %.4g  trunc = %.4g\n",

--- a/scripts/eu334/launch.sh
+++ b/scripts/eu334/launch.sh
@@ -242,7 +242,11 @@ kcut_fixed)
 # in one knob. Cheap and short: this is a debugging instrument, not a measurement
 # of the campaign's physics.
 ed_probe)
-    q -N eu334_edprobe -l h_rt=2:00:00 -v ED_NSTEP=${ED_NSTEP:-25000} \
+    # ARGUMENT, because the whole point is comparing the two: the scalar arm
+    # already condenses at both values of M, so the F = 6 arm is what separates
+    # "the spinor" from "the DDI or the ramp" in #418.
+    q -N eu334_edprobe_${2:-rb87} -l h_rt=4:00:00 \
+      -v ED_NSTEP=${ED_NSTEP:-25000},ED_ATOM=${2:-rb87} \
       scripts/eu334/submit_ed_probe.sh
     ;;
 

--- a/scripts/eu334/submit_ed_probe.sh
+++ b/scripts/eu334/submit_ed_probe.sh
@@ -7,11 +7,12 @@
 # `-o` must name an EXISTING directory or the job never starts.
 #$ -cwd
 #$ -l gpu_1=1
-#$ -l h_rt=2:00:00
+#$ -l h_rt=4:00:00
 #$ -j y
 #$ -o logs/tsubame/
 source "${EU334_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/eu334}/scripts/eu334/_preamble.sh"
 
 export ED_NSTEP="${ED_NSTEP:-25000}"
+export ED_ATOM="${ED_ATOM:-rb87}"
 
 "$SPINORBEC_TSUBAME_JULIA" --project=. scripts/eu334/ed_growth_probe.jl


### PR DESCRIPTION
## 何を分けるか

#418 の停滞（full SPGPE が #334 のランプで N_C を f=0.065 に張り付かせる、growth-only は 0.37）には、測定で除外済みの説明が 3 つあり、残りは「あの構成に固有」でした — **F=6 か、DDI か、ランプか**。

これは 1 つ目を残り 2 つから分けます。スカラー probe の値を全て固定し、**変えたのはスピンだけ**（同じ格子・トラップ・貯槽、DDI off、相互作用は c0 のみ）。

## 結果 — **F=6 は無罪**

| | growth-only (M=0) | full (M≠0) | 差 |
|---|---:|---:|---:|
| **Eu151（F=6, D=13）** | N₀ = 150.1（0.511 N_TF）| N₀ = 144.3（0.491 N_TF）| **3.9 %** |
| Rb87（F=1, D=3）| N₀ = 172.4（0.586 N_TF）| N₀ = 159.7（0.543 N_TF）| 7.4 % |

**両方とも凝縮し、F=6 の差はスカラーより小さい。** #334 のランプの 9〜37 倍とは桁が 2 つ違います。

射影 2 チャネルもここで共通モード — outflow 25.13 対 25.11、truncation 1.747e6 で一致。（D=13 で truncation がスカラーの 4.3 倍なのは、成分が増えれば注ぐノイズも増えるからで、**両腕で同じ**なのが要点です。）

## 実装

`ED_ATOM` は**引数**であって 2 本目のスクリプトではありません — 比較そのものが測定なので、スクリプトが 2 本あると乖離します。

```
bash scripts/eu334/launch.sh ed_probe eu151
bash scripts/eu334/launch.sh ed_probe rb87
```

## 運用上の注意

**2 本を同時に投げると失敗しました。** 同じノードに載り、どちらも起動直後のログ 3 行で止まって見えました — ただし**それは私の誤読**で、実際には走行中でログが未書き出しだっただけです。1 本ずつ投げれば問題ありません。ログの行数で生死を判断しないこと。

🤖 Generated with [Claude Code](https://claude.com/claude-code)