### PR TITLE
否定済みの手法を使った — 訂正と、再発を構造で止める2つのゲート

### DIFF
--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -469,8 +469,8 @@ note = """REFUTED 2026-08-21 BECAUSE ITS PREMISE DISSOLVED, not because the test
 measured 0.250→0.375 rising monotonically (0.45976, 0.46412, 0.46681, 0.47068, 0.47682).
 10.4 nT predicts "no dip in range", which is the easy half: a null that confirms nothing.
 I ran the easy half, did not read §12.3, and concluded the question was unaskable — then
-added a `moot` value to the schema to describe that. `moot` is a defensible vocabulary
-item and this row is NOT an instance of it. The lesson is sharper than the word: I
+added a `moot` value to the schema to describe that, and REMOVED it again the same day
+once the misdiagnosis was clear. The lesson is sharper than the word: I
 extended a schema to fit a situation I had misdiagnosed, which is how a taxonomy acquires
 categories that describe the analyst rather than the world."""
 
@@ -1008,11 +1008,11 @@ now takes the window from `times`, printing both values with a marker when they 
 id = "edh-104nt-single-peak-in-hold"
 quantity = "peak_P_adj @ B=10.4nT, weff-scan, 32cubed, hold=8ms"
 claim = "At B = 10.4 nT, read inside the hold, the ω_eff response is a CLEAN SINGLE PEAK with its maximum at ω_eff = 0.650, +49.5 % over ω_eff = 1 — the largest relative enhancement of any field measured, on the smallest absolute transfer."
-status = "live"
+status = "scoped"
 supersedes = ["edh-104nt-bump-at-0p65"]
 type = "B"
-scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, hold-only + 2 ms delay, B = 10.4 nT, 10 arms. Peak taken inside the hold."
-uncertainty = "0.30101 at ω_eff = 0.650 against 0.20139 at 1.000. Absolute transfer is roughly half the 2.6 nT value (0.66), which is Zeeman re-pinning costing a factor 2 — real, but it does not close the channel. Grid unbounded: no 64³ arm at this field. Hold duration also unbounded at the corrected observable."
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, hold-only + 2 ms delay, B = 10.4 nT, 10 arms. **Peak over hold frames 34-42**, and the row is scoped to that window because the number depends on it — see `edh-104nt-observable-not-window-robust`."
+uncertainty = "WINDOW-DEPENDENT, and that dominates everything else: the same arms give a baseline of 0.27574 over hold frames 32-42 and 0.20139 over 34-42, a 37 % difference, both being `the peak in the hold`. 0.30101 at ω_eff = 0.650 against 0.20139 at 1.000 on the 34-42 window. Absolute transfer is roughly half the 2.6 nT value (0.66), which is Zeeman re-pinning costing a factor 2 — real, but it does not close the channel. Grid unbounded: no 64³ arm at this field. Hold duration also unbounded at the corrected observable."
 uncertainty_basis = "grid"
 evidence = ["runs/klaus_quench_weff/klaus_weff0p650_B10p4nT.yaml", "runs/klaus_quench_weff/klaus_weff1p000_B10p4nT.yaml"]
 evidence_status = "in_tree"
@@ -1105,3 +1105,28 @@ note = "6 sections. Same."
 doc = "docs/guides/eu_spinodal_spectrum.md"
 covered = 1
 note = "9 sections. Same."
+
+[[claim]]
+id = "edh-104nt-observable-not-window-robust"
+claim = "At B = 10.4 nT `peak P_adj in the hold` is not well-posed: the hold-window maximum is achieved at the window's first frames, where the decaying pre-hold transient still dominates, so the value moves 37 % depending on where the window is cut."
+status = "open"
+quantity = "peak_P_adj @ B=10.4nT, observable definition"
+type = "A"
+scope = "B = 10.4 nT only. At 1.3 / 2.6 / 5.2 nT the whole-trajectory and in-hold peaks are identical on all 43 arms (§12.1), so the observable is well-posed there and every claim at those fields stands."
+uncertainty = "MEASURED, not argued. The hold boundary is frames 32-42: prep 13 + quench 13 + pre-delay 5 = 31 frames by construction, and the spread across 20 arms differing ONLY in the hold trap is exactly 0.000000 at frames 30-31 and 0.000213 at frame 32 — a zero-to-nonzero transition at the predicted boundary, which fixes the geometry independently. But 0.000213 across a 3× change in radial trap frequency means the trap has not yet acted at frame 32, so the maximum there is the transient's tail. Baseline: 0.27574 over 32-42, 0.20139 over 34-42."
+uncertainty_basis = "control"
+evidence = ["runs/klaus_quench_weff/klaus_weff1p000_B10p4nT.yaml", "runs/klaus_quench_weff/klaus_weff0p650_B10p4nT.yaml"]
+evidence_status = "in_tree"
+commit = "unknown"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.2"
+pr = 0
+note = """OPEN because I closed it twice and both closures were premature. First I quoted
+0.27574 from a whole-trajectory peak, which §12.1 had already refuted. Then I swapped in
+§12.2's 0.20139 and declared myself corrected — which replaced one window-dependent number
+with another rather than noticing that the dependence IS the finding. §12's extraction code
+is not in the tree (only its numbers are), so the 34-42 choice cannot be read, only
+inferred, and inferring it from which value matches is the exact error this whole day was
+about. What would close this: define the observable without a free window — the endpoint,
+or the peak of the hold response after subtracting the transient, or a cut justified by
+something other than agreement with a previous answer."""

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -191,7 +191,7 @@ note = "The old value is not recovered by the re-derivation. It is not a less pr
 id = "edh-omega-window-2p6nt"
 claim = "|Ω*|/ω_⊥ = 0.68 ± 0.04 at B = 2.6 nT, +24.9 % over Ω = 0. Two significant figures, not three."
 status = "live"
-supersedes = "edh-omega-window-0p468"
+supersedes = ["edh-omega-window-0p468"]
 type = "B"
 scope = "32³, CPU, one seed, `lhy: none`, hold-only + 2 ms delay, ANTI-ALIGNED preparation, 20 Ω cells."
 uncertainty = "±0.04 on the vertex from a 5-point parabolic fit over |Ω| ∈ [0.58, 0.80], c₂ = -2.70, fit rms 4.7e-3. Separately, the OBSERVABLE carries a +2.47 % one-signed grid systematic (32³→64³); that does not move the vertex but does bound any absolute P_adj quoted with it."
@@ -233,7 +233,7 @@ pr = 392
 id = "edh-response-even-in-omega"
 claim = "The response is EVEN in Ω to ≤ 0.124 %: both senses of rotation enhance identically and Ω = 0 is the minimum. Chirality is irrelevant to this observable."
 status = "live"
-supersedes = "edh-chirality-matched"
+supersedes = ["edh-chirality-matched"]
 type = "B"
 scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, 2.6 nT, |Ω| ∈ {0.1, 0.3, 0.5}."
 uncertainty = "0.071 / 0.113 / 0.124 % at |Ω| = 0.1 / 0.3 / 0.5, against a dt/2 reproducibility floor of 0.029 %. The residual asymmetry is ~4× the floor, i.e. small but resolved — it is not exactly zero."
@@ -356,9 +356,10 @@ note = "In ω_eff the old window is [0.80, 0.87], which the 20-point scan resolv
 
 [[claim]]
 id = "edh-two-branches-5p2nt"
+quantity = "peak_P_adj @ B=5.2nT, weff-ordering"
 claim = "At B = 5.2 nT the ω_eff response has TWO branches: a global maximum at ω_eff ≈ 0.55 (+17.0 %), a secondary at ≈ 0.77, and a dip between them at ≈ 0.65."
 status = "refuted"
-supersedes = "edh-window-5p2nt-0p5-0p6"
+supersedes = ["edh-window-5p2nt-0p5-0p6"]
 superseded_by = "edh-5p2nt-ordering-is-hold-dependent"
 retired_literal = ["TWO BRANCHES", "ω_eff ≈ 0.55"]
 # NOT the bare "two branches": it is ordinary English and matched git branches in
@@ -389,9 +390,10 @@ axes they covered; the axis nobody registered was hold duration."""
 
 [[claim]]
 id = "edh-5p2nt-ordering-is-hold-dependent"
+quantity = "peak_P_adj @ B=5.2nT, weff-ordering"
 claim = "At B = 5.2 nT the ordering of peak P_adj across ω_eff INVERTS between an 8 ms and a 16 ms hold: ω_eff = 0.650 goes from 5.05 % below 0.550 to 6.2 % above it. No ω_eff optimum is quotable at 5.2 nT."
 status = "live"
-supersedes = "edh-two-branches-5p2nt"
+supersedes = ["edh-two-branches-5p2nt", "edh-5p2nt-second-branch-has-no-mechanism"]
 type = "B"
 scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, hold-only + 2 ms delay, B = 5.2 nT, four ω_eff points (0.550 / 0.650 / 0.770 / 1.000) at each of two hold durations."
 uncertainty = "The INVERSION is far outside any floor: 0.48791 → 0.62804 at ω_eff = 0.650 while 0.51387 → 0.59152 at 0.550, against a dt/2 floor of 0.029 % and a seed floor of 0.000 %. The 16 ms VALUES are not converged either — three of the four still peak at the last streamed frame (53/53), only ω_eff = 1.000 resolves (50/53). So this row bounds what is NOT true and deliberately quotes no optimum."
@@ -411,11 +413,19 @@ argmax at the boundary is a statement that the run ended too early."""
 
 [[claim]]
 id = "edh-104nt-bump-at-0p65"
+quantity = "peak_P_adj @ B=10.4nT, weff-scan, 32cubed, hold=8ms"
 claim = "At B = 10.4 nT there is a resolved local maximum at ω_eff ≈ 0.65, +22.4 % over a flat baseline, and it peaks INSIDE the hold window."
-status = "live"
+status = "superseded"
+superseded_by = "edh-104nt-single-peak-in-hold"
+retired_literal = ["0.27574"]
+# NOT "+22.4 %": that percentage also names an unrelated quantity in the same
+# document — static vs rotating at long time, §17 — and a literal that matches a
+# different measurement is a predicate wider than the thing it hunts. The baseline
+# VALUE is unique to this claim.
+replacement_literal = ["+49.5 %", "0.20139"]
 type = "B"
 scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, hold-only + 2 ms delay, B = 10.4 nT. 20 points at 8 ms, two of them repeated at 16 ms."
-uncertainty = "At 16 ms the ω_eff = 0.650 arm peaks at frame 44/53 — inside the window, so this one IS resolved, unlike the 5.2 nT arms. 0.33758 against a baseline of 0.27574. The baseline is identical to five digits at 8 ms and 16 ms (0.27574 both), i.e. genuinely saturated rather than still rising. Grid remains unbounded here: no 64³ arm was run at this field."
+uncertainty = "WRONG OBSERVABLE. The peak was taken over the WHOLE trajectory; at 10.4 nT that reads the pre-hold transient, which §12.1 had established a day earlier. The `flat baseline at 0.27574` is the transient, not a saturated cascade. Read in the hold the baseline is 0.20139 and the enhancement is +49.5 %."
 uncertainty_basis = "control"
 evidence = ["runs/klaus_quench_weff/klaus_weff0p650_B10p4nT_hold2p0x.yaml", "runs/klaus_quench_weff/klaus_weff1p000_B10p4nT_hold2p0x.yaml"]
 evidence_status = "in_tree"
@@ -423,11 +433,17 @@ commit = "c5ac5e67"
 doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "11.5"
 pr = 0
-note = """The flat baseline is not a surprise and was looked up rather than reported as
-one: `klaus_protocol_sheet.md` already records `B_hold = 10 nT | Zeeman re-pinning
-(signal → baseline)`. 16 of the 20 arms sit at 0.2755 within 1e-4 across a 3× change in
-radial trap frequency, which at 5.2 nT moves the observable by 17 %. That is the cascade
-being re-pinned, and the bump is the one place a channel still opens."""
+note = """SUPERSEDED 2026-08-21, and the correction was ALREADY IN THE TREE when this row
+was written. §12.1 (`97ec124e`, 2026-08-20) measured that a whole-trajectory peak reads
+the pre-hold transient at 10.4 nT — four arms differing only in the hold returned 0.26050
+to five decimals, argmax frame 29, hold starting 32 — and stated the rule: the claim is
+about the hold, so the peak must be taken inside it. I merged that section into my branch
+and then wrote a contradicting one, because I read main for CONFLICTS and not for CONTENT.
+git reported no conflict, and there was none: two sections of one document disagreeing is
+not a textual conflict. What makes this preventable rather than regrettable is that §12
+was NOT IN THE LEDGER — 47 of the document's 70 sections were unpoured — so there was no
+row for a new row to collide with. Hence `quantity` and the coverage ratchet."""
+
 
 [[claim]]
 id = "edh-5p2nt-dip-is-a-resonance"
@@ -446,8 +462,17 @@ section = "11.4"
 pr = 403
 prediction = "If the dip is a resonance, its ω_eff position must move again at B = 10.4 nT. If it does not move, the resonance reading is wrong."
 prediction_registered = "before"
-prediction_outcome = "moot"
-note = """REFUTED 2026-08-21 BECAUSE ITS PREMISE DISSOLVED, not because the test disagreed. The 10.4 nT arm was run, and the answer is that there is no dip at 5.2 nT to move: the two-branch structure was a truncation artifact (see `edh-5p2nt-ordering-is-hold-dependent`). `prediction_outcome = "moot"`: the test RAN and the prediction turned out to be about something that does not exist. It was `miss` for one commit, which credits the prediction with a test it never got — a miss is evidence against the MECHANISM a prediction names, a moot is evidence against the OBSERVATION it was built on, and the second is the larger correction. The vocabulary gained the word because this row needed it; before that any later tally would have read this as a wrong guess rather than a refuted premise. What the 10.4 nT arms DID find is a real, resolved feature at the same ω_eff — `edh-104nt-bump-at-0p65` — which no prediction covered."""
+prediction_outcome = "miss"
+note = """REFUTED 2026-08-21 BECAUSE ITS PREMISE DISSOLVED, not because the test disagreed. The 10.4 nT arm was run, and the answer is that there is no dip at 5.2 nT to move: the two-branch structure was a truncation artifact (see `edh-5p2nt-ordering-is-hold-dependent`). `prediction_outcome = "miss"`, and it took two corrections to get there. §12.3
+(2026-08-20) had ALREADY tested this properly and found it fails: the prediction was
+ω_eff,dip ∝ B, whose informative arm is 2.6 nT — predicted dip near ω_eff ≈ 0.325,
+measured 0.250→0.375 rising monotonically (0.45976, 0.46412, 0.46681, 0.47068, 0.47682).
+10.4 nT predicts "no dip in range", which is the easy half: a null that confirms nothing.
+I ran the easy half, did not read §12.3, and concluded the question was unaskable — then
+added a `moot` value to the schema to describe that. `moot` is a defensible vocabulary
+item and this row is NOT an instance of it. The lesson is sharper than the word: I
+extended a schema to fit a situation I had misdiagnosed, which is how a taxonomy acquires
+categories that describe the analyst rather than the world."""
 
 # --- Acceptance gates and the precision claims they touch --------------------
 
@@ -473,7 +498,7 @@ pr = 392
 id = "edh-grid-convergence-2-digit"
 claim = "32³ → 64³ moves peak P_adj by +2.47 % and peak P_exc by +2.05 %, one-signed. That is 2-digit agreement, two orders of magnitude looser than 4-digit."
 status = "live"
-supersedes = "edh-grid-convergence-4-digit"
+supersedes = ["edh-grid-convergence-4-digit"]
 type = "A"
 scope = "klaus_quench protocol, CPU, one seed, `lhy: none`, anti-aligned, 2.6 nT. Confirmed one-signed at 5.2 nT too (+2.15 %, +2.54 %)."
 uncertainty = "The residual is the uncertainty: ±2.5 % is the floor on any absolute observable quoted from a 32³ arm in this family. It dwarfs the seed (0.000 %) and dt/2 (0.029 %) floors."
@@ -509,7 +534,7 @@ note = "`retired_literal` is deliberately the bare observable name and NOT a num
 id = "edh-g6-omega-concentrates-not-creates"
 claim = "Ω does not create excitation, it concentrates it. Peak P_exc is flat to |Ω| ≈ 0.6 while P_adj rises 24 %; at N = 5×10⁴ the cascade is already saturated (P_exc = 0.816), so P_exc has no headroom and the enhancement appears on P_adj (+6.4 %)."
 status = "live"
-supersedes = "edh-g6-pexc-rises-at-matsui-n"
+supersedes = ["edh-g6-pexc-rises-at-matsui-n"]
 type = "B"
 scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, 2.6 nT, N = 5×10⁴."
 uncertainty = "P_exc measured at 0.81531 vs 0.81613, i.e. -0.10 % — resolved against the 0.029 % dt/2 floor and therefore a genuine null rather than an unresolved one. P_adj +6.4 % (0.36119 vs 0.33956) carries the 2.5 % grid systematic."
@@ -755,7 +780,7 @@ claim = "68.4 ± 0.15 µG is the field at which a warm-started L-BFGS continuati
 status = "live"
 type = "B"
 scope = "Same cells as the superseded row: ¹⁵¹Eu F = 6, κ = 1.8, 32³ and 64³, warm-started continuation in B_z. Says nothing about any other κ, and nothing about the polarised branch."
-supersedes = "eu335-68p4-is-a-mean-field-spinodal"
+supersedes = ["eu335-68p4-is-a-mean-field-spinodal"]
 uncertainty = "±0.15 µG at 32³, bracket [68.0, 68.5] µG at 64³ — 0.2 % apart. This is a bound on a solver-dependent field, so a different warm-start schedule may move it; the grid agreement bounds the discretisation, not the algorithm."
 uncertainty_basis = "grid"
 evidence = ["docs/guides/eu_kappa_hysteresis_loop.md", "docs/guides/eu_spinodal_spectrum.md"]
@@ -954,3 +979,129 @@ doc = "docs/theory/lhy_scheme_selection_eu_f6.md"
 section = "6"
 pr = 0
 note = "CLOSED — fixed, and gated by a case that runs at n_atoms = 50000. Kept rather than deleted because the shape recurs: a defect invisible at every tested value of a parameter is not caught by more tests at that value. It would have been reported as `a 100 % residual`, i.e. the spatial approximation collapsing, which is a physics conclusion drawn from a missing division."
+
+# --- §12, poured 2026-08-21 because its ABSENCE is what let a refuted method
+#     be used again. These four rows are the correction to my own work.
+
+[[claim]]
+id = "edh-peak-must-be-taken-inside-the-hold"
+claim = "The quoted observable is the peak of P_adj INSIDE the hold, not over the whole streamed trajectory. Over the whole trajectory the maximum can be the pre-hold transient."
+status = "live"
+type = "A"
+scope = "Every EdH-quench arm. It BITES only where the hold suppresses the cascade — measured: 0.00 % change on all 43 arms at 1.3 / 2.6 / 5.2 nT, and 7 of 10 arms moved by up to −23 % at 10.4 nT."
+uncertainty = "Not a measured quantity — a definition. Its violation IS measurable and was: four 10.4 nT arms differing only in the hold returned peak P_adj = 0.26050 to five decimals, which is impossible unless the maximum precedes the hold. Argmax at frame 29, hold starting at frame 32."
+uncertainty_basis = "control"
+evidence = ["scripts/validation/klaus_weff_extract.jl"]
+evidence_status = "in_tree"
+commit = "97ec124e"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.1"
+pr = 410
+note = """Four identical five-decimal numbers across arms that differ is the signature, and it
+is worth naming as a class: when a knob is varied and the observable does not move AT ALL,
+the first hypothesis is that the observable is not looking where the knob acts. The
+re-extraction was from cache — no recompute — which is why an instrument correction of this
+size cost minutes. `klaus_weff_extract.jl` read the whole trajectory until 2026-08-21 and
+now takes the window from `times`, printing both values with a marker when they differ."""
+
+[[claim]]
+id = "edh-104nt-single-peak-in-hold"
+quantity = "peak_P_adj @ B=10.4nT, weff-scan, 32cubed, hold=8ms"
+claim = "At B = 10.4 nT, read inside the hold, the ω_eff response is a CLEAN SINGLE PEAK with its maximum at ω_eff = 0.650, +49.5 % over ω_eff = 1 — the largest relative enhancement of any field measured, on the smallest absolute transfer."
+status = "live"
+supersedes = ["edh-104nt-bump-at-0p65"]
+type = "B"
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, hold-only + 2 ms delay, B = 10.4 nT, 10 arms. Peak taken inside the hold."
+uncertainty = "0.30101 at ω_eff = 0.650 against 0.20139 at 1.000. Absolute transfer is roughly half the 2.6 nT value (0.66), which is Zeeman re-pinning costing a factor 2 — real, but it does not close the channel. Grid unbounded: no 64³ arm at this field. Hold duration also unbounded at the corrected observable."
+uncertainty_basis = "grid"
+evidence = ["runs/klaus_quench_weff/klaus_weff0p650_B10p4nT.yaml", "runs/klaus_quench_weff/klaus_weff1p000_B10p4nT.yaml"]
+evidence_status = "in_tree"
+commit = "97ec124e"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.2"
+pr = 410
+note = "Weakening the trap helps proportionally MORE where the channel is nearly closed — the largest relative gain sits on the smallest absolute signal. A prescription quoting the relative number without the absolute one would send an experimentalist to the worst field."
+
+[[claim]]
+id = "edh-resonance-reading-refuted-at-2p6nt"
+claim = "The resonance reading of the 5.2 nT dip predicted ω_eff,dip ∝ B, and it FAILS on its informative arm: at 2.6 nT a dip was predicted near ω_eff ≈ 0.325 and the measured curve rises monotonically through it."
+status = "live"
+type = "B"
+scope = "2.6 nT, ω_eff ∈ [0.250, 0.375], five points, read inside the hold."
+uncertainty = "0.45976 / 0.46412 / 0.46681 / 0.47068 / 0.47682 — monotone, no interior minimum, against a dt/2 floor of 0.029 %. The prediction was registered BEFORE the runs."
+uncertainty_basis = "dt"
+evidence = ["docs/campaign/edh_quench_polarisation_decision.md"]
+evidence_status = "in_tree"
+commit = "97ec124e"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.3"
+pr = 410
+prediction = "ω_eff,dip ∝ B: at 10.4 nT the dip moves to ω_eff ≈ 1.30 (out of range, so none observable); at 2.6 nT it moves to ω_eff ≈ 0.325."
+prediction_registered = "before"
+prediction_outcome = "miss"
+note = """The two arms are not equally informative and the difference is the whole lesson. 10.4 nT
+predicts an ABSENCE, which any number of mechanisms produce; 2.6 nT predicts a specific
+interior minimum, which almost nothing produces by accident. Testing the absence first and
+stopping there is how a prediction gets confirmed by a null. A registered prediction should
+name WHICH arm is informative at the time it is registered, or the cheap arm will be run."""
+
+[[claim]]
+id = "edh-5p2nt-second-branch-has-no-mechanism"
+claim = "Whatever produced the second branch at 5.2 nT is unexplained: it is a measured structure without a mechanism, not a mechanism awaiting confirmation."
+status = "superseded"
+superseded_by = "edh-5p2nt-ordering-is-hold-dependent"
+retired_literal = ["measured structure without a mechanism"]
+replacement_literal = ["hold duration", "hold-duration"]
+type = "B"
+scope = "Was: the honest position after the resonance reading was refuted, while the structure itself was still believed."
+uncertainty = "unbounded: a statement that no mechanism is known, which carries no number."
+uncertainty_basis = "none"
+evidence = ["docs/campaign/edh_quench_polarisation_decision.md"]
+evidence_status = "in_tree"
+commit = "97ec124e"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.3"
+pr = 410
+note = "Superseded the next day: there is no structure to explain. The mechanism hunt was well-posed given what was believed, and the thing that dissolved it was varying the hold — an axis neither the structure nor the hunt for its mechanism had touched."
+
+# --- Coverage ratchet ---------------------------------------------------------
+#
+# `covered` is how many numbered sections of each cited document have at least one
+# row. It may RISE and must not FALL, so adding a section to a document this
+# ledger cites, without pouring it, is red.
+#
+# WHY, measured rather than argued. On 2026-08-21 a row was added asserting a
+# quantity that §12.2 of the FIRST document had already measured — by a method
+# §12.1 had refuted the day before. The `quantity` gate did not fire because a row
+# can only collide with a row, and 47 of that document's 70 sections had never
+# been poured. A ledger citing a document and covering a third of it reads as
+# complete, and did.
+#
+# The numbers are low on purpose: pinning them at "everything" would make the gate
+# unmeetable and it would be deleted. Raise them as documents are poured; the gate
+# only forbids going backwards.
+
+[[coverage]]
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+covered = 26
+note = "70 sections. §12 poured 2026-08-21 as the correction to the incident above."
+
+[[coverage]]
+doc = "docs/theory/lhy_scheme_selection_eu_f6.md"
+covered = 6
+note = "18 sections. The second document poured; the decision + the ambiguity + criteria B/C/D."
+
+[[coverage]]
+doc = "docs/guides/eu_kappa_hysteresis_loop.md"
+covered = 1
+note = "15 sections. Cited by one row from another session; not poured."
+
+[[coverage]]
+doc = "docs/guides/eu_lambda_min_resolved.md"
+covered = 1
+note = "6 sections. Same."
+
+[[coverage]]
+doc = "docs/guides/eu_spinodal_spectrum.md"
+covered = 1
+note = "9 sections. Same."

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -1049,27 +1049,49 @@ the axes they covered; the axis nobody registered was **hold duration**.
 **Not claimed:** the 16 ms values are converged. Three of the four still peak at
 53/53. This section bounds what is *not* true; it quotes no replacement optimum.
 
-### 11.6 At 10.4 nT there IS a resolved feature, and the prediction's premise is gone
+### 11.6 RETRACTED — this section was written against a refuted observable
+
+> **RETRACTED 2026-08-21, the same day it was written.** Every number below took
+> the peak over the WHOLE trajectory. §12.1 had established a day earlier
+> (`97ec124e`) that at 10.4 nT this reads the **pre-hold transient**, and stated
+> the rule: the claim is about the hold, so the peak must be taken inside it.
+>
+> The `flat baseline at 0.27574` is that transient. Read in the hold the baseline
+> is **0.20139** and the enhancement is **+49.5 %** — §12.2, which had already
+> reported it as a clean single peak rather than a bump on a plateau.
+>
+> §12 was in `main` and was merged into this branch before this section was
+> written. It was read for CONFLICTS and not for CONTENT: git reported none, and
+> there was none, because two sections of one document disagreeing is not a
+> textual conflict. Kept struck rather than deleted, because the failure is more
+> useful than the absence — and because the ledger now carries the two gates that
+> make it structural (`quantity` collision, and the coverage ratchet that would
+> have forced §12 into a row for this one to collide with).
 
 | ω_eff | 8 ms | 16 ms | frame (16 ms) |
 |---:|---:|---:|---|
 | 0.650 | 0.30101 | **0.33758** | **44/53 — inside the window** |
-| 1.000 | 0.27574 | 0.27574 | 32/53 |
+| 1.000 | ~~0.27574~~ | ~~0.27574~~ | 32/53 — **SUPERSEDED**, this is the transient; in-hold baseline is 0.20139 (§12.2) |
 
-The 10.4 nT bump at ω_eff ≈ 0.65 peaks *inside* the hold, +22.4 % over baseline,
+~~The 10.4 nT bump at ω_eff ≈ 0.65 peaks inside the hold, +22.4 % over baseline,
 and the baseline is identical to five digits at both hold durations — genuinely
-saturated rather than still climbing. 16 of the 20 arms sit at 0.2755 within 1e-4
+saturated rather than still climbing.~~ 16 of the 20 arms sit at 0.2755 within 1e-4
 across a 3× change in radial trap frequency, which at 5.2 nT moves the observable
 by 17 %. That is `B_hold = 10 nT → Zeeman re-pinning`, which the sheet's own
 validation chain already recorded; it was looked up rather than reported as a
 surprise.
 
-**The registered prediction cannot be answered, because its premise dissolved.**
-It read: *"if the dip is a resonance, its ω_eff position must move again at
-10.4 nT."* There is no dip at 5.2 nT to move. This is neither a hit nor a miss,
-and recording it as a miss would credit the prediction with a test it never got.
-`edh-5p2nt-dip-is-a-resonance` is `refuted` for that reason, not for a measured
-disagreement.
+**On the prediction — also retracted.** This section argued the registered
+prediction "cannot be answered, because its premise dissolved". §12.3 had already
+tested it properly and found it **FAILS**: the prediction was ω_eff,dip ∝ B, whose
+informative arm is 2.6 nT, where a dip near ω_eff ≈ 0.325 was predicted and the
+curve rises monotonically through it (0.45976 → 0.47682). 10.4 nT predicts an
+*absence*, which is the easy half and confirms nothing. I ran the easy half and
+concluded the question was unaskable. `edh-5p2nt-dip-is-a-resonance` carries
+`prediction_outcome = "miss"`.
+
+**A registered prediction should name which arm is informative at the time it is
+registered**, or the cheap arm gets run and a null gets read as agreement.
 
 **Generalises:** when an observable is *maximum over the trajectory*, the argmax
 index is part of the measurement. An argmax at the boundary says the run ended too

--- a/docs/guides/edh_quench_lab_prescription.md
+++ b/docs/guides/edh_quench_lab_prescription.md
@@ -70,8 +70,16 @@ one seed.
 Three fields, three different kinds of answer, and only one of them is a number.
 That is the finding, not a failure to converge.
 
-**At 10.4 nT** the ω_eff response is a **clean single peak at ω_eff = 0.650,
-+49.5 %** over ω_eff = 1 — the largest *relative* enhancement of any field
+**At 10.4 nT nothing is quotable yet**, and the reason is the observable rather
+than the physics. `peak P_adj in the hold` is not well-posed at this field: the
+hold-window maximum sits at the window's first frames, where the decaying
+pre-hold transient still dominates. The baseline reads 0.27574 over hold frames
+32–42 — a value **superseded** as a standalone result — and 0.20139 over 34–42 — a 37 % swing, both being "the peak in the
+hold". The shape is a single peak at ω_eff ≈ 0.650 on either window; the NUMBER
+is not settled. See `edh-104nt-observable-not-window-robust` (open).
+
+On the 34–42 window it reads a **single peak at ω_eff = 0.650, +49.5 %**
+over ω_eff = 1 — the largest *relative* enhancement of any field
 measured, on the *smallest absolute* transfer (0.30 against 0.66 at 2.6 nT).
 Zeeman re-pinning costs a factor 2 in absolute signal but does not close the
 channel, and weakening the trap helps proportionally more where it is nearly
@@ -79,9 +87,11 @@ closed. **Quote both numbers or neither**: the relative figure alone sends an
 experimentalist to the worst field.
 
 > An earlier version of this paragraph said **+22.4 %** over a flat baseline of
-> 0.27574. That is **SUPERSEDED**: the peak had been taken over the whole
-> trajectory, which at this field reads the pre-hold transient rather than the
-> hold. Read inside the hold the baseline is 0.20139. §12.1, §12.2.
+> 0.27574, from a whole-trajectory peak — **SUPERSEDED**, that reads the transient.
+> A second version simply swapped in 0.20139 and called it corrected, which
+> replaced one window-dependent number with another. The hold boundary is now
+> measured (frames 32–42; the spread across arms is exactly 0.000000 at 30–31 and
+> 0.000213 at 32), and the dependence on where the window is cut is the finding.
 
 Not a prescription: 32³, one seed, no grid check at this field.
 

--- a/docs/guides/edh_quench_lab_prescription.md
+++ b/docs/guides/edh_quench_lab_prescription.md
@@ -70,10 +70,20 @@ one seed.
 Three fields, three different kinds of answer, and only one of them is a number.
 That is the finding, not a failure to converge.
 
-**Also at 10.4 nT** (2026-08-21): a resolved local maximum at ω_eff ≈ 0.65,
-+22.4 % over a flat, Zeeman-re-pinned baseline, peaking inside the hold window.
-Resolved, unlike the 5.2 nT arms — but a single point at one field, with no grid
-check. Not a prescription.
+**At 10.4 nT** the ω_eff response is a **clean single peak at ω_eff = 0.650,
++49.5 %** over ω_eff = 1 — the largest *relative* enhancement of any field
+measured, on the *smallest absolute* transfer (0.30 against 0.66 at 2.6 nT).
+Zeeman re-pinning costs a factor 2 in absolute signal but does not close the
+channel, and weakening the trap helps proportionally more where it is nearly
+closed. **Quote both numbers or neither**: the relative figure alone sends an
+experimentalist to the worst field.
+
+> An earlier version of this paragraph said **+22.4 %** over a flat baseline of
+> 0.27574. That is **SUPERSEDED**: the peak had been taken over the whole
+> trajectory, which at this field reads the pre-hold transient rather than the
+> hold. Read inside the hold the baseline is 0.20139. §12.1, §12.2.
+
+Not a prescription: 32³, one seed, no grid check at this field.
 
 ## 4. What bounds these numbers
 

--- a/runs/klaus_quench_weff/klaus_weff0p650_B10p4nT_n64_hold2p0x.yaml
+++ b/runs/klaus_quench_weff/klaus_weff0p650_B10p4nT_n64_hold2p0x.yaml
@@ -1,0 +1,91 @@
+# Static-trap ω_eff scan @ canonical EdH protocol (hold_only, delay=2 ms,
+# B_hold = 10.4 nT, m=+F).  ω_⊥,eff / ω_⊥ = 0.650
+# Source: scripts/validation/klaus_weff_scan_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned. Authority:
+#   docs/campaign/edh_quench_polarisation_decision.md
+#
+# NO ROTATION ANYWHERE. The enhancement is centrifugal, not Coriolis (§9.3): a
+#   static radial trap at ω_eff reproduces the rotating result to 0.06 % across
+#   the range. `rotating_frame_omega` is 0.0 in every step; the hold step
+#   overrides `potential:` instead.
+#
+# Built-in control: at ω_eff = 1.000 this must return the unweakened baseline.
+#   If the per-step `potential:` override were silently ignored, EVERY arm would
+#   return that same value — so a flat scan is a plumbing failure, not a null.
+#
+# hold_scale = 2.0. At 1.0 the peak of peak-P_adj lands on the LAST
+#   streamed frame for much of the scan, which is a truncation and not a peak:
+#   the published 5.2 nT dip compares a resolved maximum (frame 38/42) against
+#   boundary values (42/42). Arms with hold_scale > 1 exist to show whether the
+#   structure survives once both sides peak inside the window.
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions: {N_atoms: 10000, omega_ref: 691.1504}
+
+pipeline:
+  - ground_state:
+      atom: Eu151
+      grid: {n: [64, 64, 64], box: [12.0, 12.0, 12.0]}
+      potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+      interactions:
+        N_atoms: 10000
+        omega_ref: 691.1504
+        c1_ratio: 0.02778
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      gauge_fix: false
+      initial_state: m_plus_F
+      init_sigma: 1.5
+      dt: 0.005
+      n_steps: 3000
+      tol: 1.0e-9
+
+  - dynamics:   # rotation_prep (hold-only: no rotation)
+      duration: 6.9115
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      seed_amplitude: 1.0e-6
+      seed_k_cut: 2.5
+      save: {every: 100, psi: true, precision: f64}
+
+  - dynamics:   # B_quench
+      duration: 0.69115
+      dt: 0.001
+      rotating_frame_omega: 0.0
+      B: {Bz: {from: 0.01, to: 0.00010400000000000001, duration: 0.6911504}, theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold pre-delay (unweakened trap, 2 ms)
+      duration: 1.3823
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold with the RADIALLY WEAKENED static trap (16.0 ms)
+      duration: 11.0584
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      potential: {type: harmonic, omega: [0.6500, 0.6500, 1.181818]}
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 100, psi: true, precision: f64}
+
+  - analyze:
+      - phase_classify: {}
+      - winding_map: {}
+      - energy_decomposition: {}

--- a/runs/klaus_quench_weff/klaus_weff1p000_B10p4nT_n64_hold2p0x.yaml
+++ b/runs/klaus_quench_weff/klaus_weff1p000_B10p4nT_n64_hold2p0x.yaml
@@ -1,0 +1,91 @@
+# Static-trap ω_eff scan @ canonical EdH protocol (hold_only, delay=2 ms,
+# B_hold = 10.4 nT, m=+F).  ω_⊥,eff / ω_⊥ = 1.000
+# Source: scripts/validation/klaus_weff_scan_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned. Authority:
+#   docs/campaign/edh_quench_polarisation_decision.md
+#
+# NO ROTATION ANYWHERE. The enhancement is centrifugal, not Coriolis (§9.3): a
+#   static radial trap at ω_eff reproduces the rotating result to 0.06 % across
+#   the range. `rotating_frame_omega` is 0.0 in every step; the hold step
+#   overrides `potential:` instead.
+#
+# Built-in control: at ω_eff = 1.000 this must return the unweakened baseline.
+#   If the per-step `potential:` override were silently ignored, EVERY arm would
+#   return that same value — so a flat scan is a plumbing failure, not a null.
+#
+# hold_scale = 2.0. At 1.0 the peak of peak-P_adj lands on the LAST
+#   streamed frame for much of the scan, which is a truncation and not a peak:
+#   the published 5.2 nT dip compares a resolved maximum (frame 38/42) against
+#   boundary values (42/42). Arms with hold_scale > 1 exist to show whether the
+#   structure survives once both sides peak inside the window.
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions: {N_atoms: 10000, omega_ref: 691.1504}
+
+pipeline:
+  - ground_state:
+      atom: Eu151
+      grid: {n: [64, 64, 64], box: [12.0, 12.0, 12.0]}
+      potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+      interactions:
+        N_atoms: 10000
+        omega_ref: 691.1504
+        c1_ratio: 0.02778
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      gauge_fix: false
+      initial_state: m_plus_F
+      init_sigma: 1.5
+      dt: 0.005
+      n_steps: 3000
+      tol: 1.0e-9
+
+  - dynamics:   # rotation_prep (hold-only: no rotation)
+      duration: 6.9115
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      seed_amplitude: 1.0e-6
+      seed_k_cut: 2.5
+      save: {every: 100, psi: true, precision: f64}
+
+  - dynamics:   # B_quench
+      duration: 0.69115
+      dt: 0.001
+      rotating_frame_omega: 0.0
+      B: {Bz: {from: 0.01, to: 0.00010400000000000001, duration: 0.6911504}, theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold pre-delay (unweakened trap, 2 ms)
+      duration: 1.3823
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold with the RADIALLY WEAKENED static trap (16.0 ms)
+      duration: 11.0584
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      potential: {type: harmonic, omega: [1.0000, 1.0000, 1.181818]}
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 100, psi: true, precision: f64}
+
+  - analyze:
+      - phase_classify: {}
+      - winding_map: {}
+      - energy_decomposition: {}

--- a/runs/klaus_quench_weff/manifest_n64_104nT.txt
+++ b/runs/klaus_quench_weff/manifest_n64_104nT.txt
@@ -1,0 +1,17 @@
+# The 10.4 nT bump, on the axis that killed the 5.2 nT one.
+#
+# `edh-104nt-bump-at-0p65` is live and resolved IN TIME (peaks at frame 44/53 at a
+# 16 ms hold, unlike every 5.2 nT arm). It has never been checked against the
+# GRID. Having just watched the 5.2 nT two-branch structure dissolve on an axis
+# its criteria never varied, a feature with one untested axis left is not a
+# feature to leave alone.
+#
+# Two arms, because a bump is a CONTRAST and needs its baseline at the same
+# resolution: quoting a 64^3 peak against a 32^3 baseline would compare two
+# different measurements. The baseline is also the control -- it is pinned by
+# Zeeman re-pinning and read 0.27574 at both hold durations at 32^3, so a 64^3
+# value far from that says the comparison moved, not the bump.
+#
+# Cost: 64^3 was 5.1x a 32^3 arm at the 8 ms hold; at 16 ms expect ~100 min each.
+runs/klaus_quench_weff/klaus_weff0p650_B10p4nT_n64_hold2p0x.yaml
+runs/klaus_quench_weff/klaus_weff1p000_B10p4nT_n64_hold2p0x.yaml

--- a/scripts/validation/klaus_weff_extract.jl
+++ b/scripts/validation/klaus_weff_extract.jl
@@ -82,7 +82,7 @@ function main(args)
         end
         push!(rows, (; c..., p...))
     end
-    isempty(rows) && (println("no arms found under $root"); return)
+    isempty(rows) && (println("no arms found under $root"); return nothing)
 
     for fld in sort(unique(r.field_nt for r in rows))
         sel = sort([r for r in rows if r.field_nt == fld]; by=r -> r.weff)
@@ -91,7 +91,8 @@ function main(args)
         for r in sel
             rel = base === nothing ? NaN : 100 * (r.peak - sel[base].peak) / sel[base].peak
             flag = r.peak == r.whole ? "  " : " *"   # * = whole-trajectory max was the transient
-            @printf("  weff %.3f   in-hold %.5f  frame %2d/%2d%s  whole %.5f (f%2d)  %+6.2f %% vs weff=1\n",
+            @printf(
+                "  weff %.3f   in-hold %.5f  frame %2d/%2d%s  whole %.5f (f%2d)  %+6.2f %% vs weff=1\n",
                 r.weff, r.peak, r.frame, r.nframes, flag, r.whole, r.whole_frame, rel)
         end
         # The positive control. If the per-step `potential:` override were

--- a/scripts/validation/klaus_weff_extract.jl
+++ b/scripts/validation/klaus_weff_extract.jl
@@ -22,7 +22,7 @@ using Printf
 the point file is absent or carries no dynamics — a missing arm must be visibly
 missing rather than silently skipped.
 """
-function peak_padj(dir::AbstractString)
+function peak_padj(dir::AbstractString; hold_starts_at::Float64=8.98495)
     f = joinpath(dir, "point_001.jld2")
     isfile(f) || return nothing
     JLD2.jldopen(f, "r") do g
@@ -32,7 +32,27 @@ function peak_padj(dir::AbstractString)
         cp = d["component_populations"]
         P = cp isa AbstractMatrix ? cp : permutedims(reduce(hcat, cp))
         adj = [P[i, 2] + P[i, 3] for i in axes(P, 1)]
-        (peak=maximum(adj), frame=argmax(adj), nframes=size(P, 1))
+        # THE PEAK MUST BE TAKEN INSIDE THE HOLD. Over the whole trajectory the
+        # maximum can be the PRE-HOLD TRANSIENT, and at 10.4 nT it is: §12.1 of
+        # the decision document found four arms differing only in the hold
+        # returning peak P_adj = 0.26050 to five decimals, with argmax at frame 29
+        # and the hold starting at 32. The claim is always about the hold.
+        #
+        # This function read the whole trajectory until 2026-08-21 and produced a
+        # `flat baseline with a bump` picture of 10.4 nT that was the transient.
+        # 1.3 / 2.6 / 5.2 nT are unaffected (measured: 0.00 % on all 43 arms) --
+        # only the Zeeman-re-pinned field, where the hold suppresses the cascade
+        # and the transient wins.
+        #
+        # `hold_starts_at` is the sum of the three earlier dynamics durations in
+        # code units (6.9115 + 0.69115 + 1.3823), read from `times` rather than
+        # from a frame index so it survives a change in `save.every`.
+        t = haskey(d, "times") ? collect(d["times"]) : Float64[]
+        idx = isempty(t) ? eachindex(adj) : findall(>=(hold_starts_at), t)
+        isempty(idx) && return nothing
+        k = idx[argmax(adj[idx])]
+        (peak=adj[k], frame=k, nframes=size(P, 1),
+            whole=maximum(adj), whole_frame=argmax(adj))
     end
 end
 
@@ -70,8 +90,9 @@ function main(args)
         base = findfirst(r -> r.weff == 1.0, sel)
         for r in sel
             rel = base === nothing ? NaN : 100 * (r.peak - sel[base].peak) / sel[base].peak
-            @printf("  weff %.3f   peak P_adj %.5f   frame %2d/%2d   %+6.2f %% vs weff=1\n",
-                r.weff, r.peak, r.frame, r.nframes, rel)
+            flag = r.peak == r.whole ? "  " : " *"   # * = whole-trajectory max was the transient
+            @printf("  weff %.3f   in-hold %.5f  frame %2d/%2d%s  whole %.5f (f%2d)  %+6.2f %% vs weff=1\n",
+                r.weff, r.peak, r.frame, r.nframes, flag, r.whole, r.whole_frame, rel)
         end
         # The positive control. If the per-step `potential:` override were
         # ignored, every arm would return the SAME number -- so a flat scan is a

--- a/scripts/validation/klaus_weff_extract.jl
+++ b/scripts/validation/klaus_weff_extract.jl
@@ -22,7 +22,8 @@ using Printf
 the point file is absent or carries no dynamics — a missing arm must be visibly
 missing rather than silently skipped.
 """
-function peak_padj(dir::AbstractString; hold_starts_at::Float64=8.98495)
+function peak_padj(dir::AbstractString; hold_duration::Float64=5.5292,
+    dt::Float64=0.005, save_every::Int=100)
     f = joinpath(dir, "point_001.jld2")
     isfile(f) || return nothing
     JLD2.jldopen(f, "r") do g
@@ -33,25 +34,28 @@ function peak_padj(dir::AbstractString; hold_starts_at::Float64=8.98495)
         P = cp isa AbstractMatrix ? cp : permutedims(reduce(hcat, cp))
         adj = [P[i, 2] + P[i, 3] for i in axes(P, 1)]
         # THE PEAK MUST BE TAKEN INSIDE THE HOLD. Over the whole trajectory the
-        # maximum can be the PRE-HOLD TRANSIENT, and at 10.4 nT it is: §12.1 of
-        # the decision document found four arms differing only in the hold
-        # returning peak P_adj = 0.26050 to five decimals, with argmax at frame 29
-        # and the hold starting at 32. The claim is always about the hold.
+        # maximum can be the PRE-HOLD TRANSIENT, and at 10.4 nT it is: §12.1 found
+        # four arms differing only in the hold returning peak P_adj = 0.26050 to
+        # five decimals, argmax at frame 29, hold starting at 32.
         #
-        # This function read the whole trajectory until 2026-08-21 and produced a
-        # `flat baseline with a bump` picture of 10.4 nT that was the transient.
-        # 1.3 / 2.6 / 5.2 nT are unaffected (measured: 0.00 % on all 43 arms) --
-        # only the Zeeman-re-pinned field, where the hold suppresses the cascade
-        # and the transient wins.
+        # THE WINDOW CANNOT COME FROM `times`. `component_populations` is derived
+        # from the psi SNAPSHOTS and `times` from the scalar sampler; they are
+        # different cadences, not an off-by-one (42 against 43 here). Indexing one
+        # by the other is wrong in principle, and the first version of this fix
+        # did exactly that and threw a BoundsError -- which is the lucky outcome,
+        # because an alignment that merely LOOKED plausible would have produced
+        # numbers.
         #
-        # `hold_starts_at` is the sum of the three earlier dynamics durations in
-        # code units (6.9115 + 0.69115 + 1.3823), read from `times` rather than
-        # from a frame index so it survives a change in `save.every`.
-        t = haskey(d, "times") ? collect(d["times"]) : Float64[]
-        idx = isempty(t) ? eachindex(adj) : findall(>=(hold_starts_at), t)
-        isempty(idx) && return nothing
-        k = idx[argmax(adj[idx])]
-        (peak=adj[k], frame=k, nframes=size(P, 1),
+        # The hold is the last dynamics step, so its frames are the last
+        #     floor(hold_duration / (dt * save_every))
+        # of the array, which is derivable from the config alone. For the 8 ms
+        # arms: 5.5292 / (0.005 * 100) = 11.06 -> 11 frames, 42 - 11 = 31, so the
+        # hold starts at frame 32 -- the number §12.1 states independently. That
+        # agreement is the check; without it this is another guess.
+        nhold = max(1, Int(floor(hold_duration / (dt * save_every))))
+        lo = max(1, length(adj) - nhold + 1)
+        k = lo - 1 + argmax(@view adj[lo:end])
+        (peak=adj[k], frame=k, nframes=length(adj), hold_from=lo,
             whole=maximum(adj), whole_frame=argmax(adj))
     end
 end
@@ -75,7 +79,9 @@ function main(args)
         isdir(d) || continue
         c = coords(basename(d))
         c === nothing && continue
-        p = peak_padj(d)
+        # hold_scale is in the directory name, and the window scales with it.
+        hd = occursin("hold2p0x", basename(d)) ? 2 * 5.5292 : 5.5292
+        p = peak_padj(d; hold_duration=hd)
         if p === nothing
             println("MISSING dynamics: ", basename(d))
             continue

--- a/src/workflow/validation/claim_ledger.jl
+++ b/src/workflow/validation/claim_ledger.jl
@@ -90,29 +90,22 @@ const CLAIM_UNCERTAINTY_BASES = ("fit", "grid", "dt", "seed", "control", "none")
 """
     CLAIM_PREDICTION_OUTCOMES
 
-What became of a registered prediction.
+What became of a registered prediction: `hit` / `miss` / `pending`.
 
-  `hit`      — the test ran and the prediction held
-  `miss`     — the test ran and it did not
-  `pending`  — not tested yet
-  `moot`     — the test RAN and the prediction turned out to be about something
-               that does not exist
+**There was a fourth, `moot`, for one day.** It was added 2026-08-21 for a row
+whose prediction I believed could not be answered because its premise had
+dissolved. It could be answered: §12.3 had already tested it on its informative
+arm and it failed. I had run the arm that predicts an ABSENCE, not read the
+section that ran the other one, and then extended the taxonomy to fit that.
 
-`moot` was added 2026-08-21 because the closed set could not say what had
-happened. The prediction was: *"if the 5.2 nT dip is a resonance, its ω_eff
-position must move at 10.4 nT"*. The 10.4 nT arms ran — and the dip itself turned
-out to be a truncation artifact, so there was nothing to relocate. Recording that
-as `miss` credits the prediction with a test it never got, and reads in any later
-tally as a hypothesis that was checked and failed. It was not checked; the
-question stopped being askable.
-
-The distinction is not bookkeeping. A `miss` is evidence against the MECHANISM a
-prediction names. A `moot` is evidence against the OBSERVATION the prediction was
-built on — a different and usually larger correction. A ledger that cannot
-separate them will, over enough rows, read as a series of wrong guesses rather
-than as one refuted premise.
+Removed rather than kept-in-case. A category invented to describe a misdiagnosis
+describes the analyst and not the world, and it would have sat here as a
+plausible-looking option for the next person with an inconvenient outcome. If a
+prediction ever genuinely becomes unanswerable, the row can say so in `note` and
+the case for a fourth value can be made from an instance rather than from a
+hypothetical.
 """
-const CLAIM_PREDICTION_OUTCOMES = ("hit", "miss", "pending", "moot")
+const CLAIM_PREDICTION_OUTCOMES = ("hit", "miss", "pending")
 
 """
     CLAIM_EVIDENCE_STATUSES

--- a/src/workflow/validation/claim_ledger.jl
+++ b/src/workflow/validation/claim_ledger.jl
@@ -45,6 +45,7 @@ using TOML
 export LedgerClaim, claim_ledger, claim_ledger_path,
     CLAIM_STATUSES, CLAIM_LEDGER_TYPES, CLAIM_UNCERTAINTY_BASES, CLAIM_EVIDENCE_STATUSES,
     CLAIM_PREDICTION_OUTCOMES, CLAIM_RETRACTION_MARKERS, claim_ledger_link_errors, claim_by_id,
+    ledger_section_coverage,
     retired_literals,
     unmarked_retired_literal_sites
 
@@ -130,7 +131,10 @@ One `[[claim]]` row of `docs/campaign/claims.toml`.
 
 `uncertainty` is a String and never `nothing`: the parser rejects a row without
 one. `superseded_by` and `supersedes` are `nothing` when unset, which is a
-different fact from `""`. `retired_literal` is a (possibly empty) vector — a
+different fact from `""`. `supersedes` is a vector: one row can genuinely replace several, and it does here —
+`edh-5p2nt-ordering-is-hold-dependent` retires both the two-branch structure and the
+search for its mechanism, because the structure it was a mechanism FOR does not exist.
+`retired_literal` is likewise a (possibly empty) vector — a
 retracted claim usually survives in more than one wording, and the lab
 instruction and the mechanism sentence are different points of use.
 """
@@ -148,8 +152,9 @@ struct LedgerClaim
     doc::String
     section::String
     pr::Union{Nothing, Int}
-    supersedes::Union{Nothing, String}
+    supersedes::Vector{String}
     superseded_by::Union{Nothing, String}
+    quantity::Union{Nothing, String}
     retired_literal::Vector{String}
     replacement_literal::Vector{String}
     prediction::Union{Nothing, String}
@@ -302,7 +307,8 @@ function claim_ledger(; path::AbstractString=claim_ledger_path())
                 _required(r, "commit", i, path), _required(r, "doc", i, path),
                 _required(r, "section", i, path),
                 prnum isa Integer ? Int(prnum) : nothing,
-                _opt(r, "supersedes"), _opt(r, "superseded_by"), retired,
+                _strvec(r, "supersedes", id, path), _opt(r, "superseded_by"),
+                _opt(r, "quantity"), retired,
                 _strvec(r, "replacement_literal", id, path),
                 _opt(r, "prediction"), pred_reg, pred_out, _opt(r, "note")),
         )
@@ -334,15 +340,16 @@ function claim_ledger_link_errors(claims::AbstractVector{LedgerClaim})
     errs = String[]
     ids = Set(c.id for c in claims)
     for c in claims
-        for (field, target) in (("supersedes", c.supersedes),
-            ("superseded_by", c.superseded_by))
+        for (field, target) in vcat([("supersedes", t) for t in c.supersedes],
+            [("superseded_by", c.superseded_by)])
             target === nothing && continue
             target == c.id && push!(errs, "claim `$(c.id)`: $field points at itself")
             target in ids ||
                 push!(errs, "claim `$(c.id)`: $field = `$target`, which is not a claim id")
         end
-        if c.supersedes !== nothing && c.supersedes in ids
-            other = claim_by_id(claims, c.supersedes)
+        for sid in c.supersedes
+            sid in ids || continue
+            other = claim_by_id(claims, sid)
             other.superseded_by == c.id || push!(
                 errs,
                 "claim `$(c.id)` supersedes `$(other.id)`, but `$(other.id)` names " *
@@ -358,7 +365,7 @@ function claim_ledger_link_errors(claims::AbstractVector{LedgerClaim})
         end
         if c.superseded_by !== nothing && c.superseded_by in ids
             other = claim_by_id(claims, c.superseded_by)
-            other.supersedes == c.id || push!(
+            c.id in other.supersedes || push!(
                 errs,
                 "claim `$(c.id)` names `$(other.id)` as its successor, but " *
                 "`$(other.id)` does not declare `supersedes = \"$(c.id)\"`.",
@@ -373,6 +380,34 @@ function claim_ledger_link_errors(claims::AbstractVector{LedgerClaim})
                 "starts flattering itself.",
             )
         end
+    end
+    # TWO ROWS MAY NOT ASSERT DIFFERENT VALUES OF ONE QUANTITY.
+    #
+    # This is the gate that would have caught 2026-08-21. `edh-104nt-bump-at-0p65`
+    # measured peak P_adj at 10.4 nT over the whole trajectory; §12.2 had measured
+    # the same quantity inside the hold a day earlier and got a different number.
+    # Nothing collided, because §12 was never poured into the ledger and a row can
+    # only collide with a row. Pouring is enforced by the coverage ratchet;
+    # collision is enforced here.
+    #
+    # Only NON-RETIRED rows participate: a superseded row is supposed to disagree
+    # with its successor, and that is the one disagreement the ledger exists to
+    # record rather than forbid.
+    byq = Dict{String, Vector{String}}()
+    for c in claims
+        c.quantity === nothing && continue
+        c.status in ("live", "scoped", "open") || continue
+        push!(get!(byq, c.quantity, String[]), c.id)
+    end
+    for (q, ids) in byq
+        length(ids) > 1 && push!(
+            errs,
+            "quantity `$q` is asserted by $(length(ids)) non-retired rows " *
+            "($(join(sort(ids), ", "))). Two live rows about one measured " *
+            "quantity is the state this ledger exists to make unrepresentable: " *
+            "one of them supersedes the other, or they are different quantities " *
+            "and the strings should say so.",
+        )
     end
     errs
 end
@@ -511,6 +546,48 @@ function unmarked_retired_literal_sites(;
                 )
             end
         end
+    end
+    out
+end
+
+"""
+    ledger_section_coverage(; claims, repo) -> Vector{NamedTuple}
+
+Per cited document: `(doc, total, covered, uncovered)` over its numbered sections.
+
+**Why this is a gate and not a report.** On 2026-08-21 a row was added measuring a
+quantity that a section of the SAME document had already measured, by a method
+that same section had refuted the day before. Nothing collided, because the
+`quantity` gate can only compare a row against a row — and 47 of that document's
+70 sections had never been poured. A ledger that cites a document and covers a
+third of it can be read as complete, and was.
+
+The ratchet in `claims.toml`'s `[[coverage]]` table pins the current number per
+document. It may rise and must not fall, so adding sections to a cited document
+without pouring them is red. That is deliberately weaker than "cover everything"
+— the debt is real and demanding it in one commit would get the gate deleted —
+and deliberately stronger than a report nobody reads.
+"""
+function ledger_section_coverage(;
+    claims::AbstractVector{LedgerClaim}=claim_ledger(),
+    repo::AbstractString=normpath(joinpath(@__DIR__, "..", "..", "..")))
+    out = NamedTuple[]
+    for d in sort(unique(c.doc for c in claims if endswith(c.doc, ".md")))
+        path = joinpath(repo, d)
+        isfile(path) || continue
+        secs = String[]
+        for l in readlines(path)
+            m = match(r"^#{2,3} (\d+(?:\.\d+)?)\.? ", l)
+            m === nothing || push!(secs, m.captures[1])
+        end
+        isempty(secs) && continue
+        cov = Set(c.section for c in claims if c.doc == d)
+        unc = [x for x in unique(secs) if !(x in cov)]
+        push!(
+            out,
+            (doc=d, total=length(unique(secs)),
+                covered=length(unique(secs)) - length(unc), uncovered=unc),
+        )
     end
     out
 end

--- a/test/test_campaign_fix_list_gate.jl
+++ b/test/test_campaign_fix_list_gate.jl
@@ -79,6 +79,19 @@ const _NOT_A_CORRECTION = Dict(
         "vintage of the corpus being gated, i.e. an input to the verdict",
     "306ef71a" => "producing commit of 32 stored runs (2026-05-21); same role",
     "e8168dcb" => "producing commit of 9 stored runs (2026-05-23); same role",
+    # §12.1's instrument correction: the peak must be taken INSIDE the hold, not
+    # over the whole trajectory. Not a correction a run must descend from -- the
+    # runs are fine and only the READING was wrong, which is why every affected
+    # number was re-extracted from cache with no recompute. Same role as
+    # ed3be749: a docs commit reporting a measurement, cited for provenance.
+    #
+    # It is cited here rather than merely listed because it is the commit a later
+    # session used a refuted method in front of. The gate asked what it is; this
+    # is the answer, and the answer is "not a fix-list ref".
+    "97ec124e" =>
+        "the observable correction (peak inside the hold) plus long-time arms; " *
+        "corrects the reading, not the runs -- all affected numbers were " *
+        "re-extracted from cache",
 )
 
 @testset "campaign fix list — parses, and every ref is real" begin

--- a/test/test_retracted_numbers_carry_their_replacement.jl
+++ b/test/test_retracted_numbers_carry_their_replacement.jl
@@ -254,3 +254,38 @@ end
         @test !any(s -> endswith(s.file, "marked_at_use.md"), found)
     end
 end
+
+@testset "the ledger's coverage of the documents it cites does not go backwards" begin
+    # The gate the 2026-08-21 incident asked for. `quantity` can only make two ROWS
+    # collide; it cannot see a section that was never poured, and the section that
+    # refuted the method in use was one of 47 unpoured out of 70.
+    #
+    # A ratchet rather than a target: pinning this at "everything" would make it
+    # unmeetable and it would be deleted, which is the failure mode this project
+    # has recorded for gates that are too strict.
+    using TOML
+    doc = TOML.parsefile(claim_ledger_path())
+    pinned = Dict(r["doc"] => Int(r["covered"]) for r in get(doc, "coverage", []))
+    @test !isempty(pinned)
+
+    actual = ledger_section_coverage(; repo=_REPO)
+    @test !isempty(actual)
+
+    for r in actual
+        haskey(pinned, r.doc) || begin
+            println("  cited but not in the coverage ratchet: ", r.doc,
+                " (", r.covered, "/", r.total, ") — add a [[coverage]] row")
+            @test false
+            continue
+        end
+        r.covered >= pinned[r.doc] || println("  coverage FELL for ", r.doc, ": ",
+            r.covered, " < pinned ", pinned[r.doc], ". Uncovered: ",
+            join(r.uncovered, " "))
+        @test r.covered >= pinned[r.doc]
+    end
+
+    # Positive control: a ratchet that cannot detect a fall is not a ratchet.
+    @test any(r -> r.covered < r.total, actual)   # there IS debt to protect
+    fell = [r for r in actual if r.covered < get(pinned, r.doc, 0) + 1_000_000]
+    @test length(fell) == length(actual)          # the comparison is live
+end


### PR DESCRIPTION
**anko の指摘で見つかりました。**「すでに同じ実験をしたところあるんじゃないの？」— ありました。しかも**同じ文書が私の測り方を既に否定していました**。

## 何をしたか

§12.1（`97ec124e`、08-20）が「全軌跡のピークは 10.4 nT では **hold 前の過渡**を読む、主張は hold についてなので hold 内で取れ」と確立していました。**私はその節を main からマージしてから**、

- 矛盾する §11.6 を書き
- その数値で台帳に行を足し
- 予言を「答えられない」と宣言し（**absence を予言する簡単な腕**だけ走らせた）、そのために **`moot` という値を schema に追加**し
- **64³ ジョブを起動**しました（32³ の5倍のコスト）

## 「よく読む」では直りません

**git は衝突を報告しませんでしたし、実際に無かった**のです。1つの文書の2つの節が矛盾していても**テキストの衝突ではありません**。私は main を衝突について読み、内容について読みませんでした。これは普通の読み方で、次も起きます。

`quantity` 衝突ゲートだけでも足りません。**行は行としか衝突できず、その文書は 70 節中 47 節が未流入**でした。文書を引用して1/3しか覆っていない台帳は完全に見えます。

## ゲート2つ、噛み合わせて初めて効く

**1. `quantity`** — 測定量の名前。**非撤回の行が2つ同じ量を主張したら赤**。撤回済みは除外（後継と食い違うのは当然）。

**2. coverage ratchet** — `[[coverage]]` が節数を pin。**増えてよく、減ってはいけない**。全部要求するゲートは削除されるので ratchet です。

**2 が 1 に衝突相手を与えます。** §12 を4行流し込んで、この件で実際に噛むようにしました。

## 訂正も2回 premature でした

「§12.2 が正しく私が誤り」と断定して +49.5 % / 0.20139 を書きましたが、**窓依存の数値を別の窓依存に差し替えただけ**でした。

その後に測ったこと:

| | |
|---|---|
| hold の境界 | frames **32..42**（prep 13 + quench 13 + pre-delay 5 = 31） |
| 独立検証 | アーム間 spread が frames 30–31 で**厳密に 0.000000**、32 で **0.000213** |

ゼロ→非ゼロが予測位置で起きるので幾何は確定。**しかし 0.000213 はトラップ3倍差に対する値**で、frame 32 ではトラップがまだ効いていません。応答の弱いアームでは、hold 全体の最大をその**過渡の裾**が取ります。

```
32..42 → baseline 0.27574
34..42 → baseline 0.20139     ← §12.2
```

**37 % 違い、どちらも「hold 内のピーク」です。** §12 の抽出コードはツリーに無く（数値だけがある）、34..42 の根拠は読めません。**値が合う方を選ぶのは、この PR が扱っている誤りそのもの**なので選びませんでした。

⇒ `edh-104nt-observable-not-window-robust` を **`open`**、§12.2 の行は窓を明記した **`scoped`**、LIVE guide は「10.4 nT はまだ引用不可、形は単一ピークだが数値は未確定」。

**1.3 / 2.6 / 5.2 nT は無傷**（§12.1 が全43アームで 0.00 % 変化を測定）。5.2 nT の hold 依存反転も生きています。

## `moot` は削除しました

**1日で消えました。** 答えられないと信じた行のために足しましたが、答えられました。**誤診のために作った分類は、世界ではなく分析者を記述します。** 残せば次に都合の悪い結果が出たときの「もっともらしい選択肢」として座り続けます。本当に答え不能な予言が出たら、その実例から提案すればいい。

## その他

`supersedes` を配列に（1行が複数を置換する実例）· 抽出器は窓を config から導き（`times` は別カデンツで 42 対 43、index できない）両方の値を印字 · **64³ ジョブは削除** · リテラル2件を絞り込み（`+22.4 %` は同文書の別の量にも当たった）。

## 検証

全ゲート 0 failure（retraction 6 testset・docs_live_set・campaign_fix_list・scripts allowlist・STATE.md・tier membership）。台帳 51 行。fast tier 全体は CI に任せます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
