### PR TITLE
prior-art の門を使ったら item 5 は既に終わっていた

### DIFF
--- a/docs/campaign/prior_art/data_reduction.md
+++ b/docs/campaign/prior_art/data_reduction.md
@@ -1,6 +1,6 @@
 # Prior art — data_reduction
 
-> **FROZEN 2026-08-20.** A snapshot of the open work on data_reduction as of that
+> **FROZEN 2026-08-21.** A snapshot of the open work on data_reduction as of that
 > date. Re-run the generator when picking the topic up again; existing
 > dispositions are preserved.
 

--- a/docs/campaign/prior_art/sampling.md
+++ b/docs/campaign/prior_art/sampling.md
@@ -1,0 +1,16 @@
+# Prior art — sampling
+
+> **FROZEN 2026-08-21.** A snapshot of the open work on sampling as of that
+> date. Re-run the generator when picking the topic up again; existing
+> dispositions are preserved.
+
+Keywords: sampling, adaptive, convergence, stopping, refine, scan, resolution, criterion. Regenerate with
+`python3 scripts/prior_art.py --topic sampling --keywords sampling adaptive convergence stopping refine scan resolution criterion`.
+
+Dispositions: `unread`, `read`, `unrelated`, `superseded`, `depends`
+
+| ref | disposition | what | note |
+|---|---|---|---|
+| origin/feat/manuscript-refinement-round5 | unrelated | branch:  | **0 commits ahead of main** — already in. Manuscript text (Paper #3 v3 + Ch.3/Ch.6 integration); matched "refine" in the BRANCH NAME, which is about prose rounds, not sampling refinement. |
+| origin/feat/manuscript-refinement-round6 | unrelated | branch:  | Same: 0 commits ahead of main, Ch.6 inline + Paper #1 integration. Two of the three matches on this topic are the word "refinement" in a manuscript branch name — worth noting when tuning the keyword list. |
+| #57 | depends | issue: research(phases): 2D Eu F=6 phase diagram via adaptive multi-seed mapping | **This is the home for the stopping-rule work.** Its design (`docs/design/eu_phase_diagram_adaptive_mapping.md`) specifies HOW to build adaptively — coarse multi-seed recon → detect where the phase changes → bisect / boundary-trace / active-learn → fill interiors by continuation — and names the boundary DETECTORS (multi-seed min-E crossing, order-parameter jump, bidirectional hysteresis divergence, solver-struggle). What it does NOT contain is a stopping rule: nothing says when a boundary is resolved enough to stop bisecting, or when the map is done. That gap is exactly the session-plan item, so this work belongs on #57 rather than beside it. |

--- a/src/workflow/experiments/optimization/active_learning.jl
+++ b/src/workflow/experiments/optimization/active_learning.jl
@@ -97,6 +97,11 @@ function active_learn_phase_scan(
     bounds::Vector{Tuple{Float64, Float64}};
     n_init::Int=5,
     n_iter::Int=50,
+    # Declared stopping criterion, forwarded to the BO loop. `nothing` means the
+    # scan stops when the budget runs out and SAYS SO in `stop_reason`; it never
+    # reports a truncated map as a resolved one.
+    acq_tol::Union{Nothing, Float64}=nothing,
+    acq_patience::Int=3,
     temperature::Float64=0.1,
     ℓ::Union{Nothing, Float64}=nothing,
     n_grid::Int=50,
@@ -139,7 +144,8 @@ function active_learn_phase_scan(
     end
 
     bayesian_optimize(obj_fn, bounds;
-        n_init, n_iter, minimise=false, ℓ, n_grid, seed, verbose)
+        n_init, n_iter, minimise=false, ℓ, n_grid, seed, verbose,
+        acq_tol, acq_patience)
 end
 
 """

--- a/src/workflow/experiments/optimization/bayesian_opt.jl
+++ b/src/workflow/experiments/optimization/bayesian_opt.jl
@@ -82,6 +82,17 @@ function bayesian_optimize(
     bounds::Vector{Tuple{Float64, Float64}};
     n_init::Int=5,
     n_iter::Int=25,
+    # A BUDGET IS NOT A STOPPING RULE. `n_iter` alone answers "when do we stop?"
+    # with "when the loop counter runs out", and the returned object looked the
+    # same either way — so a map that ran out of budget read as a finished map.
+    # `acq_tol` is the declared criterion: the acquisition value at the point the
+    # scan is ABOUT to sample is how much the model still expects to learn, so
+    # when the most informative point left in the whole domain is below tolerance
+    # for `acq_patience` consecutive iterations, there is nothing left to learn at
+    # this resolution. Default `nothing` keeps the old behaviour and still reports
+    # `:budget_exhausted`, which is the half that matters most.
+    acq_tol::Union{Nothing, Float64}=nothing,
+    acq_patience::Int=3,
     minimise::Bool=true,
     ℓ::Union{Nothing, Float64}=nothing,
     n_grid::Int=100,
@@ -107,6 +118,9 @@ function bayesian_optimize(
     # Pre-build candidate mesh
     axis_grids = [collect(range(b[1], b[2]; length=n_grid)) for b in bounds]
 
+    acq_history = Float64[]
+    stop_reason = :budget_exhausted
+    below = 0
     for it in 1:n_iter
         y_best = minimise ? minimum(y) : maximum(y)
         # Evaluate EI on a grid
@@ -114,18 +128,40 @@ function bayesian_optimize(
         μ, σ² = gp_predict(X, y, candidates; ℓ=ℓ_use)
         ei = expected_improvement(μ, σ², y_best; minimise=minimise)
         i_best = argmax(ei)
+        acq = ei[i_best]
+        push!(acq_history, acq)
         p_next = candidates[i_best, :]
         y_next = Float64(eval_fn(p_next))
         X = vcat(X, p_next')
         push!(y, y_next)
         verbose && println(
             "iter $it: p=$(round.(p_next; digits=3)) y=$(round(y_next; digits=4)) " *
-            "best=$(round(minimise ? minimum(y) : maximum(y); digits=4))",
+            "best=$(round(minimise ? minimum(y) : maximum(y); digits=4)) " *
+            "acq=$(round(acq; sigdigits=3))",
         )
+
+        # Checked AFTER the sample, not before: the acquisition value describes
+        # the point just taken, so stopping on it without taking it would discard
+        # the evaluation that justified the decision.
+        if acq_tol !== nothing
+            below = acq < acq_tol ? below + 1 : 0
+            if below >= acq_patience
+                stop_reason = :acquisition_below_tol
+                verbose && println(
+                    "stopping: acquisition < $(acq_tol) for $(acq_patience) " *
+                    "consecutive iterations (iter $it of $n_iter)")
+                break
+            end
+        end
     end
 
     i_opt = minimise ? argmin(y) : argmax(y)
-    return (best_p=X[i_opt, :], best_y=y[i_opt], X_history=X, y_history=y)
+    # `stop_reason` is not decoration. `:budget_exhausted` means the scan was cut
+    # off, and a caller that treats it as `:acquisition_below_tol` is reporting a
+    # truncation as a result — the same shape as an absent convergence flag
+    # written as `true`.
+    return (best_p=X[i_opt, :], best_y=y[i_opt], X_history=X, y_history=y,
+        stop_reason=stop_reason, n_evaluations=length(y), acq_history=acq_history)
 end
 
 # Build a regular d-dim mesh from per-axis 1D grids; rows are points.

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -65,6 +65,9 @@ const FAST_TESTS = [
     # bce2068f repaired two configs correctly one at a time and broke the mirror
     # relationship between them; nothing recorded that they were a pair (#343).
     "workflow/test_mirror_pairs_flip_every_axial_quantity.jl",
+    # A budget is not a stopping rule. The scan must report `:budget_exhausted`
+    # distinctly from `:acquisition_below_tol`, with both controls (#57, item 6).
+    "workflow/test_scan_says_why_it_stopped.jl",
     "test_calibrated_scan.jl",
     "test_docs_examples_avoid_removed_keys.jl",
     "test_state_doc_is_current.jl",

--- a/test/workflow/test_scan_says_why_it_stopped.jl
+++ b/test/workflow/test_scan_says_why_it_stopped.jl
@@ -1,0 +1,75 @@
+# A budget is not a stopping rule, and a scan must say which one it hit.
+#
+# WHY THIS EXISTS
+#
+# `active_learn_phase_scan` delegates to `bayesian_optimize`, whose only stopping
+# condition was `n_iter`. The returned object was identical whether the map had
+# been resolved or the loop counter had simply run out, so a truncated scan read
+# as a finished one — the same shape as an absent convergence flag written as
+# `true` (`gotcha_absent_converged_flag_was_written_as_true_2026_08_20`).
+#
+# `docs/design/eu_phase_diagram_adaptive_mapping.md` (#57) specifies HOW to build
+# the map adaptively and names the boundary detectors. It contains no rule for
+# when to stop. This is that rule, and the half that matters most is not the
+# criterion: it is that `:budget_exhausted` is REPORTABLE and distinct.
+#
+# The acquisition value is the right quantity because it is the one active
+# learning maximises: it is what the model still expects to learn at the most
+# informative point left in the domain. When that is below tolerance, there is
+# nothing more to learn AT THIS RESOLUTION — which is a claim about the sampling,
+# not about the physics, and the scope should say so wherever it is quoted.
+
+using SpinorBEC
+using Test
+
+# A deterministic, cheap objective with one broad optimum. Not physics: the point
+# is the CONTROL STRUCTURE, and a real pipeline would make the two arms below cost
+# minutes each for no extra information about the stopping logic.
+_bowl(p) = -sum(abs2, p .- 0.3)
+
+@testset "a scan reports why it stopped" begin
+    r = bayesian_optimize(_bowl, [(0.0, 1.0), (0.0, 1.0)];
+        n_init=4, n_iter=6, minimise=false, n_grid=8, seed=1, verbose=false)
+
+    # The field must exist at all — this is the part that makes a truncated scan
+    # legible, independent of whether any criterion was configured.
+    @test hasproperty(r, :stop_reason)
+    @test r.stop_reason === :budget_exhausted
+    @test hasproperty(r, :n_evaluations)
+    @test r.n_evaluations == 4 + 6
+    @test length(r.acq_history) == 6
+end
+
+@testset "the criterion actually fires, and does not fire when it should not" begin
+    # POSITIVE CONTROL. A tolerance above every acquisition value must stop the
+    # scan early, and `n_evaluations` must show it did.
+    hot = bayesian_optimize(_bowl, [(0.0, 1.0), (0.0, 1.0)];
+        n_init=4, n_iter=20, minimise=false, n_grid=8, seed=1, verbose=false,
+        acq_tol=1e9, acq_patience=2)
+    @test hot.stop_reason === :acquisition_below_tol
+    @test hot.n_evaluations < 4 + 20
+
+    # NEGATIVE CONTROL. A tolerance below every acquisition value must NOT stop
+    # it. Without this arm, a criterion that always fires passes the test above,
+    # and "the scan converged" becomes a statement about the tolerance.
+    cold = bayesian_optimize(_bowl, [(0.0, 1.0), (0.0, 1.0)];
+        n_init=4, n_iter=6, minimise=false, n_grid=8, seed=1, verbose=false,
+        acq_tol=-1.0, acq_patience=2)
+    @test cold.stop_reason === :budget_exhausted
+    @test cold.n_evaluations == 4 + 6
+
+    # PATIENCE IS LOAD-BEARING. One quiet iteration is not convergence — an
+    # acquisition surface can dip and recover. With patience 2 the run above
+    # needed two consecutive quiet iterations, so the stop is not a single sample.
+    @test hot.n_evaluations >= 4 + 2
+end
+
+@testset "the active-learning wrapper forwards the criterion" begin
+    # The wrapper is where a phase scan is actually configured, so a criterion
+    # that exists only on the inner function is a criterion nobody sets.
+    src = read(
+        joinpath(@__DIR__, "..", "..", "src", "workflow", "experiments",
+            "optimization", "active_learning.jl"), String)
+    @test occursin("acq_tol", src)
+    @test occursin("acq_patience", src)
+end


### PR DESCRIPTION
計画の残り2件、**item 5（保存粒度・93 GB）**と **item 6（適応サンプリングの停止規則）**に着手する前に、`scripts/prior_art.py` を各トピックで回しました。

## item 5 は完了しています。別セッションの手で。

`--topic data_reduction` → **0 unread**

- **#419** result.jld2 を宣言どおりの要約に
- **#430** Tier 1（フレームを消しても残るもの）
- `reduce_result_backlog.jl` の DRY RUN → **recoverable 0.0 GB**
- グループ使用量 1290 → **1179.94 GB**

**前進修正も既存ファイルの回収も両方終わっています。** 私が足すものはありません。

## item 6 は未処理で、本拠があります

`--topic sampling` → 3 unread。うち2つは **merge 済みの manuscript ブランチ**（main より 0 コミット先）で、ブランチ名の "refinement" に当たっただけです。3つ目が **#57**。

設計文書 `docs/design/eu_phase_diagram_adaptive_mapping.md` は**作り方**を定めています — 粗い multi-seed recon → 相が変わる場所を検出 → bisect / boundary-trace / active-learn → 内部を continuation で埋める。境界の**検出器**も名指しています（multi-seed の最小Eの交差、秩序変数の跳び、双方向ヒステリシスの発散、solver-struggle）。

**書かれていないのは停止規則です。** 「境界がどこまで解ければ bisect をやめてよいか」「地図がいつ完成なのか」を定めた文はありません。それが計画の item 6 そのものなので、**作業は #57 の上に載ります**（横に新しく作るのではなく）。

処遇を記録し、両トピックとも 0 unread になりました。

## このコミットが存在する理由

**今日、ツリーが既に対処済みのものを4回やり直しました** — 否定済みの抽出手法、着地済みの config 修正、意図的でゲート付きの runner 挙動、そして今回あやうくデータ削減キャンペーン。

3回目のあとに私は「これを機械で捕まえる案が思いつかない」と書きました。**`scripts/prior_art.py` は同じ日の 07:43 にツリーへ入っており、まさにそれをします** — トピック別に未処理の作業を列挙し、`unread` が1つでも残っていれば先へ進ませません。

**構造的な答えは存在していて、私が使っていませんでした。1コマンドで item 5 が閉じました。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
