### PR TITLE
観測量の定義を跨いで生き残らない順序は主張しない — そして 10.4 nT では peak が過渡を読んでいた

### DIFF
--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -1108,7 +1108,7 @@ note = "9 sections. Same."
 
 [[claim]]
 id = "edh-104nt-observable-not-window-robust"
-claim = "At B = 10.4 nT `peak P_adj in the hold` is not well-posed: the hold-window maximum is achieved at the window's first frames, where the decaying pre-hold transient still dominates, so the value moves 37 % depending on where the window is cut."
+claim = "At B = 10.4 nT `peak P_adj in the hold` does not measure the hold for 16 of 20 arms: their maximum falls on frame 32, the hold's FIRST frame, where the decaying pre-hold transient still dominates. It is not merely window-dependent — for 80 % of the scan it is reading a different physical quantity."
 status = "open"
 quantity = "peak_P_adj @ B=10.4nT, observable definition"
 type = "A"
@@ -1130,3 +1130,32 @@ inferred, and inferring it from which value matches is the exact error this whol
 about. What would close this: define the observable without a free window — the endpoint,
 or the peak of the hold response after subtracting the transient, or a cut justified by
 something other than agreement with a previous answer."""
+
+[[claim]]
+id = "edh-104nt-peak-reads-the-transient-for-80-percent"
+claim = "At B = 10.4 nT the peak-in-hold reading takes frame 32 — the hold's first frame — for 16 of 20 arms, and those peak values RISE monotonically with ω_eff, opposite to the physical trend. Ranking the scan by `peak` therefore ranks the transient."
+status = "live"
+type = "A"
+scope = "B = 10.4 nT, 20 arms at the 8 ms hold. Not a statement about 1.3 / 2.6 / 5.2 nT, where §12.1 measured the whole-trajectory and in-hold peaks identical on all 43 arms."
+uncertainty = "Counts, not estimates: 16 arms with argmax at frame 32 (the set of argmax frames over those 16 is exactly {32}), 4 with argmax at 42. Rank correlation between `peak` and `mean` is -0.507 over all 20, -0.797 over the 16 edge arms, and -0.400 over the 4 interior ones — the last on n = 4, which is one rank swap and decides nothing."
+uncertainty_basis = "control"
+evidence = ["runs/klaus_quench_weff/klaus_weff1p000_B10p4nT.yaml", "runs/klaus_quench_weff/klaus_weff0p650_B10p4nT.yaml"]
+evidence_status = "in_tree"
+commit = "unknown"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.2"
+pr = 0
+prediction = "If the negative peak-vs-mean rank correlation comes from `peak` reading the transient on the flat arms, then (1) those arms have argmax at frame 32, (2) their peak values rise monotonically with ω_eff, and (3) restricting to arms with argmax >= 34 makes the correlation positive."
+prediction_registered = "before"
+prediction_outcome = "miss"
+note = """(1) and (2) HOLD; (3) FAILS — the interior correlation is -0.400, not positive, though on
+n = 4 it decides nothing either way. A fourth expectation stated alongside them, that the
+edge `mean` would fall monotonically with ω_eff, also fails: `mean` is not monotone. So the
+mechanism is established for the edge population and the interior remains unexplained.
+Recorded with the misses because a prediction that is 2-for-4 and reported as confirmed is
+how a mechanism gets believed.
+CONSEQUENCE FOR `AGREE`: the three readings agreeing on argmax = 0.650 is NOT evidence of
+robustness. `peak` can only place its argmax among the 4 interior arms — the other 16 are
+all pinned at the same transient value — so the argmax and the ranking come from different
+populations. An agreement produced that way says nothing about the other 16."""
+

--- a/docs/campaign/prior_art/observable.md
+++ b/docs/campaign/prior_art/observable.md
@@ -1,0 +1,14 @@
+# Prior art — observable
+
+> **FROZEN 2026-08-21.** A snapshot of the open work on observable as of that
+> date. Re-run the generator when picking the topic up again; existing
+> dispositions are preserved.
+
+Keywords: observable, peak, hold, window, transient, extraction, P_adj, metric. Regenerate with
+`python3 scripts/prior_art.py --topic observable --keywords observable peak hold window transient extraction P_adj metric`.
+
+Dispositions: `unread`, `read`, `unrelated`, `superseded`, `depends`
+
+| ref | disposition | what | note |
+|---|---|---|---|
+| #289 | unrelated | issue: nightly: the mutation job still exhausts its timeout after the 1/7 sharding, and it holds the heavy-YAML result hostage | CI mutation-testing walltime and sharding. Matched "hold" inside "holds ... hostage" — the keyword is the protocol's hold step, this is English. Nothing about how an observable is extracted. |

--- a/scripts/validation/klaus_weff_extract.jl
+++ b/scripts/validation/klaus_weff_extract.jl
@@ -54,8 +54,16 @@ function peak_padj(dir::AbstractString; hold_duration::Float64=5.5292,
         # agreement is the check; without it this is another guess.
         nhold = max(1, Int(floor(hold_duration / (dt * save_every))))
         lo = max(1, length(adj) - nhold + 1)
-        k = lo - 1 + argmax(@view adj[lo:end])
+        w = @view adj[lo:end]
+        k = lo - 1 + argmax(w)
+        # THREE READINGS OF ONE HOLD. At 10.4 nT the peak is not well-posed — its
+        # maximum sits at the window's first frames, where the decaying pre-hold
+        # transient still dominates, and the value moves 37 % with the cut. The
+        # answer is not to pick a window but to keep all three and refuse an
+        # ordering they disagree on. They fail differently: `peak` is contaminated
+        # by the transient, `mean` is diluted by it, `final` is a single sample.
         (peak=adj[k], frame=k, nframes=length(adj), hold_from=lo,
+            mean=sum(w) / length(w), final=adj[end],
             whole=maximum(adj), whole_frame=argmax(adj))
     end
 end

--- a/scripts/validation/klaus_weff_extract.jl
+++ b/scripts/validation/klaus_weff_extract.jl
@@ -60,6 +60,19 @@ function peak_padj(dir::AbstractString; hold_duration::Float64=5.5292,
     end
 end
 
+"""Rank correlation between two readings — do they ORDER the arms alike?"""
+function _spearman(a::AbstractVector, b::AbstractVector)
+    n = length(a)
+    n < 2 && return NaN
+    ra = sortperm(sortperm(a))
+    rb = sortperm(sortperm(b))
+    ma, mb = sum(ra) / n, sum(rb) / n
+    num = sum((ra[i] - ma) * (rb[i] - mb) for i in 1:n)
+    da = sqrt(sum((ra[i] - ma)^2 for i in 1:n))
+    db = sqrt(sum((rb[i] - mb)^2 for i in 1:n))
+    (da == 0 || db == 0) ? NaN : num / (da * db)
+end
+
 """Parse `klaus_weff0p714_B5p2nT_<hash>` back into its two scan coordinates."""
 function coords(name::AbstractString)
     m = match(r"klaus_weff(\d+p\d+)_B(\d+p\d+)nT", name)
@@ -98,8 +111,8 @@ function main(args)
             rel = base === nothing ? NaN : 100 * (r.peak - sel[base].peak) / sel[base].peak
             flag = r.peak == r.whole ? "  " : " *"   # * = whole-trajectory max was the transient
             @printf(
-                "  weff %.3f   in-hold %.5f  frame %2d/%2d%s  whole %.5f (f%2d)  %+6.2f %% vs weff=1\n",
-                r.weff, r.peak, r.frame, r.nframes, flag, r.whole, r.whole_frame, rel)
+                "  weff %.3f   peak %.5f (f%2d)  mean %.5f  final %.5f%s  %+6.2f %%\n",
+                r.weff, r.peak, r.frame, r.mean, r.final, flag, rel)
         end
         # The positive control. If the per-step `potential:` override were
         # ignored, every arm would return the SAME number -- so a flat scan is a
@@ -111,6 +124,23 @@ function main(args)
             println("  !! is not reaching the hold step. This is NOT a physical null.")
         elseif length(sel) > 1
             @printf("  control OK: spread %.5f over %d arms\n", spread, length(sel))
+        end
+
+        # DOES THE ORDERING SURVIVE THE DEFINITION? Rank the arms by each reading.
+        # If the three disagree, the ordering is a property of the extraction and
+        # no optimum should be quoted from this field — which is the state 10.4 nT
+        # was in when a number was published from it twice.
+        if length(sel) > 2
+            pv = [r.peak for r in sel]
+            mv = [r.mean for r in sel]
+            fv = [r.final for r in sel]
+            topw(v) = sel[argmax(v)].weff
+            agree = topw(pv) == topw(mv) == topw(fv)
+            @printf("  argmax weff: peak %.3f  mean %.3f  final %.3f  -> %s\n",
+                topw(pv), topw(mv), topw(fv),
+                agree ? "AGREE" : "DISAGREE - quote no optimum at this field")
+            @printf("  rank corr: (peak,mean) %.3f   (peak,final) %.3f\n",
+                _spearman(pv, mv), _spearman(pv, fv))
         end
     end
 


### PR DESCRIPTION
10.4 nT の観測量が窓依存だという `open` 行を詰めた結果、**もっと悪い（そして検定可能な）ことが分かりました**。

## 対処は「窓を1つ選ぶ」ではありません

今日の所見が窓依存そのものだったので、**不変性の要求**にしました。hold を3通りに読み、**3つが一致しない順序は主張しません**。

| 読み | 自由パラメータ | 固有の壊れ方 |
|---|---|---|
| **peak** | 窓の開始位置 | 過渡に汚染される |
| **mean** | 無し（hold が決まれば） | 過渡に薄められる |
| **final** | 無し（窓が無い） | 1サンプルのノイズ |

壊れ方が互いに違うので、**3つとも同じ順序を出すなら、それはどれか1つの産物ではありません**。

hold の境界は自由パラメータではありません — prep 13 + quench 13 + pre-delay 5 = 31 という構成上の値で、**アーム間 spread が frames 30–31 で厳密に 0.000000、32 で 0.000213** という独立の測定で確認済みです。

## 測定 — 10.4 nT では peak が hold を測っていない

**20本中16本が frame 32（hold の1枠目）で最大**を取ります。その argmax frame の集合は**厳密に `{32}`**。そして**その peak 値は ω_eff とともに単調増加** — 過渡の裾の振る舞いで、物理の向きと逆です。interior でピークを打つのは4本だけ。

```
rank corr(peak, mean):   全20本 −0.507   edge16本 −0.797   interior4本 −0.400
```

つまり `peak P_adj in the hold` は「窓に敏感」なのではありません。**スキャンの 80 % で別の物理量を読んでいます。** `peak` で順位をつけることは、過渡で順位をつけることです。

## `AGREE` は頑健性の証拠ではありませんでした

3つの読みは argmax = 0.650 で一致します。しかし **`peak` は argmax を interior の4本からしか置けません**（残り16本は同じ過渡値に張り付いている）。**argmax と順位が別の母集団から出ています。** そうやって生まれた一致は、残りの16本について何も言いません。

## 予言 4 分の 2

測る前に登録しました。

| | |
|---|---|
| (1) flat な腕は argmax が frame 32 | **当たり** |
| (2) その peak は ω_eff とともに単調増加 | **当たり** |
| (3) argmax ≥ 34 に絞れば相関は正 | **外れ**（−0.400、n=4 で1順位分） |
| (4) edge の mean は単調減少 | **外れ**（単調でない） |

**機構は edge の16本については確立し、interior は未説明のままです。** 外れも一緒に記録しました — **4分の2を「確認された」と報告するのが、機構が信じられてしまう経路**なので。

## 5.2 nT も同じ検定に落ちます

```
argmax weff:  peak 0.650   mean 0.550   final 0.650   -> DISAGREE
rank corr:    (peak,mean) 0.759   (peak,final) 0.750
```

**2つの場が、別々の壊れ方で引用不可**です。私は 10.4 nT の方しか記録していませんでした。

## 手順

`prior_art.py --topic observable` を先に実行。一致は #289 の1件で、`holds the heavy-YAML result hostage` の "hold" への誤爆。処遇を記録して 0 unread。

抽出は**全部キャッシュから**で、再計算はゼロです。

## 検証

全ゲート 0 failure。台帳 52 行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
