### PR TITLE
feat(spgpe): the ramp scale moves the target, not the condensate

### DIFF
--- a/docs/guides/figures/eu_evaporation_spgpe.jl
+++ b/docs/guides/figures/eu_evaporation_spgpe.jl
@@ -70,9 +70,17 @@ const SPGPE_ATOM = Rb87
 The euv3 two-component evaporation, plus `ω̄(t)` reconstructed on the same grid
 `spgpe_reservoir` uses.
 """
-function zero_d_trajectory(; N0_load=3.5e6, T0_load=50e-6, K3=1.61e-40, save_every=2)
+function zero_d_trajectory(; N0_load=3.5e6, T0_load=50e-6, K3=1.61e-40, save_every=2,
+    ramp_scale=1.0)
     trap = euv3_evap_trap()
-    ramp = euv3_evaporation_ramp()
+    # ramp_scale stretches the time axis, holding the beam powers. The design scan puts
+    # the peak equilibrium N_0 at 0.3-0.5x — 6.01e4 against 4.41e4 at 1x — and the
+    # quasi-static check clears both (30.6 and 74.2 elastic collisions per e-folding of
+    # the trap depth, against 0.02-0.05 below 0.3x where the model is not valid). This is
+    # how the c-field is asked whether it reaches the number the constraint names.
+    ramp = let r0 = euv3_evaporation_ramp()
+        ramp_scale == 1.0 ? r0 : FortRamp(r0.times .* ramp_scale, r0.powers_W)
+    end
     p = EvapParams(; a_s=Eu151.a_s, tau_bg=15.0, K3=K3)
     r = run_evaporation_bec(trap, ramp, p; N0=N0_load, T0=T0_load, save_every)
     g = evap_trap_grid(trap, ramp)

--- a/docs/guides/spgpe.md
+++ b/docs/guides/spgpe.md
@@ -214,12 +214,18 @@ Evaluated along the euv3 trajectory:
 | 1.992 | 5485 | 118 | 3.47 | 5157 | 0.94 |
 | 2.390 | 3576 | 64 | 2.95 | 3513 | 0.98 |
 
-**The peak is $N_0\approx4.0\times10^4$ at $t=1.73$ s, 80 % of the measured
+**The peak is $N_0 = 4.41\times10^4$ at $t=1.70$ s, 88 % of the measured
 $5.02\times10^4$** (PRL 129, 223401) — and it falls monotonically after that to
 $3.5\times10^3$ at the end of the ramp. Running the evaporation to completion throws
-condensate away: past 1.73 s the losses beat the cooling. So "optimising" this ramp
+condensate away: past 1.70 s the losses beat the cooling. So "optimising" this ramp
 means **stopping it at the peak**, and the 0-D model's own final $N_0=1789$ (3.6 % of
 measured) is the value at the wrong end of a curve rather than a failure of the model.
+
+> **The table above samples the trajectory at 18 points and therefore misses the peak.**
+> It reports $4.01\times10^4$ at $t=1.726$; scanning every point finds
+> $4.41\times10^4$ at $t=1.702$, between two of its rows. The two numbers were 10 %
+> apart and the difference is sampling, not physics — the finer scan is the one to
+> quote. Both are produced by the same constraint from the same trajectory.
 
 **Three caveats, none of them small.**
 

--- a/docs/guides/spgpe.md
+++ b/docs/guides/spgpe.md
@@ -304,14 +304,31 @@ cutoff shrinks, while the later handoff skips that stretch and loses an eighth.
 
 - **Early handoff — the C region empties.** The cutoff tracks $T$ down through a large
   range and the projector removes atoms faster than the reservoir refills them.
-- **Late handoff — coherence, not population.** Slowing the *same* $(N,T)$ path 3× leaves
-  $N_C$ essentially unchanged (580 → 590, 444 → 446) and multiplies $N_0$ by 7× and 2.9×
-  at the two points measured so far. Slowing does not put more atoms in C; it lets the
-  ones already there become coherent.
+- **Late handoff — coherence, not population.** $N_C$ is set by the trajectory and the
+  cutoff, not by how fast either moves: slowing the *same* $(N,T)$ path 3× leaves it
+  essentially unchanged (580 → 590, 444 → 446, 363 → 355). What changes is the coherent
+  fraction of it.
+
+**Slowing does NOT help, and the first two points said it did.** Matched trajectory times,
+handoff 1.85 s:
+
+| $t$ | 7076 | 7280 | 7485 | 7689 | 7893 | 8097 |
+|---|---|---|---|---|---|---|
+| 1× $N_0$ | 10.8 | 20.3 | **41.8** | **64.8** | **68.1** | **49.5** |
+| 3× $N_0$ | **75.1** | **59.8** | 34.0 | 28.1 | 22.4 | 20.3 |
+
+The 3× run starts ahead — it has had three times as long to build anything by the first
+marker — and then **declines monotonically** while the 1× run climbs to $f_0 = 0.255$ and
+overtakes it from the third point on. A verdict taken at either end is the opposite of the
+one taken at the other, and the two-point version of this paragraph said 7× and 2.9× in
+favour of slowing.
 
 The slowdown run is a **numerical** experiment, not a ramp design: a genuinely slower ramp
-costs more three-body loss and would lower $N_\mathrm{total}$ everywhere. It isolates the
-rate of cutoff change from the loss a slower ramp would incur.
+costs more three-body loss and would lower $N_\mathrm{total}$ everywhere. That was scanned
+separately and points the same way — $N_0^\mathrm{eq}$ at the peak falls monotonically
+from $6.0\times10^4$ at 0.5× to $1.4\times10^4$ at 5×, so **loss dominates and a faster
+ramp is better on both counts**. 0.5× already exceeds the measured $5.02\times10^4$, and
+with no turnover in $[0.5, 5]$ that scan found its own edge rather than an optimum.
 
 The $\gamma$ scan **was run once before and thrown away**: the $N_0$ estimator read
 `psi[:,:,:,1]` while `thermal_cfield!` seeds the last component, so at $D=13$ it projected

--- a/docs/guides/spgpe.md
+++ b/docs/guides/spgpe.md
@@ -285,8 +285,33 @@ has not been isolated on its own — at 10× $\gamma$ the field still empties, f
 to 198.
 
 **So: this evaporation ramp allows $4\times10^4$ condensed atoms thermodynamically, and
-the c-field does not reach them, because the ramp empties the classical region faster
-than the derived reservoir rates refill it.**
+the c-field does not reach them.** *Why* it does not is two different things at two
+different handoffs, and the single-mechanism sentence this paragraph carried until
+2026-08-21 was taken from the earlier one alone.
+
+Compare the two handoffs at the **same trajectory time**, where the C-region populations
+are nearly equal:
+
+| handoff | $N_C$ at start | $N_C$ at $t\approx7100$ | lost | $N_0$ | $f_0$ |
+|---|---|---|---|---|---|
+| 1.73 s | 2397 | 606 | **75 %** | 0.37 | 0.001 |
+| 1.85 s | 657 | 580 | **12 %** | **10.8** | 0.019 |
+
+Same number of atoms in C, thirty times the condensate — and the 1.73 s run has been
+running *longer*, so it is not short of time. What differs is what it went through:
+starting at $\epsilon_\mathrm{cut}=31$ it loses three quarters of the C region as the
+cutoff shrinks, while the later handoff skips that stretch and loses an eighth.
+
+- **Early handoff — the C region empties.** The cutoff tracks $T$ down through a large
+  range and the projector removes atoms faster than the reservoir refills them.
+- **Late handoff — coherence, not population.** Slowing the *same* $(N,T)$ path 3× leaves
+  $N_C$ essentially unchanged (580 → 590, 444 → 446) and multiplies $N_0$ by 7× and 2.9×
+  at the two points measured so far. Slowing does not put more atoms in C; it lets the
+  ones already there become coherent.
+
+The slowdown run is a **numerical** experiment, not a ramp design: a genuinely slower ramp
+costs more three-body loss and would lower $N_\mathrm{total}$ everywhere. It isolates the
+rate of cutoff change from the loss a slower ramp would incur.
 
 The $\gamma$ scan **was run once before and thrown away**: the $N_0$ estimator read
 `psi[:,:,:,1]` while `thermal_cfield!` seeds the last component, so at $D=13$ it projected

--- a/docs/guides/spgpe.md
+++ b/docs/guides/spgpe.md
@@ -323,6 +323,33 @@ overtakes it from the third point on. A verdict taken at either end is the oppos
 one taken at the other, and the two-point version of this paragraph said 7× and 2.9× in
 favour of slowing.
 
+### The design answer: halve the ramp
+
+Stretching the `FortRamp` time axis (same beam powers, more time) and reading the peak
+equilibrium $N_0$ off the same constraint:
+
+| slow | duration | $N_0^\mathrm{peak}$ | coll / e-fold | |
+|---|---|---|---|---|
+| 0.05× | 0.12 s | 3.29e4 | 0.020 | **INVALID** |
+| 0.10× | 0.24 s | 1.85e4 | 0.026 | **INVALID** |
+| 0.20× | 0.48 s | 3.41e4 | 0.054 | **INVALID** |
+| 0.30× | 0.72 s | 5.99e4 | 30.6 | OK |
+| **0.50×** | **1.2 s** | **6.01e4** | 74.2 | OK |
+| 1.00× | 2.4 s | 4.41e4 | 122 | OK |
+| 2.00× | 4.8 s | 2.83e4 | 161 | OK |
+
+**Halving the ramp is worth +36 %** — $4.41\times10^4 \to 6.01\times10^4$, above the
+measured $5.02\times10^4$ — and the optimum is a broad valley over 0.3–0.5×.
+
+The fast end is **not** physics. `condensate.jl` assumes "standard quasi-static
+two-component evaporation", and below 0.3× the trap depth outruns thermalisation: 0.02 to
+0.05 elastic collisions per e-folding of the depth against the conventional requirement of
+a few. That is exactly the region where $N_0^\mathrm{peak}$ goes non-monotone
+(3.29 → 1.85 → 1.64 → 3.41e4), which is what a model looks like when asked outside its
+assumptions — and it is why the validity column exists here rather than the recommendation
+being quoted from the first table alone. The recommended 0.3–0.5× sits at 30.6 and 74.2,
+comfortably inside.
+
 The slowdown run is a **numerical** experiment, not a ramp design: a genuinely slower ramp
 costs more three-body loss and would lower $N_\mathrm{total}$ everywhere. That was scanned
 separately and points the same way — $N_0^\mathrm{eq}$ at the peak falls monotonically

--- a/scripts/kz/eu_number_conserving.jl
+++ b/scripts/kz/eu_number_conserving.jl
@@ -70,8 +70,9 @@ function run_nc(; n::Int=48, box::Float64=16.0, K3::Float64=1.61e-40,
     eps_cut_nT::Float64=3.0, seed::Int=9001, dt::Float64=0.02,
     t_frac::Float64=1.0, t_start_s::Float64=1.85, backend=CPUBackend(),
     number_damping::Bool=true, energy_damping::Bool=true,
-    gamma_mult::Float64=1.0, cayley_iters::Int=2, slowdown::Float64=1.0)
-    traj = zero_d_trajectory(; K3)
+    gamma_mult::Float64=1.0, cayley_iters::Int=2, slowdown::Float64=1.0,
+    ramp_scale::Float64=1.0)
+    traj = zero_d_trajectory(; K3, ramp_scale)
     r = traj.r
     # Internal units: the 0-D model is in SI, the field is in units of omega_ref.
     ω_ref = traj.omega_of(r.t[1])
@@ -247,6 +248,28 @@ if abspath(PROGRAM_FILE) == @__FILE__
     if mode == "smoke"
         out = run_nc(; n=44, box=10.0, t_frac=0.05)
         @printf("\nunsatisfiable: %d of %d\n", out.unsat, out.n_cb)
+
+    elseif mode == "halframp"
+        # Does the c-field reach the number the halved ramp allows?
+        #
+        # The design scan says the peak equilibrium N_0 is 6.01e4 at 0.5x against 4.41e4
+        # at 1x, and the quasi-static check clears 0.5x at 74.2 collisions per e-folding.
+        # That is a THERMODYNAMIC target. On the 1x ramp the field reaches 0.071 of a
+        # constraint 3498, so a better target is not by itself a better outcome.
+        #
+        # Handoff scaled with the ramp, so the field starts at the same FRACTION of the
+        # evaporation rather than at the same wall-clock second — 1.85/2.4 of the way in.
+        rs = parse(Float64, get(ENV, "SBEC_RAMP_SCALE", "0.5"))
+        @printf("\n########## ramp_scale %.2fx ##########\n", rs)
+        o = run_nc(; n=44, box=10.0, dt=0.02, t_frac=1.0,
+            t_start_s=(1.85 / 2.4) * 2.4 * rs, ramp_scale=rs)
+        h = isempty(o.hist) ? nothing : o.hist[end]
+        if h !== nothing
+            g = mu_from_total_lda(h.N_tot; T=h.T, c0=0.02, eps_cut=1.5 + 3 * h.T)
+            @printf("  END  N_C=%.4g  field N0=%.4g  eq N0=%.4g  ratio=%.5f\n",
+                h.N_C, h.N0, g.N0, h.N0 / max(g.N0, 1))
+        end
+        @printf("  unsatisfiable: %d of %d\n", o.unsat, o.n_cb)
 
     elseif mode == "slowramp"
         # Does giving the same (N, T) path more time let the field keep up?

--- a/scripts/kz/eu_number_conserving.jl
+++ b/scripts/kz/eu_number_conserving.jl
@@ -70,7 +70,7 @@ function run_nc(; n::Int=48, box::Float64=16.0, K3::Float64=1.61e-40,
     eps_cut_nT::Float64=3.0, seed::Int=9001, dt::Float64=0.02,
     t_frac::Float64=1.0, t_start_s::Float64=1.85, backend=CPUBackend(),
     number_damping::Bool=true, energy_damping::Bool=true,
-    gamma_mult::Float64=1.0, cayley_iters::Int=2)
+    gamma_mult::Float64=1.0, cayley_iters::Int=2, slowdown::Float64=1.0)
     traj = zero_d_trajectory(; K3)
     r = traj.r
     # Internal units: the 0-D model is in SI, the field is in units of omega_ref.
@@ -115,6 +115,16 @@ function run_nc(; n::Int=48, box::Float64=16.0, K3::Float64=1.61e-40,
     # (N, T) at the handoff, so a condensate that would have formed earlier is
     # excluded by construction.
     t0_int = t_start_s * ω_ref
+    # `slowdown` traverses the SAME (N, T) path over `slowdown` times as much field time.
+    # The mechanism the ramp verdict points at is that eps_cut tracks T down faster than
+    # the reservoir refills C, so the field arrives empty — 34 atoms against the 2858 a
+    # fixed-point run starts with. If that is right, giving the same path more time must
+    # help; if it does not, the mechanism is wrong.
+    #
+    # NOT a physical ramp design: a real slower ramp costs more three-body loss, so
+    # N_total(t) would be lower everywhere. This isolates the RATE of cutoff change from
+    # the loss that a slower ramp would incur, and only the first is being tested here.
+    traj_t(tf) = t0_int + (tf - t0_int) / slowdown
     T_hot = T_of(t0_int)
     # eps_cut must TRACK T. Fixing it at the handoff value leaves the cutoff at 23.3
     # while T falls 7.28 -> 2.28, i.e. ten thermal energies above mu by the end, and
@@ -128,9 +138,9 @@ function run_nc(; n::Int=48, box::Float64=16.0, K3::Float64=1.61e-40,
     eps_cut_of = tq -> 1.5 + eps_cut_nT * T_of(tq)
     eps_cut_hot = eps_cut_of(t0_int)
     k_cut = sqrt(2 * eps_cut_hot)
-    ts_ec = collect(range(t0_int, t_int[end]; length=64))
+    ts_ec = collect(range(t0_int, t0_int + slowdown * (t_int[end] - t0_int); length=64))
     k_cut_wave = PiecewiseLinearWaveform(ts_ec,
-        [sqrt(2 * eps_cut_of(tq)) for tq in ts_ec])
+        [sqrt(2 * eps_cut_of(traj_t(tq))) for tq in ts_ec])
     eps_cut = eps_cut_hot
     grid = make_grid(GridConfig((n, n, n), (box, box, box)))
     k_max = π * n / box
@@ -188,20 +198,21 @@ function run_nc(; n::Int=48, box::Float64=16.0, K3::Float64=1.61e-40,
     bad = Ref(0)
     # The controller must use the SAME cutoff the projector does, or it solves for a
     # mu against an I region that is not the one the field sees.
-    cb = number_conserving_callback(mu_ref, N_of, T_of, eps_cut_of; every=25,
+    cb = number_conserving_callback(mu_ref, tf -> N_of(traj_t(tf)),
+        tf -> T_of(traj_t(tf)), tf -> eps_cut_of(traj_t(tf)); every=25,
         counter=bad, t_offset=t0_int, c0_lda=c0_field)
     res = SPGPEReservoir(; T=FunctionWaveform(T_of), mu=FeedbackWaveform(mu_ref),
         a_s=0.007 * gamma_mult, k_cut=k_cut_wave, gamma=NaN, M=NaN,  # DERIVED
         number_damping, energy_damping, allow_unphysical_rates=(gamma_mult != 1.0))
 
     dV = cell_volume(grid)
-    n_steps = round(Int, t_frac * (t_int[end] - t0_int) / dt)
+    n_steps = round(Int, t_frac * slowdown * (t_int[end] - t0_int) / dt)
     marks = round.(Int, n_steps .* (0.1:0.1:1.0))
     hist = NamedTuple[]
     for s in 1:n_steps
         split_step!(ws)
         # Absolute ramp time: N_of and T_of must be read where the run actually is.
-        apply_spgpe_step!(ws, res, dt; t=t0_int + s * dt, seed=seed + s,
+        apply_spgpe_step!(ws, res, dt; t=traj_t(t0_int + s * dt), seed=seed + s,
             cayley_iters=cayley_iters)
         cb(ws, s)
         if s in marks
@@ -221,7 +232,7 @@ function run_nc(; n::Int=48, box::Float64=16.0, K3::Float64=1.61e-40,
             push!(hist, (; t=t0_int + s * dt, N_C=NC, N0=N0_all, N0_seedcomp=N0,
                 N_tot=N_of(t0_int + s * dt),
                 mu=mu_ref[], T=T_of(t0_int + s * dt)))
-            ta = t0_int + s * dt
+            ta = traj_t(t0_int + s * dt)
             @printf("  t=%8.1f N_tot=%-10.4g N_C=%-10.4g N0=%-10.4g f0=%-6.3f mu=%-8.3f T=%-7.3f eps_cut=%-7.2f unsat=%d\n",
                 ta, N_of(ta), NC, N0_all, N0_all / max(NC, 1), mu_ref[], T_of(ta),
                 eps_cut_of(ta), bad[])
@@ -236,6 +247,22 @@ if abspath(PROGRAM_FILE) == @__FILE__
     if mode == "smoke"
         out = run_nc(; n=44, box=10.0, t_frac=0.05)
         @printf("\nunsatisfiable: %d of %d\n", out.unsat, out.n_cb)
+
+    elseif mode == "slowramp"
+        # Does giving the same (N, T) path more time let the field keep up?
+        # Handoff 1.85 s at slowdown 1 is already measured: N_0 = 39.7 against a
+        # constraint 3498. SBEC_SLOWDOWN selects the arm, one per job — three full ramps
+        # in one reservation hit the 6-hour wall twice in this arc.
+        sd = parse(Float64, get(ENV, "SBEC_SLOWDOWN", "3.0"))
+        @printf("\n########## slowdown %.1fx, handoff 1.85 s ##########\n", sd)
+        o = run_nc(; n=44, box=10.0, dt=0.02, t_frac=1.0, t_start_s=1.85, slowdown=sd)
+        h = isempty(o.hist) ? nothing : o.hist[end]
+        if h !== nothing
+            g = mu_from_total_lda(h.N_tot; T=h.T, c0=0.02, eps_cut=1.5 + 3 * h.T)
+            @printf("  END  N_C=%.4g  field N0=%.4g  eq N0=%.4g  ratio=%.5f  (1x gave 39.7)\n",
+                h.N_C, h.N0, g.N0, h.N0 / max(g.N0, 1))
+        end
+        @printf("  unsatisfiable: %d of %d\n", o.unsat, o.n_cb)
 
     elseif mode == "gammascan2"
         # Is "the field does not condense" the finite-gamma lag, or another defect?

--- a/scripts/kz/eu_number_conserving.jl
+++ b/scripts/kz/eu_number_conserving.jl
@@ -260,8 +260,13 @@ if abspath(PROGRAM_FILE) == @__FILE__
         # Handoff scaled with the ramp, so the field starts at the same FRACTION of the
         # evaporation rather than at the same wall-clock second — 1.85/2.4 of the way in.
         rs = parse(Float64, get(ENV, "SBEC_RAMP_SCALE", "0.5"))
-        @printf("\n########## ramp_scale %.2fx ##########\n", rs)
-        o = run_nc(; n=44, box=10.0, dt=0.02, t_frac=1.0,
+        sd = parse(Int, get(ENV, "SBEC_SEED", "9001"))
+        @printf("\n########## ramp_scale %.2fx  seed %d ##########\n", rs, sd)
+        # One seed per job. The first pass measured 27.8 at 0.5x against 39.7 at 1x —
+        # pointing against the halved ramp — but both are under 1.2% of their own
+        # equilibrium, so it is a comparison of two small numbers with no scatter
+        # attached. Two points once already carried this arc to the opposite conclusion.
+        o = run_nc(; n=44, box=10.0, dt=0.02, t_frac=1.0, seed=sd,
             t_start_s=(1.85 / 2.4) * 2.4 * rs, ramp_scale=rs)
         h = isempty(o.hist) ? nothing : o.hist[end]
         if h !== nothing

--- a/scripts/kz/ramp_quasistatic_validity.jl
+++ b/scripts/kz/ramp_quasistatic_validity.jl
@@ -1,0 +1,46 @@
+# Is the 0-D model still quasi-static at the ramps its own scan recommends?
+#
+# The design scan says the peak equilibrium N_0 is best at 0.3-0.5x — 6.0e4 against 4.4e4
+# for the current ramp, and above the measured 5.02e4. It also returns a NON-MONOTONE fast
+# end: 3.29e4 / 1.85e4 / 1.64e4 / 3.41e4 at 0.05 / 0.10 / 0.15 / 0.20x, where physics
+# should be smooth. That is the signature of a model being asked a question outside its
+# assumptions, and condensate.jl states the assumption in its header: "standard
+# quasi-static two-component evaporation" — the gas is taken to stay in thermal
+# equilibrium throughout.
+#
+# The condition is that the trap depth changes slowly against the elastic collision rate.
+# gamma_el is on EvapResult (the thermal-only solver), so run that along each stretched
+# ramp and report collisions per e-folding of the depth. A recommendation the model cannot
+# support is worse than no recommendation.
+using SpinorBEC, Printf
+include(joinpath(@__DIR__, "../../docs/guides/figures/eu_evaporation_spgpe.jl"))
+
+stretch(r::FortRamp, s::Real) = FortRamp(r.times .* s, r.powers_W)
+
+@printf("%-7s %-10s %-12s %-12s %-12s %-10s\n",
+    "slow", "duration", "min coll/ef", "median", "gamma_el max", "verdict")
+for s in (0.05, 0.1, 0.2, 0.3, 0.5, 1.0, 2.0)
+    trap = euv3_evap_trap()
+    ramp = stretch(euv3_evaporation_ramp(), s)
+    p = EvapParams(; a_s=Eu151.a_s, tau_bg=15.0, K3=1.61e-40)
+    r = run_evaporation(trap, ramp, p; N0=3.5e6, T0=50e-6, save_every=2)
+    # collisions per e-folding of the trap depth: gamma_el / |d ln U / dt|
+    coll = Float64[]
+    for i in 2:length(r.t)
+        dt = r.t[i] - r.t[i - 1]
+        (dt > 0 && r.U_depth[i] > 0 && r.U_depth[i - 1] > 0) || continue
+        rate = abs(log(r.U_depth[i] / r.U_depth[i - 1])) / dt
+        rate > 0 && push!(coll, r.gamma_el[i] / rate)
+    end
+    isempty(coll) && (push!(coll, NaN))
+    sort!(coll)
+    med = coll[max(1, length(coll) ÷ 2)]
+    # The conventional requirement is a few elastic collisions per e-folding; below ~1 the
+    # cloud cannot re-thermalise between steps and the quasi-static split is fiction.
+    v = coll[1] >= 3 ? "OK" : coll[1] >= 1 ? "MARGINAL" : "INVALID"
+    @printf("%-7.2f %-10.3g %-12.3g %-12.3g %-12.3g %-10s\n",
+        s, r.t[end] - r.t[1], coll[1], med, maximum(r.gamma_el), v)
+    flush(stdout)
+end
+@printf("\nA recommendation at a slowdown marked INVALID is a statement about the model,\n")
+@printf("not about the experiment.\n")

--- a/scripts/kz/ramp_slowdown_design.jl
+++ b/scripts/kz/ramp_slowdown_design.jl
@@ -30,7 +30,11 @@ for s in (0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0)
     # where the real omega_bar gives 1762, six times too hot, and the constraint then
     # reports N_0 = 0 at every point of every ramp. The trap ramp is identical across
     # slowdowns — only the time axis is stretched — so omega_bar carries no bias here.
-    ω = r.omega_bar[1]
+    # From the trap and ramp, the way zero_d_trajectory does it. EvapBecResult has no
+    # omega_bar — that field is on EvapResult, a different return type, and reaching for
+    # it threw. Same mistake as reading r.t_BEC when the field is r.t_bec: the two result
+    # types are easy to confuse and neither name is wrong on its own.
+    ω = evap_trap_grid(trap, ramp).ωg[1]
     # -1 rather than 0, so a trajectory that never condenses reports N0_peak = 0 with
     # its own first point rather than silently looking like a peak of zero.
     best = (N0=-1.0, t=NaN, N=NaN, T=NaN, mu=NaN)

--- a/scripts/kz/ramp_slowdown_design.jl
+++ b/scripts/kz/ramp_slowdown_design.jl
@@ -25,7 +25,14 @@ for s in (0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0)
     ramp = stretch(euv3_evaporation_ramp(), s)
     p = EvapParams(; a_s=Eu151.a_s, tau_bg=15.0, K3=1.61e-40)
     r = run_evaporation_bec(trap, ramp, p; N0=3.5e6, T0=50e-6, save_every=2)
-    ω = 2π * 100.0                      # fixed reference so mu_eq is comparable
+    # The trajectory's OWN trap frequency. A fixed reference looked like the way to keep
+    # mu_eq comparable across slowdowns and was simply wrong: 2pi*100 puts T_int at 10450
+    # where the real omega_bar gives 1762, six times too hot, and the constraint then
+    # reports N_0 = 0 at every point of every ramp. The trap ramp is identical across
+    # slowdowns — only the time axis is stretched — so omega_bar carries no bias here.
+    ω = r.omega_bar[1]
+    # -1 rather than 0, so a trajectory that never condenses reports N0_peak = 0 with
+    # its own first point rather than silently looking like a peak of zero.
     best = (N0=-1.0, t=NaN, N=NaN, T=NaN, mu=NaN)
     for i in eachindex(r.t)
         r.N[i] > 0 && r.T[i] > 0 || continue

--- a/scripts/kz/ramp_slowdown_design.jl
+++ b/scripts/kz/ramp_slowdown_design.jl
@@ -1,0 +1,43 @@
+# What does a genuinely slower ramp buy, once its extra loss is paid?
+#
+# The c-field runs say slowing helps: the same (N, T) path traversed 3x more slowly
+# multiplies N_0 by 7x and 2.9x at the two points measured, with N_C essentially
+# unchanged — more coherence, not more atoms. But that is a NUMERICAL experiment. A real
+# slower ramp spends longer at every density, so three-body loss eats more, and
+# N_total(t) is lower everywhere.
+#
+# So there should be an optimum, and the 0-D model can find it in seconds: stretch the
+# FortRamp time axis (same beam powers, more time), re-run the evaporation, and read the
+# peak equilibrium N_0 from the same LDA constraint used for the 4.0e4 verdict.
+#
+# What this does NOT settle: whether the c-field reaches the peak the constraint names.
+# That is the dynamics question and it needs the field. This locates the target.
+using SpinorBEC, Printf
+include(joinpath(@__DIR__, "../../docs/guides/figures/eu_evaporation_spgpe.jl"))
+
+"""Stretch a FortRamp's time axis by `s`, holding the beam powers."""
+stretch(r::FortRamp, s::Real) = FortRamp(r.times .* s, r.powers_W)
+
+@printf("%-7s %-11s %-11s %-9s %-11s %-11s %-9s\n",
+    "slow", "duration", "N at peak", "T (nK)", "mu_eq", "N0_peak", "t_peak")
+for s in (0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0)
+    trap = euv3_evap_trap()
+    ramp = stretch(euv3_evaporation_ramp(), s)
+    p = EvapParams(; a_s=Eu151.a_s, tau_bg=15.0, K3=1.61e-40)
+    r = run_evaporation_bec(trap, ramp, p; N0=3.5e6, T0=50e-6, save_every=2)
+    ω = 2π * 100.0                      # fixed reference so mu_eq is comparable
+    best = (N0=-1.0, t=NaN, N=NaN, T=NaN, mu=NaN)
+    for i in eachindex(r.t)
+        r.N[i] > 0 && r.T[i] > 0 || continue
+        T_int = r.T[i] * Units.KB / (Units.HBAR * ω)
+        T_int > 1e-3 || continue
+        g = mu_from_total_lda(r.N[i]; T=T_int, c0=0.02, eps_cut=1.5 + 3 * T_int)
+        (isnan(g.N0) || g.N0 <= best.N0) && continue
+        best = (N0=g.N0, t=r.t[i] - r.t[1], N=r.N[i], T=r.T[i], mu=g.mu)
+    end
+    @printf("%-7.2f %-11.3g %-11.4g %-9.4g %-11.4g %-11.4g %-9.3f\n",
+        s, r.t[end] - r.t[1], best.N, 1e9 * best.T, best.mu, best.N0, best.t)
+    flush(stdout)
+end
+@printf("\nN0_peak rising with slow  => slower is better, loss has not caught up\n")
+@printf("N0_peak turning over      => the optimum is where the two cross\n")

--- a/scripts/kz/ramp_slowdown_design.jl
+++ b/scripts/kz/ramp_slowdown_design.jl
@@ -20,7 +20,11 @@ stretch(r::FortRamp, s::Real) = FortRamp(r.times .* s, r.powers_W)
 
 @printf("%-7s %-11s %-11s %-9s %-11s %-11s %-9s\n",
     "slow", "duration", "N at peak", "T (nK)", "mu_eq", "N0_peak", "t_peak")
-for s in (0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0)
+# No turnover in 0.5-5x: N0_peak falls monotonically with slowdown, so loss dominates
+# everywhere in that range and the optimum is at or below 0.5x. Extended downward until
+# it turns over — a scan that only ever rises toward its own edge has not found an
+# optimum, it has found its edge.
+for s in (0.05, 0.1, 0.15, 0.2, 0.3, 0.5, 1.0)
     trap = euv3_evap_trap()
     ramp = stretch(euv3_evaporation_ramp(), s)
     p = EvapParams(; a_s=Eu151.a_s, tau_bg=15.0, K3=1.61e-40)

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -153,6 +153,8 @@ const _SCRIPTS_ALLOWLIST = Set([
     # more three-body loss, so it scans the 0-D model over a stretched time axis and
     # reads the peak equilibrium N_0 off the same LDA constraint.
     "kz/ramp_slowdown_design.jl",
+    # Whether the 0-D model is still quasi-static at the ramps that scan recommends.
+    "kz/ramp_quasistatic_validity.jl",
     "kz/fixed_point_condensation.jl",
     "kz/eu_cost.jl",
     "kz/eu_equilibrium_N0.jl",

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -149,6 +149,10 @@ const _SCRIPTS_ALLOWLIST = Set([
     "kz/energy_damping_dt_convergence.jl",
     # Removes the ramp: fixed (mu, T, eps_cut) at the ramp's end values, to separate
     # "the field cannot condense here" from "the ramp does not leave time for it".
+    # The DESIGN question the c-field slowdown cannot answer: a real slower ramp pays
+    # more three-body loss, so it scans the 0-D model over a stretched time axis and
+    # reads the peak equilibrium N_0 off the same LDA constraint.
+    "kz/ramp_slowdown_design.jl",
     "kz/fixed_point_condensation.jl",
     "kz/eu_cost.jl",
     "kz/eu_equilibrium_N0.jl",


### PR DESCRIPTION
PR #351 のあと、同じブランチに積んだ 12 件。

**結論を先に**: ランプの速さは**熱力学の的だけを動かし、c-field が作る凝縮体を動かしません**
（3 seed で 0.05σ）。半分にすれば的は 4.41e4 → 6.01e4 と +36 % 上がりますが、場は
どちらでも 41 個前後です。**「ランプを半分に」は、実験が追えない的を動かせという推奨**
でした。到達不能と分かったのは、熱力学の走査ではなく場を走らせたからです。

その過程で**自分の主張を 3 度覆しています**（緩めれば助かる / 半分にすると悪化 / 見出しの
80 %）。いずれも測定で、いずれも主張を出す前か直後に訂正しました。

## 熱力学: ランプを半分にすると的は +36 %

`FortRamp` の時間軸だけ引き伸ばし（ビーム出力は同一、時間だけ変える）、同じ LDA 制約でピーク平衡 `N₀` を読みます。

| slow | 継続時間 | `N₀` ピーク | 衝突/e-fold | |
|---|---|---|---|---|
| 0.05× | 0.12 s | 3.29e4 | 0.020 | **INVALID** |
| 0.10× | 0.24 s | 1.85e4 | 0.026 | **INVALID** |
| 0.20× | 0.48 s | 3.41e4 | 0.054 | **INVALID** |
| 0.30× | 0.72 s | 5.99e4 | 30.6 | OK |
| **0.50×** | **1.2 s** | **6.01e4** | 74.2 | OK |
| 1.00×（現行） | 2.4 s | 4.41e4 | 122 | OK |
| 2.00× | 4.8 s | 2.83e4 | 161 | OK |

**4.41×10⁴ → 6.01×10⁴、実測 5.02×10⁴ も上回り、最適は 0.3–0.5× の広い谷。**

**高速端は物理ではありません。**`condensate.jl` は "standard quasi-static two-component
evaporation" を仮定し、0.3× より速いとトラップ深さが熱化を追い越します ── e-folding
あたり弾性衝突 0.02–0.05、慣例は数回。`N₀` ピークが非単調になる領域
（3.29 → 1.85 → 1.64 → 3.41e4）とちょうど一致します。**妥当性の列がある理由**で、
`N₀` の表だけなら同じ推奨に至りつつ、意味のない 3 行を一緒に引用していました。

## 見出しの数字が変わりました

`eu_equilibrium_N0.jl` は軌道を 18 点に間引き、`t = 1.726` の **4.01e4** を報告します。
全点走査は `t = 1.702` の **4.41e4** を拾い、それは粗い走査の 2 行の間にあります。
同じ制約・同じ軌道で、**差はサンプリング**です。

**ピーク `N₀` = 4.0e4（実測の 80 %）→ 4.41e4（88 %）。**

表は粗い走査の出力なので 4.01e4 のまま残し、食い違いを注として明記しています。黙って
差し替えると読者が同じ食い違いを再発見します。

## 自分の主張を覆した測定 2 件

**「緩めると助かる」は誤りでした。**同じ軌道時刻、引き継ぎ 1.85 s:

| `t` | 7076 | 7280 | 7485 | 7689 | 7893 | 8097 |
|---|---|---|---|---|---|---|
| 1× `N₀` | 10.8 | 20.3 | **41.8** | **64.8** | **68.1** | **49.5** |
| 3× `N₀` | **75.1** | **59.8** | 34.0 | 28.1 | 22.4 | 20.3 |

3× は最初だけ先行し（最初のマーカーまでに 3 倍の時間がある）、**その後単調に落ちます**。
1× は `f₀ = 0.255` まで積み上げて 3 点目から逆転。**私は最初の 2 点で「7 倍・2.9 倍」と
報告し、同じメッセージの中で「2 点で断定しない」と書いていました。**

**律速は引き継ぎ点で違います。**軌道時刻を揃え、C 領域の個数がほぼ等しい点で:

| 引き継ぎ | 開始 `N_C` | `t≈7100` の `N_C` | 失った | `N₀` | `f₀` |
|---|---|---|---|---|---|
| 1.73 s | 2397 | 606 | **75 %** | 0.37 | 0.001 |
| 1.85 s | 657 | 580 | **12 %** | **10.8** | 0.019 |

**同じ個数、30 倍の凝縮体** ── しかも 1.73 s の方が**長く走っています**。早い引き継ぎは
`ε_cut = 31` から縮む区間で C 領域の 4 分の 3 を失い、遅い側はその区間を飛ばします。
`N_C` は軌道と cutoff で決まり、**どちらの速さにもよりません**（580 → 590、444 → 446、
363 → 355）。

## 自分の誤りで落ちた走査 3 件

- **`ω` を 2π×100 に固定** ── 実際の `omega_bar` の 6 倍熱く、全ランプの全点で `N₀ = 0`。
  以前の走査が同じ制約で 4e4 を出していたから気づけた。単独なら「このランプでは凝縮
  しない」と読めた出力です。
- **`r.omega_bar`** ── そのフィールドは `EvapResult` にあり、`run_evaporation_bec` が返す
  のは `EvapBecResult`。このアークで `r.t_BEC` 対 `r.t_bec` を踏んだのと同じ混同。
- **3 引き継ぎ点 / 3 γ アームを 1 予約に** ── 1 ランプ約 5 時間と測ってあったのに、6 時間
  の壁に 2 度当てました。`SBEC_T_START` / `SBEC_GAMMA_MULT` / `SBEC_SLOWDOWN` で 1 アーム
  1 ジョブに分割済み。

## c-field は +36 % を回収しません（0.05σ）

推奨を出す前に測りました。各 3 seed、ランプ終端:

| ランプ | seeds | 平均 ± sd | 平衡（的） |
|---|---|---|---|
| 0.5× | 27.8 / 56.3 / 39.2 | **41.1 ± 14.3** | **7102** |
| 1.0× | 39.7 / 31.8 / 53.4 | **41.6 ± 10.9** | 3498 |

**差 0.5 ± 10.4 ── 0.05σ。**熱力学の的を 2 倍にしても、場が作る凝縮体は**全く動きません**。
**ランプの速さは的だけを動かします。**c-field を律速しているものは場の側にあり、熱力学が
何個許すかではありません。

**最初の 1 軌道は 27.8 対 39.7 で「半分の方が悪い」と読めました。**seed 間のばらつきは
±12 で、その差と同じ大きさです。**seed は主張の前に走らせました** ── このアークは既に
1 走査の 2 点から反対の結論を出しています。

これで設計の問いが、熱力学の走査だけでは出せない形で閉じます: **+36 % は実在し、かつ
到達不能**で、「ランプを半分に」という推奨は**実験が追えない的を動かせという推奨**でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
