### PR TITLE
ω_eff の構造は呼吸モードの位相で、カスケードの共鳴ではない

### DIFF
--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -1083,8 +1083,12 @@ note = "Superseded the next day: there is no structure to explain. The mechanism
 
 [[coverage]]
 doc = "docs/campaign/edh_quench_polarisation_decision.md"
-covered = 26
-note = "70 sections. §12 poured 2026-08-21 as the correction to the incident above."
+covered = 27
+note = """70 sections. §12 poured 2026-08-21 as the correction to the incident above; §9.1,
+§10.1, §10.2 and §12.1 followed the same day. The ratchet moved only 26 -> 27 for four new
+rows because most cite sections already covered — which is the honest arithmetic and worth
+seeing: pouring rows is not the same as covering sections, and a ledger can grow while its
+coverage does not."""
 
 [[coverage]]
 doc = "docs/theory/lhy_scheme_selection_eu_f6.md"
@@ -1159,3 +1163,121 @@ robustness. `peak` can only place its argmax among the 4 interior arms — the o
 all pinned at the same transient value — so the argmax and the ranking come from different
 populations. An agreement produced that way says nothing about the other 16."""
 
+
+[[claim]]
+id = "edh-optimum-not-quotable-at-either-field"
+claim = "Neither B = 5.2 nT nor B = 10.4 nT yields a quotable ω_eff optimum: three readings of the same cached arms place the argmax at three different points, and at 10.4 nT the mean-reading argmax sits on the scan boundary."
+status = "live"
+quantity = "weff optimum @ EdH quench, 5.2 and 10.4 nT"
+type = "B"
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned. Readings: peak-in-hold, mean-over-hold, hold endpoint. All from cache, no recompute."
+uncertainty = "argmax by reading — 5.2 nT: 0.550 (peak at the 8 ms hold), 0.650 (peak over all arms), 0.750 (mean); 10.4 nT: 0.650 (peak, mean, final agree) against 0.350 for the mean over the 20-arm scan, which is the LOWER EDGE of the sampled range. A boundary argmax is not an optimum — it says the range does not contain one."
+uncertainty_basis = "control"
+evidence = ["runs/klaus_quench_weff/klaus_weff0p750_B5p2nT.yaml", "runs/klaus_quench_weff/klaus_weff0p350_B10p4nT.yaml"]
+evidence_status = "in_tree"
+commit = "unknown"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.2"
+pr = 0
+note = """`mean` is NOT hereby declared the right reading. It is a different physical quantity —
+the hold average, diluted by the same transient that contaminates `peak` — and picking it
+because it is well-posed would be choosing a definition to get an answer, which is the
+error this whole thread is about. What the mean reading DOES establish is negative and
+solid: under a reading with no free parameter, 5.2 nT is a single broad maximum with no dip
+and no second branch, +6.3 % rather than the published +17.0 %, and 10.4 nT has no interior
+maximum at all. Three readings, three argmaxes, one of them on the boundary."""
+
+[[claim]]
+id = "edh-104nt-scan-range-excludes-the-mean-optimum"
+claim = "The 10.4 nT ω_eff scan does not contain its own mean-reading optimum: the mean rises monotonically toward the lower edge (0.350, +10.6 %) and the interior is a minimum at 0.790 (−11.6 %)."
+status = "open"
+quantity = "weff scan range @ B=10.4nT"
+type = "A"
+scope = "The 20-arm 8 ms scan over ω_eff ∈ [0.350, 1.000] at 10.4 nT."
+uncertainty = "A boundary argmax carries no interval — the optimum is somewhere below 0.350 or there is none. The shape between 0.500 and 0.650 is nearly flat (+1.97 % to +2.78 %), so the rise toward the edge is the only structure with any amplitude."
+uncertainty_basis = "grid"
+evidence = ["runs/klaus_quench_weff/klaus_weff0p350_B10p4nT.yaml"]
+evidence_status = "in_tree"
+commit = "unknown"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.2"
+pr = 0
+note = """OPEN, and the cheap next step is arms below ω_eff = 0.350 — NOT a 64³ grid check, which
+was the queued job before this. Grid-refining a scan whose optimum is outside its own range
+would have measured resolution against a boundary artifact. The 64³ arms stay cancelled
+until a reading and a range are settled. Note also that the centrifugal limit bounds this
+from below: ω_eff = √(1−Ω²) → 0 as |Ω| → ω_⊥, so a static trap below ~0.3 is a very weak
+radial trap and the cloud size becomes the constraint."""
+
+# --- §9, §10 and §12 poured 2026-08-21. The coverage ratchet exists because §12
+#     being unpoured is what let a refuted method be used again; leaving the
+#     sections either side of it unpoured would be the same bet on a different
+#     number.
+
+[[claim]]
+id = "edh-2p6nt-omega-scan-has-an-interior-maximum"
+claim = "At B = 2.6 nT the Ω scan has an interior maximum at |Ω| = 0.70 (peak P_adj 0.65905, +24.9 % over Ω = 0), falling to 0.441 at |Ω| = 1.00."
+status = "live"
+quantity = "peak_P_adj @ B=2.6nT, Omega-scan, 32cubed"
+type = "B"
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, hold-only + 2 ms delay, 20 Ω cells. Whole-trajectory and in-hold peaks are IDENTICAL at this field (§12.1, measured on all 16 arms), so the reading is not in question here as it is at 10.4 nT."
+uncertainty = "±0.04 on the vertex from a 5-point parabolic fit over |Ω| ∈ [0.58, 0.80], c₂ = −2.70, fit rms 4.7e-3. Criteria C1-C4 fixed before launch: interior maximum required, > 5 % enhancement, ≥5-point fit with negative curvature and interior vertex, digits limited by the fit."
+uncertainty_basis = "fit"
+evidence = ["runs/klaus_quench/klaus_quench_omm0p7_holdonly_delay2ms_refine.yaml"]
+evidence_status = "in_tree"
+commit = "b2d746cc"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "9.1"
+pr = 392
+note = "This field is the one where the observable is not contested, which is why it remains the anchor while 5.2 and 10.4 nT are unquotable."
+
+[[claim]]
+id = "edh-2p6nt-static-scan-reproduces-the-rotating-one"
+claim = "At B = 2.6 nT a static weakened trap reproduces the rotating scan at every matched ω_eff, worst disagreement 0.06 % across ω_eff ∈ [0.6, 1.0] — not only at the optimum."
+status = "live"
+quantity = "static-vs-rotating agreement @ B=2.6nT"
+type = "B"
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, four matched points."
+uncertainty = "0.00 / 0.06 / 0.06 / 0.04 % at ω_eff = 1.000 / 0.750 / 0.714 / 0.600, against a dt/2 reproducibility floor of 0.029 %. The agreement is at the floor, i.e. as good as the method can show."
+uncertainty_basis = "dt"
+evidence = ["34 static-trap arms, §10.1"]
+evidence_status = "absent"
+commit = "b2d746cc"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "10.1"
+pr = 392
+note = "The substitution is what makes ω_eff the scan variable at all. It holds at 2.6 nT; §17 (another session) finds it splits at long hold, where the peak agrees and the endpoint does not."
+
+[[claim]]
+id = "edh-1p3nt-has-no-operating-window"
+claim = "At B = 1.3 nT there is no operating window: +1.8 % across a flat range in ω_eff ∈ [0.65, 1.0]. The absence is the finding, and `|Ω|/ω_⊥ ≈ 0.3 at 1.3 nT` has no replacement."
+status = "live"
+quantity = "weff optimum @ B=1.3nT"
+type = "B"
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, 7 arms. Whole-trajectory and in-hold peaks identical on all 7 (§12.1)."
+uncertainty = "+1.8 % over a flat range against a dt/2 floor of 0.029 % — resolved as a rise, but far below the 24.9 % at 2.6 nT. Bounded as an absence rather than a value: no fit was attempted because there is no interior maximum to fit."
+uncertainty_basis = "dt"
+evidence = ["7 static-trap arms at 1.3 nT, §10.2"]
+evidence_status = "absent"
+commit = "b2d746cc"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "10.2"
+pr = 392
+note = "Do not re-fit. A flat +1.8 % has a numerical argmax and quoting it would manufacture a prescription out of the noise floor — the same move the 5.2 nT two-branch reading made with more amplitude."
+
+[[claim]]
+id = "edh-observable-correction-touched-one-field-only"
+claim = "Re-extracting the peak inside the hold changed 10.4 nT and nothing else: 0.00 % on all 43 arms at 1.3, 2.6 and 5.2 nT, against 7 of 10 arms moving by up to −23 % at 10.4 nT."
+status = "live"
+quantity = "in-hold vs whole-trajectory peak, per field"
+type = "A"
+scope = "Every arm measured up to 2026-08-20, re-extracted from cache with no recompute."
+uncertainty = "Exact zeros, not small numbers: the two readings coincide arm-for-arm at the three lower fields. That is what makes the correction diagnostic rather than a global rescaling — it isolates the Zeeman-re-pinned field, where the hold suppresses the cascade and the transient wins."
+uncertainty_basis = "control"
+evidence = ["docs/campaign/edh_quench_polarisation_decision.md"]
+evidence_status = "in_tree"
+commit = "97ec124e"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.1"
+pr = 410
+note = "The reason §9, §10 and §11 survive an instrument correction of this size is measured here, not assumed. Worth keeping as a row because 'the fix only touched one field' is exactly the kind of claim that gets asserted without the table."

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -1339,3 +1339,57 @@ doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "9.4"
 pr = 392
 note = "Recorded because it is the number anyone sizing a grid check will guess wrong in the expensive direction, and because it is what made the cancelled 64³ job look affordable."
+
+# --- The mechanism, found by measuring the cloud instead of the populations ----
+
+[[claim]]
+id = "edh-quench-excites-a-breathing-mode"
+claim = "The B quench leaves the cloud breathing, and ω_eff sets the breathing FREQUENCY, not whether it breathes: the ω_eff = 1.000 arm — whose trap is never changed — oscillates in radial RMS radius with a period of ~5 frames, while ω_eff = 0.650 oscillates with ~11."
+status = "live"
+quantity = "radial breathing @ B=10.4nT"
+type = "B"
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, B = 10.4 nT, radial RMS radius over the hold, read from cached snapshots. Seen at both hold lengths."
+uncertainty = "unbounded: the periods were read off by eye from 11 and 22 samples with no fit, so `~5` and `~11` frames carry no interval. What IS bounded is the EXISTENCE of the oscillation — the ω_eff = 1.000 trace runs 2.885 → 1.999 → 2.693 → 1.984 → 3.163, swings of 30-40 % against a dt/2 reproducibility floor of 0.029 %."
+uncertainty_basis = "none"
+evidence = ["runs/klaus_quench_weff/klaus_weff1p000_B10p4nT.yaml", "runs/klaus_quench_weff/klaus_weff0p650_B10p4nT.yaml"]
+evidence_status = "in_tree"
+commit = "unknown"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.2"
+pr = 0
+note = "The ω_eff = 1.000 arm is the control that makes this a statement about the QUENCH: its trap is identical before and during the hold, so an oscillation there cannot be caused by weakening the trap."
+
+[[claim]]
+id = "edh-weff-structure-is-breathing-phase-not-resonance"
+claim = "The ω_eff structure at B = 10.4 nT is a phase sample of the breathing mode at a fixed hold length, not a resonance in the cascade: radial expansion over the hold has a minimum at ω_eff ≈ 0.59-0.62 where the cloud CONTRACTS, and doubling the hold moves the ratios."
+status = "live"
+quantity = "origin of the weff structure @ B=10.4nT"
+type = "B"
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, B = 10.4 nT, 26 arms over ω_eff ∈ [0.15, 1.00] at the 8 ms hold plus two at 16 ms."
+uncertainty = "The ratio r(end)/r(hold start) runs 1.571 (ω_eff = 0.200) → 0.949 (0.590, the minimum) → 1.140 (0.830) → 1.097 (1.000). Doubling the hold moves it from 0.989 to 1.006 at ω_eff = 0.650 and from 1.096 to 1.033 at 1.000 — a resonance would not move. The first 11 frames of the 8 ms and 16 ms holds agree exactly, which is the check that the window extraction is right."
+uncertainty_basis = "control"
+evidence = ["runs/klaus_quench_weff/klaus_weff0p590_B10p4nT.yaml", "runs/klaus_quench_weff/klaus_weff0p650_B10p4nT_hold2p0x.yaml"]
+evidence_status = "in_tree"
+commit = "unknown"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.2"
+pr = 0
+prediction = "If the structure is a breathing phase rather than a resonance, doubling the hold must move the expansion ratio; a resonance would leave it where it is."
+prediction_registered = "before"
+prediction_outcome = "hit"
+note = """NOT a supersession of `edh-104nt-peak-reads-the-transient-for-80-percent`, and it was
+written as one for a minute until the link checker refused it. That row is still true —
+22 of 26 arms take their maximum at frame 32 — and this one EXPLAINS it. Explanation and
+replacement are different relations, and the ledger only has vocabulary for the second.
+
+THIS EXPLAINS THE POPULATION I HAD RECORDED AS UNEXPLAINED. The four arms whose `peak`
+falls in the hold interior — 0.590, 0.620, 0.650, 0.680 — are EXACTLY the four with the
+smallest radial expansion, three of them contracting. Where the cloud is compressed at the
+end of the window the density is high, the cascade is still running, and the maximum lands
+on the last frame; everywhere else the cloud expands, density falls, the cascade stalls and
+the maximum is the pre-hold transient. Two independent readings — the argmax frame of
+P_adj, and the radial dynamics — pick out the same four arms.
+It also removes the reason to look for a cascade resonance at either field: a structure in
+ω_eff at fixed hold length is what a breathing phase looks like. That does not by itself
+refute the 5.2 nT reading, which has not been measured this way — but it is now the
+hypothesis to beat there, and it is cheap to test from the same cached snapshots."""

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -1281,3 +1281,61 @@ doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "12.1"
 pr = 410
 note = "The reason §9, §10 and §11 survive an instrument correction of this size is measured here, not assumed. Worth keeping as a row because 'the fix only touched one field' is exactly the kind of claim that gets asserted without the table."
+
+[[claim]]
+id = "sec12-extraction-method-not-in-the-tree"
+claim = "§12.2's numbers are reproducible but its METHOD is not: the tree carries the values and not the code that produced them, and the window they correspond to (hold frames 34-42) is not derivable from the config."
+status = "open"
+quantity = "provenance of the 12.2 extraction"
+type = "A"
+scope = "The 10.4 nT in-hold re-extraction of 2026-08-20 (`97ec124e`). Not a statement about the numbers, which reproduce exactly."
+uncertainty = "Reproduced to five decimals: max over hold frames 34-42 gives 0.20139 at ω_eff = 1.000, matching §12.2. But frames 32-42 is what the config implies — prep 13 + quench 13 + pre-delay 5 = 31, and the arm-to-arm spread is exactly 0.000000 at frames 30-31 and 0.000213 at 32 — so the two-frame difference has no derivation, only a value that matches."
+uncertainty_basis = "control"
+evidence = ["scripts/validation/klaus_weff_extract.jl"]
+evidence_status = "in_tree"
+commit = "97ec124e"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.2"
+pr = 410
+note = """This is `evidence_status = absent` applied to a METHOD rather than to data, and it is the
+sharper version: absent arms can be re-run, an absent extraction has to be re-derived, and
+re-deriving it from which value matches is how a window gets chosen to fit an answer. I did
+exactly that for one commit before catching it.
+What closes this is not archaeology. `scripts/validation/klaus_weff_extract.jl` is now in
+the tree, computes three readings, and derives its window from the config with the frame
+arithmetic written down — so from here the method travels with the number. §12.2's own two
+frames remain unexplained and its numbers should be quoted with the window stated."""
+
+[[claim]]
+id = "edh-g4-mirror-agrees-to-five-decimals"
+claim = "The repaired mirror pair agrees to < 1e-5 on peak P_adj (0.61698 vs 0.61698), stronger than the `3-digit match` the sheet claimed for the pre-repair pair."
+status = "live"
+quantity = "mirror pair agreement @ 2.6nT"
+type = "A"
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, the two `*_keeprot*` arms. Acceptance gate G4."
+uncertainty = "< 1e-5 relative, i.e. below the dt/2 reproducibility floor of 0.029 % by three orders. Bounded by the comparison itself; there is no fit."
+uncertainty_basis = "control"
+evidence = ["runs/klaus_quench/klaus_quench_omm0p5_keeprot.yaml", "runs/klaus_quench/klaus_quench_omp0p5_keeprot_mirror.yaml"]
+evidence_status = "in_tree"
+commit = "b2d746cc"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "9.4"
+pr = 392
+note = "Both members now sit at the anti-aligned preparation, so the pair is mirror-correct AND in the regime where the enhancement exists — the two were separate repairs."
+
+[[claim]]
+id = "edh-cost-64cubed-is-5x-not-8x"
+claim = "A 64³ arm costs 5.1× a 32³ one (3026 s against ~590 s on the same core), not the 8× the cell count suggests, because the FFT work does not scale linearly and the run is partly memory-bound at 3.0 GB RSS."
+status = "live"
+quantity = "64cubed vs 32cubed walltime ratio"
+type = "A"
+scope = "klaus_quench protocol, CPU, 8 ms hold. A cost model, not physics."
+uncertainty = "unbounded: two timings, one core, no repetition — nothing here bounds the ratio. It is an order-of-magnitude planning number, and the gate refusing the first wording is the point: `two timings and no repetition` reads like a bound and is not one."
+uncertainty_basis = "none"
+evidence = ["runs/klaus_quench/klaus_quench_omm0p5_keeprot_n64.yaml"]
+evidence_status = "in_tree"
+commit = "b2d746cc"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "9.4"
+pr = 392
+note = "Recorded because it is the number anyone sizing a grid check will guess wrong in the expensive direction, and because it is what made the cancelled 64³ job look affordable."

--- a/runs/klaus_quench_weff/klaus_weff0p150_B10p4nT.yaml
+++ b/runs/klaus_quench_weff/klaus_weff0p150_B10p4nT.yaml
@@ -1,0 +1,91 @@
+# Static-trap ω_eff scan @ canonical EdH protocol (hold_only, delay=2 ms,
+# B_hold = 10.4 nT, m=+F).  ω_⊥,eff / ω_⊥ = 0.150
+# Source: scripts/validation/klaus_weff_scan_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned. Authority:
+#   docs/campaign/edh_quench_polarisation_decision.md
+#
+# NO ROTATION ANYWHERE. The enhancement is centrifugal, not Coriolis (§9.3): a
+#   static radial trap at ω_eff reproduces the rotating result to 0.06 % across
+#   the range. `rotating_frame_omega` is 0.0 in every step; the hold step
+#   overrides `potential:` instead.
+#
+# Built-in control: at ω_eff = 1.000 this must return the unweakened baseline.
+#   If the per-step `potential:` override were silently ignored, EVERY arm would
+#   return that same value — so a flat scan is a plumbing failure, not a null.
+#
+# hold_scale = 1.0. At 1.0 the peak of peak-P_adj lands on the LAST
+#   streamed frame for much of the scan, which is a truncation and not a peak:
+#   the published 5.2 nT dip compares a resolved maximum (frame 38/42) against
+#   boundary values (42/42). Arms with hold_scale > 1 exist to show whether the
+#   structure survives once both sides peak inside the window.
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions: {N_atoms: 10000, omega_ref: 691.1504}
+
+pipeline:
+  - ground_state:
+      atom: Eu151
+      grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+      potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+      interactions:
+        N_atoms: 10000
+        omega_ref: 691.1504
+        c1_ratio: 0.02778
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      gauge_fix: false
+      initial_state: m_plus_F
+      init_sigma: 1.5
+      dt: 0.005
+      n_steps: 3000
+      tol: 1.0e-9
+
+  - dynamics:   # rotation_prep (hold-only: no rotation)
+      duration: 6.9115
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      seed_amplitude: 1.0e-6
+      seed_k_cut: 2.5
+      save: {every: 100, psi: true, precision: f64}
+
+  - dynamics:   # B_quench
+      duration: 0.69115
+      dt: 0.001
+      rotating_frame_omega: 0.0
+      B: {Bz: {from: 0.01, to: 0.00010400000000000001, duration: 0.6911504}, theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold pre-delay (unweakened trap, 2 ms)
+      duration: 1.3823
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold with the RADIALLY WEAKENED static trap (8.0 ms)
+      duration: 5.5292
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      potential: {type: harmonic, omega: [0.1500, 0.1500, 1.181818]}
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 100, psi: true, precision: f64}
+
+  - analyze:
+      - phase_classify: {}
+      - winding_map: {}
+      - energy_decomposition: {}

--- a/runs/klaus_quench_weff/klaus_weff0p200_B10p4nT.yaml
+++ b/runs/klaus_quench_weff/klaus_weff0p200_B10p4nT.yaml
@@ -1,0 +1,91 @@
+# Static-trap ω_eff scan @ canonical EdH protocol (hold_only, delay=2 ms,
+# B_hold = 10.4 nT, m=+F).  ω_⊥,eff / ω_⊥ = 0.200
+# Source: scripts/validation/klaus_weff_scan_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned. Authority:
+#   docs/campaign/edh_quench_polarisation_decision.md
+#
+# NO ROTATION ANYWHERE. The enhancement is centrifugal, not Coriolis (§9.3): a
+#   static radial trap at ω_eff reproduces the rotating result to 0.06 % across
+#   the range. `rotating_frame_omega` is 0.0 in every step; the hold step
+#   overrides `potential:` instead.
+#
+# Built-in control: at ω_eff = 1.000 this must return the unweakened baseline.
+#   If the per-step `potential:` override were silently ignored, EVERY arm would
+#   return that same value — so a flat scan is a plumbing failure, not a null.
+#
+# hold_scale = 1.0. At 1.0 the peak of peak-P_adj lands on the LAST
+#   streamed frame for much of the scan, which is a truncation and not a peak:
+#   the published 5.2 nT dip compares a resolved maximum (frame 38/42) against
+#   boundary values (42/42). Arms with hold_scale > 1 exist to show whether the
+#   structure survives once both sides peak inside the window.
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions: {N_atoms: 10000, omega_ref: 691.1504}
+
+pipeline:
+  - ground_state:
+      atom: Eu151
+      grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+      potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+      interactions:
+        N_atoms: 10000
+        omega_ref: 691.1504
+        c1_ratio: 0.02778
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      gauge_fix: false
+      initial_state: m_plus_F
+      init_sigma: 1.5
+      dt: 0.005
+      n_steps: 3000
+      tol: 1.0e-9
+
+  - dynamics:   # rotation_prep (hold-only: no rotation)
+      duration: 6.9115
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      seed_amplitude: 1.0e-6
+      seed_k_cut: 2.5
+      save: {every: 100, psi: true, precision: f64}
+
+  - dynamics:   # B_quench
+      duration: 0.69115
+      dt: 0.001
+      rotating_frame_omega: 0.0
+      B: {Bz: {from: 0.01, to: 0.00010400000000000001, duration: 0.6911504}, theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold pre-delay (unweakened trap, 2 ms)
+      duration: 1.3823
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold with the RADIALLY WEAKENED static trap (8.0 ms)
+      duration: 5.5292
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      potential: {type: harmonic, omega: [0.2000, 0.2000, 1.181818]}
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 100, psi: true, precision: f64}
+
+  - analyze:
+      - phase_classify: {}
+      - winding_map: {}
+      - energy_decomposition: {}

--- a/runs/klaus_quench_weff/klaus_weff0p250_B10p4nT.yaml
+++ b/runs/klaus_quench_weff/klaus_weff0p250_B10p4nT.yaml
@@ -1,0 +1,91 @@
+# Static-trap ω_eff scan @ canonical EdH protocol (hold_only, delay=2 ms,
+# B_hold = 10.4 nT, m=+F).  ω_⊥,eff / ω_⊥ = 0.250
+# Source: scripts/validation/klaus_weff_scan_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned. Authority:
+#   docs/campaign/edh_quench_polarisation_decision.md
+#
+# NO ROTATION ANYWHERE. The enhancement is centrifugal, not Coriolis (§9.3): a
+#   static radial trap at ω_eff reproduces the rotating result to 0.06 % across
+#   the range. `rotating_frame_omega` is 0.0 in every step; the hold step
+#   overrides `potential:` instead.
+#
+# Built-in control: at ω_eff = 1.000 this must return the unweakened baseline.
+#   If the per-step `potential:` override were silently ignored, EVERY arm would
+#   return that same value — so a flat scan is a plumbing failure, not a null.
+#
+# hold_scale = 1.0. At 1.0 the peak of peak-P_adj lands on the LAST
+#   streamed frame for much of the scan, which is a truncation and not a peak:
+#   the published 5.2 nT dip compares a resolved maximum (frame 38/42) against
+#   boundary values (42/42). Arms with hold_scale > 1 exist to show whether the
+#   structure survives once both sides peak inside the window.
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions: {N_atoms: 10000, omega_ref: 691.1504}
+
+pipeline:
+  - ground_state:
+      atom: Eu151
+      grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+      potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+      interactions:
+        N_atoms: 10000
+        omega_ref: 691.1504
+        c1_ratio: 0.02778
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      gauge_fix: false
+      initial_state: m_plus_F
+      init_sigma: 1.5
+      dt: 0.005
+      n_steps: 3000
+      tol: 1.0e-9
+
+  - dynamics:   # rotation_prep (hold-only: no rotation)
+      duration: 6.9115
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      seed_amplitude: 1.0e-6
+      seed_k_cut: 2.5
+      save: {every: 100, psi: true, precision: f64}
+
+  - dynamics:   # B_quench
+      duration: 0.69115
+      dt: 0.001
+      rotating_frame_omega: 0.0
+      B: {Bz: {from: 0.01, to: 0.00010400000000000001, duration: 0.6911504}, theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold pre-delay (unweakened trap, 2 ms)
+      duration: 1.3823
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold with the RADIALLY WEAKENED static trap (8.0 ms)
+      duration: 5.5292
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      potential: {type: harmonic, omega: [0.2500, 0.2500, 1.181818]}
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 100, psi: true, precision: f64}
+
+  - analyze:
+      - phase_classify: {}
+      - winding_map: {}
+      - energy_decomposition: {}

--- a/runs/klaus_quench_weff/klaus_weff0p280_B10p4nT.yaml
+++ b/runs/klaus_quench_weff/klaus_weff0p280_B10p4nT.yaml
@@ -1,0 +1,91 @@
+# Static-trap ω_eff scan @ canonical EdH protocol (hold_only, delay=2 ms,
+# B_hold = 10.4 nT, m=+F).  ω_⊥,eff / ω_⊥ = 0.280
+# Source: scripts/validation/klaus_weff_scan_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned. Authority:
+#   docs/campaign/edh_quench_polarisation_decision.md
+#
+# NO ROTATION ANYWHERE. The enhancement is centrifugal, not Coriolis (§9.3): a
+#   static radial trap at ω_eff reproduces the rotating result to 0.06 % across
+#   the range. `rotating_frame_omega` is 0.0 in every step; the hold step
+#   overrides `potential:` instead.
+#
+# Built-in control: at ω_eff = 1.000 this must return the unweakened baseline.
+#   If the per-step `potential:` override were silently ignored, EVERY arm would
+#   return that same value — so a flat scan is a plumbing failure, not a null.
+#
+# hold_scale = 1.0. At 1.0 the peak of peak-P_adj lands on the LAST
+#   streamed frame for much of the scan, which is a truncation and not a peak:
+#   the published 5.2 nT dip compares a resolved maximum (frame 38/42) against
+#   boundary values (42/42). Arms with hold_scale > 1 exist to show whether the
+#   structure survives once both sides peak inside the window.
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions: {N_atoms: 10000, omega_ref: 691.1504}
+
+pipeline:
+  - ground_state:
+      atom: Eu151
+      grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+      potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+      interactions:
+        N_atoms: 10000
+        omega_ref: 691.1504
+        c1_ratio: 0.02778
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      gauge_fix: false
+      initial_state: m_plus_F
+      init_sigma: 1.5
+      dt: 0.005
+      n_steps: 3000
+      tol: 1.0e-9
+
+  - dynamics:   # rotation_prep (hold-only: no rotation)
+      duration: 6.9115
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      seed_amplitude: 1.0e-6
+      seed_k_cut: 2.5
+      save: {every: 100, psi: true, precision: f64}
+
+  - dynamics:   # B_quench
+      duration: 0.69115
+      dt: 0.001
+      rotating_frame_omega: 0.0
+      B: {Bz: {from: 0.01, to: 0.00010400000000000001, duration: 0.6911504}, theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold pre-delay (unweakened trap, 2 ms)
+      duration: 1.3823
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold with the RADIALLY WEAKENED static trap (8.0 ms)
+      duration: 5.5292
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      potential: {type: harmonic, omega: [0.2800, 0.2800, 1.181818]}
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 100, psi: true, precision: f64}
+
+  - analyze:
+      - phase_classify: {}
+      - winding_map: {}
+      - energy_decomposition: {}

--- a/runs/klaus_quench_weff/klaus_weff0p310_B10p4nT.yaml
+++ b/runs/klaus_quench_weff/klaus_weff0p310_B10p4nT.yaml
@@ -1,0 +1,91 @@
+# Static-trap ω_eff scan @ canonical EdH protocol (hold_only, delay=2 ms,
+# B_hold = 10.4 nT, m=+F).  ω_⊥,eff / ω_⊥ = 0.310
+# Source: scripts/validation/klaus_weff_scan_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned. Authority:
+#   docs/campaign/edh_quench_polarisation_decision.md
+#
+# NO ROTATION ANYWHERE. The enhancement is centrifugal, not Coriolis (§9.3): a
+#   static radial trap at ω_eff reproduces the rotating result to 0.06 % across
+#   the range. `rotating_frame_omega` is 0.0 in every step; the hold step
+#   overrides `potential:` instead.
+#
+# Built-in control: at ω_eff = 1.000 this must return the unweakened baseline.
+#   If the per-step `potential:` override were silently ignored, EVERY arm would
+#   return that same value — so a flat scan is a plumbing failure, not a null.
+#
+# hold_scale = 1.0. At 1.0 the peak of peak-P_adj lands on the LAST
+#   streamed frame for much of the scan, which is a truncation and not a peak:
+#   the published 5.2 nT dip compares a resolved maximum (frame 38/42) against
+#   boundary values (42/42). Arms with hold_scale > 1 exist to show whether the
+#   structure survives once both sides peak inside the window.
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions: {N_atoms: 10000, omega_ref: 691.1504}
+
+pipeline:
+  - ground_state:
+      atom: Eu151
+      grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+      potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+      interactions:
+        N_atoms: 10000
+        omega_ref: 691.1504
+        c1_ratio: 0.02778
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      gauge_fix: false
+      initial_state: m_plus_F
+      init_sigma: 1.5
+      dt: 0.005
+      n_steps: 3000
+      tol: 1.0e-9
+
+  - dynamics:   # rotation_prep (hold-only: no rotation)
+      duration: 6.9115
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      seed_amplitude: 1.0e-6
+      seed_k_cut: 2.5
+      save: {every: 100, psi: true, precision: f64}
+
+  - dynamics:   # B_quench
+      duration: 0.69115
+      dt: 0.001
+      rotating_frame_omega: 0.0
+      B: {Bz: {from: 0.01, to: 0.00010400000000000001, duration: 0.6911504}, theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold pre-delay (unweakened trap, 2 ms)
+      duration: 1.3823
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold with the RADIALLY WEAKENED static trap (8.0 ms)
+      duration: 5.5292
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      potential: {type: harmonic, omega: [0.3100, 0.3100, 1.181818]}
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 100, psi: true, precision: f64}
+
+  - analyze:
+      - phase_classify: {}
+      - winding_map: {}
+      - energy_decomposition: {}

--- a/runs/klaus_quench_weff/klaus_weff0p340_B10p4nT.yaml
+++ b/runs/klaus_quench_weff/klaus_weff0p340_B10p4nT.yaml
@@ -1,0 +1,91 @@
+# Static-trap ω_eff scan @ canonical EdH protocol (hold_only, delay=2 ms,
+# B_hold = 10.4 nT, m=+F).  ω_⊥,eff / ω_⊥ = 0.340
+# Source: scripts/validation/klaus_weff_scan_gen.jl
+#
+# anti-aligned-seed: the EdH cascade only runs from the Zeeman-HIGHEST stretched
+#   state. Measured 2026-08-19 (#343): rotation contrast +16.5 % anti-aligned
+#   against -0.45 % aligned. Authority:
+#   docs/campaign/edh_quench_polarisation_decision.md
+#
+# NO ROTATION ANYWHERE. The enhancement is centrifugal, not Coriolis (§9.3): a
+#   static radial trap at ω_eff reproduces the rotating result to 0.06 % across
+#   the range. `rotating_frame_omega` is 0.0 in every step; the hold step
+#   overrides `potential:` instead.
+#
+# Built-in control: at ω_eff = 1.000 this must return the unweakened baseline.
+#   If the per-step `potential:` override were silently ignored, EVERY arm would
+#   return that same value — so a flat scan is a plumbing failure, not a null.
+#
+# hold_scale = 1.0. At 1.0 the peak of peak-P_adj lands on the LAST
+#   streamed frame for much of the scan, which is a truncation and not a peak:
+#   the published 5.2 nT dip compares a resolved maximum (frame 38/42) against
+#   boundary values (42/42). Arms with hold_scale > 1 exist to show whether the
+#   structure survives once both sides peak inside the window.
+
+defaults:
+  kind: spinor
+  backend: cpu
+  interactions: {N_atoms: 10000, omega_ref: 691.1504}
+
+pipeline:
+  - ground_state:
+      atom: Eu151
+      grid: {n: [32, 32, 32], box: [12.0, 12.0, 12.0]}
+      potential: {type: harmonic, omega: [1.0, 1.0, 1.181818]}
+      interactions:
+        N_atoms: 10000
+        omega_ref: 691.1504
+        c1_ratio: 0.02778
+      ddi: {enabled: true, secular: true}
+      lhy: {kind: none}
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      gauge_fix: false
+      initial_state: m_plus_F
+      init_sigma: 1.5
+      dt: 0.005
+      n_steps: 3000
+      tol: 1.0e-9
+
+  - dynamics:   # rotation_prep (hold-only: no rotation)
+      duration: 6.9115
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.01 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      seed_amplitude: 1.0e-6
+      seed_k_cut: 2.5
+      save: {every: 100, psi: true, precision: f64}
+
+  - dynamics:   # B_quench
+      duration: 0.69115
+      dt: 0.001
+      rotating_frame_omega: 0.0
+      B: {Bz: {from: 0.01, to: 0.00010400000000000001, duration: 0.6911504}, theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold pre-delay (unweakened trap, 2 ms)
+      duration: 1.3823
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 50, psi: true, precision: f64}
+
+  - dynamics:   # hold with the RADIALLY WEAKENED static trap (8.0 ms)
+      duration: 5.5292
+      dt: 0.005
+      rotating_frame_omega: 0.0
+      potential: {type: harmonic, omega: [0.3400, 0.3400, 1.181818]}
+      B: {Bz: "0.00010400000000000001 Gauss", theta: 0.0, phi: 0.0}
+      ddi: {enabled: true, secular: false}
+      lhy: {kind: none}
+      save: {every: 100, psi: true, precision: f64}
+
+  - analyze:
+      - phase_classify: {}
+      - winding_map: {}
+      - energy_decomposition: {}

--- a/runs/klaus_quench_weff/manifest_104nT_lowweff.txt
+++ b/runs/klaus_quench_weff/manifest_104nT_lowweff.txt
@@ -1,0 +1,24 @@
+# Below the lower edge of the 10.4 nT scan.
+#
+# The mean reading — no free parameter once the hold is fixed — rises
+# monotonically toward omega_eff = 0.350, which is the LOWER EDGE of the sampled
+# range, with the interior a minimum at 0.790. A boundary argmax is not an
+# optimum: it says the range does not contain one. These six arms extend it.
+#
+# NOT a 64^3 grid check, which was the queued job before this and is still
+# cancelled. Refining the resolution of a scan whose optimum lies outside its own
+# range measures resolution against a boundary artifact.
+#
+# Physical floor, and it is real: omega_eff = sqrt(1 - Omega^2), so these
+# correspond to |Omega| = 0.94 to 0.99 — at the centrifugal limit the effective
+# radial trap vanishes and the cloud is no longer bound in the plane. As a STATIC
+# trap there is no rotation, but the same weak radial confinement applies, so the
+# arms near 0.15 are expected to be dominated by expansion rather than by the
+# cascade. If the mean keeps rising all the way down, that is the signature of
+# the cloud leaving the trap, not of a better operating point.
+runs/klaus_quench_weff/klaus_weff0p150_B10p4nT.yaml
+runs/klaus_quench_weff/klaus_weff0p200_B10p4nT.yaml
+runs/klaus_quench_weff/klaus_weff0p250_B10p4nT.yaml
+runs/klaus_quench_weff/klaus_weff0p280_B10p4nT.yaml
+runs/klaus_quench_weff/klaus_weff0p310_B10p4nT.yaml
+runs/klaus_quench_weff/klaus_weff0p340_B10p4nT.yaml


### PR DESCRIPTION
**個体数ではなく雲を測ったら**、私が「未説明」と記録していた母集団が説明され、共鳴を探す理由がなくなりました。

## クエンチが呼吸モードを励起している

**`ω_eff = 1.000` のアーム — hold 中にトラップを一切変えていない — が振動しています。**

```
r_rms:  2.885 → 2.487 → 1.999 → 2.194 → 2.602 → 2.693 → 2.397 → 1.984 → 2.176 → 2.812 → 3.163
```

トラップは前も最中も同一なので、**この振動は「弱めたこと」では起こせません**。ω_eff が変えるのは**呼吸の振動数**です — 1.000 で周期 ~5 枠、0.650 で ~11 枠。

## だから ω_eff の構造は位相のサンプリング

hold が固定長なので、終端での半径は**周期のどこにいるか**で決まります。26本の膨張比:

```
0.200  1.571
0.590  0.949  ← 最小。雲が収縮している
0.830  1.140
1.000  1.097
```

## 予言（測定前に登録）→ 当たり

> 位相であって共鳴でないなら、**hold を倍にすると比は動く**。共鳴なら動かない。

| ω_eff | 8 ms | 16 ms |
|---|---|---|
| 0.650 | 0.989 | **1.006** |
| 1.000 | 1.096 | **1.033** |

**動きました。** そして 8 ms と 16 ms の**最初の 11 枠が厳密に一致**します — 窓の切り出しが正しいことの検算です。

## interior の4本が説明されます

`peak` が hold 内部でピークを打つ4本 — **0.590 / 0.620 / 0.650 / 0.680** — は、**膨張が最小の4本と厳密に同じ**で、うち3本は収縮しています。

雲が窓の終端で圧縮されているアームでは**密度が高く、カスケードがまだ走っている**ので最大値が最終枠に来ます。他では雲が膨張して密度が落ち、カスケードが止まり、最大値は hold 前の過渡になります。

**2つの独立な読み — P_adj の argmax フレームと、径方向ダイナミクス — が同じ4本を選び出しています。**

## 私の事前解釈は2つとも死にました

どちらも測定前に登録したものです。

- **peak density**: ω_eff=0.150 の減少（−21.9 %）は、トラップを変えていない 1.000（−17.2 %）と同程度
- **径方向半径**: 膨張は ×1.55 で**飽和**し、Thomas-Fermi が要求する ×2.14 に**届かない**

**「低 ω_eff で雲がトラップを出ている」は棄却**されました。

## 台帳が私自身の行を2度拒否しました

- パーサが「目視で読んだ、fit していない」を**境界のように読める**として拒否
- リンク検査が `supersedes` を拒否 — **あちらの行はまだ真で、こちらはそれを説明している**だけだから

**説明と置換は別の関係**で、schema には後者の語彙しかありません。近い方のリンクで埋めず、**限界として記録**しました。

## 検証

全ゲート 0 failure。台帳 63 行。抽出は**全てキャッシュから**で、新規の実行はこの PR にありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
