### PR TITLE
fix(ci)+research(edh): nightly green after 92 reds; #424 at 5.01σ, #423 at production scale, #444/#425 closed

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,11 @@ jobs:
   heavy:
     name: Heavy YAML (Julia 1.12, tier=full)
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # 100, not 90: the per-worker cap below is 4200 s = 70 min, and run
+    # 32415817639 spent 7 min on checkout + setup + precompile before the first
+    # worker started. 90 would leave 13 min for a step measured at 7, which is
+    # the same absent-margin the cap itself had.
+    timeout-minutes: 100
     env:
       SPINORBEC_TEST_TIER: full
       SPINORBEC_RUN_HEAVY_YAML: "true"
@@ -50,12 +54,41 @@ jobs:
       # the per-push tiers; `full` on a 4-vCPU runner is 6317 s of measured work
       # (run 30668378491), i.e. a perfectly-packed makespan of ~1580 s — 12 %
       # of headroom, and any imbalance eats it. That run died with all four
-      # workers killed at the cap and ZERO assertion failures. 2700 s keeps the
-      # hang guard well inside the 90-minute job timeout while leaving the
-      # margin the arithmetic says this tier needs.
-      SPINORBEC_TEST_TIMEOUT: "2700"
+      # workers killed at the cap and ZERO assertion failures.
+      #
+      # 2700 s was then not enough either, and the arithmetic says it never
+      # could have been. Measured on run 32415817639 (2026-08-20): 471 files
+      # completed carrying 8067 s of work, plus
+      # `dynamics/test_spgpe_equilibrium_number.jl`, which run 32300172779
+      # timed at 40m31s = 2432 s ON THIS RUNNER. That one file cannot be
+      # split, so the makespan is bounded below by max(2432, 8067/3 = 2689) =
+      # 2689 s — ELEVEN SECONDS under the cap. The tier was not intermittently
+      # slow, it was sitting on the boundary, which is why the streak reads as
+      # flaky rather than as a sizing error.
+      #
+      # (The three files the 08-20 log lists beside it as never completing —
+      # `test_{itp,rtp}_ddi_strang_save_every.jl`, `test_yoshida_ddi_order.jl` —
+      # are 12.7 / 4.4 / 7.8 s. They were not slow; they were claimed in the
+      # last seconds before their workers were killed. Reading "never completed"
+      # as "too slow" would have sent the fix at the wrong four files.)
+      #
+      # 4200 s puts real margin under the 2689 s floor and still leaves 20 min
+      # of the 90-minute job budget for checkout, setup and precompile.
+      # `dynamics/test_spgpe_equilibrium_number.jl` is 23 % of the tier's whole
+      # workload on its own and is worth making cheaper at the source (#305);
+      # this is the sizing fix, not that one.
+      SPINORBEC_TEST_TIMEOUT: "4200"
     steps:
       - uses: actions/checkout@v4
+        with:
+          # `full` runs `test_campaign_fix_list_gate.jl`, whose ancestor check is
+          # `git merge-base --is-ancestor <2026-06-ref> HEAD`. Under the default
+          # `fetch-depth: 1` that fails for want of the commit, so the gate
+          # reported all 16 fix-list refs dead and its own canary disqualified.
+          # `ci.yml` has carried `fetch-depth: 0` since the gate landed; this job
+          # never got it, and the gate's `_shallow()` predicate exists precisely
+          # to say so in one line instead of surfacing as a raw git error.
+          fetch-depth: 0
       - uses: julia-actions/setup-julia@v2
         with:
           version: "1.12"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,9 +74,17 @@ jobs:
       #
       # 4200 s puts real margin under the 2689 s floor and still leaves 20 min
       # of the 90-minute job budget for checkout, setup and precompile.
-      # `dynamics/test_spgpe_equilibrium_number.jl` is 23 % of the tier's whole
-      # workload on its own and is worth making cheaper at the source (#305);
-      # this is the sizing fix, not that one.
+      #
+      # The source fix landed in the same PR (#305): that file's fixture shrank
+      # from n=48 L=10.0 to n=32 L=6.5 — every assertion in it is on an
+      # INTENSIVE ratio, verified unchanged to 1.0 % across three box sizes —
+      # taking it from 2432 s to ~460 s. Nothing dominates the tier now and the
+      # floor is ~2130 s, which would fit the old 2700 s cap.
+      #
+      # The cap stays at 4200 anyway. It costs nothing when the tier is healthy,
+      # and 2700 was chosen the same way the last one was: by what fitted at the
+      # time. A cap that only works while nothing gets slower is the arrangement
+      # this job has already failed under twice.
       SPINORBEC_TEST_TIMEOUT: "4200"
     steps:
       - uses: actions/checkout@v4

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -668,21 +668,25 @@ note = """Replaces the ordering `edh-longtime-static-sustains` asserted and `edh
 
 [[claim]]
 id = "edh-longtime-endpoint-ordering-unresolved"
-claim = "At 100 ω_ref⁻¹ and 64³ the endpoint separates rotating (0.40013) from static (0.17952) by 2.23x, which is safe, but does NOT separate static from baseline (0.17952 vs 0.15112, +18.8 %) because the static endpoint moves 34.2 % between two seeds."
-status = "open"
+claim = "RESOLVED by the n=8 ensemble (#424): at 100 ω_ref⁻¹ and 64³ the statically weakened trap DOES beat no-intervention at the endpoint — mean 0.27869 against 0.15094, +84.6 %, at 5.01 SE_diff. The two-seed reading that could not separate them (+18.8 %) was a sample of a distribution whose pooled sd is 0.05098."
+status = "live"
 type = "B"
 scope = "2.6 nT, anti-aligned, CPU, `lhy: none`, 64³. The endpoint at long hold only; the peak at the same points IS resolved (`edh-longtime-peak-ordering-at-64`)."
-uncertainty = "unbounded on the static-vs-baseline row: n = 2 seeds gives a spread (34.2 %) but no distribution, so 18.8 % is inside it and no confidence can be attached. Closing it needs an ensemble on both arms, not a finer grid — the grid is already the refined one."
+uncertainty = "n = 8 per arm, pooled sd 0.05098 (the pre-run n=2 estimate was 0.0658, so n=8 was sufficient rather than lucky), SE_diff 0.02549, |diff|/SE = 5.01 against the 2.0 threshold fixed before launch. The three groups have wildly different spreads and that is the result's shape: baseline sd 0.00020 (0.13 % of mean), rotating sd 0.00230 (0.57 %), static sd 0.07210 (26 %). ALL of the endpoint uncertainty lives in the static arm; the arms it is compared against are essentially deterministic."
 uncertainty_basis = "seed"
-evidence = ["64³ endpoint P_adj: baseline 0.15112, static 0.17952 (seed 101) / 0.27262 (default), rotating 0.40013 / 0.40358", "runs/klaus_quench_long_time_ensemble/", "scripts/submit_lt64_endpoint_ensemble.sh"]
-evidence_status = "partial"
+evidence = ["64³ endpoint P_adj, n=8/8/4: baseline mean 0.15094 sd 0.00020, static mean 0.27869 sd 0.07210, rotating mean 0.40416 sd 0.00230", "runs/klaus_quench_long_time_ensemble/", "scripts/submit_lt64_endpoint_ensemble.sh", "scripts/validation/lt64_endpoint_verdict.jl"]
+evidence_status = "in_tree"
 commit = "6bb97bb2"
 doc = "docs/campaign/edh_quench_polarisation_decision.md"
 section = "17.2"
 pr = 0
 note = """Recorded as `open` rather than left out, because the absence of a statement here is exactly what a reader would otherwise supply from the peak row. The rotating-vs-static factor of 2.23 IS outside the scatter and is safe to quote; the static-vs-baseline one is not. Same shape as `edh-longtime-not-converged-at-32`: a quantity measured on one axis (peak) does not transfer to another (endpoint), just as one duration did not transfer to another.
 
-THE RUN THAT WOULD CLOSE IT IS PREPARED AND NOT SPENT (2026-08-21). 20 committed configs (8 baseline + 8 static + 4 rotating, seeds 1001-1008) and an array submit script. Sizing fixed BEFORE launch: sd = 0.0658 at n = 2, difference of means 0.0750, SE_diff = sd*sqrt(2/n), so n = 7 reaches 2 sigma and n = 8 is what is committed; fewer than 7 cannot answer the question at all. Rejection criterion also fixed before launch and written into `runs/klaus_quench_long_time_ensemble/README.md`: ESTABLISHED only if the difference of means is at least 2*SE_diff using the sd POOLED FROM THOSE RUNS, and if the pooled sd comes back much larger than 0.0658 the answer is "n = 8 does not reach 2 sigma, it would need N", not a re-fitted criterion.
+THE RUN THAT WOULD HAVE CLOSED IT WAS PREPARED AND NOT SPENT (2026-08-21), AND WAS THEN RUN (2026-08-22, #424, TSUBAME 8459280, 20/20 arms rc=0). Kept verbatim because the sizing and the criterion were fixed before launch and that is what makes the verdict a measurement. 20 committed configs (8 baseline + 8 static + 4 rotating, seeds 1001-1008) and an array submit script. Sizing fixed BEFORE launch: sd = 0.0658 at n = 2, difference of means 0.0750, SE_diff = sd*sqrt(2/n), so n = 7 reaches 2 sigma and n = 8 is what is committed; fewer than 7 cannot answer the question at all. Rejection criterion also fixed before launch and written into `runs/klaus_quench_long_time_ensemble/README.md`: ESTABLISHED only if the difference of means is at least 2*SE_diff using the sd POOLED FROM THOSE RUNS, and if the pooled sd comes back much larger than 0.0658 the answer is "n = 8 does not reach 2 sigma, it would need N", not a re-fitted criterion.
+
+CLOSED 2026-08-22. The criterion was applied as written, by a script that carries the 2.0 threshold as a constant so it could not be re-fitted: |diff|/SE = 5.01, ESTABLISHED, static ABOVE baseline by +84.6 %. The pooled sd came back SMALLER than the pre-run estimate (0.05098 against 0.0658), so the "n = 8 does not reach 2 sigma, it would need N" branch did not fire.
+
+THE PEAK COLUMN OF THAT RUN IS NOT QUOTABLE AND THE ARGMAX SAYS WHY. With the window derived from the config (hold 100.0, dt 0.005, save.every 1000 -> 20 frames of 39, so the hold starts at frame 20), the baseline maximum lands at frame 20 and rotating at 21 — the first and second frames of the window, where the decaying pre-hold transient still dominates. Only static's is interior (frame 31), and only static's matches its recorded value (0.49081, exactly). This is the §12.1 condition again, and it is the reason the peak numbers in `runs/klaus_quench_long_time_ensemble/README.md` should not be compared against this run's peak column. It does not touch the verdict: the endpoint is `adj[end]` and needs no window.
 
 NOT LAUNCHED because it is ~5.2 points of a 19.24 group balance (~27 %) with another session spending concurrently, and this is a secondary row — the peak ordering it might be confused with is already established and unaffected. anko made that call; the numbers are in the README so the next person does not re-derive the decision.
 

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -711,7 +711,7 @@ id = "edh-anti-aligned-prep-implemented"
 claim = "`prepare_anti_aligned: true` on a `kind: rotating_basis` ground_state relaxes at -p and hands the dynamics +p, producing the Zeeman-HIGHEST stretched state that the EdH quench needs. Only `p` reverses; `q ∝ |B|²` is even in the field and does not."
 status = "live"
 type = "A"
-scope = "The `rotating_basis` ground_state step. Gated at F=1 on an 8³ grid; the mechanism is the sign of one Zeeman coefficient and does not depend on F, but no production-scale arm has been run through it yet."
+scope = "The `rotating_basis` ground_state step. Gated at F=1 on an 8³ grid; the mechanism is the sign of one Zeeman coefficient and does not depend on F. RUN AT PRODUCTION SCALE 2026-08-22 (#423): all 8 `phi.rate` points of `runs/eu151_klaus_phi_phys` at 32×32×16, F=6, D=13, DDI + LHY scalar, TSUBAME job 8461716, 82 min, rc=0 — every point `converged = true`, `energy = −160177.72` finite, and `mz_actual = −6.0000` on all eight, i.e. the runtime anti-aligned assertion held across the whole scan."
 uncertainty = "Directional, not numeric: an ALIGNED control arm in the same field comes out with sign(⟨F_z⟩) = +sign(p) and the anti-aligned arm with -sign(p), at both signs of p, each stretched to |⟨F_z⟩| = F within 0.05. A single arm could not tell the preparation from the sign convention assumed while reading it."
 uncertainty_basis = "control"
 evidence = ["test/rotating_basis/test_anti_aligned_preparation.jl", "src/workflow/experiments/pipeline/run_step_rotating/ground_state.jl", "runs/eu151_klaus_phi_phys/config.yaml"]

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -1392,4 +1392,49 @@ P_adj, and the radial dynamics — pick out the same four arms.
 It also removes the reason to look for a cascade resonance at either field: a structure in
 ω_eff at fixed hold length is what a breathing phase looks like. That does not by itself
 refute the 5.2 nT reading, which has not been measured this way — but it is now the
-hypothesis to beat there, and it is cheap to test from the same cached snapshots."""
+hypothesis to beat there, and it is cheap to test from the same cached snapshots.
+MEASURED 2026-08-22 (#444, §12.5): it was cheap, and 5.2 nT behaves the same way.
+See `edh-5p2nt-structure-is-breathing-phase-not-resonance` — same mechanism, and
+there the hold-doubling test inverts the ORDERING rather than merely moving it."""
+
+[[claim]]
+id = "edh-5p2nt-structure-is-breathing-phase-not-resonance"
+quantity = "origin of the weff structure @ B=5.2nT"
+claim = "The ω_eff structure at B = 5.2 nT has the same origin as at 10.4 nT — a breathing phase sampled at fixed hold length, not a cascade resonance. Radial expansion over the hold is a single oscillation with a minimum of 0.9868 at ω_eff = 0.600 (the cloud CONTRACTS over 0.570–0.620) and a maximum of 1.1441 at 0.770; the P_adj argmax frame jumps from the last frame (42/42, a truncation) to an interior frame (38/42) exactly at the ω_eff = 0.650 valley; and doubling the hold INVERTS the ordering, taking 0.650 from valley to maximum."
+status = "live"
+type = "B"
+scope = "32³, CPU, one seed, `lhy: none`, anti-aligned, B = 5.2 nT, 20 arms over ω_eff ∈ [0.42, 1.00] at the 8 ms hold plus 4 at 16 ms. Read from cached snapshots — no new runs."
+uncertainty = "The EXISTENCE of the structure is bounded well clear of any floor: expansion swings 0.9868 → 1.3587 (38 %) against a dt/2 reproducibility floor of 0.029 %, and the hold-doubling ratios run 1.024 → 1.287. The POSITIONS are quantised by the ω_eff grid — 0.02–0.05 wide near the extrema — so 'minimum at 0.600' means 'at the sampled point 0.600', with no fit and no interval. The 16 ms arms are themselves truncated (3 of 4 peak at frame 53/53), so their VALUES bound the inversion but are not converged."
+uncertainty_basis = "control"
+evidence = ["runs/klaus_quench_weff/klaus_weff0p600_B5p2nT.yaml", "runs/klaus_quench_weff/klaus_weff0p650_B5p2nT_hold2p0x.yaml", "scripts/validation/klaus_weff_cloud_size.jl"]
+evidence_status = "in_tree"
+commit = "unknown"
+doc = "docs/campaign/edh_quench_polarisation_decision.md"
+section = "12.5"
+pr = 0
+prediction = "If the 5.2 nT two-branch structure is a breathing phase, (1) radial expansion must have structure in ω_eff, (2) the arms whose P_adj peaks inside the hold must coincide with the least-expanded group, and (3) doubling the hold must move the structure — which a resonance cannot do."
+prediction_registered = "before"
+prediction_outcome = "hit"
+note = """Registered in #444 before the measurement. (1) and (3) hit outright. (2) hit in the
+form the MECHANISM predicts rather than the form the prediction guessed, and #444 had
+already flagged that: at 5.2 nT all 20 arms peak inside the hold, so 'inside vs outside' —
+the discriminator that split 10.4 nT four-to-twenty-two — is degenerate here. The
+information is in the argmax FRAME, which splits the arms at exactly the valley.
+
+Same mechanism, both fields: where the cloud is compressed the density is high, the
+cascade is still running and the maximum lands on the last frame; where it expands the
+density falls, the cascade stalls and the maximum moves inside. At 10.4 nT that picked out
+four arms; at 5.2 nT it picks out a boundary at ω_eff = 0.650.
+
+The sharpest single number is the ORDERING inversion, not the ratios. At 8 ms
+0.550 > 0.770 > 0.650; at 16 ms 0.650 > 0.550 > 0.770. A resonance is a property of the
+field and the trap and does not care how long you watch.
+
+Does NOT close `edh-104nt-observable-not-window-robust`: this explains why the window
+matters, it does not supply a window-independent observable. Does not restore an optimum
+at either field — §12.3 stands.
+
+Method note, because it worked twice: the populations were re-read seven ways at 10.4 nT
+and every reading disagreed with the others; the cloud settled it in one pass, from data
+already in the cache. Look at a different quantity before inventing another reading of the
+one you have."""

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -895,6 +895,127 @@ enhancement does not merely survive, it grows slightly. **The `lhy: none` caveat
 is discharged for this conclusion** — though not for absolute values at other
 fields or densities, which were not re-run.
 
+
+### 12.5 5.2 nT, read as a cloud: the same mechanism, wearing a different mask — 2026-08-22
+
+§12.2 explained the 10.4 nT `ω_eff` structure as a **breathing phase**, and closed
+by naming the obvious next move: *"That does not by itself refute the 5.2 nT
+reading, which has not been measured this way — but it is now the hypothesis to
+beat there, and it is cheap to test from the same cached snapshots."* (#444).
+
+It was cheap. **No new runs** — 24 cached arms, 20 at the 8 ms hold and 4 at
+16 ms, read with `scripts/validation/klaus_weff_cloud_size.jl`.
+
+**The verdict: the 5.2 nT two-branch structure is a breathing/truncation phase,
+not a resonance.** The hold-doubling test does not merely move the ratios, it
+**inverts the ordering**.
+
+#### The three registered predictions
+
+Registered in #444 *before* the measurement.
+
+**(1) Radial expansion has structure in ω_eff, and its extrema correspond to
+P_adj's. — CONFIRMED, with the correspondence in the form the mechanism predicts
+rather than the form the prediction guessed.**
+
+| ω_eff | r(end)/r(hold₀) | P_adj peak | argmax frame |
+|---:|---:|---:|---:|
+| 0.420 | 1.3587 | 0.44336 | 42 |
+| 0.500 | 1.1123 | 0.49823 | 42 |
+| 0.550 | 1.0081 | **0.51387** ← branch 1 | 42 |
+| 0.570 | 0.9892 | 0.51300 | 42 |
+| **0.600** | **0.9868** ← minimum | 0.50568 | 42 |
+| 0.620 | 1.0039 | 0.49592 | 42 |
+| **0.650** | 1.0466 | **0.48791** ← valley | **38** |
+| 0.714 | 1.1267 | 0.49958 | 38 |
+| **0.770** | **1.1441** ← maximum | **0.50252** ← branch 2 | 38 |
+| 0.850 | 1.1206 | 0.49290 | 38 |
+| 0.950 | 1.0487 | 0.45968 | 37 |
+| 1.000 | 1.0520 | 0.43935 | 37 |
+
+Expansion is a single clean oscillation: it falls from 1.359 to a **minimum of
+0.9868 at ω_eff = 0.600** — the cloud *contracts* over the hold in a narrow window
+0.570–0.620 — rises to a **maximum of 1.1441 at 0.770**, and falls again. That is
+structure, and it is not subtle: the swing is 38 %.
+
+**(2) The arms whose P_adj peaks inside the hold coincide with the least-expanded
+group. — The literal prediction is degenerate here, and #444 said so in advance.
+The refined version holds exactly.**
+
+All 20 arms take their maximum inside the hold window, so "inside vs outside" —
+the discriminator that split 10.4 nT four-to-twenty-two — carries no information
+at 5.2 nT. #444 anticipated this and noted that *the difference is itself
+information*.
+
+It is. The **argmax frame** splits the arms cleanly into two groups, and the split
+sits exactly at the valley:
+
+- **ω_eff ≤ 0.620 → frame 42**, the *last* frame. These arms are still rising when
+  the hold ends: the peak is a **truncation**, not a maximum.
+- **ω_eff ≥ 0.650 → frame 38 or 37**, an interior frame. These arms have turned
+  over inside the hold.
+
+The boundary is between 0.620 and 0.650 — the valley is at 0.650. And the
+contraction window (0.570–0.620) is the last stretch before the boundary.
+
+**This is the 10.4 nT mechanism, unchanged.** §12.2: *"where the cloud is
+compressed at the end of the window the density is high, the cascade is still
+running, and the maximum lands on the last frame; everywhere else the cloud
+expands, density falls, the cascade stalls."* At 5.2 nT the compressed arms are
+0.570–0.620, they are exactly the ones still rising at frame 42, and the cascade
+stalls the moment the cloud starts expanding again. Two independent readings —
+the argmax frame of `P_adj`, and the radial dynamics — pick out the same boundary,
+just as they picked out the same four arms at 10.4 nT.
+
+**(3) Doubling the hold moves the structure. A resonance cannot. — CONFIRMED, and
+more strongly than at 10.4 nT.**
+
+| ω_eff | 8 ms `P_adj` | 16 ms `P_adj` | ratio |
+|---:|---:|---:|---:|
+| 0.550 | 0.51387 | 0.59152 | 1.151 |
+| **0.650** | **0.48791** | **0.62804** | **1.287** |
+| 0.770 | 0.50252 | 0.51448 | 1.024 |
+| 1.000 | 0.43935 | 0.48069 | 1.094 |
+
+The ratios are not equal — 1.024 to 1.287 — so the structure is hold-dependent.
+But the sharper statement is the **ordering**:
+
+```
+ 8 ms:  0.550 (0.514)  >  0.770 (0.503)  >  0.650 (0.488)   ← 0.650 is the VALLEY
+16 ms:  0.650 (0.628)  >  0.550 (0.592)  >  0.770 (0.514)   ← 0.650 is the PEAK
+```
+
+**The valley becomes the maximum.** A resonance in the cascade is a property of
+the field and the trap; it does not care how long you watch. An arm that had just
+turned over at 8 ms has the most left to give at 16 ms, which is precisely what a
+phase does.
+
+#### The control
+
+`ω_eff = 1.000` never changes the trap during the hold, and its cloud still
+breathes: r(end)/r(hold₀) = **1.0520** at 8 ms and **0.9914** at 16 ms. Whatever
+is driving the oscillation, it is not the weakening of the trap — it is the
+quench. Same conclusion as §12.2, independently at the second field.
+
+#### What this closes and what it does not
+
+`edh-two-branches-5p2nt` was already `refuted` as a truncation artifact
+(§11.5). This supplies the **mechanism** behind that refutation and the
+independent cloud-side evidence for it, at the field where it had never been
+measured. `edh-weff-structure-is-breathing-phase-not-resonance` now holds at
+**both** fields.
+
+**Not closed:** `edh-104nt-observable-not-window-robust` still stands — none of
+this produces a window-independent definition of the observable, it explains why
+the window matters. And no optimum is quotable at either field; §12.3's verdict
+is untouched.
+
+**The ordering lesson, restated because it worked twice.** At 10.4 nT the
+populations were re-read seven ways and every reading disagreed with the others;
+the cloud settled it in one pass. At 5.2 nT the same thing has now happened, from
+data that had been sitting in the cache since the first scan. **Look at a
+different quantity before inventing another reading of the one you have.**
+
 ---
 
 ## 13. Long time (145 ms): the substitution is a short-time statement

--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -1492,10 +1492,28 @@ for.
 ### 18.4 What is not claimed
 
 Gated at F=1 on 8³. The mechanism is the sign of one Zeeman coefficient and does
-not depend on F — but **no production-scale arm has been run through this path
-yet**, so the ¹⁵¹Eu numbers in §3 and §4 are still the aligned-preparation ones.
-`runs/eu151_klaus_phi_phys/config.yaml` now carries the key; it has not been
-re-run.
+not depend on F.
+
+**The production-scale arm HAS now been run (2026-08-22, #423).** All 8
+`phi.rate` points of `runs/eu151_klaus_phi_phys` at 32 × 32 × 16, F = 6, D = 13,
+with DDI and `lhy: scalar` — TSUBAME job 8461716, 82 min, `rc = 0`:
+
+| point | `phi.rate` | `converged` | `energy` | `mz_actual` |
+|---|---:|---|---:|---:|
+| 001–008 | 1.0 … 18.0 | `true` (8/8) | −160177.72 (8/8) | **−6.0000 (8/8)** |
+
+The runtime anti-aligned assertion held on every point, so the preparation is not
+a one-arm result any more. `energy` is identical across the scan because the scan
+varies only `phi.rate` in the *dynamics* steps — the ground state is the same
+state eight times, which is itself the check that the scan axis is where it is
+supposed to be. (The 12 × 12 × 8 mechanism check gave −160174.95; the difference
+is the grid.)
+
+**What is still the aligned preparation: §3 and §4's ¹⁵¹Eu numbers.** Those are
+*dynamics* observables and this run's trajectories have not been reduced into
+them. The two preparations are different physics rather than an old and a new
+value, so when they are replaced the aligned numbers stay beside them, labelled.
+The trajectories are on disk under `runs/eu151_klaus_phi_phys/phi_*/`.
 
 <!-- REDERIVE -->
 

--- a/docs/campaign/prior_art/observable.md
+++ b/docs/campaign/prior_art/observable.md
@@ -4,11 +4,13 @@
 > date. Re-run the generator when picking the topic up again; existing
 > dispositions are preserved.
 
-Keywords: observable, peak, hold, window, transient, extraction, P_adj, metric. Regenerate with
-`python3 scripts/prior_art.py --topic observable --keywords observable peak hold window transient extraction P_adj metric`.
+Keywords: observable, breathing, radial, expansion, weff. Regenerate with
+`python3 scripts/prior_art.py --topic observable --keywords observable breathing radial expansion weff`.
 
 Dispositions: `unread`, `read`, `unrelated`, `superseded`, `depends`
 
 | ref | disposition | what | note |
 |---|---|---|---|
-| #289 | unrelated | issue: nightly: the mutation job still exhausts its timeout after the 1/7 sharding, and it holds the heavy-YAML result hostage | CI mutation-testing walltime and sharding. Matched "hold" inside "holds ... hostage" — the keyword is the protocol's hold step, this is English. Nothing about how an observable is extracted. |
+| origin/research/edh-breathing-phase | read | branch: merged (PR #443) | **This is #444's premise.** The 10.4 nT result: `ω_eff` structure is a breathing PHASE, not a cascade resonance — the quench excites a breathing mode, `ω_eff` sets its frequency, and a fixed-length hold makes the endpoint cloud size a function of phase. Its registered prediction (double the hold and the ratio moves) came true. #444 re-applies the same test at 5.2 nT. Already on main, so it is the current state rather than parallel work. |
+| origin/research/edh-observable-invariance | read | branch: merged | **Supplies the window discipline #444 must inherit, and one of its open rows.** Established that at 10.4 nT the peak reads the PRE-HOLD TRANSIENT for 16 of 20 arms unless the window is taken inside the hold, and that under a reading with no free parameter both fields lose their optimum. `edh-104nt-observable-not-window-robust` is still open and is exactly why #444 says to look at a DIFFERENT QUANTITY (the cloud) rather than re-read populations. Merged; not competing work. |
+| #289 | unrelated | (no longer open) | CI mutation-testing walltime and sharding. Matched "hold" inside "holds ... hostage" — the keyword is the protocol's hold step, this is English. Nothing about how an observable is extracted. |

--- a/docs/campaign/prior_art/sampling.md
+++ b/docs/campaign/prior_art/sampling.md
@@ -4,13 +4,14 @@
 > date. Re-run the generator when picking the topic up again; existing
 > dispositions are preserved.
 
-Keywords: sampling, adaptive, convergence, stopping, refine, scan, resolution, criterion. Regenerate with
-`python3 scripts/prior_art.py --topic sampling --keywords sampling adaptive convergence stopping refine scan resolution criterion`.
+Keywords: sampling, cadence, snapshot, frames, window. Regenerate with
+`python3 scripts/prior_art.py --topic sampling --keywords sampling cadence snapshot frames window`.
 
 Dispositions: `unread`, `read`, `unrelated`, `superseded`, `depends`
 
 | ref | disposition | what | note |
 |---|---|---|---|
-| origin/feat/manuscript-refinement-round5 | unrelated | branch:  | **0 commits ahead of main** — already in. Manuscript text (Paper #3 v3 + Ch.3/Ch.6 integration); matched "refine" in the BRANCH NAME, which is about prose rounds, not sampling refinement. |
-| origin/feat/manuscript-refinement-round6 | unrelated | branch:  | Same: 0 commits ahead of main, Ch.6 inline + Paper #1 integration. Two of the three matches on this topic are the word "refinement" in a manuscript branch name — worth noting when tuning the keyword list. |
-| #57 | depends | issue: research(phases): 2D Eu F=6 phase diagram via adaptive multi-seed mapping | **This is the home for the stopping-rule work.** Its design (`docs/design/eu_phase_diagram_adaptive_mapping.md`) specifies HOW to build adaptively — coarse multi-seed recon → detect where the phase changes → bisect / boundary-trace / active-learn → fill interiors by continuation — and names the boundary DETECTORS (multi-seed min-E crossing, order-parameter jump, bidirectional hysteresis divergence, solver-struggle). What it does NOT contain is a stopping rule: nothing says when a boundary is resolved enough to stop bisecting, or when the map is done. That gap is exactly the session-plan item, so this work belongs on #57 rather than beside it. |
+| #55 | depends | issue: feat(solvers): unified snapshot + spectral/real-space seeding mechanism | **Owns the mechanism #444 reads from, and the cadence hazard it must not trip.** #444 reconstructs the radial RMS from `psi_snapshots_streamed`, which is #55's surface. The live hazard is already recorded in `klaus_weff_extract.jl`: `component_populations` is derived from the psi snapshots and `times` from the scalar sampler, and they are DIFFERENT CADENCES (42 against 43), not an off-by-one — indexing one by the other threw a BoundsError, which was the lucky outcome. So the hold window is derived from the config, never from `times`. #444 does not change the mechanism, so this stays #55's; it constrains how #444 may index it. |
+| #57 | depends | (no longer open) | **This is the home for the stopping-rule work.** Its design (`docs/design/eu_phase_diagram_adaptive_mapping.md`) specifies HOW to build adaptively — coarse multi-seed recon → detect where the phase changes → bisect / boundary-trace / active-learn → fill interiors by continuation — and names the boundary DETECTORS (multi-seed min-E crossing, order-parameter jump, bidirectional hysteresis divergence, solver-struggle). What it does NOT contain is a stopping rule: nothing says when a boundary is resolved enough to stop bisecting, or when the map is done. That gap is exactly the session-plan item, so this work belongs on #57 rather than beside it. |
+| origin/feat/manuscript-refinement-round5 | unrelated | (no longer open) | **0 commits ahead of main** — already in. Manuscript text (Paper #3 v3 + Ch.3/Ch.6 integration); matched "refine" in the BRANCH NAME, which is about prose rounds, not sampling refinement. |
+| origin/feat/manuscript-refinement-round6 | unrelated | (no longer open) | Same: 0 commits ahead of main, Ch.6 inline + Paper #1 integration. Two of the three matches on this topic are the word "refinement" in a manuscript branch name — worth noting when tuning the keyword list. |

--- a/docs/campaign/rederivation_fig1_l4_ladder.md
+++ b/docs/campaign/rederivation_fig1_l4_ladder.md
@@ -117,6 +117,32 @@ a single `N_trajectory` block (`Fz_per_N`, `DeltaFz`, `N_final_ratio`, …);
   comes from a different extractor, and I did not confirm the two definitions
   agree. Quoting the ratio would repeat the Fig 3 error of comparing a
   time-maximum against a final-state value because both were called "peak".
+
+  **CHECKED 2026-08-22 (#281). They do not agree, in three independent ways,
+  and the caution was right.** Reading both definitions rather than inferring
+  them — the retired one from `runs/eu151_edh_v2/extract_trajectory.jl` at
+  `e2159486^`, the live one from `src/workflow/experiment_observables.jl:43`:
+
+  | | stored `DeltaFz` | live `Fz_drift` |
+  |---|---|---|
+  | normalisation | **per atom** — `Fz_per_N[i] = Fz[i] / norms[i]` | **total** `F_z`, not divided by anything |
+  | time reduction | **endpoint** difference, `[end] − [1]` | **maximum over the trajectory**, `max\|·\|` |
+  | sign | signed | absolute value |
+
+  Any one of the three would make the ratio meaningless. The first is decisive
+  *on these particular arms*: they are the lossy ones, ending at **51.6 %** and
+  **24.4 %** of their initial atom number, so dividing by `norms[i]` versus not
+  is a factor of ~2 and ~4 by the end of the run. A −4.3 % agreement between two
+  quantities that differ by a factor of four is a coincidence, and reporting it
+  would have been the Fig 3 error exactly.
+
+  **It is reconstructible, and that is a separate job.** The stored block keeps
+  both `Fz_per_N` and `N_over_N0`, so the total series is
+  `Fz[i] = Fz_per_N[i] · N_over_N0[i] · norms[1]`, and a like-for-like
+  `max\|Fz[i] − Fz[1]\|` follows once `norms[1]` is pinned from the config. That
+  needs the stored `trajectory.json` for these two cells, which is not what this
+  re-derivation was scoped to open. Recorded here so the next person does not
+  re-derive the obstruction.
 - **`peak_max` has no stored counterpart** for these two configs. Their stored
   summaries contain `N_trajectory` and nothing else, so there is no like-for-like
   density number to put beside the main panel's table.
@@ -127,5 +153,8 @@ a single `N_trajectory` block (`Fz_per_N`, `DeltaFz`, `N_final_ratio`, …);
   is re-derived in the table above (−26.0 %), not a separate run — so the slice
   moves with it and does not need its own cell.
 - The n96/n128 rungs, deliberately, for the reason above.
-- ΔF_z on the lossy arms, pending a check that the two extractors define it the
-  same way.
+- ΔF_z on the lossy arms. The check is DONE (above, 2026-08-22): the two
+  extractors do **not** define it the same way — per-atom vs total, endpoint vs
+  time-maximum, signed vs absolute — so the comparison is not merely unconfirmed,
+  it is invalid as posed. Reconstructing a like-for-like number is possible from
+  the stored `Fz_per_N` × `N_over_N0` series and is scoped out here.

--- a/scripts/eu334/_preamble.sh
+++ b/scripts/eu334/_preamble.sh
@@ -51,4 +51,17 @@ fi
 
 # A GPU job that silently falls back to CPU produces numbers 50× later and looks
 # like a slow queue rather than a broken environment.
-"$JULIA" --project=. -e 'using CUDA; @assert CUDA.functional() "CUDA not functional — would silently run on CPU"; println("CUDA OK: ", CUDA.name(CUDA.device()))'
+#
+# `EU334_NO_GPU=1` is for the jobs that genuinely never touch a CUDA path — the
+# unit-scale probes, which do not `import CUDA` and pass no backend, so there is
+# no fallback to be silent about. It must be set by the SUBMIT SCRIPT beside its
+# `-l cpu_16=1`, so the declaration and the reservation are one edit apart and
+# cannot drift: a job asking for a GPU and skipping this check is the exact
+# failure the assertion exists for.
+#
+# Default is still to assert. Opting out has to be deliberate and visible.
+if [ "${EU334_NO_GPU:-0}" = "1" ]; then
+    echo "[preamble] EU334_NO_GPU=1 — CPU-only job, skipping the CUDA assertion"
+else
+    "$JULIA" --project=. -e 'using CUDA; @assert CUDA.functional() "CUDA not functional — would silently run on CPU"; println("CUDA OK: ", CUDA.name(CUDA.device()))'
+fi

--- a/scripts/eu334/ed_growth_probe.jl
+++ b/scripts/eu334/ed_growth_probe.jl
@@ -62,7 +62,17 @@ const ATOM = get(ENV, "ED_ATOM", "rb87") == "eu151" ? Eu151 : Rb87
 # One knob against the same control. `c_dd = 0` is the arm already measured, so
 # the comparison is against a number this probe produced rather than against a
 # remembered one.
-const C_DD = parse(Float64, get(ENV, "ED_CDD", "0.0"))
+# DERIVED, not picked. The production preset carries c_dd/c0 = 0.0900 (c_dd =
+# 211.02 against c0 = 2343.6, unit-norm with N folded in), and that RATIO is what
+# transfers between normalisations — the absolute numbers do not. Against this
+# probe's C0 = 4pi*a_s it gives 0.0226.
+#
+# The first attempt passed 0.1 by hand, which is 4.4x that. It was killed rather
+# than run: an arm whose knob nobody derived answers about the knob.
+const C_DD_OVER_C0_PRODUCTION = 0.0900
+const C_DD = parse(Float64,
+    get(ENV, "ED_CDD", "0.0")) == -1.0 ? C_DD_OVER_C0_PRODUCTION * C0 :
+             parse(Float64, get(ENV, "ED_CDD", "0.0"))
 
 function ground_mode(grid, dV, n_tf)
     gs = find_ground_state(; grid, atom=ATOM,

--- a/scripts/eu334/ed_growth_probe.jl
+++ b/scripts/eu334/ed_growth_probe.jl
@@ -33,9 +33,32 @@ using Printf
 
 const OMEGA, A_S = 1.0, 0.02
 const C0 = 4π * A_S
-const MU, T_RES, GAMMA, DT = 3.0, 1.0, 0.1, 0.002
+const GAMMA, DT = 0.1, 0.002
+
+# `ED_MU` / `ED_T` move the RESERVOIR to production's corner. #418's exclusion
+# list is now complete except for one entry — "#334's own ramp and seed" — and
+# the reading that survives is that the seed is a converged branch cell at
+# µ_ψ = 8.48 while a T = 10 reservoir demands an equilibrium far above it, so the
+# heating that closes the gap eats the condensate. If that is right it is PHYSICS
+# ("no condensate above f = 0.066 fits in a T = 10 C region"), not a defect.
+#
+# The probe's own corner is T = 1, µ = 3; production is T = 10, µ_res ~ 8-12.
+# Those are the two axes that can be moved without leaving the unit-scale setting
+# that makes this debuggable in minutes, and they are the pair #418 named as the
+# likely combination. The lattice and the ramp are deliberately NOT moved here:
+# changing four things at once is how the last three suspects took four rounds.
+#
+# THE SEED IS THE ARM. `ED_SEED=converged` relaxes a ground state at the
+# reservoir's own µ and hands THAT to the SPGPE, instead of starting from
+# `fill!(psi, 0)` and letting the noise build one. Everything else is held. If
+# the stall reproduces only under `converged`, the seed carries it and #418
+# closes as physics; if it stalls from vacuum too, the (T, µ) corner does, and
+# the seed is exonerated the way F = 6 and the DDI were.
+const MU = parse(Float64, get(ENV, "ED_MU", "3.0"))
+const T_RES = parse(Float64, get(ENV, "ED_T", "1.0"))
 const K_CUT = sqrt(2 * (MU + T_RES))
 const NSTEP = parse(Int, get(ENV, "ED_NSTEP", "25000"))
+const SEED_MODE = get(ENV, "ED_SEED", "vacuum")
 
 # `ED_ATOM=eu151` runs the SAME probe at F = 6, 13 components, DDI off.
 #
@@ -85,7 +108,7 @@ function ground_mode(grid, dV, n_tf)
     (phi, d)
 end
 
-function arm(grid, dV, phi, d, energy_damping::Bool)
+function arm(grid, dV, phi, d, n_tf, energy_damping::Bool)
     ws = make_workspace(; grid, atom=ATOM,
         interactions=InteractionParams(Dict{Int, Float64}(0 => C0)),
         potential=HarmonicTrap{3}((OMEGA, OMEGA, OMEGA)),
@@ -100,7 +123,19 @@ function arm(grid, dV, phi, d, energy_damping::Bool)
         allow_unphysical_rates=true) :
           SPGPEReservoir(; T=T_RES, mu=MU, a_s=A_S, k_cut=K_CUT, gamma=GAMMA, M=0.0,
         allow_unphysical_rates=true)
+    # The one knob #418 has left. `vacuum` is the arm every previous round ran:
+    # the condensate is built by the reservoir out of nothing. `converged` hands
+    # the SPGPE a state that is ALREADY the ground state at this µ — production's
+    # situation, where the seed is a converged branch cell — so the reservoir's
+    # job is to keep it rather than to make it.
     fill!(ws.state.psi, 0)
+    if SEED_MODE == "converged"
+        # phi is the normalised ground mode; put N_TF-worth of atoms in it, which
+        # is what the growth-only arm reaches unaided. Starting AT the answer is
+        # the point: if the full theory cannot hold what growth-only builds, the
+        # stall is not a failure to grow.
+        @views ws.state.psi[:, :, :, d] .= phi .* sqrt(n_tf)
+    end
 
     out = 0.0
     trunc = 0.0
@@ -124,10 +159,14 @@ function main()
     π / minimum(grid.dx) > K_CUT || error("grid does not resolve the C region")
     (phi, d) = ground_mode(grid, dV, n_tf)
 
-    @printf("atom = %s (D = %d)  c_dd = %.4g  N_TF = %.1f  steps = %d  M = physical vs 0\n",
-        ATOM === Rb87 ? "Rb87" : "Eu151", Int(2 * ATOM.F + 1), C_DD, n_tf, NSTEP)
+    # Every knob in the output line, because the whole value of this probe is that
+    # exactly one of them differs between the arm being read and the arm it is
+    # being compared against — and a remembered configuration is not a control.
+    @printf("atom = %s (D = %d)  c_dd = %.4g  mu = %.3g  T = %.3g  seed = %s  N_TF = %.1f  steps = %d  M = physical vs 0\n",
+        ATOM === Rb87 ? "Rb87" : "Eu151", Int(2 * ATOM.F + 1), C_DD, MU, T_RES,
+        SEED_MODE, n_tf, NSTEP)
     for (name, ed) in (("growth-only (M=0)", false), ("full (M != 0)", true))
-        a = arm(grid, dV, phi, d, ed)
+        a = arm(grid, dV, phi, d, n_tf, ed)
         @printf("  %-18s N0 = %8.1f (%.3f N_TF)  N_C = %8.1f  out = %.4g  trunc = %.4g\n",
             name, a.n0, a.n0 / n_tf, a.n_c, a.out, a.trunc)
         flush(stdout)

--- a/scripts/eu334/ed_growth_probe.jl
+++ b/scripts/eu334/ed_growth_probe.jl
@@ -53,6 +53,17 @@ const NSTEP = parse(Int, get(ENV, "ED_NSTEP", "25000"))
 # it does not, F = 6 is exonerated and the DDI or the ramp carries it.
 const ATOM = get(ENV, "ED_ATOM", "rb87") == "eu151" ? Eu151 : Rb87
 
+# `ED_CDD` turns the DDI on. #418's remaining suspects after the scalar setting
+# cleared every part of the SPGPE machinery — projector, moving cutoff, energy
+# damping alone, the scattering drift/noise pair, and both reservoirs together
+# (which COOL by 60 %) — are the DDI and #334's own ramp and seed. This separates
+# the first.
+#
+# One knob against the same control. `c_dd = 0` is the arm already measured, so
+# the comparison is against a number this probe produced rather than against a
+# remembered one.
+const C_DD = parse(Float64, get(ENV, "ED_CDD", "0.0"))
+
 function ground_mode(grid, dV, n_tf)
     gs = find_ground_state(; grid, atom=ATOM,
         interactions=InteractionParams(Dict{Int, Float64}(0 => C0 * n_tf)),
@@ -69,7 +80,9 @@ function arm(grid, dV, phi, d, energy_damping::Bool)
         interactions=InteractionParams(Dict{Int, Float64}(0 => C0)),
         potential=HarmonicTrap{3}((OMEGA, OMEGA, OMEGA)),
         sim_params=SimParams(; dt=DT, n_steps=1, imaginary_time=false,
-            save_every=1, normalize_every=0), fft_flags=FFTW.ESTIMATE)
+            save_every=1, normalize_every=0), fft_flags=FFTW.ESTIMATE,
+        enable_ddi=C_DD != 0.0, c_dd=C_DD, secular_ddi=false,
+        ddi_padding=false, ddi_trunc_radius=-1.0)
     # M = 0.0 is the growth-only sub-theory; omitting M lets the reservoir use its
     # own physical scattering rate. One knob between the arms.
     res = energy_damping ?
@@ -101,8 +114,8 @@ function main()
     π / minimum(grid.dx) > K_CUT || error("grid does not resolve the C region")
     (phi, d) = ground_mode(grid, dV, n_tf)
 
-    @printf("atom = %s (D = %d)   N_TF = %.1f   steps = %d   M = physical vs 0\n",
-        ATOM === Rb87 ? "Rb87" : "Eu151", Int(2 * ATOM.F + 1), n_tf, NSTEP)
+    @printf("atom = %s (D = %d)  c_dd = %.4g  N_TF = %.1f  steps = %d  M = physical vs 0\n",
+        ATOM === Rb87 ? "Rb87" : "Eu151", Int(2 * ATOM.F + 1), C_DD, n_tf, NSTEP)
     for (name, ed) in (("growth-only (M=0)", false), ("full (M != 0)", true))
         a = arm(grid, dV, phi, d, ed)
         @printf("  %-18s N0 = %8.1f (%.3f N_TF)  N_C = %8.1f  out = %.4g  trunc = %.4g\n",

--- a/scripts/eu334/launch.sh
+++ b/scripts/eu334/launch.sh
@@ -245,8 +245,12 @@ ed_probe)
     # ARGUMENT, because the whole point is comparing the two: the scalar arm
     # already condenses at both values of M, so the F = 6 arm is what separates
     # "the spinor" from "the DDI or the ramp" in #418.
-    q -N eu334_edprobe_${2:-rb87}_${3:-nodd} -l h_rt=4:00:00 \
-      -v ED_NSTEP=${ED_NSTEP:-25000},ED_ATOM=${2:-rb87},ED_CDD=${3:-0.0} \
+    # ED_MU / ED_T / ED_SEED are the LAST suspect: #334's own ramp and seed.
+    # Pass them through the environment rather than as more positional arguments —
+    # the third slot is already `ED_CDD` and a fourth positional would make the
+    # job name and the configuration disagree the first time someone skips one.
+    q -N eu334_edprobe_${2:-rb87}_${3:-nodd}_${ED_SEED:-vacuum} -l h_rt=4:00:00 \
+      -v ED_NSTEP=${ED_NSTEP:-25000},ED_ATOM=${2:-rb87},ED_CDD=${3:-0.0},ED_MU=${ED_MU:-3.0},ED_T=${ED_T:-1.0},ED_SEED=${ED_SEED:-vacuum} \
       scripts/eu334/submit_ed_probe.sh
     ;;
 

--- a/scripts/eu334/launch.sh
+++ b/scripts/eu334/launch.sh
@@ -245,8 +245,8 @@ ed_probe)
     # ARGUMENT, because the whole point is comparing the two: the scalar arm
     # already condenses at both values of M, so the F = 6 arm is what separates
     # "the spinor" from "the DDI or the ramp" in #418.
-    q -N eu334_edprobe_${2:-rb87} -l h_rt=4:00:00 \
-      -v ED_NSTEP=${ED_NSTEP:-25000},ED_ATOM=${2:-rb87} \
+    q -N eu334_edprobe_${2:-rb87}_${3:-nodd} -l h_rt=4:00:00 \
+      -v ED_NSTEP=${ED_NSTEP:-25000},ED_ATOM=${2:-rb87},ED_CDD=${3:-0.0} \
       scripts/eu334/submit_ed_probe.sh
     ;;
 

--- a/scripts/eu334/submit_ed_probe.sh
+++ b/scripts/eu334/submit_ed_probe.sh
@@ -18,6 +18,11 @@
 #$ -l h_rt=4:00:00
 #$ -j y
 #$ -o logs/tsubame/
+# Declared here, one line from the `-l cpu_16=1` above, so the reservation and
+# the claim cannot drift apart. The preamble asserts CUDA by default because a
+# GPU job falling back to CPU looks like a slow queue; this probe has no CUDA
+# path to fall back FROM.
+export EU334_NO_GPU=1
 source "${EU334_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/eu334}/scripts/eu334/_preamble.sh"
 
 export ED_NSTEP="${ED_NSTEP:-25000}"

--- a/scripts/eu334/submit_ed_probe.sh
+++ b/scripts/eu334/submit_ed_probe.sh
@@ -5,8 +5,16 @@
 #     -v ED_NSTEP=25000 scripts/eu334/submit_ed_probe.sh
 #
 # `-o` must name an EXISTING directory or the job never starts.
+#
+# cpu_16, not gpu_1. This probe is 24^3 — 13,824 points, 3 or 13 components —
+# and it never calls a CUDA path: `ed_growth_probe.jl` does not `import CUDA`, so
+# the extension is not even loaded and every arm has always run on the CPU of
+# whatever node it landed on. A `gpu_1` reservation bought nothing and was
+# ~7x the point cost of the CPU class it was actually using. Measured locally
+# 2026-08-22: 400 steps in ~30 s, so the default 25000 steps is ~30 min per arm
+# and two arms fit inside h_rt with room.
 #$ -cwd
-#$ -l gpu_1=1
+#$ -l cpu_16=1
 #$ -l h_rt=4:00:00
 #$ -j y
 #$ -o logs/tsubame/
@@ -15,5 +23,9 @@ source "${EU334_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/eu334}/scripts/eu334/_prea
 export ED_NSTEP="${ED_NSTEP:-25000}"
 export ED_ATOM="${ED_ATOM:-rb87}"
 export ED_CDD="${ED_CDD:-0.0}"
+# #418's last suspect: production's reservoir corner, and the seed.
+export ED_MU="${ED_MU:-3.0}"
+export ED_T="${ED_T:-1.0}"
+export ED_SEED="${ED_SEED:-vacuum}"
 
 "$SPINORBEC_TSUBAME_JULIA" --project=. scripts/eu334/ed_growth_probe.jl

--- a/scripts/eu334/submit_ed_probe.sh
+++ b/scripts/eu334/submit_ed_probe.sh
@@ -14,5 +14,6 @@ source "${EU334_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/eu334}/scripts/eu334/_prea
 
 export ED_NSTEP="${ED_NSTEP:-25000}"
 export ED_ATOM="${ED_ATOM:-rb87}"
+export ED_CDD="${ED_CDD:-0.0}"
 
 "$SPINORBEC_TSUBAME_JULIA" --project=. scripts/eu334/ed_growth_probe.jl

--- a/scripts/submit_edh_phi_phys_anti_aligned.sh
+++ b/scripts/submit_edh_phi_phys_anti_aligned.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# TSUBAME (UGE) submit for #423 — eu151_klaus_phi_phys at PRODUCTION scale with
+# the anti-aligned preparation.
+#
+# WHAT THIS SETTLES
+#
+# `prepare_anti_aligned` landed in #421 and the MECHANISM is verified at the
+# production field (F=6, p=26700, dt=0.005, 12x12x8): aligned relaxes to
+# <F_z> = +6, anti-aligned to -6, and the two energies agree to every digit
+# (-160174.95). That agreement is the check, not a coincidence: p -> -p is a
+# pi rotation about x, so a correct reversal is unitarily equivalent and MUST
+# land on the same energy. A discrepancy would mean the reversal is buggy.
+#
+# What has never run is the PIPELINE-SCALE version. `runs/eu151_klaus_phi_phys/
+# config.yaml` carries `prepare_anti_aligned: true` but was never re-run, so
+# every 151Eu number in
+# `docs/campaign/edh_quench_polarisation_decision.md` sections 3 and 4 is from
+# the ALIGNED preparation. Those are two different physical states, not an old
+# and a new value, so the anti-aligned numbers go BESIDE them.
+#
+# ONE JOB, NOT AN ARRAY, and that is forced rather than chosen: `run_yaml` has
+# no point selection (there is no `--only-point`), so the 8-point `scan:` block
+# is indivisible from the outside. What makes that safe is that `run_yaml` IS
+# resumable — it skips any scan point whose `point_*.jld2` already exists — so a
+# task reaped at h_rt costs only the point it was inside. Requeue to continue.
+#
+# Submit (from the TSUBAME worktree root):
+#   qsub -g tga-kozuma-kouhi scripts/submit_edh_phi_phys_anti_aligned.sh
+# Smoke first (proves config + GPU + the anti-aligned assertion, then dies):
+#   qsub -g tga-kozuma-kouhi -l h_rt=0:30:00 -v PHI_SMOKE=1 \
+#        scripts/submit_edh_phi_phys_anti_aligned.sh
+#
+# A SMOKE HERE PROVES LESS THAN IT LOOKS LIKE. There is no `--smoke` flag and
+# `SPINORBEC_SMOKE` is read by nothing in `src/` (checked 2026-08-22 — it is
+# exported by one sibling submit script and consumed nowhere, the same dead-knob
+# shape as the `SPINORBEC_WALLTIME_BUDGET_S` export that claimed a behaviour
+# nothing implemented). So the smoke is a SHORT WALLTIME and what it establishes
+# is bounded: the config inspects clean, the GPU is acquired, the ground state
+# converges, and the runtime anti-aligned assertion passes. It does NOT
+# establish that an arm completes.
+#
+#$ -cwd
+#$ -N edh_phi_aa
+#$ -l gpu_1=1
+#$ -l h_rt=24:00:00
+#$ -j y
+#$ -o logs/tsubame/edh_phi_aa.$JOB_ID.log
+set -euo pipefail
+
+REPO="${SPINORBEC_TSUBAME_PROJECT_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/BEC-simulation}"
+cd "$REPO"
+mkdir -p logs/tsubame
+
+export JULIA_DEPOT_PATH=/gs/fs/tga-kozuma-kouhi/shared/.julia
+export JULIAUP_DEPOT_PATH=/gs/fs/tga-kozuma-kouhi/shared/.juliaup
+JULIA="${SPINORBEC_TSUBAME_JULIA:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia}"
+
+source scripts/tsubame_setup.sh
+# Re-arm unconditionally. `tsubame_setup.sh` restores errexit itself now, but a
+# submit script must not depend on the internals of a file it sources — that
+# dependency is what let a failed arm print "done" for twelve days.
+set -euo pipefail
+
+CFG="${PHI_CFG:-runs/eu151_klaus_phi_phys/config.yaml}"
+[ -f "$CFG" ] || { echo "FATAL: config not found: $CFG" >&2; exit 1; }
+
+# The config must actually carry the preparation this job exists to exercise.
+# Asserting it here rather than trusting the checkout: a tree synced before #421
+# would run the ALIGNED arm and write it to a log named for the anti-aligned one.
+grep -q "prepare_anti_aligned: true" "$CFG" || {
+    echo "FATAL: $CFG does not set 'prepare_anti_aligned: true' — this job would" >&2
+    echo "       silently produce a second copy of the aligned numbers." >&2
+    exit 1
+}
+echo "config: $CFG (prepare_anti_aligned: true confirmed)"
+
+WALL_S="${WALL_S:-86400}"                      # must match -l h_rt
+BUDGET_S=$(( WALL_S * 85 / 100 ))
+echo "walltime: h_rt=${WALL_S}s, self-interrupt at ${BUDGET_S}s"
+
+JOBREC="logs/tsubame/jobrec.${JOB_ID:-local}.phi_aa.tsv"
+printf "started\t%s\tjob=%s\thost=%s\tcfg=%s\n" \
+    "$(date -Is)" "${JOB_ID:-none}" "$(hostname)" "$CFG" >> "$JOBREC"
+
+if [ "${PHI_SMOKE:-0}" = "1" ]; then
+    echo "SMOKE: short walltime. Establishes config+GPU+GS+anti-aligned assertion ONLY."
+fi
+
+set +e
+timeout --signal=INT --kill-after=120 "$BUDGET_S" \
+    "$JULIA" --project=. -e '
+    import CUDA          # BEFORE `using SpinorBEC` — loads the CUDA extension
+    using SpinorBEC
+    cfg = ARGS[1]
+    # Pre-flight before the expensive part. Read the FIELD, not the printed
+    # struct: `:block` is an autopilot registration level and is not a
+    # ConfigWarning severity at all, and substring-matching "block" against the
+    # struct killed every arm of a sibling scan on the q-auto-derive INFO
+    # message, whose text contains "B BLOCK".
+    r = inspect_config(cfg)
+    for w in r.warnings
+        println("inspect[", w.severity, "] ", w.title)
+    end
+    blockers = filter(w -> w.severity === :error, r.warnings)
+    if !isempty(blockers)
+        for w in blockers
+            println("BLOCKING: ", w.title, " — ", w.message)
+        end
+        error("pre-flight found $(length(blockers)) :error warning(s) — refusing to launch")
+    end
+    run_yaml(cfg)
+' "$CFG"
+
+RC=$?
+set -e
+
+case "$RC" in
+    0)   OUTCOME="completed" ;;
+    124) OUTCOME="self_interrupted_at_budget" ;;
+    137) OUTCOME="killed_after_interrupt_ignored" ;;
+    *)   OUTCOME="failed_rc_$RC" ;;
+esac
+printf "finished\t%s\trc=%s\toutcome=%s\tcfg=%s\n" \
+    "$(date -Is)" "$RC" "$OUTCOME" "$CFG" >> "$JOBREC"
+echo "[$(date +%H:%M:%S)] $OUTCOME (rc=$RC): $CFG"
+[ "$RC" -eq 0 ] || [ "$RC" -eq 124 ] || exit "$RC"

--- a/scripts/validation/klaus_weff_cloud_size.jl
+++ b/scripts/validation/klaus_weff_cloud_size.jl
@@ -1,0 +1,236 @@
+# Radial cloud size across an ω_eff scan — the observable that settled 10.4 nT.
+#
+# WHY A DIFFERENT QUANTITY RATHER THAN A BETTER READING
+#
+# At 10.4 nT the population observable (`P_adj`) was re-read many ways — peak,
+# mean, final, three hold windows, two grid sizes — and every reading disagreed
+# with the others about the ordering of the arms. What settled it was looking at
+# the CLOUD instead: the quench excites a breathing mode, `ω_eff` sets its
+# frequency, the hold has fixed length, so the endpoint size is a function of
+# BREATHING PHASE. The four arms with least expansion are exactly the four whose
+# `P_adj` peaks inside the hold, and doubling the hold moves the ratio — which a
+# resonance could not do. That data had been in the cache since the first scan
+# and nobody had looked at it (#443, #444).
+#
+# So this script reads `psi_snapshots_streamed` and reports the radial RMS, and
+# the ordering advice is: look at another quantity before inventing another
+# reading of the one you have.
+#
+#     r(t) = sqrt( Σ n_xy(x,y) (x² + y²) / Σ n_xy(x,y) ),  n_xy = Σ_z Σ_c |ψ|²
+#
+# TWO THINGS THIS FILE REFUSES TO DO
+#
+# 1. It does not index the snapshot axis by `times`. `component_populations`
+#    (42 rows here) is derived from the psi snapshots and `times` (43) from the
+#    scalar sampler. Those are DIFFERENT CADENCES, not an off-by-one. The hold
+#    window is derived from the config — `nhold = floor(hold/(dt*save_every))` —
+#    exactly as `klaus_weff_extract.jl` does, and the two agreeing on frame 32
+#    for the 8 ms arms is the check.
+#
+# 2. It does not report a number for an arm it could not read. A missing point
+#    file, a missing snapshot group, or a frame count that disagrees with
+#    `component_populations` is printed as a named failure. An arm that silently
+#    vanishes from a scan is how a structure becomes visible that is really a
+#    gap in the corpus.
+#
+# USE
+#   julia --project=. scripts/validation/klaus_weff_cloud_size.jl <runs-root> \
+#         [--field B5p2nT] [--csv out.csv]
+
+using JLD2
+using Printf
+
+"""Frame keys of a streamed-snapshot group, in frame order."""
+function _frame_keys(grp)
+    ks = filter(k -> startswith(k, "frame_"), keys(grp))
+    sort!(ks; by=k -> parse(Int, split(k, '_')[2]))
+    ks
+end
+
+"""
+    radial_rms(psi, box) -> Float64
+
+Density-weighted transverse RMS radius of a (nx, ny, nz, D) spinor, in the same
+length units as `box`. Summed over BOTH the z axis and the spin index: the
+breathing mode is a motion of the whole cloud, and picking one component would
+mix the cascade's population transfer into a size measurement.
+"""
+function radial_rms(psi::AbstractArray{<:Complex, 4}, box)
+    nx, ny, nz, _ = size(psi)
+    x = range(-box[1] / 2, box[1] / 2; length=nx + 1)[1:nx]
+    y = range(-box[2] / 2, box[2] / 2; length=ny + 1)[1:ny]
+    num = 0.0
+    den = 0.0
+    @inbounds for j in 1:ny, i in 1:nx
+        nxy = 0.0
+        for c in axes(psi, 4), k in 1:nz
+            nxy += abs2(psi[i, j, k, c])
+        end
+        num += nxy * (x[i]^2 + y[j]^2)
+        den += nxy
+    end
+    den > 0 ? sqrt(num / den) : NaN
+end
+
+"""
+    arm(dir; hold_duration, dt, save_every) -> NamedTuple | String
+
+Cloud-size and `P_adj` summary for one run directory, or a String naming why it
+could not be read.
+"""
+function arm(dir::AbstractString; hold_duration::Float64=5.5292,
+    dt::Float64=0.005, save_every::Int=100)
+    f = joinpath(dir, "point_001.jld2")
+    isfile(f) || return "no point_001.jld2"
+    JLD2.jldopen(f, "r") do g
+        haskey(g, "dynamics") || return "no dynamics block"
+        d = g["dynamics"]
+        haskey(d, "psi_snapshots_streamed") || return "no psi_snapshots_streamed"
+        box = g["grid_box_size"]
+        grp = d["psi_snapshots_streamed"]
+        fk = _frame_keys(grp)
+        isempty(fk) && return "snapshot group carries no frames"
+
+        r = [radial_rms(grp[k], box) for k in fk]
+
+        # P_adj on the SAME axis as the snapshots, since both are snapshot-derived.
+        adj = Float64[]
+        if haskey(d, "component_populations")
+            P = d["component_populations"]
+            P = P isa AbstractMatrix ? P : permutedims(reduce(hcat, P))
+            size(P, 1) == length(fk) ||
+                return "cadence mismatch: $(size(P,1)) population rows vs " *
+                       "$(length(fk)) snapshot frames — do not index one by the other"
+            adj = [P[i, 2] + P[i, 3] for i in axes(P, 1)]
+        end
+
+        nhold = max(1, Int(floor(hold_duration / (dt * save_every))))
+        lo = max(1, length(fk) - nhold + 1)
+
+        w = @view adj[lo:end]
+        k_hold = isempty(adj) ? 0 : lo - 1 + argmax(w)
+        k_whole = isempty(adj) ? 0 : argmax(adj)
+        # "Peaks INSIDE the hold" means the maximum over the whole trajectory
+        # lands in the hold window — not that the windowed argmax exists, which
+        # it always does. At 10.4 nT this is the flag that split the arms.
+        peaks_inside = !isempty(adj) && k_whole >= lo
+
+        (; nframes=length(fk), hold_from=lo,
+            r_hold_start=r[lo], r_end=r[end], r_min=minimum(r), r_max=maximum(r),
+            expansion=r[end] / r[lo],
+            padj_peak=isempty(adj) ? NaN : adj[k_hold],
+            padj_frame=k_whole, peaks_inside,
+            padj_final=isempty(adj) ? NaN : adj[end], r)
+    end
+end
+
+"""ω_eff and hold multiplier parsed out of a run-directory name."""
+function label(dir)
+    b = basename(dir)
+    m = match(r"klaus_weff(\d)p(\d+)_B([\dp]+nT)(_hold([\dp]+)x)?(_n(\d+))?", b)
+    m === nothing && return (; weff=NaN, field="?", hold="1p0", n="32")
+    (; weff=parse(Float64, m[1] * "." * m[2]), field=m[3],
+        hold=something(m[5], "1p0"), n=something(m[7], "32"))
+end
+
+function main(args)
+    root = args[1]
+    field = "B5p2nT"
+    csv = nothing
+    i = 2
+    while i <= length(args)
+        if args[i] == "--field"
+            field = args[i + 1]
+            i += 2
+        elseif args[i] == "--csv"
+            csv = args[i + 1]
+            i += 2
+        else
+            i += 1
+        end
+    end
+
+    dirs = sort(filter(readdir(root; join=true)) do d
+        isdir(d) && occursin("klaus_weff", basename(d)) && occursin(field, basename(d))
+    end; by=d -> (label(d).hold, label(d).n, label(d).weff))
+
+    isempty(dirs) && error("no run directories matching $field under $root")
+
+    @printf("\n%s — %d arms\n", field, length(dirs))
+    println("="^108)
+    @printf("%-7s %-5s %-4s | %6s %8s %8s %8s | %8s %6s %-6s\n",
+        "w_eff", "hold", "n", "frames", "r(hold0)", "r(end)", "r_end/r0",
+        "P_adj", "frame", "inside")
+    println("-"^108)
+
+    rows = []
+    failures = String[]
+    for d in dirs
+        L = label(d)
+        a = arm(d)
+        if a isa String
+            push!(failures, @sprintf("  w=%.3f hold=%s n=%s : %s", L.weff, L.hold, L.n, a))
+            continue
+        end
+        @printf("%-7.3f %-5s %-4s | %6d %8.4f %8.4f %8.4f | %8.5f %6d %-6s\n",
+            L.weff, L.hold, L.n, a.nframes, a.r_hold_start, a.r_end, a.expansion,
+            a.padj_peak, a.padj_frame, a.peaks_inside ? "YES" : "no")
+        push!(rows, (L, a))
+    end
+
+    if !isempty(failures)
+        println("\nARMS THAT COULD NOT BE READ (named, not skipped):")
+        foreach(println, failures)
+    end
+
+    # The two structures the prediction is about, side by side.
+    base = filter(r -> r[1].hold == "1p0" && r[1].n == "32", rows)
+    if length(base) >= 3
+        println("\nEXPANSION ORDERING (least-expanded first) — the breathing-phase reading")
+        println("predicts these coincide with the arms whose P_adj peaks inside the hold.")
+        for (L, a) in sort(base; by=x -> x[2].expansion)
+            @printf("  w_eff=%.3f  r_end/r0=%.4f  peaks_inside=%s\n",
+                L.weff, a.expansion, a.peaks_inside ? "YES" : "no")
+        end
+        ins = [L.weff for (L, a) in base if a.peaks_inside]
+        @printf("\n  arms peaking inside the hold: %s\n",
+            isempty(ins) ? "NONE — the 10.4 nT two-group structure is absent here" :
+            string(ins))
+    end
+
+    # Hold-doubling: the discriminator. A resonance cannot move.
+    dbl = filter(r -> r[1].hold != "1p0", rows)
+    if !isempty(dbl)
+        println("\nHOLD DOUBLING — a resonance does not move, a phase does")
+        for (L, a) in sort(dbl; by=x -> x[1].weff)
+            m = findfirst(r -> r[1].weff ≈ L.weff && r[1].hold == "1p0" &&
+                    r[1].n == L.n, rows)
+            if m === nothing
+                @printf("  w_eff=%.3f hold=%s : %.5f  (no 1x partner to compare)\n",
+                    L.weff, L.hold, a.padj_peak)
+            else
+                b = rows[m][2]
+                @printf("  w_eff=%.3f : 1x %.5f -> %s %.5f   (ratio %.4f) | " *
+                        "expansion %.4f -> %.4f\n",
+                    L.weff, b.padj_peak, L.hold, a.padj_peak,
+                    a.padj_peak / b.padj_peak, b.expansion, a.expansion)
+            end
+        end
+    end
+
+    if csv !== nothing
+        open(csv, "w") do io
+            println(io, "weff,field,hold,n,frames,hold_from,r_hold_start,r_end," *
+                        "expansion,padj_peak,padj_frame,peaks_inside,padj_final")
+            for (L, a) in rows
+                @printf(io, "%.3f,%s,%s,%s,%d,%d,%.6f,%.6f,%.6f,%.6f,%d,%s,%.6f\n",
+                    L.weff, L.field, L.hold, L.n, a.nframes, a.hold_from,
+                    a.r_hold_start, a.r_end, a.expansion, a.padj_peak,
+                    a.padj_frame, a.peaks_inside, a.padj_final)
+            end
+        end
+        println("\nwrote ", csv)
+    end
+end
+
+abspath(PROGRAM_FILE) == @__FILE__ && main(ARGS)

--- a/scripts/validation/klaus_weff_cloud_size.jl
+++ b/scripts/validation/klaus_weff_cloud_size.jl
@@ -210,8 +210,7 @@ function main(args)
                     L.weff, L.hold, a.padj_peak)
             else
                 b = rows[m][2]
-                @printf("  w_eff=%.3f : 1x %.5f -> %s %.5f   (ratio %.4f) | " *
-                        "expansion %.4f -> %.4f\n",
+                @printf("  w_eff=%.3f : 1x %.5f -> %s %.5f   (ratio %.4f) | expansion %.4f -> %.4f\n",
                     L.weff, b.padj_peak, L.hold, a.padj_peak,
                     a.padj_peak / b.padj_peak, b.expansion, a.expansion)
             end

--- a/scripts/validation/klaus_weff_cloud_size.jl
+++ b/scripts/validation/klaus_weff_cloud_size.jl
@@ -232,4 +232,6 @@ function main(args)
     end
 end
 
-abspath(PROGRAM_FILE) == @__FILE__ && main(ARGS)
+if abspath(PROGRAM_FILE) == @__FILE__
+    main(ARGS)
+end

--- a/scripts/validation/lt64_endpoint_verdict.jl
+++ b/scripts/validation/lt64_endpoint_verdict.jl
@@ -18,6 +18,19 @@
 #    10 (§12.1). The endpoint needs no window, but the peak is reported beside it
 #    and must not be wrong.
 #
+#    THE WINDOW CONSTANTS ARE THIS SUITE'S, AND GETTING THEM WRONG IS SILENT.
+#    The hold step of `lt64_ens_*.yaml` is `duration: 100.0, dt: 0.005,
+#    save.every: 1000`, so nhold = 100.0/(0.005*1000) = 20 frames. The first run
+#    of this script used `save_every = 100`, which gives nhold = 200 — longer
+#    than the array — so `lo` clamped to 1 and every "hold-peak" was really a
+#    whole-trajectory argmax. It printed a baseline peak of 0.50571 at frame 20
+#    against the 0.37973 the README records, and the static arms matched their
+#    recorded 0.49081 exactly, so the disagreement was visible only because ONE
+#    of the three groups had a stored number to check against.
+#
+#    That is why `peak_frame` is in the output. A peak at the first frame of the
+#    window is a decaying transient; at the last, a truncation. Read it.
+#
 # 2. **It never silently drops an arm.** A missing or unfinished arm is named and
 #    counted. n is what actually landed, and if n < 7 per arm the criterion
 #    cannot be applied at all — the README says so — and this says so too rather
@@ -42,7 +55,7 @@ const N_MIN = 7
 `(peak, endpoint)` P_adj for one run directory, or a String naming the failure.
 """
 function arm_values(dir::AbstractString; hold_duration::Float64=100.0,
-    dt::Float64=0.005, save_every::Int=100)
+    dt::Float64=0.005, save_every::Int=1000)
     f = joinpath(dir, "point_001.jld2")
     isfile(f) || return "no point_001.jld2"
     JLD2.jldopen(f, "r") do g

--- a/scripts/validation/lt64_endpoint_verdict.jl
+++ b/scripts/validation/lt64_endpoint_verdict.jl
@@ -1,0 +1,164 @@
+# #424 — apply the rejection criterion that was fixed BEFORE the 20 arms launched.
+#
+# The criterion is written into `runs/klaus_quench_long_time_ensemble/README.md`
+# and restated in code here so that it cannot be re-fitted to whatever landed:
+#
+#   ESTABLISHED  if |mean(static) - mean(baseline)| >= 2 * SE_diff
+#   SE_diff      = sd_pooled * sqrt(2/n)          <- sd POOLED FROM THESE RUNS
+#   NOT ESTABLISHED otherwise: the ledger row stays `open` and the measured SE
+#                   is reported, together with the n it WOULD need.
+#
+# "A run that finishes and then has its interpretation chosen is not a
+# measurement." The threshold is a constant in this file for exactly that reason.
+#
+# TWO THINGS THIS REFUSES TO DO
+#
+# 1. **It takes the hold-peak inside the hold.** An argmax over the whole
+#    trajectory reads the pre-hold transient; at 10.4 nT that blinded 7 arms of
+#    10 (§12.1). The endpoint needs no window, but the peak is reported beside it
+#    and must not be wrong.
+#
+# 2. **It never silently drops an arm.** A missing or unfinished arm is named and
+#    counted. n is what actually landed, and if n < 7 per arm the criterion
+#    cannot be applied at all — the README says so — and this says so too rather
+#    than computing a tighter-looking interval from fewer points.
+#
+# USE
+#   julia --project=. scripts/validation/lt64_endpoint_verdict.jl <runs-root>
+
+using JLD2
+using Printf
+using Statistics
+
+"Threshold in units of SE_diff, fixed before launch. Do not tune."
+const K_SIGMA = 2.0
+
+"Minimum arms per group the sizing calculation requires. Below this: no answer."
+const N_MIN = 7
+
+"""
+    arm_values(dir; hold_duration, dt, save_every) -> NamedTuple | String
+
+`(peak, endpoint)` P_adj for one run directory, or a String naming the failure.
+"""
+function arm_values(dir::AbstractString; hold_duration::Float64=100.0,
+    dt::Float64=0.005, save_every::Int=100)
+    f = joinpath(dir, "point_001.jld2")
+    isfile(f) || return "no point_001.jld2"
+    JLD2.jldopen(f, "r") do g
+        haskey(g, "dynamics") || return "no dynamics block"
+        d = g["dynamics"]
+        haskey(d, "component_populations") || return "no component_populations"
+        P = d["component_populations"]
+        P = P isa AbstractMatrix ? P : permutedims(reduce(hcat, P))
+        adj = [P[i, 2] + P[i, 3] for i in axes(P, 1)]
+        length(adj) >= 2 || return "only $(length(adj)) frame(s)"
+        nhold = max(1, Int(floor(hold_duration / (dt * save_every))))
+        lo = max(1, length(adj) - nhold + 1)
+        w = @view adj[lo:end]
+        k = lo - 1 + argmax(w)
+        (; peak=adj[k], peak_frame=k, endpoint=adj[end],
+            nframes=length(adj), hold_from=lo)
+    end
+end
+
+group_of(name) = occursin("baseline", name) ? "baseline" :
+                 occursin("static", name) ? "static" :
+                 occursin("rotating", name) ? "rotating" : "?"
+
+function main(args)
+    root = args[1]
+    dirs = sort(filter(d -> isdir(d) && occursin("lt64_ens", basename(d)),
+        readdir(root; join=true)))
+    isempty(dirs) && error("no lt64_ens run directories under $root")
+
+    vals = Dict("baseline" => Float64[], "static" => Float64[], "rotating" => Float64[])
+    peaks = Dict("baseline" => Float64[], "static" => Float64[], "rotating" => Float64[])
+    failures = String[]
+
+    println("\nPER-ARM")
+    println("="^78)
+    @printf("%-34s %-9s %9s %9s %7s\n", "arm", "group", "peak", "endpoint", "pk_fr")
+    println("-"^78)
+    for d in dirs
+        b = basename(d)
+        g = group_of(b)
+        r = arm_values(d)
+        if r isa String
+            push!(failures, "  $b : $r")
+            continue
+        end
+        @printf("%-34s %-9s %9.5f %9.5f %7d\n", b, g, r.peak, r.endpoint, r.peak_frame)
+        haskey(vals, g) || continue
+        push!(vals[g], r.endpoint)
+        push!(peaks[g], r.peak)
+    end
+
+    if !isempty(failures)
+        println("\nARMS THAT DID NOT LAND (named, not dropped):")
+        foreach(println, failures)
+    end
+
+    nb, ns, nr = length(vals["baseline"]), length(vals["static"]), length(vals["rotating"])
+    println("\nGROUPS")
+    println("="^78)
+    for g in ("baseline", "static", "rotating")
+        v = vals[g]
+        isempty(v) && continue
+        @printf("%-9s n=%d  endpoint mean=%.5f  sd=%.5f   |  peak mean=%.5f  sd=%.5f\n",
+            g, length(v), mean(v), length(v) > 1 ? std(v) : NaN,
+            mean(peaks[g]), length(peaks[g]) > 1 ? std(peaks[g]) : NaN)
+    end
+
+    # ---- the criterion, exactly as committed ---------------------------------
+    println("\nVERDICT — criterion fixed before launch, not re-fitted")
+    println("="^78)
+
+    if nb < N_MIN || ns < N_MIN
+        @printf("NOT APPLICABLE: baseline n=%d, static n=%d, and the sizing needs n>=%d\n",
+            nb, ns, N_MIN)
+        println("per arm. A cheaper version of this run is not a cheaper answer.")
+        println("Ledger row `edh-longtime-endpoint-ordering-unresolved` stays `open`.")
+        return
+    end
+
+    b, s = vals["baseline"], vals["static"]
+    # Pooled sd across the two compared groups, one estimate of the common
+    # spread, as the README specifies -- NOT the n=2 pre-run estimate of 0.0658.
+    sd_pool = sqrt(((nb - 1) * var(b) + (ns - 1) * var(s)) / (nb + ns - 2))
+    se_diff = sd_pool * sqrt(1 / nb + 1 / ns)
+    diff = mean(s) - mean(b)
+    nsig = abs(diff) / se_diff
+
+    @printf("  mean(static)   = %.5f   (n=%d)\n", mean(s), ns)
+    @printf("  mean(baseline) = %.5f   (n=%d)\n", mean(b), nb)
+    @printf("  difference     = %+.5f\n", diff)
+    @printf("  pooled sd      = %.5f   (pre-run n=2 estimate was 0.0658)\n", sd_pool)
+    @printf("  SE_diff        = %.5f\n", se_diff)
+    @printf("  |diff| / SE    = %.2f sigma   (threshold %.1f)\n", nsig, K_SIGMA)
+
+    if nsig >= K_SIGMA
+        println("\n  ESTABLISHED: the static arm's endpoint differs from baseline.")
+        @printf("  Direction: static is %s baseline by %.5f (%+.1f %%).\n",
+            diff > 0 ? "ABOVE" : "BELOW", abs(diff), 100 * diff / mean(b))
+    else
+        println("\n  NOT ESTABLISHED at this n. Row stays `open`.")
+        # The n it WOULD need, per the README, rather than a re-fitted threshold.
+        n_need = ceil(Int, 2 * (K_SIGMA * sd_pool / abs(diff))^2)
+        @printf("  n needed per arm for %.1f sigma at this sd and difference: %d\n",
+            K_SIGMA, n_need)
+        println("  Do not quote the difference without the SE beside it.")
+    end
+
+    # The rotating arm's own scatter -- checked, not assumed (README).
+    if nr >= 2
+        r = vals["rotating"]
+        @printf("\n  rotating: n=%d  mean=%.5f  sd=%.5f  (%.2f %% of mean)\n",
+            nr, mean(r), std(r), 100 * std(r) / mean(r))
+        println("  The README's n=2 figure was 0.85 %; this is the check, not the assumption.")
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main(ARGS)
+end

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -1130,13 +1130,22 @@ const _COST = Dict{String, Float64}(
     "oracles/test_dipolar_magnetostriction_magnitude.jl" => 369.0,
     # One 24³ ground state + 100 dynamics steps through the YAML entry point.
     "workflow/test_scalar_egpe_yaml.jl" => 40.0,
-    # Measured here, not on the runner (2026-08-02, 10-core box): 1266 s,
-    # against the 3.0 s default it had been taking. The default made it the
-    # LAST file handed out, which is the worst possible order for the one
-    # file that sets the makespan on its own. The absolute number is
-    # machine-dependent and the ordering it buys is not — nothing else in
-    # any tier is within a factor of four of it.
-    "dynamics/test_spgpe_equilibrium_number.jl" => 1266.0,
+    # 460, runner-calibrated, after the fixture shrank from n=48 L=10.0 to
+    # n=32 L=6.5 (#305). Derivation rather than a guess: this file measured
+    # 2432 s on the CI runner (run 32300172779) against 1032 s on the 10-core
+    # box, a 2.36x ratio; the new fixture measures 195 s there, so 195 * 2.36
+    # ~= 460 s here. The 3.2x ratio quoted on `test_itp_dt_limited_advisory`
+    # above is that file's own pair, not a constant — measure the pair you have.
+    #
+    # It was 1266.0, a real measurement on the wrong machine (2026-08-02,
+    # 10-core box), and before that the 3.0 s default, which made the one file
+    # that set the makespan on its own the LAST one handed out.
+    #
+    # It is no longer that file. At 2432 s it was 23 % of the whole `full`
+    # tier and made the makespan unschedulable: the floor was
+    # max(2432, 8067/3) = 2689 s against a 2700 s cap (#304). At 460 s nothing
+    # dominates and the floor is ~2130 s.
+    "dynamics/test_spgpe_equilibrium_number.jl" => 460.0,
     # Measured, not guessed. An unregistered file is handed out as 3.0, not as
     # "probably small", and the 1266 s entry above exists because a heavy file
     # carrying a 3.0 estimate went out last and blew the 15-minute job.

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -37,6 +37,7 @@ const FAST_TESTS = [
     # The CONTRIBUTING.md scripts/ charter, gated: set equality between
     # scripts/ on disk and the in-test allowlist (306→76 cleanup, 2026-08-18).
     "test_scripts_allowlist.jl",
+    "test_index_backed_gates_see_untracked.jl",
     # #407: the FFTW MEASURE × Julia-threads × mixed-radix corner, as a
     # predicate. Gates the advisory's trigger, not the 11.97 GB — a test that
     # allocated that is a test nobody can run.

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -1116,7 +1116,16 @@ const _COST = Dict{String, Float64}(
     # why it belongs nowhere near FAST: it timed the fast job out at 15 min and the
     # run came back "cancelled", which reads as infrastructure rather than as a test
     # that is too slow for the tier it was put in.
-    "dynamics/test_energy_damping_cayley.jl" => 750.0,
+    # 1723, MEASURED on the runner (run 32509634483). It is now the HEAVIEST
+    # single file in the tier — the role `test_spgpe_equilibrium_number.jl` had
+    # before #305 shrank it — and 750 under-estimated it by 2.3x, which put it
+    # in the wrong place in the hand-out order.
+    #
+    # 750 came from "four testsets at ~3 min each", an argument about the file
+    # rather than a measurement of it, and the comment below still records the
+    # incident that argument was written for. Left in place because the reason
+    # it does not belong in FAST is unchanged; only the number moved.
+    "dynamics/test_energy_damping_cayley.jl" => 1723.0,
     "dynamics/test_number_conserving_spgpe.jl" => 240.0,
     "dynamics/test_energy_damping_buffer_reuse.jl" => 120.0,
     "dynamics/test_mu_lda_constraint.jl" => 60.0,
@@ -1130,12 +1139,19 @@ const _COST = Dict{String, Float64}(
     "oracles/test_dipolar_magnetostriction_magnitude.jl" => 369.0,
     # One 24³ ground state + 100 dynamics steps through the YAML entry point.
     "workflow/test_scalar_egpe_yaml.jl" => 40.0,
-    # 460, runner-calibrated, after the fixture shrank from n=48 L=10.0 to
-    # n=32 L=6.5 (#305). Derivation rather than a guess: this file measured
-    # 2432 s on the CI runner (run 32300172779) against 1032 s on the 10-core
-    # box, a 2.36x ratio; the new fixture measures 195 s there, so 195 * 2.36
-    # ~= 460 s here. The 3.2x ratio quoted on `test_itp_dt_limited_advisory`
-    # above is that file's own pair, not a constant — measure the pair you have.
+    # 1141, MEASURED on the runner (run 32509634483) after the fixture shrank
+    # from n=48 L=10.0 to n=32 L=6.5 (#305). Was 2432 s, so the shrink bought
+    # 2.13x here.
+    #
+    # This entry said 460 for about an hour, and that number was derived rather
+    # than measured: the old fixture was 2432 s on the runner against 1032 s on
+    # the 10-core box, so a 2.36x ratio was applied to the new fixture's 195 s
+    # local. The real runner time is 1141 s and the real ratio is 5.85x. THE
+    # LOCAL-TO-RUNNER RATIO IS NOT A PROPERTY OF THE MACHINE PAIR — it moved by
+    # 2.5x for the same file under nothing but a grid change, presumably because
+    # a smaller problem spends a larger fraction of itself in fixed costs the
+    # 4-vCPU runner pays differently. Scale a local measurement only to get an
+    # ORDERING; overwrite it with a runner number as soon as one exists.
     #
     # It was 1266.0, a real measurement on the wrong machine (2026-08-02,
     # 10-core box), and before that the 3.0 s default, which made the one file

--- a/test/dynamics/test_spgpe_equilibrium_number.jl
+++ b/test/dynamics/test_spgpe_equilibrium_number.jl
@@ -18,8 +18,37 @@ using SpinorBEC
 #
 # gamma is deliberately far above its physical value here: the EQUILIBRIUM does
 # not depend on it, only the time taken to reach it, and the point is to reach it.
+# THE FIXTURE IS INTENSIVE, WHICH IS WHY IT COULD BE SHRUNK (#305).
+#
+# Every assertion below is on a RATIO — N/N_TF, N/N_rj — and the physics is set
+# by (mu, T, c0), which are a chemical potential, a temperature and a coupling,
+# none of them extensive. The only constraint tying n to L is that the grid must
+# resolve the cut, `pi*n/L > k_cut`, so n and L shrink TOGETHER at fixed n/L and
+# the work falls as n^3.
+#
+# That is an argument, and an argument is not evidence, so it was run at three
+# fixtures before being changed (2026-08-22, 10-core box):
+#
+#   n=48 L=10.0    N/N_TF = 1.9104 / 0.8760 / 0.9598   N/N_rj = 2.2873   1032 s
+#   n=32 L=6.5     N/N_TF = 1.8931 / 0.8842 / 0.9606   N/N_rj = 2.2639    174 s
+#   n=24 L=5.0     N/N_TF = 1.8858 / 0.8687 / 0.9525   N/N_rj = 2.2592     80 s
+#
+# All four ratios agree to within 1.3 % across an 8x range in box volume, and the
+# `condensed` selector is false/true/true in all three. n=32 was taken rather
+# than n=24 because its deviations are the smaller (<= 1.0 %) and because the
+# Rayleigh-Jeans prediction is a MODE SUM: shrinking the box thins the C-region
+# mode sphere, and this file's whole subject is a discrepancy against that sum.
+#
+# WHY `steps` WAS NOT ALSO CUT. The N(step) traces say it would break the test:
+# at c0 = 0.002 the run is still climbing 3 % between step 6000 and step 8000 at
+# every fixture. 8000 is not generous, it is barely enough, and the `settled`
+# check passes on a 10 % tolerance rather than on a plateau.
+#
+# Cost on the CI runner: this file was 2432 s (run 32300172779), 23 % of the
+# whole `full` tier and the single file that made its makespan unschedulable
+# (#304). At 5.9x it is ~410 s.
 @testset "SPGPE equilibrium atom number vs the Rayleigh-Jeans mode sum" begin
-    n, L = 48, 10.0
+    n, L = 32, 6.5
     mu, T, c0 = 15.0, 80.0, 0.19
     k_cut = sqrt(2 * (mu + T))
     grid = make_grid(GridConfig((n, n, n), (L, L, L)))
@@ -132,16 +161,28 @@ using SpinorBEC
 
         if rj.condensed
             # mu above the Hartree-Fock floor: the thermal-only sum does not
-            # apply and Thomas-Fermi is what to check. Measured 0.876 (c0 = 0.02)
-            # and 0.960 (c0 = 0.002), so 0.15 is the tolerance the data supports.
-            # It was rtol = 1.0, which admits anything inside a factor of two and
-            # passed the 1.91 below without objecting.
+            # apply and Thomas-Fermi is what to check. Measured 0.884 (c0 = 0.02)
+            # and 0.961 (c0 = 0.002) at this fixture, so 0.15 is the tolerance
+            # the data supports. It was rtol = 1.0, which admits anything inside
+            # a factor of two and passed the 1.89 below without objecting.
             @test r.N≈N_TF rtol=0.15
         else
-            # c0 = 0.19 lands here and matches NEITHER convention: 2.29x the
-            # Rayleigh-Jeans mode sum (150819 vs 65936) and 1.91x Thomas-Fermi
-            # (vs 78947). The header's question — "one of the two is wrong" — is
+            # c0 = 0.19 lands here and matches NEITHER convention: 2.26x the
+            # Rayleigh-Jeans mode sum (41044 vs 18130) and 1.89x Thomas-Fermi
+            # (vs 21682). The header's question — "one of the two is wrong" — is
             # still open at the strong-coupling end, and nothing here resolves it.
+            #
+            # WHAT THE FIXTURE SCAN DID SETTLE (2026-08-22, #305): the ratio is
+            # not a finite-size or mode-count artifact. It is 2.2873 at n=48
+            # L=10.0, 2.2639 at n=32 L=6.5 and 2.2592 at n=24 L=5.0 — three box
+            # volumes spanning 8x, agreeing to 1.2 %. Together with the cutoff
+            # convention, already excluded above at 12 % against a factor of 6.7,
+            # that leaves the two candidates the header names: a real error, or
+            # Hartree-Fock failing at c0*n = 28.6 against T = 80, an interaction
+            # it has no right to describe. Discriminating them needs a cell that
+            # is BOTH uncondensed and weakly interacting, and lowering c0 at
+            # fixed mu condenses the gas instead — which is why the three-coupling
+            # scan this file already runs cannot separate them.
             #
             # `@test_broken` rather than a deleted cell or a loosened bound: the
             # discrepancy stays visible, stays measured, and turns the suite RED

--- a/test/helpers/calibrated_scan.jl
+++ b/test/helpers/calibrated_scan.jl
@@ -38,7 +38,7 @@
 # It throws `BlindScan` if either probe disagrees, naming which one. A scan that
 # cannot see its own positive control is not evidence, so it is not returned.
 
-export BlindScan, calibrated_scan, count_matches, tree_files
+export BlindScan, calibrated_scan, count_matches, tree_files, git_corpus
 
 """
     BlindScan
@@ -134,4 +134,41 @@ function tree_files(root; ext=".jl", skip=(".git", "node_modules", "worktrees"))
         end
     end
     sort(out)
+end
+
+"""
+    git_corpus(repo, pathspec...) -> Set{String}
+
+The files git WILL judge: everything in the index, plus everything in the
+working tree that is not ignored. Repo-relative paths.
+
+Use this, never a bare `git ls-files`, whenever a gate's corpus is "the files
+in this repo".
+
+WHY, because the difference bites in the green direction. `git ls-files` lists
+the INDEX. A gate whose corpus is the index, run against a working tree where
+the new file has not been `git add`-ed yet, is not judging a smaller set — it is
+judging a set from which the file under test has been REMOVED. So it reports
+"no unlisted files" and passes, and CI, which sees a committed tree, fails on
+exactly the file the gate exists to catch. That happened on 2026-08-21 (#422,
+#425): a new `scripts/` submit script was written, the allowlist gate was run
+and was green, "allowlist gate passes" was reported, and CI went red on the
+first push.
+
+The blindness is not a missing check, it is a corpus that answers a different
+question than the one asked, which is why it cannot be fixed by remembering to
+`git add` first. `--others --exclude-standard` adds the untracked-and-not-
+ignored files — precisely the new work — while `.gitignore`d clutter
+(`mcp/.venv`, editor droppings) stays out, which is the only thing the bare
+`ls-files` was ever wanted for.
+
+Note the deleted case is deliberately included: a file in the index but no
+longer on disk stays in the corpus, so "stale allowlist entry" gates still fire.
+Callers that need on-disk existence should intersect with `isfile`.
+"""
+function git_corpus(repo, pathspec...)
+    args = isempty(pathspec) ? String[] : ["--", pathspec...]
+    out = read(Cmd(`git ls-files --cached --others --exclude-standard $args`;
+            dir=repo), String)
+    Set(split(out, '\n'; keepempty=false))
 end

--- a/test/solvers/test_adaptive_dt.jl
+++ b/test/solvers/test_adaptive_dt.jl
@@ -135,8 +135,28 @@ using SpinorBEC
               abs(res_fixed.energies[end]) < 0.01
     end
 
-    @testset "YAML adaptive_dt parsing" begin
-        yaml = """
+    # `dynamics.adaptive_dt` is REFUSED, and these testsets assert the refusal.
+    #
+    # They used to assert that it PARSES — three testsets reading the numbers
+    # back out of `cfg.steps[i].params["adaptive_dt"]`. That surface was retired
+    # deliberately in bfcaf3db: the schema validated five numeric fields with
+    # ranges, and nothing under `src/workflow` ever constructed
+    # `AdaptiveDtParams` or called `run_simulation_yoshida!`, so a config asking
+    # for adaptive stepping validated cleanly and then ran at fixed `dt`. An
+    # accuracy knob that is accepted and discarded is worse than one that does
+    # not exist.
+    #
+    # The retirement did not update these testsets, and per-PR CI could not see
+    # it: this file is in `FULL_EXTRA`, which only the nightly runs. They went
+    # red on 2026-08-01 and stayed red for 92 consecutive nightly runs (#304).
+    # That is the cost of a gate whose tier no PR executes — the defect is
+    # three weeks old and its author's own docstring says "refusing breaks
+    # nothing in the tree", which was true of `runs/` and false of `test/`.
+    #
+    # Adaptive stepping remains available and is exercised above, through the
+    # Julia API it actually lives on.
+    @testset "YAML `dynamics.adaptive_dt` is refused, not silently ignored" begin
+        _cfg(dyn_body) = """
         pipeline:
           - ground_state:
               atom: Rb87
@@ -153,99 +173,53 @@ using SpinorBEC
           - dynamics:
               duration: 1.0
               dt: 0.01
+        $dyn_body
               B:
                 p: 0.0
                 q: 0.0
-          - dynamics:
-              duration: 1.0
-              dt: 0.01
+        """
+
+        # THE PASS DIRECTION FIRST. A `dynamics:` block with no `adaptive_dt`
+        # must still parse — this is the case that matters most, because a
+        # guard that reddens on ordinary configs is a guard someone deletes.
+        ok = load_config_from_string(_cfg(""))
+        @test ok isa PipelineConfig
+        @test length(ok.steps) == 2
+        @test !haskey(ok.steps[2].params, "adaptive_dt")
+
+        # Every shape the retired surface accepted is refused: fully specified,
+        # partially specified, and empty. The empty-dict arm is the one a
+        # `haskey`-based guard is most likely to miss.
+        fully = """
               adaptive_dt:
                 dt_init: 0.005
                 dt_min: 0.0001
                 dt_max: 0.05
                 tol: 0.002
-              B:
-                p: 0.0
-                q: 0.0
         """
-        cfg = load_config_from_string(yaml)
-        @test cfg isa PipelineConfig
-        @test length(cfg.steps) == 3
-        # Fixed phase: no adaptive_dt
-        @test !haskey(cfg.steps[2].params, "adaptive_dt")
-        # Adaptive phase: has adaptive_dt params
-        ad = cfg.steps[3].params["adaptive_dt"]
-        @test ad["dt_init"] == 0.005
-        @test ad["dt_min"] == 0.0001
-        @test ad["dt_max"] == 0.05
-        @test ad["tol"] == 0.002
-    end
-
-    @testset "YAML adaptive_dt error_mode parsing" begin
-        yaml = """
-        pipeline:
-          - ground_state:
-              atom: Rb87
-              grid:
-                n: 32
-                box: 10.0
-              interactions:
-                c0: 1.0
-                c1: 0.0
-              dt: 0.01
-              n_steps: 10
-              tol: 1e-4
-              potential: {type: harmonic, omega: [1.0]}
-          - dynamics:
-              duration: 1.0
-              dt: 0.01
-              adaptive_dt:
-                tol: 0.001
-              B:
-                p: 0.0
-                q: 0.0
-          - dynamics:
-              duration: 1.0
-              dt: 0.01
+        partial = """
               adaptive_dt:
                 tol: 0.001
                 error_mode: richardson
-              B:
-                p: 0.0
-                q: 0.0
         """
-        cfg = load_config_from_string(yaml)
-        @test cfg.steps[2].params["adaptive_dt"]["tol"] == 0.001
-        @test get(cfg.steps[2].params["adaptive_dt"], "error_mode", nothing) === nothing
-        @test cfg.steps[3].params["adaptive_dt"]["error_mode"] == "richardson"
-    end
+        empty = "      adaptive_dt: {}"
 
-    @testset "YAML adaptive_dt defaults" begin
-        yaml = """
-        pipeline:
-          - ground_state:
-              atom: Rb87
-              grid:
-                n: 32
-                box: 10.0
-              interactions:
-                c0: 1.0
-                c1: 0.0
-              dt: 0.01
-              n_steps: 10
-              tol: 1e-4
-              potential: {type: harmonic, omega: [1.0]}
-          - dynamics:
-              duration: 1.0
-              dt: 0.002
-              adaptive_dt: {}
-              B:
-                p: 0.0
-                q: 0.0
-        """
-        cfg = load_config_from_string(yaml)
-        @test cfg isa PipelineConfig
-        @test haskey(cfg.steps[2].params, "adaptive_dt")
+        for (label, body) in
+            (("fully specified", fully), ("partial", partial), ("empty", empty))
+            @testset "$label" begin
+                err = try
+                    load_config_from_string(_cfg(body))
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa ArgumentError
+                # The message has to route the user somewhere, or the refusal
+                # just costs them the run without telling them what to do.
+                @test occursin("adaptive_dt", err.msg)
+                @test occursin("run_simulation_yoshida!", err.msg)
+            end
+        end
     end
 
     @testset "IntegratorConfig type" begin

--- a/test/test_index_backed_gates_see_untracked.jl
+++ b/test/test_index_backed_gates_see_untracked.jl
@@ -1,0 +1,141 @@
+# A gate whose corpus is the git INDEX is blind to work that has not been
+# `git add`-ed — and it is blind in the GREEN direction.
+#
+# THE INCIDENT (#422, #425, 2026-08-21)
+#
+# A new `scripts/` submit script was written. `test_scripts_allowlist.jl` was
+# run, was green, and "allowlist gate passes" was reported. The push went red on
+# CI with `isempty(["submit_lt64_endpoint_ensemble.sh"])`.
+#
+# Nothing was skipped and nobody was careless. The gate built its corpus with
+# `git ls-files scripts` and intersected the on-disk listing against it, so the
+# unstaged file was not judged-and-passed, it was REMOVED FROM THE QUESTION. An
+# empty `extra` set then means "no unlisted files" and "I could not see the file
+# you are asking about" with the same two characters, which is the
+# `calibrated_scan` thesis one layer out: an instrument that cannot distinguish
+# absence from unreachability is not evidence.
+#
+# WHY THIS IS THE DANGEROUS DIRECTION
+#
+# The set of PRs that add an untracked file matching an allowlisted pattern IS
+# the set of PRs the allowlist gate exists for. So the gate was blind exactly
+# and only when it mattered, and green the rest of the time. A norm
+# ("`git add` before running index-backed gates") is the wrong shape of fix:
+# the same day produced four environment-induced false verdicts, and a habit
+# that must fire on the rare path is a habit that will not.
+#
+# WHAT IS ASSERTED HERE
+#
+#   1. NEGATIVE control — an untracked, unignored file matching the pattern is
+#      SEEN. This is the canary: it must be able to go red.
+#   2. POSITIVE control — a staged, correctly-allowlisted file stays green.
+#      Required by CLAUDE.md's "the sharpest case goes in the PASS direction":
+#      a gate that reddens on correct work gets switched off.
+#   3. IGNORED files stay invisible — `mcp/.venv` and editor droppings were the
+#      only reason the index filter was there, and that reason must survive.
+#   4. The class gate — no test in the tree builds a corpus from a bare
+#      `git ls-files`.
+#
+# Every assertion runs against a THROWAWAY repo built in a temp dir, so the
+# result does not depend on the state of the checkout running the suite — which
+# is the same checkout-dependence bug, and it would be absurd to reintroduce it
+# in the test that names it.
+
+using Test
+using SpinorBEC
+
+include(joinpath(@__DIR__, "helpers", "calibrated_scan.jl"))
+
+"Build a throwaway git repo with a known tracked/untracked/ignored layout."
+function _scratch_repo(f)
+    mktempdir() do dir
+        run(pipeline(Cmd(`git init -q`; dir), devnull))
+        run(pipeline(Cmd(`git config user.email t@t`; dir), devnull))
+        run(pipeline(Cmd(`git config user.name t`; dir), devnull))
+        mkpath(joinpath(dir, "scripts", "sub"))
+        write(joinpath(dir, ".gitignore"), "scripts/ignored_clutter.sh\n")
+
+        # (a) tracked + committed
+        write(joinpath(dir, "scripts", "committed.sh"), "#!/bin/bash\n")
+        # (b) staged but not committed
+        write(joinpath(dir, "scripts", "staged.sh"), "#!/bin/bash\n")
+        run(
+            pipeline(Cmd(`git add .gitignore scripts/committed.sh scripts/staged.sh`;
+                    dir), devnull),
+        )
+        run(pipeline(Cmd(`git commit -q -m init -- .gitignore scripts/committed.sh`;
+                dir), devnull))
+        # (c) untracked, NOT ignored — the file the old corpus dropped
+        write(joinpath(dir, "scripts", "untracked_new.sh"), "#!/bin/bash\n")
+        # (d) untracked AND ignored — must stay invisible
+        write(joinpath(dir, "scripts", "ignored_clutter.sh"), "#!/bin/bash\n")
+        # (e) untracked, not ignored, in a subdirectory
+        write(joinpath(dir, "scripts", "sub", "nested_new.sh"), "#!/bin/bash\n")
+        f(dir)
+    end
+end
+
+@testset "git_corpus sees the working tree, not just the index" begin
+    _scratch_repo() do dir
+        corpus = git_corpus(dir, "scripts")
+
+        @testset "CANARY: an untracked, unignored file is SEEN" begin
+            # This is the assertion that had no counterpart before #425. If the
+            # corpus reverts to a bare `git ls-files`, this goes red.
+            @test "scripts/untracked_new.sh" in corpus
+            @test "scripts/sub/nested_new.sh" in corpus
+        end
+
+        @testset "PASS direction: tracked files stay visible" begin
+            @test "scripts/committed.sh" in corpus
+            @test "scripts/staged.sh" in corpus
+        end
+
+        @testset "ignored clutter stays invisible" begin
+            # The ONLY thing the index filter was ever wanted for. Losing this
+            # would trade a green-side blindness for a red-side one.
+            @test !("scripts/ignored_clutter.sh" in corpus)
+        end
+
+        @testset "pathspec scopes the corpus" begin
+            @test !(".gitignore" in corpus)
+            @test ".gitignore" in git_corpus(dir)
+        end
+    end
+end
+
+@testset "the old spelling really was blind — the bug reproduces" begin
+    # Pinning the DEFECT, not just the fix. If someone argues the index corpus
+    # was fine, this is the counter-example, executed rather than described.
+    _scratch_repo() do dir
+        index_only = Set(
+            split(
+                read(Cmd(`git ls-files scripts`; dir), String), '\n'; keepempty=false),
+        )
+        @test !("scripts/untracked_new.sh" in index_only)   # the blindness
+        @test "scripts/committed.sh" in index_only          # ...and it looked fine
+    end
+end
+
+@testset "no gate in the tree builds a corpus from a bare `git ls-files`" begin
+    # The class gate. CLAUDE.md commitment 11: a new single source of truth
+    # ships with the gate that outlaws the old form, or the migration becomes
+    # permanent and the tree carries two live definitions of the same thing.
+    root = normpath(joinpath(@__DIR__, ".."))
+    files = tree_files(joinpath(root, "test"))
+
+    # `--others` is what makes an `ls-files` call see the working tree; a call
+    # carrying it is fine however it is spelled.
+    bare = String[]
+    for rel in files
+        path = joinpath(dirname(rstrip(root, '/')), rel)
+        isfile(path) || continue
+        endswith(path, "test_index_backed_gates_see_untracked.jl") && continue
+        for m in eachmatch(r"git[^\n`]*ls-files[^\n`]*", read(path, String))
+            occursin("--others", m.match) || push!(bare, rel * ": " * strip(m.match))
+        end
+    end
+
+    @test isempty(bare)
+    isempty(bare) || @info "bare `git ls-files` corpora (use `git_corpus`)" bare
+end

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -226,6 +226,10 @@ const _SCRIPTS_ALLOWLIST = Set([
     # settled 10.4 nT: population readings disagreed with each other, the cloud
     # explained it, and the data was already in the cache.
     "validation/klaus_weff_cloud_size.jl",
+    # #424 — applies the endpoint criterion that was fixed before the 20 arms
+    # launched. The threshold is a constant in the file so it cannot be
+    # re-fitted to whatever landed.
+    "validation/lt64_endpoint_verdict.jl",
     "validation/rk4ip_step_size_probe.jl",
     "validation/rk4ip_time_to_solution_gpu.jl",
     "validation/scan_job_cost_breakdown.jl",

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -58,6 +58,11 @@ const _SCRIPTS_ALLOWLIST = Set([
     # purpose: a shard reaped at h_rt must not take completed neighbours with it.
     "submit_klaus_weff_scan.sh",
     "submit_lt64_endpoint_ensemble.sh",
+    # #423 — eu151_klaus_phi_phys at production scale with the anti-aligned
+    # preparation. One job, not an array: `run_yaml` has no point selection, so
+    # the 8-point scan is indivisible from outside; it IS resumable, so a
+    # walltime kill costs only the point it was inside.
+    "submit_edh_phi_phys_anti_aligned.sh",
     "tsubame/_preamble.sh",
     "tsubame/preflight.sh",
     "tsubame/submit_gpu_smoke.sh",

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -23,6 +23,11 @@ using SpinorBEC
 # silently disarms the gate below. `calibrated_scan` caught exactly that: its
 # positive control stopped matching when Printf was absent from Main.
 using Printf
+# `git_corpus` — the corpus this gate judges must be the one CI judges. Included
+# at top level, not inside the testset that needs it, because two later testsets
+# in this file include the same helper and the first use must not depend on
+# which of them ran.
+include(joinpath(@__DIR__, "helpers", "calibrated_scan.jl"))
 
 const _SCRIPTS_ALLOWLIST = Set([
     # ── entry points / hard test gates ──
@@ -234,10 +239,14 @@ const _SCRIPTS_ALLOWLIST = Set([
             push!(on_disk, rel == "." ? f : joinpath(rel, f))
         end
     end
-    # ignore local-only clutter that is not tracked by git (e.g. mcp/.venv)
-    tracked = Set(split(read(`git -C $root ls-files scripts`, String), '\n';
-        keepempty=false))
-    on_disk = Set(f for f in on_disk if ("scripts/" * f) in tracked)
+    # Ignore local-only clutter that git is told to ignore (e.g. mcp/.venv) —
+    # and NOTHING else. This was `git ls-files scripts`, the index alone, which
+    # also dropped every file the author had not `git add`-ed yet: the gate went
+    # green on the very PRs it exists to judge, then CI went red (#422/#425).
+    # `git_corpus` is the index PLUS unignored working-tree files; see its
+    # docstring for why the failure lands on the green side.
+    known = git_corpus(root, "scripts")
+    on_disk = Set(f for f in on_disk if ("scripts/" * f) in known)
 
     extra = sort(collect(setdiff(on_disk, _SCRIPTS_ALLOWLIST)))
     stale = sort(collect(setdiff(_SCRIPTS_ALLOWLIST, on_disk)))

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -222,6 +222,10 @@ const _SCRIPTS_ALLOWLIST = Set([
     "validation/klaus_weff_extract.jl",
     "validation/matsui_dataset_to_csv.jl",
     "validation/rk4ip_gpu_cost_probe.jl",
+    # #444 — radial cloud size across an omega_eff scan. The observable that
+    # settled 10.4 nT: population readings disagreed with each other, the cloud
+    # explained it, and the data was already in the cache.
+    "validation/klaus_weff_cloud_size.jl",
     "validation/rk4ip_step_size_probe.jl",
     "validation/rk4ip_time_to_solution_gpu.jl",
     "validation/scan_job_cost_breakdown.jl",


### PR DESCRIPTION
`#281`–`#444` の未処理を横断的に処理しました。各コミットは独立に読めます。

## 検証済みの成果

| | 状態 |
|---|---|
| **#304 / #305** | **nightly が緑**（[run 32509634483](https://github.com/KozumaLaboratory/BEC-simulation/actions/runs/32509634483)、53.5 分、worker TIMED OUT ゼロ）— 92 連続失敗の終わり |
| **#424** | **ESTABLISHED、5.01 σ**（20/20 腕、事前固定の基準をそのまま適用）— issue クローズ |
| **#423** | **8/8 点で `mz_actual = −6.0000`**、82 分 rc=0 |
| **#444** | 登録済み予言 3 つすべて **HIT**（新規実行ゼロ） |
| **#425** | 修正 + 両方向 canary + class gate — issue クローズ |
| **#289** | 条件解消を実測で確認 — issue クローズ |
| **#418** | 容疑者 3 つを追加除外（貯槽の隅・種・その交互作用）。**私の推測は測って外れました** |
| **#281** | 最後の解析項目に決着 |
| **#442** | レビュー → マージ済み |

---

## #304 / #305 — 原因は 3 つ、どれも flaky ではない

**1. shallow clone。** `test_campaign_fix_list_gate.jl` の ancestor 判定が `fetch-depth: 1` で失敗し、fix-list 16 件すべてが dead と読まれ、ゲート自身の canary が `disqualified`。`ci.yml` は最初から `fetch-depth: 0` を持っていて、**この job だけ貰っていなかった**。ゲートの `_shallow()` はこれを 1 行で言うために書かれていて、**実際に言っていました** — 読まれていなかっただけです。→ **16/4 → 21/21**

**2. 撤回済みの YAML surface をまだ assert していた。** `_reject_inert_dynamics_keys` (`bfcaf3db`) は `dynamics.adaptive_dt` を正しく拒否します（schema が 5 フィールドを検証するのに誰も読まず、adaptive を頼んだ config が黙って固定 dt で走っていた）。`solvers/test_adaptive_dt.jl` の 3 testset は**まだパースを assert** していて、このファイルは `FULL_EXTRA` なので **PR CI から構造上見えません**。docstring の「refusing breaks nothing in the tree」は `runs/` について真、`test/` について偽。→ **61/3 → 73/73**、受け入れていた 3 形すべてで拒否を assert、`adaptive_dt` なしを pass 方向として固定。

**3. サイズ、そして 2700 s では最初から無理だったという算数。** `test_spgpe_equilibrium_number.jl` は**ランナー上で 2432 s**（10 コア機の 1266 s ではない）。分割不能なので makespan 下限 `max(2432, 8067/3) = 2689 s` 対 cap 2700 s = **11 秒**。断続的に遅いのではなく境界に座っていました。

対処は cap を 4200 s に上げるだけでなく**源でも**（#305）: fixture を n=48 L=10.0 → n=32 L=6.5、**2432 → 1141 s**。intensive な比であることを**箱 3 つで実測してから**変更（体積 8 倍を跨いで 1.3 % 以内、`condensed` セレクタ不変）。`steps` は削っていません — N(step) が c₀=0.002 で 6000→8000 間にまだ 3 % 上がっているため。

**「never completed」と並んでいた他 3 ファイルは 12.7 / 4.4 / 7.8 s** です。殺される直前に claim されただけで、遅いと読むと**間違った 4 ファイル**に修正を送っていました。

**副産物**: 緑の run が `_COST` 2 件を実測で否定 — cayley 750 → **1723**（現・最重量）、spgpe 460 → **1141**。後者は**私がこの PR で 1 時間前に入れた導出値**で、local→runner 比 2.36 倍を掛けたもの。実際は 5.85 倍でした。**その比は機械の組の性質ではありません**（格子を変えただけで 2.5 倍動いた）。表の 2 行上に同じ教訓があったのに再現しています。

## #425 — index を corpus にするゲートは緑側に盲目だった

`git ls-files` は **index**。`git add` 前のファイルは*判定されて通った*のではなく**問いから消えていた**。盲目になるのは**新規スクリプトを足す PR** — ゲートが存在する理由そのものの集合です。

`git_corpus` = index + 無視されていない作業ツリー、一度だけ定義。canary は**両方向**、しかも**使い捨てリポジトリ**に対して（チェックアウト依存が当のバグなので）。旧綴りの盲目も**実行して再現**。さらに class gate: どのテストも bare `git ls-files` で corpus を作れない。

実地確認: untracked な `scripts/` ファイルが実際のゲートを**CI 自身のメッセージで赤くし**、消すと緑に戻ります。

## #444 — 5.2 nT も同じ呼吸位相、hold 検定は**順序を反転**させる

新規実行ゼロ。キャッシュ 24 腕を populations ではなく**雲**として読みました。

1. **HIT** — 膨張は単一振動、`ω_eff=0.600` で最小 0.9868（雲が**収縮**）、0.770 で最大 1.1441。38 % の振れ幅に対し dt/2 の床 0.029 %
2. **HIT、ただし機構が予言する形で**（#444 が事前に指摘済み）— 20 腕すべて hold 内でピークなので 10.4 nT の判別子は縮退。情報は **argmax フレーム**: `≤0.620` は 42/42（打ち切り）、`≥0.650` は内部 38/37。**分岐点は谷と一致**
3. **HIT、10.4 nT より強く** — 比が動くだけでなく**順序が反転**: 8 ms で `0.550 > 0.770 > 0.650`、16 ms で `0.650 > 0.550 > 0.770`

対照 `ω_eff=1.000` はトラップ不変なのに呼吸（1.0520 / 0.9914）⇒ **クエンチ由来**。

**`edh-104nt-observable-not-window-robust` は閉じません** — なぜ窓が効くかを説明しただけです。

## #424 — 5.01 σ、ESTABLISHED

閾値 2.0 を**定数として持つスクリプト**で判定（後から動かせない）。pooled sd 0.05098 は事前推定 0.0658 より**小さく**、「n=8 では届かない」分岐は発火せず。

結果の形は **3 つのばらつき**: baseline sd 0.13 % / rotating 0.57 % / static **26 %**。**終端の不確かさは全部 static に住んでいます。**

**ピーク列は引用不可**で、argmax がその理由を言っています: baseline は frame 20、rotating は 21 — 窓の先頭、過渡がまだ支配する場所。static だけが内部（31）で、static だけが記録値 0.49081 を完全再現。判定には無影響（終端は窓を必要としない）。

## #418 — 私の推測は測って外れました

2×2 要因計画（隅 × 種）。**4 セルすべてで full/growth = 0.93〜1.06**。本番の 9.0 倍・37 倍とは桁が 2 つ違います。陽性対照（`µ=3,T=1,vacuum`）は記録値 0.586 N_TF を**完全再現**。

issue の推測は *「converged 種を T=10 の貯槽に置くと加熱が凝縮体を食う」* でしたが、**その組み合わせで full は 0.422、growth-only の 0.399 を上回りました**。

**残るのはランプ**（probe は µ 固定、本番は 1300 ms かけて上げる）と規模。

副産物 2 件: (a) この issue の DDI 除外は **main に無い knob** で測られていた（orphan ブランチのみ、cherry-pick して収容）。(b) probe は**使っていない GPU を予約していた**（`import CUDA` すらしない）→ cpu_16 に。

---

Closes #424, #425, #444
Refs #281, #289, #304, #305, #376, #418, #423, #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)