### PR TITLE
fix(spgpe): #305's factor of 6.7 was a missing spin count; #376 closed; #418/#435 instrumented

### DIFF
--- a/runs/saito_li_torus/README.md
+++ b/runs/saito_li_torus/README.md
@@ -78,12 +78,28 @@ set by dt rather than by the Hamiltonian. This is why `method: lbfgs`.
 | 64³ box 6 | 0.0732 μm | −1.5754124 | 0.513 | 0.812 μm | 1.0e-4 |
 | 96³ box 6 | 0.0488 μm | −1.5754124 | 0.516 | 0.817 μm | 9.4e-5 |
 | 88³ box 8 | 0.0709 μm | −1.5754118 | 0.513 | 0.825 μm | 2.7e-7 |
+| **128³ box 6** | **0.0366 μm** | **−1.5754124** | **0.516** | **0.819 μm** | **8.8e-5** |
 
-Energy is identical to 7 digits across a 1.5× refinement in dx **and** a 1.33×
-enlargement of the box at fixed resolution; the radius moves 1.6 % over both.
+Energy is identical to 7 digits across a **2.0× refinement in dx** and a 1.33×
+enlargement of the box at fixed resolution; the radius moves 1.6 % over all four.
 The 88³ box-8 cell is the box test proper — the box grows while dx does not —
 and its edge density is 2.7e-7 of the peak, so the object is self-bound rather
 than held by the periodic boundary.
+
+The 128³ cell was added 2026-08-22 (#376) and is the flat fourth point it was
+expected to be: same energy to 7 digits, peak ρ/N and r_peak inside the spread
+the other three already showed. It also re-checks the two structural facts at
+the finest grid — every one of the 13 components winds with **v_m = −m** at
+r_peak, and **J_z = L_z = F_z = 0** — so flux closure is not a coarse-grid
+artefact. Against the published profile it sits at peak ρ/N +1.5 %, r_peak
++0.5 %, FWHM_hi 0.0 %.
+
+**WHERE THIS STOPPED, stated rather than implied.** dx = 0.0366 μm. The paper's
+grid is ≈ 0.01 μm, which at box 6 a_ho would need n ≈ 468 — not run and not
+planned. So this is a four-point convergence line down to **3.7× coarser than
+the paper**, and the phrase "converged" is not claimed at the paper's spacing.
+The F = 6 object is ~3× the size of the F = 1 one, which is the reason to expect
+the coarser grid to suffice, and that is an expectation, not a measurement.
 
 Every cell reaches the L-BFGS energy-comparison floor at |∇E| ≈ 3e-6 and so
 reports `converged=false`. That flag means "tol=1e-9 was below what the method

--- a/runs/saito_li_torus/cells/stiff_n64_Bz0p000.yaml
+++ b/runs/saito_li_torus/cells/stiff_n64_Bz0p000.yaml
@@ -1,0 +1,40 @@
+mixins:
+  saito_li_droplet:
+    grid:
+      box:
+        - 6
+        - 6
+        - 6
+      n:
+        - 64
+        - 64
+        - 64
+    atom: "Eu151"
+    potential:
+      type: "none"
+    interactions:
+      omega_ref: 691.15
+      c1_ratio: 0.0
+      N_atoms: 15000
+      c_total: 584.37
+pipeline:
+  - ground_state:
+      B:
+        Bz: "0.0 Gauss"
+      ddi: {}
+      method: "lbfgs"
+      use:
+        - "saito_li_droplet"
+      tol: 1.0e-9
+      initial_state: "spin_coherent"
+      init_state_params:
+        init_theta: 1.5707963267948966
+        init_vortex_charge: 1
+        init_phi: 1.5707963267948966
+      lhy:
+        kind: "scalar"
+        c_lhy: 276.28
+      n_steps: 4000
+defaults:
+  kind: "spinor"
+  backend: "gpu"

--- a/runs/saito_li_torus/cells/stiff_n64_Bz0p025.yaml
+++ b/runs/saito_li_torus/cells/stiff_n64_Bz0p025.yaml
@@ -1,0 +1,40 @@
+mixins:
+  saito_li_droplet:
+    grid:
+      box:
+        - 6
+        - 6
+        - 6
+      n:
+        - 64
+        - 64
+        - 64
+    atom: "Eu151"
+    potential:
+      type: "none"
+    interactions:
+      omega_ref: 691.15
+      c1_ratio: 0.0
+      N_atoms: 15000
+      c_total: 584.37
+pipeline:
+  - ground_state:
+      B:
+        Bz: "2.5e-5 Gauss"
+      ddi: {}
+      method: "lbfgs"
+      use:
+        - "saito_li_droplet"
+      tol: 1.0e-9
+      initial_state: "spin_coherent"
+      init_state_params:
+        init_theta: 1.5707963267948966
+        init_vortex_charge: 1
+        init_phi: 1.5707963267948966
+      lhy:
+        kind: "scalar"
+        c_lhy: 276.28
+      n_steps: 4000
+defaults:
+  kind: "spinor"
+  backend: "gpu"

--- a/runs/saito_li_torus/cells/stiff_n64_Bz0p050.yaml
+++ b/runs/saito_li_torus/cells/stiff_n64_Bz0p050.yaml
@@ -1,0 +1,40 @@
+mixins:
+  saito_li_droplet:
+    grid:
+      box:
+        - 6
+        - 6
+        - 6
+      n:
+        - 64
+        - 64
+        - 64
+    atom: "Eu151"
+    potential:
+      type: "none"
+    interactions:
+      omega_ref: 691.15
+      c1_ratio: 0.0
+      N_atoms: 15000
+      c_total: 584.37
+pipeline:
+  - ground_state:
+      B:
+        Bz: "5.0e-5 Gauss"
+      ddi: {}
+      method: "lbfgs"
+      use:
+        - "saito_li_droplet"
+      tol: 1.0e-9
+      initial_state: "spin_coherent"
+      init_state_params:
+        init_theta: 1.5707963267948966
+        init_vortex_charge: 1
+        init_phi: 1.5707963267948966
+      lhy:
+        kind: "scalar"
+        c_lhy: 276.28
+      n_steps: 4000
+defaults:
+  kind: "spinor"
+  backend: "gpu"

--- a/runs/saito_li_torus/cells/stiff_n64_Bz0p100.yaml
+++ b/runs/saito_li_torus/cells/stiff_n64_Bz0p100.yaml
@@ -1,0 +1,40 @@
+mixins:
+  saito_li_droplet:
+    grid:
+      box:
+        - 6
+        - 6
+        - 6
+      n:
+        - 64
+        - 64
+        - 64
+    atom: "Eu151"
+    potential:
+      type: "none"
+    interactions:
+      omega_ref: 691.15
+      c1_ratio: 0.0
+      N_atoms: 15000
+      c_total: 584.37
+pipeline:
+  - ground_state:
+      B:
+        Bz: "1.0e-4 Gauss"
+      ddi: {}
+      method: "lbfgs"
+      use:
+        - "saito_li_droplet"
+      tol: 1.0e-9
+      initial_state: "spin_coherent"
+      init_state_params:
+        init_theta: 1.5707963267948966
+        init_vortex_charge: 1
+        init_phi: 1.5707963267948966
+      lhy:
+        kind: "scalar"
+        c_lhy: 276.28
+      n_steps: 4000
+defaults:
+  kind: "spinor"
+  backend: "gpu"

--- a/scripts/eu334/ed_growth_probe.jl
+++ b/scripts/eu334/ed_growth_probe.jl
@@ -29,6 +29,7 @@
 
 using SpinorBEC
 using FFTW
+using FFTW: fft, fftshift
 using Printf
 
 const OMEGA, A_S = 1.0, 0.02
@@ -59,6 +60,32 @@ const T_RES = parse(Float64, get(ENV, "ED_T", "1.0"))
 const K_CUT = sqrt(2 * (MU + T_RES))
 const NSTEP = parse(Int, get(ENV, "ED_NSTEP", "25000"))
 const SEED_MODE = get(ENV, "ED_SEED", "vacuum")
+
+# `ED_SEED0` offsets the noise stream. Two runs of the SAME configuration came
+# back N0 = 272.2 and 726.1 (2.7x) on 2026-08-22, on different nodes. The probe's
+# stream is deterministic (`ED_SEED0 + s`), so that is not seed scatter — the
+# likeliest reading is that the F=6 + DDI arm is dynamically chaotic and
+# amplifies bitwise-different-but-equal arithmetic. Either way the arm cannot be
+# quoted at n = 1, and this knob is what makes an ensemble possible.
+const SEED0 = parse(Int, get(ENV, "ED_SEED0", "90000"))
+
+# `ED_MU_RAMP` is #418's LAST untested difference, and after the 2x2 factorial it
+# is the last one full stop.
+#
+# The factorial (2026-08-22) cleared the reservoir corner, the seed, and their
+# interaction: full/growth came back 0.93-1.06 in all four cells against
+# production's 9.0x and 37x. Everything about the CONFIGURATION is now exonerated
+# — projector, moving cutoff, energy damping, F=6, DDI, the scattering pair, both
+# reservoirs, (T, mu), the seed. What is left is that production RAMPS mu while
+# this probe holds it fixed.
+#
+# `ED_MU_RAMP=<mu_end>` sweeps mu linearly from MU to mu_end across the run, the
+# shape #334 drives (8.48 -> 11.72 over 1300 ms). The reservoir is rebuilt each
+# step, which is the honest way to do it: k_cut depends on mu, so a ramp that
+# held k_cut fixed would be a different experiment and would silently re-answer
+# the cutoff-motion question that was already excluded.
+const MU_RAMP_END = parse(Float64, get(ENV, "ED_MU_RAMP", "0.0"))
+const MU_RAMPS = MU_RAMP_END > 0.0
 
 # `ED_ATOM=eu151` runs the SAME probe at F = 6, 13 components, DDI off.
 #
@@ -118,11 +145,14 @@ function arm(grid, dV, phi, d, n_tf, energy_damping::Bool)
         ddi_padding=false, ddi_trunc_radius=-1.0)
     # M = 0.0 is the growth-only sub-theory; omitting M lets the reservoir use its
     # own physical scattering rate. One knob between the arms.
-    res = energy_damping ?
-          SPGPEReservoir(; T=T_RES, mu=MU, a_s=A_S, k_cut=K_CUT, gamma=GAMMA,
-        allow_unphysical_rates=true) :
-          SPGPEReservoir(; T=T_RES, mu=MU, a_s=A_S, k_cut=K_CUT, gamma=GAMMA, M=0.0,
-        allow_unphysical_rates=true)
+    # Built per-mu so the ramp arm can rebuild it; identical to the old inline
+    # form when mu does not move.
+    mkres(mu) = energy_damping ?
+                SPGPEReservoir(; T=T_RES, mu=mu, a_s=A_S, k_cut=sqrt(2 * (mu + T_RES)),
+        gamma=GAMMA, allow_unphysical_rates=true) :
+                SPGPEReservoir(; T=T_RES, mu=mu, a_s=A_S, k_cut=sqrt(2 * (mu + T_RES)),
+        gamma=GAMMA, M=0.0, allow_unphysical_rates=true)
+    res = mkres(MU)
     # The one knob #418 has left. `vacuum` is the arm every previous round ran:
     # the condensate is built by the reservoir out of nothing. `converged` hands
     # the SPGPE a state that is ALREADY the ground state at this µ — production's
@@ -140,8 +170,12 @@ function arm(grid, dV, phi, d, n_tf, energy_damping::Bool)
     out = 0.0
     trunc = 0.0
     for s in 1:NSTEP
+        if MU_RAMPS
+            # Linear in step index, the same shape #334's FortRamp drives mu on.
+            res = mkres(MU + (MU_RAMP_END - MU) * (s - 1) / (NSTEP - 1))
+        end
         split_step!(ws)
-        r = apply_spgpe_step!(ws, res, DT; t=0.0, seed=90_000 + s)
+        r = apply_spgpe_step!(ws, res, DT; t=0.0, seed=SEED0 + s)
         out += get(r, :cutoff_outflow, 0.0)
         trunc += get(r, :noise_truncated, 0.0)
         @views for c in 1:(d - 1)
@@ -149,11 +183,45 @@ function arm(grid, dV, phi, d, n_tf, energy_damping::Bool)
         end
     end
     psi = Array(view(ws.state.psi, :, :, :, d))
-    (n0=abs2(sum(conj.(phi) .* psi) * dV), n_c=sum(abs2, psi) * dV, out=out, trunc=trunc)
+
+    # WHERE IN k THE POPULATION SITS. #418 found that F=6 and the DDI are each
+    # harmless alone and together drive the cutoff outflow up 786x. A total
+    # outflow says it happens; it does not say whether the C region is bleeding
+    # from its EDGE (population pushed to high k, then cut) or uniformly.
+    #
+    # Radial bins of |psi(k)|^2 as a fraction of the norm, in units of k_cut, so
+    # arms with different k_cut are comparable. The outermost bin is the one the
+    # projector acts on.
+    kb = zeros(4)
+    let ph = fftshift(fft(ws.state.psi)), kmax = K_CUT
+        n = size(ws.state.psi)
+        for I in CartesianIndices(ph)
+            # k from the shifted index, per axis, in the grid's own units
+            k2 = 0.0
+            for ax in 1:3
+                L_ax = grid.config.box_size[ax]
+                idx = I[ax] - (n[ax] ÷ 2) - 1
+                k2 += (2π * idx / L_ax)^2
+            end
+            f = sqrt(k2) / kmax
+            b = f < 0.25 ? 1 : f < 0.5 ? 2 : f < 0.8 ? 3 : 4
+            kb[b] += abs2(ph[I])
+        end
+        t = sum(kb)
+        t > 0 && (kb ./= t)
+    end
+
+    (n0=abs2(sum(conj.(phi) .* psi) * dV), n_c=sum(abs2, psi) * dV, out=out,
+        trunc=trunc, kbins=kb)
 end
 
 function main()
-    grid = make_grid(GridConfig((24, 24, 24), (10.0, 10.0, 10.0)))
+    # #418's remaining axis after every mechanism was exonerated: SCALE. The
+    # probe is 24^3 box 10 and production is 64^3 box 24, and nothing has yet
+    # varied that. Defaults reproduce every arm run so far.
+    gn = parse(Int, get(ENV, "ED_N", "24"))
+    gb = parse(Float64, get(ENV, "ED_BOX", "10.0"))
+    grid = make_grid(GridConfig((gn, gn, gn), (gb, gb, gb)))
     dV = cell_volume(grid)
     n_tf = ((2 * MU / OMEGA)^2.5) / (15 * A_S)
     π / minimum(grid.dx) > K_CUT || error("grid does not resolve the C region")
@@ -162,13 +230,17 @@ function main()
     # Every knob in the output line, because the whole value of this probe is that
     # exactly one of them differs between the arm being read and the arm it is
     # being compared against — and a remembered configuration is not a control.
-    @printf("atom = %s (D = %d)  c_dd = %.4g  mu = %.3g  T = %.3g  seed = %s  N_TF = %.1f  steps = %d  M = physical vs 0\n",
-        ATOM === Rb87 ? "Rb87" : "Eu151", Int(2 * ATOM.F + 1), C_DD, MU, T_RES,
+    @printf("grid = %d^3 box %.3g   seed0 = %d\n", gn, gb, SEED0)
+    @printf("atom = %s (D = %d)  c_dd = %.4g  mu = %.3g%s  T = %.3g  seed = %s  N_TF = %.1f  steps = %d  M = physical vs 0\n",
+        ATOM === Rb87 ? "Rb87" : "Eu151", Int(2 * ATOM.F + 1), C_DD, MU,
+        MU_RAMPS ? @sprintf("->%.3g", MU_RAMP_END) : "", T_RES,
         SEED_MODE, n_tf, NSTEP)
     for (name, ed) in (("growth-only (M=0)", false), ("full (M != 0)", true))
         a = arm(grid, dV, phi, d, n_tf, ed)
         @printf("  %-18s N0 = %8.1f (%.3f N_TF)  N_C = %8.1f  out = %.4g  trunc = %.4g\n",
             name, a.n0, a.n0 / n_tf, a.n_c, a.out, a.trunc)
+        @printf("  %-18s |psi(k)|^2 by |k|/k_cut:  <0.25 %.4f | 0.25-0.5 %.4f | 0.5-0.8 %.4f | >0.8 %.4f\n",
+            "", a.kbins[1], a.kbins[2], a.kbins[3], a.kbins[4])
         flush(stdout)
     end
 end

--- a/scripts/eu334/launch.sh
+++ b/scripts/eu334/launch.sh
@@ -250,7 +250,7 @@ ed_probe)
     # the third slot is already `ED_CDD` and a fourth positional would make the
     # job name and the configuration disagree the first time someone skips one.
     q -N eu334_edprobe_${2:-rb87}_${3:-nodd}_${ED_SEED:-vacuum} -l h_rt=4:00:00 \
-      -v ED_NSTEP=${ED_NSTEP:-25000},ED_ATOM=${2:-rb87},ED_CDD=${3:-0.0},ED_MU=${ED_MU:-3.0},ED_T=${ED_T:-1.0},ED_SEED=${ED_SEED:-vacuum} \
+      -v ED_NSTEP=${ED_NSTEP:-25000},ED_ATOM=${2:-rb87},ED_CDD=${3:-0.0},ED_MU=${ED_MU:-3.0},ED_T=${ED_T:-1.0},ED_SEED=${ED_SEED:-vacuum},ED_MU_RAMP=${ED_MU_RAMP:-0.0},ED_N=${ED_N:-24},ED_BOX=${ED_BOX:-10.0} \
       scripts/eu334/submit_ed_probe.sh
     ;;
 

--- a/scripts/eu334/submit_ed_probe.sh
+++ b/scripts/eu334/submit_ed_probe.sh
@@ -32,5 +32,12 @@ export ED_CDD="${ED_CDD:-0.0}"
 export ED_MU="${ED_MU:-3.0}"
 export ED_T="${ED_T:-1.0}"
 export ED_SEED="${ED_SEED:-vacuum}"
+# 0 = fixed mu (every arm so far). >0 ramps MU -> that value across the run.
+export ED_MU_RAMP="${ED_MU_RAMP:-0.0}"
+# The last axis: scale. Defaults are the 24^3 box 10 every arm so far used.
+export ED_N="${ED_N:-24}"
+export ED_BOX="${ED_BOX:-10.0}"
+# Noise-stream offset, so the F=6 + DDI arm can be run as an ensemble.
+export ED_SEED0="${ED_SEED0:-90000}"
 
 "$SPINORBEC_TSUBAME_JULIA" --project=. scripts/eu334/ed_growth_probe.jl

--- a/scripts/submit_saito_torus_cell.sh
+++ b/scripts/submit_saito_torus_cell.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# TSUBAME (UGE) submit for one `runs/saito_li_torus/cells/*.yaml` resolution cell.
+#
+# #376: `torus_n128_box6.yaml` was generated and never run — the local attempt
+# was abandoned when a parallel session had half the GPU and it thrashed. It was
+# not "tried and passed", it is absent.
+#
+# WHY 128³ NEEDS THIS RATHER THAN THE LOCAL CARD. One psi vector at 128³ × D=13
+# in ComplexF64 is 0.41 GiB, and L-BFGS keeps 2m of them: at the default m=10
+# that is 8.12 GiB of history alone, before psi, the gradient, the FFT plans and
+# the DDI buffers. On a 16 GB card that is not workable; on TSUBAME's H100 it is
+# comfortable at the DEFAULT m, which is what matters — the other three cells in
+# this convergence set ran at the default, and changing the solver's memory for
+# one point of a four-point line makes the fourth point answer a different
+# question.
+#
+# WHAT THIS CELL CAN AND CANNOT DO. The three existing cells agree on E to seven
+# digits (−1.5754124 / −1.5754124 / −1.5754118). A fourth point is corroboration.
+# It is NOT the evidence for the state — #336 rests on the flux-closure identity
+# (0.23 %) and the published-profile match (1.3 %), because at cancellation ratio
+# R = 0.0167 an ITP answer can be grid-independent to 0.4 % and box-independent
+# to 2 % while being 44 % wrong (`test/oracles/test_itp_dt_limited_advisory.jl`).
+# A convergence scan is not a correctness argument here and must not be quoted as
+# one.
+#
+# Submit:
+#   qsub -g tga-kozuma-kouhi -v CELL=runs/saito_li_torus/cells/torus_n128_box6.yaml \
+#        scripts/submit_saito_torus_cell.sh
+#
+#$ -cwd
+#$ -N saito_cell
+#$ -l gpu_1=1
+#$ -l h_rt=12:00:00
+#$ -j y
+#$ -o logs/tsubame/saito_cell.$JOB_ID.log
+set -euo pipefail
+
+REPO="${SPINORBEC_TSUBAME_PROJECT_ROOT:-/gs/fs/tga-kozuma-kouhi/uk07267/BEC-simulation}"
+cd "$REPO"
+mkdir -p logs/tsubame
+
+export JULIA_DEPOT_PATH=/gs/fs/tga-kozuma-kouhi/shared/.julia
+export JULIAUP_DEPOT_PATH=/gs/fs/tga-kozuma-kouhi/shared/.juliaup
+JULIA="${SPINORBEC_TSUBAME_JULIA:-/gs/fs/tga-kozuma-kouhi/shared/.juliaup/bin/julia}"
+
+source scripts/tsubame_setup.sh
+# Re-arm unconditionally: a submit script must not depend on the internals of a
+# file it sources.
+set -euo pipefail
+
+CELL="${CELL:?CELL=<path to a cells/*.yaml> is required}"
+[ -f "$CELL" ] || { echo "FATAL: cell not found: $CELL" >&2; exit 1; }
+echo "cell: $CELL"
+
+WALL_S="${WALL_S:-43200}"                      # must match -l h_rt
+BUDGET_S=$(( WALL_S * 85 / 100 ))
+echo "walltime: h_rt=${WALL_S}s, self-interrupt at ${BUDGET_S}s"
+
+JOBREC="logs/tsubame/jobrec.${JOB_ID:-local}.saito.tsv"
+printf "started\t%s\tjob=%s\thost=%s\tcell=%s\n" \
+    "$(date -Is)" "${JOB_ID:-none}" "$(hostname)" "$CELL" >> "$JOBREC"
+
+set +e
+timeout --signal=INT --kill-after=120 "$BUDGET_S" \
+    "$JULIA" --project=. -e '
+    import CUDA          # BEFORE `using SpinorBEC` — loads the CUDA extension
+    using SpinorBEC
+    cfg = ARGS[1]
+    r = inspect_config(cfg)
+    for w in r.warnings
+        println("inspect[", w.severity, "] ", w.title)
+    end
+    blockers = filter(w -> w.severity === :error, r.warnings)
+    if !isempty(blockers)
+        for w in blockers
+            println("BLOCKING: ", w.title, " — ", w.message)
+        end
+        error("pre-flight found $(length(blockers)) :error warning(s) — refusing to launch")
+    end
+    println("GPU: ", CUDA.name(CUDA.device()),
+        "  free/total GiB: ", round.(CUDA.available_memory() / 2^30; digits=2), "/",
+        round(CUDA.total_memory() / 2^30; digits=2))
+    run_yaml(cfg)
+' "$CELL"
+
+RC=$?
+set -e
+
+case "$RC" in
+    0)   OUTCOME="completed" ;;
+    124) OUTCOME="self_interrupted_at_budget" ;;
+    137) OUTCOME="killed_after_interrupt_ignored" ;;
+    *)   OUTCOME="failed_rc_$RC" ;;
+esac
+printf "finished\t%s\trc=%s\toutcome=%s\tcell=%s\n" \
+    "$(date -Is)" "$RC" "$OUTCOME" "$CELL" >> "$JOBREC"
+echo "[$(date +%H:%M:%S)] $OUTCOME (rc=$RC): $CELL"
+[ "$RC" -eq 0 ] || [ "$RC" -eq 124 ] || exit "$RC"

--- a/test/dynamics/test_spgpe_equilibrium_number.jl
+++ b/test/dynamics/test_spgpe_equilibrium_number.jl
@@ -49,6 +49,14 @@ using SpinorBEC
 # (#304). At 5.9x it is ~410 s.
 @testset "SPGPE equilibrium atom number vs the Rayleigh-Jeans mode sum" begin
     n, L = 32, 6.5
+    # THE SPIN COUNT, and it is the whole of the discrepancy this file was
+    # written about. The field has D = 2F+1 components; the mode sums below run
+    # over SPATIAL modes only, so each k carries D of them. Omitting D made the
+    # predictor low by up to a factor of D and produced the "factor of 6.7" in
+    # the header. Measured at c0 = 0 exactly, where Rayleigh-Jeans is exact and
+    # has no self-consistency: N_run/N_analytic = 3.0055 for this D = 3 atom,
+    # and D x N_analytic matched the run to 0.18 % (#305, 2026-08-22).
+    D = 2 * Int(Rb87.F) + 1
     mu, T, c0 = 15.0, 80.0, 0.19
     k_cut = sqrt(2 * (mu + T))
     grid = make_grid(GridConfig((n, n, n), (L, L, L)))
@@ -67,6 +75,12 @@ using SpinorBEC
                 d = 0.5 * k2 + 2c0 * nn - mu
                 d > 0 && (s += T / d)
             end
+            # NO D HERE, deliberately, and it is not an oversight. This sum
+            # exists only to be compared against `classical_field_equilibrium`,
+            # which is a SCALAR closed form — it carries no spin index anywhere.
+            # Comparing a D-counted sum against it would be comparing two
+            # different quantities. `rj_at` below IS compared against the run and
+            # does carry D.
             nn = 0.5 * nn + 0.5 * (s / V)          # damped
         end
         nn * V
@@ -85,6 +99,10 @@ using SpinorBEC
     # closed form is sound in the homogeneous limit and whatever is wrong is
     # either the run or the trapped local-density step.
     @test isapprox(N_modesum, N_closed; rtol=0.3)
+    # FLAGGED, not asserted: `classical_field_equilibrium` is spin-blind, and its
+    # docstring says the same numbers "size the run". If it is used to size a
+    # SPINOR run it is low by D = 2F+1 — the very factor #305 found missing here.
+    # Not audited: this file does not know that function's callers. See #305.
 
     # The verdict, as a function of interaction strength. The SPGPE's exact
     # stationary distribution is P ∝ exp(−(H−μN)/T), the FULL interacting
@@ -135,7 +153,7 @@ using SpinorBEC
                 d > 0 || return (; N=NaN, condensed=true)
                 s += T / d
             end
-            nn = 0.5 * nn + 0.5 * (s / V)
+            nn = 0.5 * nn + 0.5 * (D * s / V)
         end
         (; N=nn * V, condensed=false)
     end
@@ -167,10 +185,30 @@ using SpinorBEC
             # a factor of two and passed the 1.89 below without objecting.
             @test r.N≈N_TF rtol=0.15
         else
-            # c0 = 0.19 lands here and matches NEITHER convention: 2.26x the
-            # Rayleigh-Jeans mode sum (41044 vs 18130) and 1.89x Thomas-Fermi
-            # (vs 21682). The header's question — "one of the two is wrong" — is
-            # still open at the strong-coupling end, and nothing here resolves it.
+            # RESOLVED 2026-08-22 (#305), and it was the PREDICTOR. Two things,
+            # measured in this order:
+            #
+            # 1. THE SPIN COUNT. At c0 = 0 exactly, Rayleigh-Jeans is exact —
+            #    independent Gaussians, no self-consistency, no approximation —
+            #    and the run came back 3.0055x the sum. D = 3 for Rb87, and the
+            #    sums here run over SPATIAL modes only. With the D above they
+            #    agree to 0.18 % in that limit.
+            #
+            # 2. WHAT IS LEFT IS HARTREE-FOCK'S OWN ERROR, and it behaves the way
+            #    an approximation must — it vanishes with the coupling:
+            #
+            #      c0n/T   0.355  0.206  0.116  0.054  0.029  0.016   ->  0
+            #      N/N_rj  1.162  1.145  1.119  1.085  1.077  1.049   -> 1.002
+            #
+            #    So the 2.29x in the header was one factor of the missing D
+            #    partly cancelled by HF error, and "one of the two is wrong" has
+            #    the answer: the predictor was, and the code was not.
+            #
+            # rtol = 0.20 admits the 1.162 this cell measures. It is NOT a
+            # fitted tolerance: the number it has to admit is HF's error at
+            # c0n/T = 0.355, and the row above shows that error going to zero
+            # along the axis that controls it. A tighter bound here would be
+            # asserting that Hartree-Fock is better than it is.
             #
             # WHAT THE FIXTURE SCAN DID SETTLE (2026-08-22, #305): the ratio is
             # not a finite-size or mode-count artifact. It is 2.2873 at n=48
@@ -184,10 +222,7 @@ using SpinorBEC
             # fixed mu condenses the gas instead — which is why the three-coupling
             # scan this file already runs cannot separate them.
             #
-            # `@test_broken` rather than a deleted cell or a loosened bound: the
-            # discrepancy stays visible, stays measured, and turns the suite RED
-            # the moment it closes, so whoever closes it is told.
-            @test_broken r.N≈rj.N rtol=0.15
+            @test r.N≈rj.N rtol=0.20
         end
     end
 end

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -68,6 +68,11 @@ const _SCRIPTS_ALLOWLIST = Set([
     # the 8-point scan is indivisible from outside; it IS resumable, so a
     # walltime kill costs only the point it was inside.
     "submit_edh_phi_phys_anti_aligned.sh",
+    # #376 — one runs/saito_li_torus/cells/*.yaml resolution cell. On TSUBAME
+    # rather than the local card: 128³ x D=13 keeps 8.12 GiB of L-BFGS history
+    # at the default m, and dropping m for one point of a four-point convergence
+    # line would make that point answer a different question.
+    "submit_saito_torus_cell.sh",
     "tsubame/_preamble.sh",
     "tsubame/preflight.sh",
     "tsubame/submit_gpu_smoke.sh",


### PR DESCRIPTION
#281–#444 の残件を詰めた 2 本目です（1 本目は #445）。

## #305 — **クローズ**。「A factor of 6.7, and one of the two is wrong」の答えは**予測器**

`c₀ = 0` を厳密に取りました。そこでは Rayleigh–Jeans が**厳密**です（独立ガウスの積、
自己無撞着なし、平均場シフトなし、予測側に近似ゼロ）:

```
N_run 7.017567e+04   N_analytic 2.334922e+04   ratio 3.0055
```

Rb87 は F=1、**D = 2F+1 = 3**。和は**空間モードだけ**を回っていて、場は k ごとに D 成分。
**D × N_analytic は run と 0.18 % 一致**します。

D を入れると残差は結合とともに単調にゼロへ — 近似はそう振る舞わなければなりません:

| c₀n/T | 0.355 | 0.206 | 0.116 | 0.054 | 0.029 | 0.016 | → 0 |
|---|---|---|---|---|---|---|---|
| N/N_rj | 1.162 | 1.145 | 1.119 | 1.085 | 1.077 | 1.049 | **1.002** |

2.29 倍の見出しは**「落ちた D」と「HF 自身の誤差」の合成**でした。
`@test_broken` → **`@test` rtol=0.20、9/9 pass**。この 0.20 は fit ではありません —
認めるべき数は c₀n/T = 0.355 での HF 誤差で、上の行がその誤差を制御軸に沿って
0 へ持っていくことを示しています。

`rj_modesum` は**意図的に D を持ちません**。それは `classical_field_equilibrium`（**スカラー**の
閉形式）とだけ比較されるので、片側だけ D を数えると別物同士の比較になります。

**旗（主張ではなく）**: `classical_field_equilibrium` はスピンを知らず、docstring は
その数値が *"size the run"* と書いています。**スピノルの run を sizing しているなら D 倍低い** —
¹⁵¹Eu なら 13。呼び出し側は監査していません。

## #376 — **クローズ**。平坦な線の 4 点目

TSUBAME 8462915、rc=0、429 反復 42.5 s。

| cell | dx | E | peak ρ/N | r_peak |
|---|---|---|---|---|
| 64³ box 6 | 0.0732 μm | −1.5754124 | 0.513 | 0.812 μm |
| 96³ box 6 | 0.0488 μm | −1.5754124 | 0.516 | 0.817 μm |
| 88³ box 8 | 0.0709 μm | −1.5754118 | 0.513 | 0.825 μm |
| **128³ box 6** | **0.0366 μm** | **−1.5754124** | **0.516** | **0.819 μm** |

**7 桁一致、dx の細分は 2.0 倍に。** 13 成分すべてが `v_m = −m`、`J_z = 0` も最細格子で再確認。

**どこで打ち切ったかを明記**: dx = 0.0366 μm は論文の ≈0.01 μm の **3.7 倍粗い**。
「論文刻みで収束」とは主張しません。`m_lbfgs` は既定のまま（4 点線の 1 点だけ
ソルバのメモリを変えると別の問いに答えることになる）。

## #418 — 機構は特定、ただし**アンサンブルが必要だと分かった**

単独ノブ 12 腕はすべて無罪（対照 3 本が 0.3 % 以内）。**F=6 × DDI の積だけが効きます**:

- **6/6 シードが 0.020–0.212**、scalar 1.320 に対し平均 **14 倍の抑制**。符号も桁も揺るがない
- **機構は cutoff の縁ではない**: 外殻 >0.8 は +23 % しか動かず、outflow は 621 倍。
  動くのは**低 k 0.6042→0.2109 から中 k 0.0980→0.3703**
- **この隅では energy damping に系統差なし**: full/growth が 0.051–5.059（**99 倍、1 を両側に跨ぐ**）、
  mean(full)/mean(growth) = 1.14

**自分の数字を 3 回撤回しました** — 隅×種の推測、ランプの推測、そして
「0.069 が本番の 0.066 を再現」（散らばりの中に埋もれる）。

**構造的な穴**: このアークは 12 本を n=1 で回して結論を出しました。単独ノブについては
それで保ちますが、**積の腕に入った瞬間に散らばりが 66 % / 99 倍に跳ね、
harness にはそれを知らせる指標がありません**。`ED_SEED0` はそのために入れてあります。

**本番の 9 倍分離は 24³ では再現しません。** 32³ box 16 の 6 シードが実行中。

## #435 — 静的剛性を測り、**issue の枠組みが反証されました**

| B_z [Gauss] | ⟨F_z⟩/N |
|---|---:|
| 2.5e−5 | −0.107399 |
| **5.0e−5** | **−0.221400** |
| 1.0e−4 | −5.851371 ← 偏極枝、応答ではない |

同じ磁場での動的平坦部は 0.0375。**quench は平衡の 1/5.9 にしか届いていません。**
剛性が平坦部を決めているなら両者は一致するはずで、**1.75 倍は剛性についての主張ではありません**。

**ただし 50 ms 延長は失敗しました** — `dt=5e-4` と `orient=rotate` 省略という
**2 つの既知の失敗モード**を私が踏み、run は**自分の箱ゲートに `*** UNUSABLE` と書きました**。
訂正版（box 12、n 120、dt=2e-4、orient=rotate）実行中。**それが出るまで上の 5.9 倍も保留**です。

## #281 — 処分の前提が消えました

live docs に対して再測定: **7 dirs / 5.1 GiB**（issue 本文 392、frozen doc 訂正後 211/60.6 GiB）。
1 回目は**メインチェックアウトの古い docs** を読み、引用されている 70 GiB を uncited と誤判定。
frozen doc の手順をそのまま実行していたら証拠を動かしていました。

Closes #305, #376
Refs #281, #418, #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)