### PR TITLE
docs(edh): §4.2's action line was overtaken — mark it where it is used (#423)

### DIFF
--- a/docs/campaign/edh_quench_polarisation_decision.md
+++ b/docs/campaign/edh_quench_polarisation_decision.md
@@ -358,6 +358,22 @@ nothing was ever chosen there.
 **Action for that config: same as the quench family — it needs `init_m_idx: 13`
 at p > 0 (or `p < 0` with `init_m_idx: 1`) to be anti-aligned.**
 
+> **SUPERSEDED, and then DONE.** The prescription above is unrealisable at this
+> field and §16.3 shows why: ITP is a projector onto the LOWEST state, so
+> `init_m_idx: 13` at p = 26700 gives `exp(-2·F·p·dt) = exp(-1602)`, which
+> underflows Float64 in one step. The run COMPLETED and returned 212992 exact
+> zeros with E = 0.0. It was not a wrong configuration, it was inexpressible.
+>
+> `prepare_anti_aligned: true` replaces it (#421): relax at `-p`, hand the
+> dynamics `+p`. The Zeeman-lowest state of `-B` is the Zeeman-highest state of
+> `+B`, and it is a true ground state of the field it was relaxed in.
+>
+> **Run at production scale 2026-08-22 (#423): 8/8 `phi.rate` points, all
+> `mz_actual = -6.0000`, all `converged`, E = -160177.72 finite.** See §18.4 for
+> the table. This paragraph is kept rather than rewritten because the reasoning
+> it contains — that p > 0 puts m = +F at the bottom — is correct and is what
+> made the config's problem visible; only its ACTION line was overtaken.
+
 > **DONE, and this paragraph was wrong from 2026-08-19 to 2026-08-20.** It said
 > "not done here: … on the re-derivation list rather than in this PR". The change
 > in fact landed in `e8dafe8e`, the same retarget commit — `init_m_idx: 13` is on


### PR DESCRIPTION
#423 の最後の受け入れ条件です。

§4.2 は `eu151_klaus_phi_phys` を反平行にするのに **`init_m_idx: 13` at p > 0** を処方しています。
§16.3 は**それが実現不可能である**ことを既に確立しています — ITP は**最低**状態への射影なので、
p = 26700 では `exp(−2·F·p·dt) = exp(−1602)` が 1 ステップで underflow し、
run は**完走して 212992 個の厳密なゼロと E = 0.0 を返しました**。

**訂正は存在していました。ただし 800 行離れたところに。**

これは retraction ゲートが存在する理由そのもの（point-of-use marker）です:
**§4.2 に action を取りに来た読者は、撤回済みの方を受け取ります。**

あわせて結末も記録:
- `prepare_anti_aligned` が置き換え（#421）
- **本番実行完了（#423）— 8/8 点、全て `mz_actual = −6.0000`、全て `converged`、E = −160177.72 有限**

段落は**書き換えず残しました**。その推論 —「p > 0 は m = +F を**底**に置くので、
あの config は他と同じく aligned だった」— は正しく、**問題を可視化したのはその推論**です。
overtaken だったのは **action の行だけ**。

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)