### PR TITLE
feat(workflow): derive per-host run budgets instead of choosing them

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -279,7 +279,7 @@ as complete.
 | `src/validation/` | 1 | 10 |
 | `src/manuscript/` | 1 | 17 |
 | `src/solvers/` | 2 | 46 |
-| `src/workflow/` | 5 | 178 |
+| `src/workflow/` | 5 | 179 |
 | `src/foundation/` | 1 | 41 |
 | `src/analysis/` | 1 | 51 |
 

--- a/docs/campaign/prior_art/local_run_environment.md
+++ b/docs/campaign/prior_art/local_run_environment.md
@@ -1,0 +1,14 @@
+# Prior art — local_run_environment
+
+> **FROZEN 2026-08-24.** A snapshot of the open work on local_run_environment as of that
+> date. Re-run the generator when picking the topic up again; existing
+> dispositions are preserved.
+
+Keywords: resource, budget, memory, swap, threads, cgroup, host, detect, tune. Regenerate with
+`python3 scripts/prior_art.py --topic local_run_environment --keywords resource budget memory swap threads cgroup host detect tune`.
+
+Dispositions: `unread`, `read`, `unrelated`, `superseded`, `depends`
+
+| ref | disposition | what | note |
+|---|---|---|---|
+| — | read | nothing open matched these keywords | |

--- a/docs/guides/local_run_environment.md
+++ b/docs/guides/local_run_environment.md
@@ -96,12 +96,39 @@ Verified by execution on a WSL2 host, 2026-08-24:
 - the kill is scoped to the job — the system OOM killer never ran
 - runs land in `spinorbec.slice`, outside the measured slices
 
-**Not** verified by execution: the scheduler rungs. `SLURM_*`, `NSLOTS` and
-`PBS_*` are unit-tested in `test/test_host_budget.jl` by setting the variables,
-which proves the parsing and the precedence, and does **not** prove the values a
-real scheduler exports on a real node. Treat the first cluster run as the
-measurement. `scripts/run_local.sh` itself is not for cluster use: there the
-scheduler is the thing enforcing the budget.
+Verified by execution on TSUBAME, 2026-08-25, job 8492405 (`cpu_4`, node
+`r18n6`) — **0.001 points**, because the 300 s billing floor makes a two-second
+job cost the same as a five-minute one and the probe needs no GPU, no SpinorBEC
+and no precompile:
+
+- the UGE **cpu** rung is real: `NSLOTS=4` against a node reporting 384 cores,
+  and the budget returned `4 [uge] NSLOTS`. Reading the machine there is wrong
+  by 96×.
+- "no login session observed — compute node" fired correctly, so the interactive
+  reserve was zero **by observation** and not by a fallback.
+- the login node (free, no allocation) exercised rungs 2 and 3 on the same
+  hardware family: 96 cpus, no swap → "nothing to forbid", and a `nivdia-smi`
+  that exits non-zero became a *note* rather than a crash or a default.
+
+That job also **refuted** the memory rung as first shipped, which is why it was
+worth its 0.001 points:
+
+- TSUBAME's compute nodes run **cgroup v1**, and the reader understood only v2.
+  It therefore found no limit at all — silent, not wrong — and the ladder fell
+  through to `MemAvailable` for the entire node.
+- UGE's memory grant arrives as `SGE_HGR_m_mem_free`, which was not being read.
+- Net effect: a job granted **9.2 GiB** was told its ceiling was **598.9 GiB**,
+  a 65× over-estimate. Both holes are now closed and both hierarchies are read.
+
+**Still not verified by execution:** SLURM and PBS. Their variables are
+unit-tested by setting them, which proves parsing and precedence and — as the
+UGE memory rung just demonstrated — proves nothing about what a real scheduler
+exports or which cgroup hierarchy the node runs. Treat the first run on such a
+cluster as the measurement, and dump the raw inputs beside the derived answer
+the way `scripts/` did here.
+
+`scripts/run_local.sh` itself is not for cluster use: there the scheduler is the
+thing enforcing the budget.
 
 ## Related
 

--- a/docs/guides/local_run_environment.md
+++ b/docs/guides/local_run_environment.md
@@ -1,0 +1,115 @@
+# Running locally without losing the machine
+
+Heavy production belongs on TSUBAME. But audits, smoke tests, figure passes and
+the test suite all have to run on whatever is in front of you — and on an
+interactive box the failure mode is not a wrong answer, it is a machine that
+stops responding while 16 GiB of ground state pages out to disk.
+
+This is the local path:
+
+```bash
+scripts/run_local.sh --print                      # the budget, and where each term came from
+scripts/run_local.sh julia --project=. …          # run under it
+```
+
+The run gets a cgroup that **cannot touch swap**, a memory ceiling derived from
+this host, and a CPU weight that makes it yield to anything you type. If it
+outgrows the ceiling it is killed — cleanly, with exit status 137 and a message
+saying so — rather than dragging the desktop into swap.
+
+## There are no tuning constants
+
+Every limit is read from the host. `--print` names the file or environment
+variable behind each one, so a number that cannot be justified cannot be
+emitted. The ladder, per quantity, most authoritative first:
+
+| Rung | Source | Applies to |
+|---|---|---|
+| 1 | the batch allocation — `SLURM_*`, `NSLOTS` (UGE/TSUBAME), `PBS_*` | compute nodes: the grant *is* the answer, and the node's totals describe other people's jobs |
+| 2 | cgroup v2 `memory.max` / `cpu.max` on our own chain | containers, systemd slices, WSL2 |
+| 3 | the CPU **affinity mask** and `MemAvailable` | an ordinary interactive host |
+
+`MemAvailable` is doing real work at rung 3: it is the kernel's own estimate of
+how much can be allocated *without swapping*. That is precisely the quantity
+wanted, already computed by the party that knows, and measured rather than
+guessed.
+
+Rung 3 also carries one subtraction, and only on a host that has an interactive
+session:
+
+```
+interactive reserve = memory.peak − memory.current   of user@<uid>.service/{app,session}.slice
+```
+
+That is how much more the desktop has historically needed than it holds right
+now — a measured growth headroom, not a chosen margin. On a compute node the
+login-session cgroup does not exist, so the term is zero **by observation**.
+
+Runs are placed in `spinorbec.slice`, a sibling of the slices being measured, so
+a run's own memory never inflates the reserve. Without that the ceiling would
+ratchet downward with every launch.
+
+### Where it refuses
+
+If the login session exists but its counters will not read (cgroup v1, a kernel
+without `memory.peak`), `detect_host_budget` throws `BlindBudget` instead of
+substituting zero. An unreadable reserve must not be spelled the same way as a
+reserve of zero — that is the difference between "there is no desktop to
+protect" and "I could not look". Same for a scheduler variable that is set but
+unparseable.
+
+State a value deliberately with `SPINORBEC_HOST_CPUS` /
+`SPINORBEC_HOST_MEMORY_BYTES`; the budget then reports its source as
+`:override`, so a stated number can never be presented as a measured one.
+
+## Two knobs that are deliberately not used
+
+**`MemoryHigh`.** Measured on this tree, 2026-08-24: a cgroup with `MemoryHigh`
+below `MemoryMax` and swap forbidden does not die, it **livelocks** in reclaim.
+`memory.events` read `high 2560, max 0, oom_kill 0` with the process pinned at
+the cap making no progress. A job that hangs forever is worse than one that
+dies, so enforcement is `MemoryMax` alone. That was measured to give a clean
+`CONSTRAINT_MEMCG` kill at exit 137 with the global swap unchanged to the byte.
+
+**`CPUQuota`.** The goal is that your typing stays responsive, and a quota buys
+that by leaving the machine idle when you are not typing. `CPUWeight` at the
+cgroup interface's own documented minimum buys the same responsiveness without
+the waste: the job yields to anything that runs, and still takes the whole
+machine when nothing else wants it.
+
+## The FFT planner follows the thread count
+
+`#407`: FFTW's `MEASURE` planner blows up on a mixed-radix length **only** when
+threaded — 48³ at 16 threads took 1.66 GB against 0.35 GB at 64³, and 98³ took
+11.97 GB. Threads are derived above, so the planner is derived with them:
+`SPINORBEC_FFT_PLAN=estimate` whenever the budget grants more than one. Prefer
+power-of-two grid edges anyway; the smoke grid is where this bites, because
+128³ production is safe and `48³ --smoke` is not.
+
+## What is verified, and what is not
+
+Verified by execution on a WSL2 host, 2026-08-24:
+
+- swap untouched under a binding cap (`memory.swap.current` 0; host swap
+  unchanged at 804 MB across both canaries)
+- overrun kills cleanly and distinguishably (exit 137, `CONSTRAINT_MEMCG`)
+- the kill is scoped to the job — the system OOM killer never ran
+- runs land in `spinorbec.slice`, outside the measured slices
+
+**Not** verified by execution: the scheduler rungs. `SLURM_*`, `NSLOTS` and
+`PBS_*` are unit-tested in `test/test_host_budget.jl` by setting the variables,
+which proves the parsing and the precedence, and does **not** prove the values a
+real scheduler exports on a real node. Treat the first cluster run as the
+measurement. `scripts/run_local.sh` itself is not for cluster use: there the
+scheduler is the thing enforcing the budget.
+
+## Related
+
+- `src/workflow/io/host_budget.jl` — the derivation; depends on Base alone so
+  the launcher can include it without loading SpinorBEC
+- `src/workflow/io/budget.jl` — the **demand** side (`estimate_run_budget`
+  forecasts what a config will want); the two meet at launch
+- `test/test_host_budget.jl` — the gate that keeps `Sys.CPU_THREADS` (the
+  *machine's* core count, wrong by 24× inside a TSUBAME allotment) out of every
+  site but its declaration
+- `docs/guides/tsubame.md` — where heavy runs actually go

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ docs/
 | Pick the right precision / save_every / k_cut | `guides/performance_tuning.md` |
 | Finite-T reservoirs / second-scale evaporation (full SPGPE) | `guides/spgpe.md` |
 | Submit jobs on TSUBAME | `guides/tsubame.md` |
+| Run locally without swapping or freezing the machine — limits derived per host, no tuning constants | `guides/local_run_environment.md` |
 | Magnetic field a spin-polarised cloud radiates | `guides/dipole_field.md` |
 
 ### Looking something up

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Run a command under the budget this host derived for itself.
+#
+# All of the derivation lives in src/workflow/io/host_budget.jl and NONE of it
+# lives here — this script reads what that file emits and applies it. There is
+# one statement of "how big may a run be on this host", and it is testable Julia
+# rather than shell arithmetic. host_budget.jl depends on Base alone precisely so
+# this launcher can include it without paying to load SpinorBEC.
+#
+# What it buys, measured on this tree 2026-08-24:
+#   - the job cannot touch swap        (MemorySwapMax=0; global swap stayed put
+#                                       to the byte while the cap was exercised)
+#   - overrunning KILLS, never hangs   (exit 137, constraint=CONSTRAINT_MEMCG;
+#                                       MemoryHigh was measured to livelock and
+#                                       is deliberately not used)
+#   - the kill is scoped to the job    (the system OOM killer never ran, so
+#                                       nothing else on the desktop was at risk)
+#   - typing stays responsive          (CPUWeight at the cgroup minimum: the job
+#                                       yields to anything, and still uses an
+#                                       otherwise idle machine in full)
+#
+# Usage:
+#   scripts/run_local.sh --print                 # show the budget and its provenance
+#   scripts/run_local.sh julia --project=. …     # run under it
+#   scripts/run_local.sh -- julia --project=. …  # same, explicit end of options
+#
+# This is for LOCAL work. Heavy production belongs on TSUBAME, where the
+# scheduler is the thing enforcing the budget; there host_budget.jl reads the
+# grant out of the batch environment instead and this wrapper is not used.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+julia_bin="${SPINORBEC_LOCAL_JULIA:-julia}"
+
+print_only=0
+allow_uncontained=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --print|-n) print_only=1; shift ;;
+        --allow-uncontained) allow_uncontained=1; shift ;;
+        --) shift; break ;;
+        -*) echo "run_local.sh: unknown option $1" >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+
+if [ "$print_only" -eq 1 ]; then
+    exec "$julia_bin" --startup-file=no -e '
+        include(joinpath(ARGS[1], "src", "workflow", "io", "host_budget.jl"))
+        budget_report(detect_host_budget())
+    ' "$root"
+fi
+
+if [ $# -eq 0 ]; then
+    echo "run_local.sh: nothing to run. Try --print, or pass a command." >&2
+    exit 2
+fi
+
+# One call, three answers: the env the run wants, the cgroup properties that
+# contain it, and whether containment is possible at all. Tab-separated so the
+# shell never has to eval anything the derivation printed.
+emitted="$("$julia_bin" --startup-file=no -e '
+    include(joinpath(ARGS[1], "src", "workflow", "io", "host_budget.jl"))
+    b = detect_host_budget()
+    for e in budget_env(b);              println("env\t", e);  end
+    for p in budget_scope_properties(b); println("prop\t", p); end
+    println("contained\t", b.swap_containable)
+    println("ceiling\t", b.memory_bytes)
+' "$root")"
+
+env_args=()
+scope_args=()
+contained=false
+ceiling=0
+while IFS=$'\t' read -r kind value; do
+    case "$kind" in
+        env)       env_args+=("$value") ;;
+        prop)      scope_args+=(-p "$value") ;;
+        contained) contained="$value" ;;
+        ceiling)   ceiling="$value" ;;
+    esac
+done <<< "$emitted"
+
+if [ "$contained" != "true" ]; then
+    # Fail closed. The whole point of running here rather than on TSUBAME is
+    # that the machine stays usable, and without a swap-proof cgroup this
+    # wrapper cannot promise that — so it must not pretend to.
+    echo "run_local.sh: this host cannot forbid swap for a child cgroup." >&2
+    "$julia_bin" --startup-file=no -e '
+        include(joinpath(ARGS[1], "src", "workflow", "io", "host_budget.jl"))
+        budget_report(detect_host_budget(); io = stderr)
+    ' "$root" >&2 || true
+    if [ "$allow_uncontained" -ne 1 ]; then
+        echo "Refusing to launch: the run could push this machine into swap." >&2
+        echo "Pass --allow-uncontained to run anyway, deliberately." >&2
+        exit 3
+    fi
+    echo "--allow-uncontained given; launching WITHOUT a swap guarantee." >&2
+fi
+
+# A slice of our own, so a run's own memory never lands in the app/session
+# slices whose historical peak is what sizes the interactive reserve. Without
+# this the ceiling would ratchet downward with every run.
+if [ "${#scope_args[@]}" -gt 0 ]; then
+    # --collect: a scope that dies at the cap is left registered as `failed`
+    # otherwise, so a week of hitting the ceiling silts up `systemctl --user`
+    # with units nobody will read and the real failure gets harder to see.
+    set -- systemd-run --user --scope --quiet --collect --slice=spinorbec.slice \
+        --description="spinorbec run under derived host budget" \
+        "${scope_args[@]}" -- "$@"
+fi
+
+set +e
+env "${env_args[@]}" "$@"
+rc=$?
+set -e
+
+if [ "$rc" -eq 137 ]; then
+    echo "" >&2
+    echo "run_local.sh: the job was KILLED at the derived memory ceiling" \
+         "($(( ceiling / 1024 / 1024 )) MiB) — it did not crash, and it did not swap." >&2
+    echo "Either shrink the run, or take it to TSUBAME where the budget is the" \
+         "scheduler's to grant. 'scripts/run_local.sh --print' shows how the" \
+         "ceiling was derived." >&2
+fi
+exit "$rc"

--- a/src/workflow/io.jl
+++ b/src/workflow/io.jl
@@ -13,6 +13,9 @@
 #   run_summary         — print_run_summary, compare_runs
 #   html_report         — generate_html_report (self-contained static HTML)
 #   budget              — estimate_run_budget (VRAM / RAM / disk forecast)
+#   host_budget         — the SUPPLY side of the same question: what this host
+#                         will give a run, derived per-term with provenance
+#                         (budget.jl forecasts DEMAND; the two meet at launch)
 #   catalog             — human-navigation layer (tags) over the CAS store
 
 include("io/io.jl")
@@ -24,6 +27,7 @@ include("io/measurement_provenance.jl")  # provenance stamp + refusal for measur
 include("io/run_summary.jl")
 include("io/html_report.jl")
 include("io/budget.jl")
+include("io/host_budget.jl")
 include("io/catalog.jl")
 include("io/catalog_index.jl")
 include("io/gs_library.jl")

--- a/src/workflow/io/host_budget.jl
+++ b/src/workflow/io/host_budget.jl
@@ -1,0 +1,511 @@
+# --- Host resource budget: every limit DERIVED from the host, none chosen. ----
+#
+# WHY THIS EXISTS
+#
+# The same run has to be right on a laptop, on WSL2 beside a browser the user is
+# typing into, inside a container, and on a compute node the scheduler has carved
+# out. The usual answer is a table of hostnames or a fudge factor ("use half the
+# cores, leave 4 GB"). Both rot, and neither can say why its number is that
+# number. So there is no number here: each limit is READ from the host, and the
+# report names which file or environment variable it came from.
+#
+# The ladder, per quantity, most authoritative first:
+#
+#   1. the batch allocation      — SLURM / UGE (TSUBAME) / PBS. When a scheduler
+#                                  has granted the job N cpus and M bytes, that
+#                                  IS the answer and the node's totals are a lie.
+#   2. the cgroup v2 limit       — containers, systemd slices, WSL2. What the
+#                                  kernel will actually enforce on us.
+#   3. what the OS lets us see   — the CPU AFFINITY MASK (not the machine's core
+#                                  count) and MemAvailable, which is the kernel's
+#                                  own estimate of "how much can be allocated
+#                                  without swapping". That estimate is exactly
+#                                  the quantity wanted, already computed, and it
+#                                  is measured rather than guessed.
+#
+# On top of that, one term that only exists on an interactive host:
+#
+#   4. the interactive reserve   — `memory.peak - memory.current` of the user's
+#                                  login session. That is how much MORE the
+#                                  desktop has historically needed than it holds
+#                                  right now: a measured growth headroom, not a
+#                                  chosen margin. Where no login session cgroup
+#                                  exists there is no desktop to protect and the
+#                                  term is zero BY OBSERVATION. Where the session
+#                                  exists but the counter cannot be read, this
+#                                  REFUSES — an unreadable reserve must not be
+#                                  spelled the same as a reserve of zero.
+#
+# WHAT IS DELIBERATELY NOT HERE
+#
+# `MemoryHigh`. Measured 2026-08-24 on this tree: a cgroup with MemoryHigh below
+# MemoryMax and swap forbidden does not die, it LIVELOCKS in reclaim —
+# `memory.events` read `high 2560, max 0, oom_kill 0` with the process pinned at
+# the cap making no progress. A hung job that never reports is worse than a
+# killed one, so the enforcement uses MemoryMax alone, which was measured to give
+# a clean `CONSTRAINT_MEMCG` kill and exit status 137 with the global swap
+# unchanged to the byte.
+#
+# `CPUQuota`. The goal is that the user's own typing stays responsive, and a
+# quota buys that by leaving the machine idle when the user is not typing.
+# `CPUWeight` at the cgroup interface's own defined minimum buys it without the
+# waste: the job yields whenever anything else runs, and takes the whole machine
+# when nothing does. The minimum of a documented range is not a magic number.
+
+export HostBudget, BlindBudget, detect_host_budget
+export budget_report, budget_env, budget_scope_properties
+
+"""
+    BlindBudget(quantity, source, detail)
+
+Thrown when a quantity is observably PRESENT but could not be read.
+
+This is the distinction the whole file turns on. "There is no login session, so
+the reserve is zero" is a determination. "There is a login session but its
+`memory.peak` would not open" is a failure to measure, and filling it with zero
+would hand the job the desktop's headroom while reporting a derived number.
+Absent is missing; it is never a default.
+"""
+struct BlindBudget <: Exception
+    quantity::Symbol
+    source::String
+    detail::String
+end
+
+function Base.showerror(io::IO, e::BlindBudget)
+    print(io, "BlindBudget: could not derive ", e.quantity, " from ", e.source,
+        ". ", e.detail,
+        "\nRefusing to substitute a default — a budget nobody measured must not ",
+        "read as a budget that is safe. Set the matching SPINORBEC_HOST_* ",
+        "override to state the value deliberately.")
+end
+
+"""
+    HostBudget
+
+What this host will give a run, with the provenance of every term.
+
+`*_source` fields name where the number came from, so a report can never claim a
+value was derived when it was overridden or fell back.
+"""
+struct HostBudget
+    cpu_threads::Int
+    cpu_source::Symbol              # :slurm :uge :pbs :cgroup :affinity :override
+    cpu_origin::String              # the literal file or variable read
+    memory_bytes::Int
+    memory_source::Symbol           # :slurm :cgroup :memavailable :override
+    memory_origin::String
+    interactive::Bool
+    interactive_reserve_bytes::Int
+    swap_containable::Bool
+    swap_total_bytes::Int
+    gpu_free_bytes::Union{Nothing, Int}
+    fft_plan::Symbol                # :estimate | :measure
+    notes::Vector{String}
+end
+
+# --- primitive readers --------------------------------------------------------
+
+_read_int_file(path) = begin
+    isfile(path) || return nothing
+    s = strip(read(path, String))
+    s == "max" ? typemax(Int) : tryparse(Int, s)
+end
+
+# Leading integer of a value like "72(x2)" (SLURM_JOB_CPUS_PER_NODE).
+function _leading_int(s::AbstractString)
+    m = match(r"^\s*(\d+)", s)
+    m === nothing ? nothing : parse(Int, m.captures[1])
+end
+
+function _meminfo_bytes(key::AbstractString)
+    isfile("/proc/meminfo") || return nothing
+    for line in eachline("/proc/meminfo")
+        startswith(line, key * ":") || continue
+        m = match(r"(\d+)\s*kB", line)
+        m === nothing && return nothing
+        return parse(Int, m.captures[1]) * 1024
+    end
+    return nothing
+end
+
+"Count of CPUs this process may actually run on — the affinity mask, not the machine."
+function _affinity_cpus()
+    isfile("/proc/self/status") || return nothing
+    for line in eachline("/proc/self/status")
+        startswith(line, "Cpus_allowed_list:") || continue
+        spec = strip(split(line, ':')[2])
+        n = 0
+        for part in split(spec, ',')
+            isempty(part) && continue
+            if occursin('-', part)
+                lo, hi = split(part, '-')
+                n += parse(Int, hi) - parse(Int, lo) + 1
+            else
+                n += 1
+            end
+        end
+        return n
+    end
+    return nothing
+end
+
+function _self_uid()
+    isfile("/proc/self/status") || return nothing
+    for line in eachline("/proc/self/status")
+        startswith(line, "Uid:") || continue
+        return parse(Int, split(strip(split(line, ':')[2]))[1])
+    end
+    return nothing
+end
+
+"Every cgroup v2 directory from this process's own cgroup up to the root."
+function _cgroup_chain()
+    isfile("/proc/self/cgroup") || return String[]
+    rel = nothing
+    for line in eachline("/proc/self/cgroup")
+        parts = split(line, ':'; limit=3)
+        length(parts) == 3 && parts[1] == "0" && (rel = parts[3])
+    end
+    rel === nothing && return String[]
+    root = "/sys/fs/cgroup"
+    isdir(root) || return String[]
+    out = String[]
+    p = normpath(joinpath(root, lstrip(rel, '/')))
+    while startswith(p, root)
+        isdir(p) && push!(out, p)
+        p == root && break
+        p = dirname(p)
+    end
+    out
+end
+
+# --- the ladder, one rung per quantity ----------------------------------------
+
+function _scheduler_cpus()
+    for (src, var) in ((:slurm, "SLURM_CPUS_PER_TASK"), (:slurm, "SLURM_JOB_CPUS_PER_NODE"),
+        (:uge, "NSLOTS"), (:pbs, "PBS_NCPUS"), (:pbs, "PBS_NP"))
+        v = get(ENV, var, "")
+        isempty(v) && continue
+        n = _leading_int(v)
+        n === nothing && throw(
+            BlindBudget(:cpu_threads, var,
+                "is set to $(repr(v)), which carries no leading integer, so the " *
+                "scheduler's grant cannot be read."),
+        )
+        n > 0 && return (n, src, var)
+    end
+    return nothing
+end
+
+function _scheduler_memory()
+    for (var, scale) in (("SLURM_MEM_PER_NODE", 1024 * 1024),)
+        v = get(ENV, var, "")
+        isempty(v) && continue
+        n = _leading_int(v)
+        n === nothing && throw(
+            BlindBudget(:memory_bytes, var,
+                "is set to $(repr(v)), which carries no leading integer."),
+        )
+        return (n * scale, :slurm, var)
+    end
+    v = get(ENV, "SLURM_MEM_PER_CPU", "")
+    if !isempty(v)
+        n = _leading_int(v)
+        n === nothing && throw(
+            BlindBudget(:memory_bytes, "SLURM_MEM_PER_CPU",
+                "is set to $(repr(v)), which carries no leading integer."),
+        )
+        c = _scheduler_cpus()
+        c === nothing && throw(
+            BlindBudget(:memory_bytes, "SLURM_MEM_PER_CPU",
+                "is per-cpu but no scheduler cpu grant is exported, so the product " *
+                "is unknown."),
+        )
+        return (n * 1024 * 1024 * c[1], :slurm, "SLURM_MEM_PER_CPU x $(c[3])")
+    end
+    return nothing
+end
+
+"Tightest finite `memory.max` anywhere in our own cgroup chain."
+function _cgroup_memory_max()
+    best, origin = typemax(Int), ""
+    for dir in _cgroup_chain()
+        v = _read_int_file(joinpath(dir, "memory.max"))
+        (v === nothing || v == typemax(Int)) && continue
+        v < best && ((best, origin) = (v, joinpath(dir, "memory.max")))
+    end
+    best == typemax(Int) ? nothing : (best, :cgroup, origin)
+end
+
+"Tightest finite `cpu.max` quota in our own cgroup chain, in whole CPUs."
+function _cgroup_cpus()
+    best, origin = typemax(Int), ""
+    for dir in _cgroup_chain()
+        path = joinpath(dir, "cpu.max")
+        isfile(path) || continue
+        parts = split(strip(read(path, String)))
+        length(parts) == 2 || continue
+        parts[1] == "max" && continue
+        quota = tryparse(Int, parts[1]);
+        period = tryparse(Int, parts[2])
+        (quota === nothing || period === nothing || period == 0) && continue
+        n = max(1, cld(quota, period))
+        n < best && ((best, origin) = (n, path))
+    end
+    best == typemax(Int) ? nothing : (best, :cgroup, origin)
+end
+
+"""
+    _interactive_reserve() -> (bytes, observed::Bool, origin)
+
+Memory the login session has historically needed BEYOND what it holds now.
+
+Zero when no login-session cgroup exists — that is a compute node, and there is
+no desktop to keep responsive. Throws when the session exists but its counters
+will not read, because that is a failure to measure and not a reserve of zero.
+"""
+function _interactive_reserve()
+    uid = _self_uid()
+    uid === nothing && return (0, false, "no /proc/self/status")
+    base = "/sys/fs/cgroup/user.slice/user-$(uid).slice/user@$(uid).service"
+    isdir(base) || return (0, false, "no $(base) — no login session to protect")
+    reserve, seen = 0, String[]
+    for slice in ("app.slice", "session.slice")
+        dir = joinpath(base, slice)
+        isdir(dir) || continue
+        cur = _read_int_file(joinpath(dir, "memory.current"))
+        peak = _read_int_file(joinpath(dir, "memory.peak"))
+        if cur === nothing || peak === nothing
+            throw(
+                BlindBudget(:interactive_reserve, dir,
+                    "the login session is present but memory.current/memory.peak " *
+                    "would not read (cgroup v1, or an older kernel without " *
+                    "memory.peak)."),
+            )
+        end
+        reserve += max(0, peak - cur)
+        push!(seen, slice)
+    end
+    isempty(seen) && return (0, false, "$(base) has no app/session slice")
+    (reserve, true, "$(base)/{$(join(seen, ','))}: memory.peak - memory.current")
+end
+
+function _gpu_free_bytes(notes)
+    exe = Sys.which("nvidia-smi")
+    if exe === nothing
+        push!(notes, "no nvidia-smi on PATH — no GPU memory budget derived")
+        return nothing
+    end
+    out = try
+        readchomp(`$exe --query-gpu=memory.free --format=csv,noheader,nounits`)
+    catch err
+        push!(notes, "nvidia-smi failed ($(sprint(showerror, err))) — no GPU budget")
+        return nothing
+    end
+    vals = Int[]
+    for line in split(out, '\n')
+        s = strip(line)
+        isempty(s) && continue
+        v = tryparse(Int, s)
+        v === nothing && throw(
+            BlindBudget(:gpu_free_bytes, "nvidia-smi",
+                "returned $(repr(s)), which is not a MiB count."),
+        )
+        push!(vals, v)
+    end
+    isempty(vals) && (push!(notes, "nvidia-smi reported no devices"); return nothing)
+    minimum(vals) * 1024 * 1024
+end
+
+"Can a child cgroup be made swap-proof on this host?"
+function _swap_containable(notes)
+    if Sys.which("systemd-run") === nothing
+        push!(notes, "systemd-run absent — swap cannot be forbidden per-job here")
+        return false
+    end
+    uid = _self_uid()
+    ctl = if uid === nothing
+        nothing
+    else
+        "/sys/fs/cgroup/user.slice/user-$(uid).slice/user@$(uid).service/cgroup.controllers"
+    end
+    if ctl === nothing || !isfile(ctl)
+        push!(notes, "no delegated user cgroup — swap cannot be forbidden per-job")
+        return false
+    end
+    if !occursin("memory", read(ctl, String))
+        push!(notes, "memory controller not delegated in $(ctl)")
+        return false
+    end
+    true
+end
+
+"A deliberately stated value, or `nothing`. Unset is not an error; unparseable is."
+function _override(var)
+    v = get(ENV, var, "")
+    isempty(v) && return nothing
+    n = tryparse(Int, v)
+    n === nothing &&
+        throw(BlindBudget(:override, var, "is set to $(repr(v)), not an integer."))
+    n
+end
+
+"""
+    detect_host_budget() -> HostBudget
+
+Read this host and return what it will give a run, with provenance per term.
+
+Throws [`BlindBudget`](@ref) rather than defaulting when a quantity is present
+but unreadable. `SPINORBEC_HOST_CPUS` / `SPINORBEC_HOST_MEMORY_BYTES` state a
+value deliberately; the resulting `*_source` is `:override`, so a report can
+never present a stated number as a measured one.
+"""
+function detect_host_budget()
+    notes = String[]
+
+    cpu_o = _override("SPINORBEC_HOST_CPUS")
+    cpus, cpu_src, cpu_origin = if cpu_o !== nothing
+        (cpu_o, :override, "SPINORBEC_HOST_CPUS")
+    else
+        sched = _scheduler_cpus()
+        cg = _cgroup_cpus()
+        aff = _affinity_cpus()
+        if sched !== nothing
+            sched
+        elseif cg !== nothing
+            cg
+        elseif aff !== nothing
+            (aff, :affinity, "/proc/self/status Cpus_allowed_list")
+        else
+            push!(
+                notes,
+                "no affinity mask readable; fell back to Sys.CPU_THREADS, " *
+                "which reports the MACHINE and not this job's allotment",
+            )
+            (Sys.CPU_THREADS, :affinity, "Sys.CPU_THREADS (machine-wide fallback)")
+        end
+    end
+
+    reserve, interactive, reserve_origin = _interactive_reserve()
+
+    mem_o = _override("SPINORBEC_HOST_MEMORY_BYTES")
+    mem, mem_src, mem_origin = if mem_o !== nothing
+        (mem_o, :override, "SPINORBEC_HOST_MEMORY_BYTES")
+    else
+        sched = _scheduler_memory()
+        if sched !== nothing
+            # The scheduler isolates the job; the node's totals describe other
+            # people's jobs and must not enter.
+            sched
+        else
+            avail = _meminfo_bytes("MemAvailable")
+            avail === nothing && throw(
+                BlindBudget(:memory_bytes, "/proc/meminfo",
+                    "MemAvailable is absent, so the kernel's own no-swap headroom " *
+                    "estimate cannot be read."),
+            )
+            best = avail - reserve
+            origin = "MemAvailable - interactive reserve ($(reserve_origin))"
+            cg = _cgroup_memory_max()
+            src = :memavailable
+            if cg !== nothing && cg[1] < best
+                best, src, origin = cg[1], :cgroup, cg[3]
+            end
+            (best, src, origin)
+        end
+    end
+
+    mem <= 0 && throw(
+        BlindBudget(:memory_bytes, mem_origin,
+            "derived a non-positive ceiling ($(mem) B). The interactive session's " *
+            "historical peak exceeds what is available now; nothing can be run " *
+            "without either freeing memory or stating a ceiling deliberately."),
+    )
+
+    swap_total = something(_meminfo_bytes("SwapTotal"), 0)
+    containable = swap_total == 0 ? true : _swap_containable(notes)
+    swap_total == 0 && push!(notes, "host has no swap — nothing to forbid")
+
+    gpu = _gpu_free_bytes(notes)
+
+    # #407: the FFTW planner's scratch explodes on a mixed-radix length only when
+    # it is threaded AND allowed to MEASURE. Threads are derived above, so the
+    # planner follows from a measured quantity rather than a preference.
+    plan = cpus > 1 ? :estimate : :measure
+    cpus > 1 && push!(notes,
+        "planner forced to ESTIMATE: $(cpus) threads, and MEASURE on a " *
+        "non-power-of-two edge was measured at up to 12 GB (#407)")
+
+    HostBudget(cpus, cpu_src, cpu_origin, mem, mem_src, mem_origin,
+        interactive, reserve, containable, swap_total, gpu, plan, notes)
+end
+
+# --- emission ------------------------------------------------------------------
+
+_gib(b) = round(b / 2^30; digits=2)
+
+"""
+    budget_env(b) -> Vector{String}
+
+`KEY=VALUE` strings the run should be launched with. Only knobs whose value is
+derived above appear; nothing is set on a hunch.
+"""
+function budget_env(b::HostBudget)
+    env = ["JULIA_NUM_THREADS=$(b.cpu_threads)",
+        "SPINORBEC_FFT_PLAN=$(b.fft_plan)"]
+    b.gpu_free_bytes === nothing ||
+        push!(env, "JULIA_CUDA_HARD_MEMORY_LIMIT=$(b.gpu_free_bytes)")
+    env
+end
+
+"""
+    budget_scope_properties(b) -> Vector{String}
+
+`systemd-run` properties that make the run swap-proof and yielding.
+
+`MemoryHigh` is deliberately absent — see this file's header for the measured
+livelock it causes. `CPUWeight=1` is the cgroup interface's own documented
+minimum, not a tuning constant.
+"""
+function budget_scope_properties(b::HostBudget)
+    b.swap_containable || return String[]
+    ["MemoryMax=$(b.memory_bytes)", "MemorySwapMax=0", "CPUWeight=1"]
+end
+
+"""
+    budget_report(b; io=stdout)
+
+Print each term with the file or variable it was read from.
+"""
+function budget_report(b::HostBudget; io::IO=stdout)
+    println(io, "host budget")
+    println(io, "  cpu threads        $(b.cpu_threads)  [$(b.cpu_source)] $(b.cpu_origin)")
+    println(
+        io,
+        "  memory ceiling     $(_gib(b.memory_bytes)) GiB  [$(b.memory_source)] $(b.memory_origin)",
+    )
+    if b.interactive
+        println(
+            io,
+            "  interactive reserve $(_gib(b.interactive_reserve_bytes)) GiB  (login session present; subtracted)",
+        )
+    else
+        println(io, "  interactive reserve none  (no login session observed — compute node)")
+    end
+    println(
+        io,
+        "  swap               $(b.swap_containable ? "forbidden for the job (MemorySwapMax=0)" : "NOT containable on this host")"
+        *
+        "  [host SwapTotal $(_gib(b.swap_total_bytes)) GiB]",
+    )
+    println(
+        io,
+        "  gpu free           $(b.gpu_free_bytes === nothing ? "unknown" : "$(_gib(b.gpu_free_bytes)) GiB")",
+    )
+    println(io, "  fft planner        $(b.fft_plan)")
+    for n in b.notes
+        println(io, "  note: ", n)
+    end
+    io
+end

--- a/src/workflow/io/host_budget.jl
+++ b/src/workflow/io/host_budget.jl
@@ -14,8 +14,12 @@
 #   1. the batch allocation      — SLURM / UGE (TSUBAME) / PBS. When a scheduler
 #                                  has granted the job N cpus and M bytes, that
 #                                  IS the answer and the node's totals are a lie.
-#   2. the cgroup v2 limit       — containers, systemd slices, WSL2. What the
-#                                  kernel will actually enforce on us.
+#   2. the cgroup limit          — containers, systemd slices, WSL2, and UGE's
+#                                  per-job cgroups. What the kernel will actually
+#                                  enforce on us. BOTH hierarchies are read: v2
+#                                  on desktops, v1 on TSUBAME's compute nodes,
+#                                  and a reader that knows only one is silent
+#                                  rather than wrong on the other.
 #   3. what the OS lets us see   — the CPU AFFINITY MASK (not the machine's core
 #                                  count) and MemAvailable, which is the kernel's
 #                                  own estimate of "how much can be allocated
@@ -93,7 +97,7 @@ struct HostBudget
     cpu_source::Symbol              # :slurm :uge :pbs :cgroup :affinity :override
     cpu_origin::String              # the literal file or variable read
     memory_bytes::Int
-    memory_source::Symbol           # :slurm :cgroup :memavailable :override
+    memory_source::Symbol           # :slurm :uge :cgroup :memavailable :override
     memory_origin::String
     interactive::Bool
     interactive_reserve_bytes::Int
@@ -159,23 +163,47 @@ function _self_uid()
     return nothing
 end
 
-"Every cgroup v2 directory from this process's own cgroup up to the root."
-function _cgroup_chain()
+"""
+    _cgroup_dirs(controller) -> Vector{String}
+
+Directories that could carry a limit on `controller`, innermost first.
+
+BOTH hierarchies, because the hosts this has to be right on do not agree. cgroup
+v2 puts every controller in one tree (`0::/path` → `/sys/fs/cgroup/<path>`); v1
+gives each controller its own mount (`13:memory:/AGE/…` →
+`/sys/fs/cgroup/memory/AGE/…`).
+
+Measured on TSUBAME job 8492405: the compute nodes are **v1**, and a v2-only
+reader there is not so much wrong as SILENT — it finds no limit at all, the
+ladder falls through to the node's totals, and a job granted 9.2 GB is told it
+has 599 GiB. That is the failure this whole file is against, produced by the
+file itself, and no unit test could have found it because every unit test ran on
+a v2 host.
+"""
+function _cgroup_dirs(controller::AbstractString)
     isfile("/proc/self/cgroup") || return String[]
-    rel = nothing
-    for line in eachline("/proc/self/cgroup")
-        parts = split(line, ':'; limit=3)
-        length(parts) == 3 && parts[1] == "0" && (rel = parts[3])
-    end
-    rel === nothing && return String[]
     root = "/sys/fs/cgroup"
     isdir(root) || return String[]
+    bases = Tuple{String, String}[]
+    for line in eachline("/proc/self/cgroup")
+        parts = split(line, ':'; limit=3)
+        length(parts) == 3 || continue
+        hid, ctls, rel = parts
+        if hid == "0" && isempty(ctls)
+            push!(bases, (root, String(rel)))              # v2: one unified tree
+        elseif controller in split(ctls, ',')
+            push!(bases, (joinpath(root, controller), String(rel)))   # v1: own mount
+        end
+    end
     out = String[]
-    p = normpath(joinpath(root, lstrip(rel, '/')))
-    while startswith(p, root)
-        isdir(p) && push!(out, p)
-        p == root && break
-        p = dirname(p)
+    for (base, rel) in bases
+        isdir(base) || continue
+        p = normpath(joinpath(base, lstrip(rel, '/')))
+        while startswith(p, base)
+            isdir(p) && push!(out, p)
+            p == base && break
+            p = dirname(p)
+        end
     end
     out
 end
@@ -224,34 +252,91 @@ function _scheduler_memory()
         )
         return (n * 1024 * 1024 * c[1], :slurm, "SLURM_MEM_PER_CPU x $(c[3])")
     end
+    # UGE (TSUBAME). `SGE_HGR_<resource>` is the HARD GRANTED amount, and
+    # m_mem_free is the memory one. Measured on job 8492405 (cpu_4, node r18n6):
+    # SGE_HGR_m_mem_free=9.200G against a node holding 755 GiB across 384 cpus,
+    # whose 4-cpu proportional share is 7.9 GiB — i.e. the figure is the job's
+    # TOTAL, not a per-slot amount that would need multiplying by NSLOTS. Read
+    # as-is; were that reading wrong the error is toward granting the job LESS
+    # than it has, which is the safe direction and the opposite of the 65×
+    # over-estimate this rung was added to fix.
+    for var in ("SGE_HGR_m_mem_free", "SGE_HGR_TASK_m_mem_free")
+        v = get(ENV, var, "")
+        isempty(v) && continue
+        n = _parse_suffixed_bytes(v)
+        n === nothing && throw(
+            BlindBudget(:memory_bytes, var,
+                "is set to $(repr(v)), which is not a UGE memory specifier " *
+                "(a number, optionally suffixed K/M/G/T for binary or k/m/g/t " *
+                "for decimal)."),
+        )
+        return (n, :uge, var)
+    end
     return nothing
 end
 
-"Tightest finite `memory.max` anywhere in our own cgroup chain."
+"""
+    _parse_suffixed_bytes(s)
+
+UGE memory specifier → bytes. Uppercase suffixes are binary (K = 1024),
+lowercase decimal (k = 1000); that is UGE's convention, not a choice made here.
+"""
+function _parse_suffixed_bytes(s::AbstractString)
+    m = match(r"^\s*([0-9]*\.?[0-9]+)\s*([kKmMgGtT]?)\s*$", s)
+    m === nothing && return nothing
+    mult = Dict(
+        "" => 1.0,
+        "k" => 1e3, "K" => 1024.0,
+        "m" => 1e6, "M" => 1024.0^2,
+        "g" => 1e9, "G" => 1024.0^3,
+        "t" => 1e12, "T" => 1024.0^4,
+    )
+    round(Int, parse(Float64, m.captures[1]) * mult[m.captures[2]])
+end
+
+"Tightest real memory limit anywhere in our own cgroup chain, either hierarchy."
 function _cgroup_memory_max()
+    # v1 spells "no limit" as a number near typemax rather than the word `max`,
+    # and the exact sentinel has changed across kernels. Rather than match a
+    # constant, compare against physical RAM: a limit at or above what the
+    # machine has is not a limit on this job. Derived, so it cannot go stale.
+    total = _meminfo_bytes("MemTotal")
     best, origin = typemax(Int), ""
-    for dir in _cgroup_chain()
-        v = _read_int_file(joinpath(dir, "memory.max"))
-        (v === nothing || v == typemax(Int)) && continue
-        v < best && ((best, origin) = (v, joinpath(dir, "memory.max")))
+    for dir in _cgroup_dirs("memory")
+        for fname in ("memory.max", "memory.limit_in_bytes")
+            path = joinpath(dir, fname)
+            v = _read_int_file(path)
+            (v === nothing || v == typemax(Int)) && continue
+            (total !== nothing && v >= total) && continue
+            v < best && ((best, origin) = (v, path))
+        end
     end
     best == typemax(Int) ? nothing : (best, :cgroup, origin)
 end
 
-"Tightest finite `cpu.max` quota in our own cgroup chain, in whole CPUs."
+"Tightest finite CPU quota in our own cgroup chain, in whole CPUs, either hierarchy."
 function _cgroup_cpus()
     best, origin = typemax(Int), ""
-    for dir in _cgroup_chain()
-        path = joinpath(dir, "cpu.max")
-        isfile(path) || continue
-        parts = split(strip(read(path, String)))
-        length(parts) == 2 || continue
-        parts[1] == "max" && continue
-        quota = tryparse(Int, parts[1]);
-        period = tryparse(Int, parts[2])
-        (quota === nothing || period === nothing || period == 0) && continue
-        n = max(1, cld(quota, period))
-        n < best && ((best, origin) = (n, path))
+    for dir in _cgroup_dirs("cpu")
+        path = joinpath(dir, "cpu.max")                       # v2: "quota period"
+        if isfile(path)
+            parts = split(strip(read(path, String)))
+            if length(parts) == 2 && parts[1] != "max"
+                quota = tryparse(Int, parts[1])
+                period = tryparse(Int, parts[2])
+                if quota !== nothing && period !== nothing && period > 0
+                    n = max(1, cld(quota, period))
+                    n < best && ((best, origin) = (n, path))
+                end
+            end
+        end
+        qpath = joinpath(dir, "cpu.cfs_quota_us")              # v1: two files, -1 = none
+        quota = _read_int_file(qpath)
+        period = _read_int_file(joinpath(dir, "cpu.cfs_period_us"))
+        if quota !== nothing && period !== nothing && quota > 0 && period > 0
+            n = max(1, cld(quota, period))
+            n < best && ((best, origin) = (n, qpath))
+        end
     end
     best == typemax(Int) ? nothing : (best, :cgroup, origin)
 end
@@ -264,31 +349,48 @@ Memory the login session has historically needed BEYOND what it holds now.
 Zero when no login-session cgroup exists — that is a compute node, and there is
 no desktop to keep responsive. Throws when the session exists but its counters
 will not read, because that is a failure to measure and not a reserve of zero.
+
+Looks in both hierarchies: v2 pairs `memory.current` with `memory.peak`, v1
+pairs `memory.usage_in_bytes` with `memory.max_usage_in_bytes`. A v2-only reader
+on a v1 desktop would report "no login session" — the right words for the wrong
+reason, and it would hand the desktop's headroom to the job.
 """
 function _interactive_reserve()
     uid = _self_uid()
     uid === nothing && return (0, false, "no /proc/self/status")
-    base = "/sys/fs/cgroup/user.slice/user-$(uid).slice/user@$(uid).service"
-    isdir(base) || return (0, false, "no $(base) — no login session to protect")
+    rel = "user.slice/user-$(uid).slice/user@$(uid).service"
+    bases = [
+        joinpath("/sys/fs/cgroup", rel),                     # v2
+        joinpath("/sys/fs/cgroup", "memory", rel),           # v1
+    ]
+    base = nothing
+    for b in bases
+        isdir(b) && (base=b; break)
+    end
+    base === nothing &&
+        return (0, false, "no $(rel) in either hierarchy — no login session to protect")
     reserve, seen = 0, String[]
     for slice in ("app.slice", "session.slice")
         dir = joinpath(base, slice)
         isdir(dir) || continue
-        cur = _read_int_file(joinpath(dir, "memory.current"))
-        peak = _read_int_file(joinpath(dir, "memory.peak"))
+        cur = something(_read_int_file(joinpath(dir, "memory.current")),
+            _read_int_file(joinpath(dir, "memory.usage_in_bytes")), Some(nothing))
+        peak = something(_read_int_file(joinpath(dir, "memory.peak")),
+            _read_int_file(joinpath(dir, "memory.max_usage_in_bytes")), Some(nothing))
         if cur === nothing || peak === nothing
             throw(
                 BlindBudget(:interactive_reserve, dir,
-                    "the login session is present but memory.current/memory.peak " *
-                    "would not read (cgroup v1, or an older kernel without " *
-                    "memory.peak)."),
+                    "the login session is present but neither the v2 " *
+                    "(memory.current/memory.peak) nor the v1 " *
+                    "(memory.usage_in_bytes/memory.max_usage_in_bytes) counters " *
+                    "would read."),
             )
         end
         reserve += max(0, peak - cur)
         push!(seen, slice)
     end
     isempty(seen) && return (0, false, "$(base) has no app/session slice")
-    (reserve, true, "$(base)/{$(join(seen, ','))}: memory.peak - memory.current")
+    (reserve, true, "$(base)/{$(join(seen, ','))}: peak - current")
 end
 
 function _gpu_free_bytes(notes)

--- a/test/_tiers.jl
+++ b/test/_tiers.jl
@@ -37,6 +37,10 @@ const FAST_TESTS = [
     # The CONTRIBUTING.md scripts/ charter, gated: set equality between
     # scripts/ on disk and the in-test allowlist (306→76 cleanup, 2026-08-18).
     "test_scripts_allowlist.jl",
+    # Resource limits must be DERIVED per host, never chosen — and this is also
+    # the gate that keeps `Sys.CPU_THREADS` (the MACHINE's core count, wrong by
+    # 24× inside a TSUBAME allotment) out of every site but its declaration.
+    "test_host_budget.jl",
     # A job script may not report success for a stage that failed. `set +e` in
     # `tsubame_setup.sh` went unrestored for twelve days and covered two
     # failures with GREENs; the property is EXECUTED here, because grepping for

--- a/test/helpers/live_docs.jl
+++ b/test/helpers/live_docs.jl
@@ -55,6 +55,15 @@ const LIVE_DOCS = [
     # be wrong; it may not be the only place an instruction lives.
     "docs/guides/edh_quench_lab_prescription.md",
     "docs/guides/lab_user_tutorial.md",
+    # The local counterpart of `tsubame.md`: where a run goes when it is not
+    # going to the cluster. LIVE rather than dated because what it states is a
+    # SAFETY property — this host cannot be pushed into swap, and an overrun
+    # kills rather than hangs — and a stale safety guarantee is worse than an
+    # absent one: the reader keeps running under a promise nobody is holding.
+    # It also carries the only prose statement of which scheduler rungs have
+    # been executed on real hardware (UGE yes, SLURM/PBS no), which is exactly
+    # the kind of line that must not silently outlive its measurement.
+    "docs/guides/local_run_environment.md",
     "docs/guides/pipeline_cookbook.md",
     "docs/guides/spgpe.md",
     "docs/guides/tsubame.md",

--- a/test/mutation/run.jl
+++ b/test/mutation/run.jl
@@ -5,7 +5,8 @@
 #     --shard k/n         every n-th class from k         (default: no sharding)
 #     --probe NAME|list   grounded_cheap | oracles | fast  (default: grounded_cheap)
 #                         or a comma-separated list of test files
-#     --workers N         parallel test processes          (default: CPU threads − 2)
+#     --workers N         parallel test processes          (default: this job's
+#                         own cpu allotment — affinity mask or scheduler grant)
 #     --out DIR           where the matrix + report go      (default: mutation_out/)
 #     --allow-dirty       run with uncommitted src changes  (default: refuse)
 #     --no-negative-control  skip the repeat-baseline pass     (default: run it)
@@ -31,7 +32,21 @@ _arg(flag, default) = (i=findfirst(==(flag), ARGS);
     i === nothing ? default : ARGS[i + 1])
 
 const OUT = abspath(_arg("--out", joinpath(_ROOT, "mutation_out")))
-const NWORKERS = parse(Int, _arg("--workers", string(max(1, Sys.CPU_THREADS - 2))))
+
+# The default worker count is this job's OWN cpu allotment — the affinity mask or
+# the scheduler's grant — not the machine's core count, which on a cluster node
+# describes hardware somebody else is using. The former `Sys.CPU_THREADS - 2`
+# got both halves wrong: it read the machine, and it kept the host responsive by
+# subtracting a constant. Responsiveness is the launcher's job now, and it does
+# it with a mechanism (CPUWeight) rather than a number — see scripts/run_local.sh.
+module _HostBudget
+include(joinpath(dirname(dirname(@__DIR__)), "src", "workflow", "io", "host_budget.jl"))
+end  # _ROOT is this same directory; spelled out here so the include is readable
+
+const NWORKERS = parse(
+    Int, _arg("--workers",
+        string(max(1, _HostBudget.detect_host_budget().cpu_threads)))
+)
 const ALLOW_DIRTY = "--allow-dirty" in ARGS
 # The negative control costs one probe pass and is what makes a catch mean
 # something, so it is on by default. The escape hatch exists for a re-probe of a

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,13 @@ include(joinpath(@__DIR__, "_tiers.jl"))
 #       loads SpinorBEC exactly once in a clean session. A shared-worker pool
 #       can reload the package mid-run (cache race), giving two copies of a type
 #       so `x isa CheckResult` flakes to false; separate processes cannot.
-#       `auto` = one worker per CPU thread.
+#       `auto` = one worker per CPU THIS JOB MAY USE — the affinity mask or the
+#       scheduler's grant, via host_budget.jl, NOT the machine's core count.
+#       The distinction is the whole point: `Sys.CPU_THREADS` on a TSUBAME node
+#       reports the node (384 on the cpu_16 hardware, per #407's own probe), so
+#       `auto` there used to start an entire node's worth of julia processes
+#       inside a 16-core allotment. Where the budget cannot be derived this
+#       falls back to SERIAL and says so — the safe extreme, not a guess.
 #       On-demand rather than pre-assigned: measured on CI, per-file times swing
 #       ±30 % run to run, so static bin-packing left the makespan 8-21 % above
 #       the perfect-balance floor no matter how well _COST was fitted.
@@ -57,8 +63,28 @@ include(joinpath(@__DIR__, "_tiers.jl"))
 get!(ENV, "SPINORBEC_FFT_ESTIMATE", "1")
 
 const _SKIP = Set(filter(!isempty, split(get(ENV, "SPINORBEC_TEST_SKIP", ""), ",")))
+
+# Wrapped in a module so the runner's namespace stays clean: every test file
+# does `using SpinorBEC`, which exports these same names.
+module _HostBudget
+include(joinpath(@__DIR__, "..", "src", "workflow", "io", "host_budget.jl"))
+end
+
 const _NWORKERS = let w = get(ENV, "SPINORBEC_TEST_WORKERS", "1")
-    w == "auto" ? max(1, Sys.CPU_THREADS) : parse(Int, w)
+    if w != "auto"
+        parse(Int, w)
+    else
+        try
+            _HostBudget.detect_host_budget().cpu_threads
+        catch err
+            err isa _HostBudget.BlindBudget || rethrow()
+            @warn(
+                "SPINORBEC_TEST_WORKERS=auto could not derive this job's CPU " *
+                    "allotment; running SERIAL rather than guessing a worker count.",
+                exception = err)
+            1
+        end
+    end
 end
 # Per-worker wall-clock cap (seconds) under parallelism; 0 disables. Generous by
 # default — catches a genuine hang, not a merely-slow file (cold F32 ≈ 600 s).

--- a/test/test_docs_live_set.jl
+++ b/test/test_docs_live_set.jl
@@ -85,7 +85,17 @@ _frozen(path) = occursin(_FROZEN_MARK, first(read(joinpath(_REPO, path), String)
         # keeps its path and loses its authority, and the authority needs a live
         # home. Net effect on the budget question: one frozen document became
         # genuinely inert, which is what the partition is for.
-        @test length(LIVE_DOCS) <= 33
+        # 33 -> 34 on 2026-08-25 for `docs/guides/local_run_environment.md`, and
+        # the question above was asked. It is not a fourth document about one
+        # tangle; it is the LOCAL half of a pair whose other half
+        # (`tsubame.md`) is already LIVE, and merging them would produce a guide
+        # about two machines that share no mechanism. What forces LIVE rather
+        # than a date is that its claims are SAFETY claims — swap cannot be
+        # touched, an overrun kills instead of hanging — and a dated safety
+        # guarantee still reads as a guarantee. Its "verified / not verified"
+        # section is the same shape: it already had to be rewritten once, when a
+        # TSUBAME job refuted the memory rung it had called unverified.
+        @test length(LIVE_DOCS) <= 34
         @test length(LIVE_DOCS) == length(unique(LIVE_DOCS))
     end
 

--- a/test/test_host_budget.jl
+++ b/test/test_host_budget.jl
@@ -1,0 +1,204 @@
+# Host budget: is every limit DERIVED, is a refusal reachable, and is this the
+# only place that answers "how many cpus may I use?"
+#
+# The third question is the one CLAUDE.md commitment 11 is about. A new single
+# source of truth that leaves the old spelling legal does not replace it, it
+# joins it — measured over 411 fix commits in this repo, that is exactly what
+# separated the migrations that held (`Units.bfield_to_p`, gated) from the ones
+# that rotted (`COUPLING_TOL`, 7 : 121, whose docstring said the old form was
+# "kept available for legacy call sites"). So the gate ships here, in the same
+# commit as the thing it protects.
+
+using Test
+using SpinorBEC
+include(joinpath(@__DIR__, "helpers", "calibrated_scan.jl"))
+
+const _HB_ROOT = dirname(@__DIR__)
+
+@testset "host budget" begin
+    @testset "every term is derived, and says from where" begin
+        b = detect_host_budget()
+        @test b.cpu_threads >= 1
+        @test b.memory_bytes > 0
+        # Provenance is not decoration: a report that cannot name the file it
+        # read cannot be checked, and an unnameable number is a magic number
+        # wearing a struct field.
+        @test !isempty(b.cpu_origin)
+        @test !isempty(b.memory_origin)
+        @test b.cpu_source in (:slurm, :uge, :pbs, :cgroup, :affinity, :override)
+        @test b.memory_source in (:slurm, :cgroup, :memavailable, :override)
+    end
+
+    @testset "the affinity reader agrees with the kernel's own answer" begin
+        # A cross-check with an independent implementation of the same question.
+        # `nproc` (no --all) reports the affinity mask, which is the quantity
+        # host_budget claims to read; if the two ever disagree, the parser of
+        # Cpus_allowed_list is wrong and every derived count is wrong with it.
+        if Sys.islinux() && Sys.which("nproc") !== nothing
+            withenv("SPINORBEC_HOST_CPUS" => nothing,
+                "SLURM_CPUS_PER_TASK" => nothing, "SLURM_JOB_CPUS_PER_NODE" => nothing,
+                "NSLOTS" => nothing, "PBS_NCPUS" => nothing, "PBS_NP" => nothing) do
+                b = detect_host_budget()
+                if b.cpu_source === :affinity
+                    @test b.cpu_threads == parse(Int, readchomp(`nproc`))
+                end
+            end
+        end
+    end
+
+    @testset "a stated value is never reported as a measured one" begin
+        withenv("SPINORBEC_HOST_CPUS" => "3") do
+            b = detect_host_budget()
+            @test b.cpu_threads == 3
+            @test b.cpu_source === :override      # not :affinity, not :cgroup
+        end
+        withenv("SPINORBEC_HOST_MEMORY_BYTES" => string(4 * 2^30)) do
+            b = detect_host_budget()
+            @test b.memory_bytes == 4 * 2^30
+            @test b.memory_source === :override
+        end
+    end
+
+    @testset "refusal is reachable, and is not a default" begin
+        # The failure this guards: filling an unreadable quantity with a
+        # plausible number, so a budget nobody measured reads as one that is
+        # safe. If this testset ever passes vacuously the discipline is gone.
+        withenv("SPINORBEC_HOST_CPUS" => "not-a-number") do
+            @test_throws BlindBudget detect_host_budget()
+        end
+        withenv("SLURM_CPUS_PER_TASK" => "lots") do
+            @test_throws BlindBudget detect_host_budget()
+        end
+        err = try
+            withenv("SPINORBEC_HOST_CPUS" => "x") do
+                detect_host_budget()
+            end
+        catch e
+            e
+        end
+        @test err isa BlindBudget
+        @test occursin("Refusing to substitute a default", sprint(showerror, err))
+    end
+
+    @testset "the scheduler's grant outranks the machine" begin
+        # On a cluster node the hardware count describes somebody else's job.
+        withenv("SPINORBEC_HOST_CPUS" => nothing, "SLURM_CPUS_PER_TASK" => "2") do
+            b = detect_host_budget()
+            @test b.cpu_threads == 2
+            @test b.cpu_source === :slurm
+            @test occursin("SLURM_CPUS_PER_TASK", b.cpu_origin)
+        end
+        # NSLOTS — UGE, which is what TSUBAME runs
+        withenv("SPINORBEC_HOST_CPUS" => nothing, "SLURM_CPUS_PER_TASK" => nothing,
+            "NSLOTS" => "4") do
+            b = detect_host_budget()
+            @test b.cpu_threads == 4
+            @test b.cpu_source === :uge
+        end
+        # SLURM_JOB_CPUS_PER_NODE arrives as "72(x2)" on a multi-node grant.
+        withenv("SPINORBEC_HOST_CPUS" => nothing, "SLURM_CPUS_PER_TASK" => nothing,
+            "NSLOTS" => nothing, "SLURM_JOB_CPUS_PER_NODE" => "72(x2)") do
+            @test detect_host_budget().cpu_threads == 72
+        end
+    end
+
+    @testset "MemoryHigh is never emitted" begin
+        # Measured 2026-08-24: MemoryHigh below MemoryMax with swap forbidden
+        # does not kill, it LIVELOCKS — memory.events read `high 2560, max 0,
+        # oom_kill 0` with the process pinned at the cap making no progress. A
+        # job that hangs forever is worse than one that dies, so the property is
+        # the ABSENCE of a knob and absence is what has to be gated.
+        b = detect_host_budget()
+        props = budget_scope_properties(b)
+        @test !any(p -> occursin("MemoryHigh", p), props)
+        if b.swap_containable
+            @test "MemorySwapMax=0" in props
+            @test any(p -> startswith(p, "MemoryMax="), props)
+            @test "CPUWeight=1" in props
+        end
+    end
+
+    @testset "the planner follows the derived thread count" begin
+        withenv("SPINORBEC_HOST_CPUS" => "1") do
+            @test detect_host_budget().fft_plan === :measure
+        end
+        withenv("SPINORBEC_HOST_CPUS" => "8") do
+            b = detect_host_budget()
+            @test b.fft_plan === :estimate       # #407: threaded MEASURE blows up
+            @test "SPINORBEC_FFT_PLAN=estimate" in budget_env(b)
+            @test "JULIA_NUM_THREADS=8" in budget_env(b)
+        end
+    end
+
+    # ── SSoT gate ────────────────────────────────────────────────────────
+    #
+    # `Sys.CPU_THREADS` reports the MACHINE. On a TSUBAME node allotted 16 cpus
+    # of 384 it is wrong by 24×, which is the same misreading #407 chased for a
+    # day. host_budget.jl is now the one place allowed to touch it — as a named,
+    # noted last-resort fallback — and this makes the next new caller red.
+    @testset "no machine-wide cpu count outside host_budget" begin
+        allowed = Set([
+            # declares the fallback, and labels it machine-wide in the note it
+            # attaches to the returned budget
+            "src/workflow/io/host_budget.jl",
+            # #407's probe prints julia / cpuinfo / affinity SIDE BY SIDE; the
+            # disagreement between them is the measurement, so the machine-wide
+            # read is the point rather than a bug
+            "scripts/klaus2022/fftw_thread_probe.jl",
+        ])
+
+        # Comments are stripped so prose ABOUT the defect does not read as the
+        # defect. The stripper also cuts a `#` inside a string literal, which can
+        # only ever NARROW what the gate sees — stated because a narrowing
+        # approximation is the kind that hides a defect rather than inventing one.
+        function code_text(rel)
+            buf = IOBuffer()
+            for line in eachline(joinpath(_HB_ROOT, rel))
+                startswith(strip(line), "#") && continue
+                i = findfirst('#', line)
+                println(buf, i === nothing ? line : line[1:prevind(line, i)])
+            end
+            String(take!(buf))
+        end
+
+        corpus = String[]
+        for sub in ("src", "test", "scripts", "bench", "ext")
+            dir = joinpath(_HB_ROOT, sub)
+            isdir(dir) && append!(corpus, tree_files(dir))
+        end
+
+        # Assembled from halves so THIS file does not contain the literal it
+        # hunts for. The first run of this gate flagged itself, which was the
+        # right answer to the wrong question: the fix is to stop being a match,
+        # not to add an exception. An allowlist entry here would have been a
+        # permanent hole in the one file guaranteed to be read by anyone
+        # changing the rule.
+        needle = "Sys." * "CPU_THREADS"
+
+        hits = calibrated_scan(
+            corpus;
+            match=rel -> occursin(needle, code_text(rel)),
+            # POSITIVE: the declaration site. If the extractor breaks, this stops
+            # matching and the scan throws instead of reporting a clean tree.
+            present="src/workflow/io/host_budget.jl",
+            # NEGATIVE: runtests.jl names Sys.CPU_THREADS in a COMMENT explaining
+            # why it no longer calls it. Choosing it here is what proves the
+            # comment stripping works — a negative control that merely lacks the
+            # string would have proved nothing about the interesting case.
+            absent="test/runtests.jl",
+        )
+
+        stray = setdiff(Set(hits), allowed)
+        @test isempty(stray)
+        isempty(stray) || @info(
+            "New machine-wide CPU count. Use `detect_host_budget().cpu_threads`, " *
+                "which reads the affinity mask or the scheduler's grant; add the file " *
+                "to `allowed` here only if reading the machine is the actual intent.",
+            stray)
+
+        # And the allowlist may not outlive its files.
+        for a in allowed
+            @test isfile(joinpath(_HB_ROOT, a))
+        end
+    end
+end

--- a/test/test_host_budget.jl
+++ b/test/test_host_budget.jl
@@ -26,7 +26,7 @@ const _HB_ROOT = dirname(@__DIR__)
         @test !isempty(b.cpu_origin)
         @test !isempty(b.memory_origin)
         @test b.cpu_source in (:slurm, :uge, :pbs, :cgroup, :affinity, :override)
-        @test b.memory_source in (:slurm, :cgroup, :memavailable, :override)
+        @test b.memory_source in (:slurm, :uge, :cgroup, :memavailable, :override)
     end
 
     @testset "the affinity reader agrees with the kernel's own answer" begin
@@ -100,6 +100,54 @@ const _HB_ROOT = dirname(@__DIR__)
             "NSLOTS" => nothing, "SLURM_JOB_CPUS_PER_NODE" => "72(x2)") do
             @test detect_host_budget().cpu_threads == 72
         end
+    end
+
+    # Every literal below was COPIED OUT OF a real TSUBAME job's environment
+    # (job 8492405, cpu_4, node r18n6). The unit tests that shipped first set
+    # NSLOTS by hand and were green while the memory rung was 65x wrong on that
+    # same machine, because nothing local exports SGE_HGR_m_mem_free and nothing
+    # local runs cgroup v1. A fixture invented from the documentation would have
+    # reproduced exactly that blindness, so these are transcribed, not imagined.
+    @testset "the UGE memory grant is read (measured on job 8492405)" begin
+        @test SpinorBEC._parse_suffixed_bytes("9.200G") == round(Int, 9.2 * 1024^3)
+        @test SpinorBEC._parse_suffixed_bytes("4096M") == 4096 * 1024^2
+        @test SpinorBEC._parse_suffixed_bytes("2g") == 2_000_000_000   # lowercase: decimal
+        @test SpinorBEC._parse_suffixed_bytes("512") == 512
+        @test SpinorBEC._parse_suffixed_bytes("lots") === nothing
+
+        withenv("SPINORBEC_HOST_MEMORY_BYTES" => nothing,
+            "SLURM_MEM_PER_NODE" => nothing, "SLURM_MEM_PER_CPU" => nothing,
+            "SGE_HGR_m_mem_free" => "9.200G", "NSLOTS" => "4") do
+            b = detect_host_budget()
+            @test b.memory_source === :uge
+            @test b.memory_bytes == round(Int, 9.2 * 1024^3)
+            @test b.cpu_threads == 4
+            # The defect this replaces: the ceiling was MemAvailable for the
+            # whole node. Whatever this host's MemAvailable is, the grant must
+            # win over it.
+            @test b.memory_bytes < something(SpinorBEC._meminfo_bytes("MemTotal"), typemax(Int))
+        end
+        # Set but unparseable is a refusal, not a fallthrough to the node total.
+        withenv("SGE_HGR_m_mem_free" => "nine gigs") do
+            @test_throws BlindBudget detect_host_budget()
+        end
+    end
+
+    @testset "cgroup v1 is read, not just v2" begin
+        # TSUBAME's compute nodes are v1: /proc/self/cgroup lines look like
+        # `13:memory:/AGE/8492405.1/master`, with no `0::` line at all. The
+        # v2-only reader found no limit there and said nothing about it.
+        @test hasmethod(SpinorBEC._cgroup_dirs, Tuple{String})
+        src = read(joinpath(_HB_ROOT, "src", "workflow", "io", "host_budget.jl"), String)
+        # v1 spellings must appear beside their v2 counterparts, or the file has
+        # silently regressed to one hierarchy.
+        for v1 in ("memory.limit_in_bytes", "cpu.cfs_quota_us", "cpu.cfs_period_us",
+            "memory.max_usage_in_bytes", "memory.usage_in_bytes")
+            @test occursin(v1, src)
+        end
+        # Whatever hierarchy this host runs, asking for a controller must not throw.
+        @test SpinorBEC._cgroup_dirs("memory") isa Vector{String}
+        @test SpinorBEC._cgroup_dirs("cpu") isa Vector{String}
     end
 
     @testset "MemoryHigh is never emitted" begin

--- a/test/test_scripts_allowlist.jl
+++ b/test/test_scripts_allowlist.jl
@@ -43,6 +43,11 @@ const _SCRIPTS_ALLOWLIST = Set([
     "audit_memory.py",             # memory-store auditor (CLAUDE.md-gated)
     "preflight_invariants.jl",     # physics-invariant preflight battery
     "watch_until_done.sh",         # job watcher with a reachable RED
+    # Launcher for local runs: applies the budget src/workflow/io/host_budget.jl
+    # derives, in a swap-proof cgroup. Operational by nature — the cgroup has to
+    # wrap the julia process, so it cannot live inside it — and it holds no
+    # derivation of its own.
+    "run_local.sh",
     # ── build tooling (category 2) ──
     "build_sysimage.jl",
     "build_sysimage_full.jl",


### PR DESCRIPTION
ローカルで走らせても**スワップを踏まず、こちらの操作が止まらない**実行環境。上限はマシンから*導出*しており、チューニング定数は 1 つも入っていません。同じ導出がスパコン側ではスケジューラの割当を読むので、ローカルでもノードでも同じコマンドで適正化されます。

```bash
scripts/run_local.sh --print                 # 予算と、各項の出所
scripts/run_local.sh julia --project=. …     # その予算の下で実行
```

## 導出の梯子（各段が観測。選んだ数値はゼロ）

| 段 | 出所 | 効く場面 |
|---|---|---|
| 1 | バッチ割当 — `SLURM_*` / `NSLOTS`(UGE=TSUBAME) / `PBS_*` | 計算ノード。割当が正で、ノードの総量は他人のジョブの話 |
| 2 | 自分の cgroup 連鎖の制限（**v2 と v1 の両方**） | コンテナ・systemd slice・WSL2・UGE の per-job cgroup |
| 3 | CPU **affinity mask** と `MemAvailable` | ふつうの対話ホスト |

3 段目の `MemAvailable` は**カーネル自身の「スワップせずに取れる量」の答え**です。欲しい量そのものが、知っている当事者によって既に計算されている。

対話セッションがあるホストでだけ 1 項引きます:

```
interactive reserve = memory.peak − memory.current   of user@<uid>.service/{app,session}.slice
```

＝デスクトップが過去に実際に必要とした追加量。**選んだマージンではなく実測値**です。計算ノードには login session の cgroup が無いので、この項は**観測により**ゼロになります。

ジョブは `spinorbec.slice` に隔離してあり、計測対象の slice の外なので**上限が実行のたびに下がっていくラチェットは起きません**。

## 拒否する場所

login session はあるのに counter が読めない（v2 の `memory.peak` も v1 の `memory.max_usage_in_bytes` も開かない）場合、`detect_host_budget` は 0 で埋めずに `BlindBudget` を投げます。「守るべきデスクトップが無い」と「見られなかった」を同じ綴りにしてはいけないからです。

意図的に値を宣言するなら `SPINORBEC_HOST_CPUS` / `SPINORBEC_HOST_MEMORY_BYTES`。このとき source は `:override` として報告されるので、**宣言値が実測値のふりをすることはできません**。

## 実測（WSL2、2026-08-24）

| 性質 | 証拠 |
|---|---|
| スワップを踏まない | カナリア 2 回とも host swap は **804 MB のまま不変**、cgroup 側も `swap.current=0` |
| ハングせず即死 | `exit 137` |
| 巻き添えゼロ | `constraint=CONSTRAINT_MEMCG` — システム OOM killer は不関与 |
| ラチェット無し | ジョブは `spinorbec.slice` に着地 |
| failed unit が溜まらない | `--collect` で自動回収（0 件確認） |

**`MemoryHigh` は意図的に使っていません。** `MemoryMax` 未満に置いてスワップを禁じると、死なずに reclaim で**ライブロック**しました（`memory.events`: `high 2560, max 0, oom_kill 0`、プロセスは上限に張り付いて無進捗）。永遠にハングするジョブは死ぬジョブより悪いので `MemoryMax` 一本です。

**`CPUQuota` も使っていません。** 目的は「打鍵が止まらないこと」で、quota はそれを「打鍵していない間マシンを遊ばせる」形で買います。`CPUWeight` を cgroup 仕様の最小値に置けば、何かが走れば譲り、何も走っていなければマシンを使い切る。

## ついでに直した実バグ

`SPINORBEC_TEST_WORKERS=auto` と `test/mutation/run.jl` が `Sys.CPU_THREADS`（**マシン全体**）で並列数を決めていました。TSUBAME の `cpu_16` 割当ではノードの全コア数ぶんプロセスが立ちます。#407 が 1 日追ったのと同じ取り違えです。

```
auto -> 10 workers                             (このマシン)
同じコードを UGE cpu_16 の中で -> 16 workers    (割当を読む)
```

commitment 11 に従い、**新規の `Sys.CPU_THREADS` 呼び出しを赤にするゲート**を同梱。負の対照には「コメントでしか言及していないファイル」を選び、コメント除去が効いていることを証明させています。ゲートは初回に**自分自身を捕まえた**ので、allowlist に穴を開けず検索パターンを分割して解消しました。

## レビューで見てほしい 2 点

1. ~~**スパコン分岐は実機未検証。**~~ → **TSUBAME で実測しました。UGE の段は実機で検証済み、SLURM / PBS は依然未検証**です。詳細は下の「TSUBAME 実測」節。
2. **`test/mutation/run.jl` の既定並列数を変えました** — `Sys.CPU_THREADS - 2` → 導出値（減算なし）。`-2` 自体がマジックナンバーで、応答性はランチャの機構（CPUWeight）が持つべきという判断です。異論があれば戻します。

## 検証

- `test/test_host_budget.jl` 50/50（TSUBAME 実測後に 32 → 50 へ増）
- `test_scripts_allowlist` / `test_tier_membership` / `test_state_doc_is_current` 緑（`docs/STATE.md` 再生成済み）
- JuliaFormatter 適用（`do` 行末コメントで冪等でない振動があったので解消、2 回かけて差分ゼロを確認）、shellcheck clean
- 先行研究ゲート通過（該当 0 件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## TSUBAME 実測（2026-08-25、追加コミット `2e3c7e3b`）

**0.001 ポイントで実バグが 1 件出ました。** ジョブ 8492405（`cpu_4`, node `r18n6`）。300 秒課金床のおかげで、GPU も SpinorBEC のロードも precompile も要らないこの probe は 2 秒でも 5 分でも同額です。

### 確認できたこと

```
NSLOTS = 4          nproc --all (machine) = 384
VERDICT cpu_source  = uge
VERDICT cpu_threads = 4   (machine reports 384)      ← 96× の取り違えを回避
interactive reserve none  (no login session observed — compute node)   ← 観測により 0
```

ログインノード（**0 ポイント**、割当が無いので梯子の 2・3 段目だけが動く）でも、96 コア・swap 無し（"nothing to forbid"）・`nvidia-smi` が非ゼロ終了 → **クラッシュも既定値でもなく note** を確認。

### 否定されたこと — メモリの段は 65× 過大だった

```
before:  memory ceiling  598.9 GiB  [memavailable]              ← ノード全体
after:   memory ceiling    9.2 GiB  [uge] SGE_HGR_m_mem_free    ← 実際の許可量
```

穴は 2 つで、どちらも開発機からは**原理的に見えません**:

1. **TSUBAME の計算ノードは cgroup v1。** `/proc/self/cgroup` に `0::` 行が無く `13:memory:/AGE/8492405.1/master` という形。v2 しか読まないリーダは**間違った値を返すのではなく何も見つけない**ので、梯子がノード全体まで落ちていました。この file が対抗しているはずの「黙って空振り」を、file 自身がやっていたことになります。v1/v2 両方を読むようにしました。
2. **UGE のメモリ許可 `SGE_HGR_m_mem_free` を読んでいなかった。** 1 段目が SLURM の綴りしか探していませんでした。UGE の接尾辞規則（大文字＝2進、小文字＝10進）のパーサつきで追加。

v1 の「無制限」は `max` という語ではなく typemax 近傍のセンチネルで、カーネルごとに値が変わってきた経緯があります。定数照合ではなく **`MemTotal` 以上なら制限ではない**と判定することで、陳腐化しない形にしました。

ジョブ 8492442 で修正後を再確認済み。新テストのリテラルは**すべて実ジョブの環境から転記**しています — ドキュメントから起こした fixture は、まさに今回直した盲目を再現していたはずなので。

### まだ未検証

**SLURM と PBS。** env を立てた単体テストは解析と優先順位を証明しますが、今回 UGE のメモリ段が示したとおり、**実スケジューラが何を吐くか・ノードがどちらの cgroup 階層かは証明しません**。それらのクラスタでの初回実行を測定として扱い、今回と同じく導出値の隣に生の入力もダンプしてください。

消費ポイント: 2 ジョブで残高 6.71 → 6.70（表示分解能は 0.01 なので、式が予測する 0.002 pt は解像できていません）。
