### PR TITLE
research(spgpe): energy damping は平衡を動かさない — 自分の候補を自分で反証（#485）

### DIFF
--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -1303,7 +1303,7 @@ lifecycle = "candidate"
 ladder = "exact: closed-form occupancy at fixed (T, mu, eps_cut) — no cutoff axis to walk. The SPREAD is the anisotropy, not a convergence residual: the TF formula as coded is isotropic (omega enters only eps_0), and a (1,1,kappa) trap carries an extra 1/kappa in the volume element, giving 1.886e4 with the factor and 3.272e4 without. Both ends are quoted."
 type = "A"
 scope = "The NUMBERS: the eu334 nucleation ramp: box 24, 64^3, kappa = 1.8, c0 = 0.046873 (norm-N form, n_atoms=1 preset), k_cut = min(sqrt(2(mu+T)), k_max = 8.378), evaluated at the ramp's TERMINAL mu. It is a statement about the STEADY STATE of the two dissipative schemes, not about which one is right for a growth problem."
-uncertainty = "The bracket 1.9e4-3.3e4 IS the uncertainty and it is a modelling spread (isotropic vs kappa-corrected TF, ideal-gas density of states), not a statistical one. The DIRECTION survives it: 2.9e3 is 6.5x below the lower end. Positive control, and it was not constructed for the purpose — the growth-only arm's measured steady state 2.96e4 falls INSIDE the independently computed range, so c0, omega and eps_cut are not mis-set; had that failed, nothing here would be readable."
+uncertainty = "The bracket 1.9e4-3.3e4 IS the uncertainty and it is a modelling spread (isotropic vs kappa-corrected TF, plus `coherent_population`'s validity condition - see the note), not a statistical one. The DIRECTION survives it: 2.9e3 is 6.5x below the lower end. Positive control, and it was not constructed for the purpose — the growth-only arm's measured steady state 2.96e4 falls INSIDE the independently computed range, so c0, omega and eps_cut are not mis-set; had that failed, nothing here would be readable."
 uncertainty_basis = "control"
 evidence = ["src/solvers/evaporation/spgpe_reservoir.jl", "src/solvers/spgpe.jl"]
 evidence_status = "in_tree"
@@ -1341,9 +1341,21 @@ ways these fixtures do not reproduce — T = 10 against 2, a RAMPING mu, 13 comp
 kappa = 1.8, and a SEED at 11530 rather than a field grown from zero. (b) Neither arm may
 have reached its stationary state: #418 read a plateau as arrival, and at production M the
 channel is slow enough that a plateau is weak evidence (400 steps move mu-tilde by 1e-4).
-(c) The equilibrium bracket in this row rests on Thomas-Fermi plus an ideal-gas density of
-states and could simply be wrong for that regime — in which case growth-only landing inside
-it was luck, and that possibility is now on the table rather than assumed away.
+(c) The equilibrium bracket in this row rests on Thomas-Fermi plus `coherent_population`,
+and that function has a VALIDITY CONDITION nothing in the tree gates.
+
+MEASURED THE SAME DAY, on (c). `coherent_population` is a BOSE sum over ideal harmonic levels
+that SKIPS every level below mu, on the stated grounds that "those are absorbed into the
+condensate that N_0(mu) already counts". Against numerical SPGPE equilibration at four
+(T, mu, c0, kappa) points with a LARGE c0 — where the TF condensate is 1-3 atoms and so
+absorbs nothing — it undercounts by 7.0x to 10.1x (53.8 against 427.8; 53.2 against 370.7;
+206.7 against 1492.7; 49.6 against 501.7), and the whole gap is in the thermal term.
+
+So the condition is "mu >> eps_0 AND the TF condensate genuinely holds the sub-mu levels",
+and eu334 satisfies it far better than those probes: c0 = 0.046873 there gives
+N_0^TF = 1.7-3.4e4 against a thermal term of 1.5e3, so the condensate dominates and does hold
+them. The bracket therefore STANDS — but on a NAMED condition that was previously unexamined
+rather than on an untested formula. Gating the function is its own issue.
 
 WHAT IT STILL OVERTURNS. #418 closed with "not a defect, two steady states, the full arm has
 ARRIVED". The arrival is what (b) doubts. And the threat to the flower nucleation result

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -1298,11 +1298,11 @@ The gate opens a different file. Say which file a count is a count OF."""
 id = "spgpe-full-steady-state-is-not-the-equilibrium"
 quantity = "N_C at the full-SPGPE steady state @ T=10, mu=11.724, kappa=1.8, 64cubed"
 claim = "The full-SPGPE (energy-damping-on) steady state N_C ~= 2.9e3 is NOT the grand-canonical equilibrium of its own reservoir: the C-region equilibrium at (T=10, mu=11.724, k_cut=6.59) is 1.9e4-3.3e4, which the growth-only steady state (2.96e4) lands inside and the full one sits 6.5x below."
-status = "live"
+status = "scoped"
 lifecycle = "candidate"
 ladder = "exact: closed-form occupancy at fixed (T, mu, eps_cut) — no cutoff axis to walk. The SPREAD is the anisotropy, not a convergence residual: the TF formula as coded is isotropic (omega enters only eps_0), and a (1,1,kappa) trap carries an extra 1/kappa in the volume element, giving 1.886e4 with the factor and 3.272e4 without. Both ends are quoted."
 type = "A"
-scope = "The eu334 nucleation ramp: box 24, 64^3, kappa = 1.8, c0 = 0.046873 (norm-N form, n_atoms=1 preset), k_cut = min(sqrt(2(mu+T)), k_max = 8.378), evaluated at the ramp's TERMINAL mu. It is a statement about the STEADY STATE of the two dissipative schemes, not about which one is right for a growth problem."
+scope = "The NUMBERS: the eu334 nucleation ramp: box 24, 64^3, kappa = 1.8, c0 = 0.046873 (norm-N form, n_atoms=1 preset), k_cut = min(sqrt(2(mu+T)), k_max = 8.378), evaluated at the ramp's TERMINAL mu. It is a statement about the STEADY STATE of the two dissipative schemes, not about which one is right for a growth problem."
 uncertainty = "The bracket 1.9e4-3.3e4 IS the uncertainty and it is a modelling spread (isotropic vs kappa-corrected TF, ideal-gas density of states), not a statistical one. The DIRECTION survives it: 2.9e3 is 6.5x below the lower end. Positive control, and it was not constructed for the purpose — the growth-only arm's measured steady state 2.96e4 falls INSIDE the independently computed range, so c0, omega and eps_cut are not mis-set; had that failed, nothing here would be readable."
 uncertainty_basis = "control"
 evidence = ["src/solvers/evaporation/spgpe_reservoir.jl", "src/solvers/spgpe.jl"]
@@ -1314,11 +1314,42 @@ pr = 0
 window = "the ramp's terminal reservoir point"
 reduction = "steady-state value (the plateau), against a closed-form equilibrium at the same (T, mu, eps_cut)"
 boundary = "n/a"
-note = """WHY THIS IS TYPE A AND NOT B. The SPGPE's stationary distribution is the
-grand-canonical exp(-(H-mu N)/T) restricted to C. Energy damping is another dissipative
-channel satisfying fluctuation-dissipation with the SAME reservoir, so it must preserve the
-SAME stationary distribution. One scheme landing 6.5x off it is a defect in the
-implementation, not a physical difference between two theories. Tracked as its own issue.
+note = """SCOPED 2026-08-25, THE SAME DAY, BY THE MEASUREMENT THIS ROW ASKED FOR. The
+numbers above stand. The INFERENCE drawn from them — "so the energy-damping implementation
+places the field off its own equilibrium" — does not, and #485 is where it died.
+
+WHAT WAS MEASURED. `test/dynamics/test_spgpe.jl` already contains the mode-resolved
+instrument: a free field (c0 = 0, no trap) where eps_k = k^2/2 is exact, so
+N_C^eq = sum_{|k|<k_cut} T/(eps_k - mu) is unambiguous. It runs at M = 0.0, i.e. with
+energy damping OFF. Turning M on in that fixture, and then adding interactions and a trap
+one axis at a time:
+
+    fixture                  M = 0     M = 1.628e-3 (production)   ratio
+    free field              4349.31    4338.87                     0.9976
+    interacting, no trap    1575.92    1575.04                     0.9994
+    interacting + trap       687.04     686.94                     0.9999
+    weakly int. + trap       833.99     834.00                     1.0000
+
+At 60x production the free field degrades to 0.8974 and the interacting+trapped case only
+to 0.9831 — i.e. the interacting case is LESS sensitive, not more. So the channel's
+stationary distribution is right to 0.01-0.24 % at the strength production uses, and the
+"broken fluctuation-dissipation relation" reading is refuted where the equilibrium is
+knowable.
+
+WHAT REMAINS, AND IT IS NOW THREE THINGS RATHER THAN ONE. (a) The eu334 regime differs in
+ways these fixtures do not reproduce — T = 10 against 2, a RAMPING mu, 13 components, DDI,
+kappa = 1.8, and a SEED at 11530 rather than a field grown from zero. (b) Neither arm may
+have reached its stationary state: #418 read a plateau as arrival, and at production M the
+channel is slow enough that a plateau is weak evidence (400 steps move mu-tilde by 1e-4).
+(c) The equilibrium bracket in this row rests on Thomas-Fermi plus an ideal-gas density of
+states and could simply be wrong for that regime — in which case growth-only landing inside
+it was luck, and that possibility is now on the table rather than assumed away.
+
+WHAT IT STILL OVERTURNS. #418 closed with "not a defect, two steady states, the full arm has
+ARRIVED". The arrival is what (b) doubts. And the threat to the flower nucleation result
+stays dissolved either way: the equilibrium sits ABOVE the flower minimum atom number
+N0* ~= 1.5e4 and growth-only lands there, so "a more complete theory forbids flower" needs
+the full arm to be AT its equilibrium, which nothing now asserts.
 
 WHAT THIS OVERTURNS. #418 closed with "not a defect, two different steady states, the full arm
 has ARRIVED rather than failed". The arrival is confirmed; the destination is not the


### PR DESCRIPTION
## 測定（数分、既存フィクスチャの再利用）

`test/dynamics/test_spgpe.jl` には自由場フィクスチャ（c₀=0、トラップなし）があり `ε_k = k²/2` が厳密なので `N_C^eq = Σ_{|k|<k_cut} T/(ε_k − µ)` が一意です。**そしてそれは M = 0.0（エネルギー減衰オフ）で走っています** — つまり growth チャネルの定常分布しかゲートしていない。

M を入れ、相互作用とトラップを1軸ずつ足しました:

| フィクスチャ | M = 0 | M = 1.628e−3（production） | 比 |
|---|---|---|---|
| 自由場 | 4349.31 | 4338.87 | **0.9976** |
| 相互作用あり・トラップなし | 1575.92 | 1575.04 | **0.9994** |
| 相互作用＋トラップ | 687.04 | 686.94 | **0.9999** |
| 弱相互作用＋トラップ | 833.99 | 834.00 | **1.0000** |

production の 60 倍（M=0.1）では自由場が 0.8974 に落ちる一方、**相互作用＋トラップは 0.9831 でより鈍感**。「位相ノイズが凝縮体を非コヒーレント化する」の予測と**逆向き**です。

⇒ **#485 の候補①（drift/noise の FD 関係が誤り）は、平衡が既知の場所では production 強度で反証。** 補強2点: チャネルは N を **1.9e−16** で保存（純位相なので原理的に原子を取れない）· 加熱率は T = 0.05〜1.0 で**線形**（FD の署名）。

## 文書化済みの誤りを繰り返しかけました

最初の probe は µ̃ を温度計に使い「quiet は冷やすのに pair は温める」を欠陥と読みました。**それは `field_chemical_potential` の docstring が名指しで警告している当のこと** — 「スカラーはモード分解の問いに答えられない、それを『駆動』と読んだら自分の対照に反証された結論が出た」。Rayleigh-Jeans フィクスチャがそのモード分解の答えで、逆を言っています。

## 前 PR で入れた行を `scoped` に

`spgpe-full-steady-state-is-not-the-equilibrium` — **数値は生きています**が、そこから引いた推論は死にました。残るのは1つではなく**3つ**:

1. **eu334 の regime が未再現** — T=10 対 2、µ がランプ、13 成分、DDI、κ=1.8、そして**ゼロから育てるのではなく 11530 の種から始まる**
2. **どちらの腕も定常に達していない可能性** — #418 はプラトーを到達と読んだが、production の M ではチャネルが遅く（400 step で µ̃ が 1e−4）、プラトーは弱い証拠
3. **TF + 理想気体の平衡見積りが誤っている可能性** — その場合 growth-only が範囲内に落ちたのは偶然。**前提から外さず選択肢として卓上に置きました**

flower の結論はどちらでも無傷です — 「より完全な理論が flower を禁止する」には full が**自分の平衡にいる**必要があり、それを今は誰も主張していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追加分 — 候補③も反証、そして新しい欠陥（#488）

### 候補③（種の位置）— 反証

これまでのフィクスチャは全部**ゼロから育てて**いて、eu334 は **11530 の種**（2つの運命の中間）から始まる。最有力の残りでした。同じ自由場フィクスチャ、3 つの開始 × 2 つの M:

| 開始 | M = 0 | M = production | final/RJ |
|---|---|---|---|
| ゼロ | 4405.1 | 4393.6 | 0.996 / 0.994 |
| 種 0.3× 平衡 | 4405.3 | 4393.7 | 0.996 / 0.994 |
| 種 3.0× 平衡 | 4409.4 | 4397.5 | 0.997 / 0.995 |

**6 腕すべて同じ値に着地。** 3 倍の種は ~1000 step で平衡まで降りてきます。⇒ 開始位置もチャネルも、着地点を選びません。

### 候補②を調べたら別の欠陥が出ました（#488 として起票）

**`coherent_population` は数値平衡に対して一度もゲートされていません。**

この関数は **Bose** 分布を**理想調和準位**上で和を取り、**µ 以下の準位を全部飛ばします** — 実装コメントの理由は「TF では µ ≫ ε₀ なので、それらは `N_0(mu)` が数える凝縮体に吸収される」。

**その仮定を破ると 7〜10 倍ずれます**（c₀ を大きくして TF 凝縮体を 1〜3 原子にすると、µ 以下の準位は何にも吸収されない）:

| T | µ | c₀ | κ | 数値平衡 | 公式 | 比 |
|---|---|---|---|---|---|---|
| 2 | 4 | 20 | 1.8 | **427.8** | 53.8 | **7.96** |
| 2 | 4 | 50 | 1.8 | **370.7** | 53.2 | **6.97** |
| 5 | 6 | 50 | 1.8 | **1492.7** | 206.7 | **7.22** |
| 2 | 4 | 50 | 1.0 | **501.7** | 49.6 | **10.12** |

差は全部**熱項**（TF 項は 1〜3 原子）。**ゲートが無い理由**: 既存の RJ テストは**テスト内で RJ 和を計算**していて、この関数を呼んでいません。

### #454 の bracket は生きています

条件は `N₀_TF ≫ N_C^th`。**eu334 は満たす** — c₀ = 0.046873 で `N₀_TF = 1.7〜3.4×10⁴` 対 熱項 1.5×10³。probe は c₀ が 400〜1000 倍大きく条件の外。

⇒ bracket は**未検証の公式ではなく、名前のついた条件**に立つようになりました。台帳行に記録済み。

### #485 に残っているもの

- **µ がランプすること** — フィクスチャは全部 reservoir 固定。eu334 だけが動く
- **γ が導出値で、フィクスチャの強制値 0.05 よりはるかに小さい可能性** — その場合どちらの腕も収束していない

### 追加の検証

直前コミットの CI は **GREEN**（7 unit）。`test_retracted_numbers_carry_their_replacement.jl` 13 testset 緑。