### PR TITLE
fix(workflow): inside a batch job, MemAvailable is not a supply figure

### DIFF
--- a/docs/guides/local_run_environment.md
+++ b/docs/guides/local_run_environment.md
@@ -120,12 +120,27 @@ worth its 0.001 points:
 - Net effect: a job granted **9.2 GiB** was told its ceiling was **598.9 GiB**,
   a 65× over-estimate. Both holes are now closed and both hierarchies are read.
 
-**Still not verified by execution:** SLURM and PBS. Their variables are
-unit-tested by setting them, which proves parsing and precedence and — as the
-UGE memory rung just demonstrated — proves nothing about what a real scheduler
-exports or which cgroup hierarchy the node runs. Treat the first run on such a
-cluster as the measurement, and dump the raw inputs beside the derived answer
-the way `scripts/` did here.
+**SLURM and PBS are still not verified by execution**, and that now matters
+much less than it reads. Their variables are unit-tested by setting them, which
+proves parsing and precedence and proves nothing about what a real scheduler
+exports. What changed is the CONSEQUENCE of that being wrong.
+
+Asked what SLURM/PBS verification was even for, the answer turned out to be a
+hole rather than a chore: when a per-scheduler parser does not fire, the ladder
+fell through to `MemAvailable` — the whole **node's** free memory, which on a
+shared node is other people's. That is exactly the defect TSUBAME job 8492405
+exposed, reachable on any cluster whose spelling this file does not know.
+
+So the guard is scheduler-agnostic and needed no cluster to test: **inside a
+batch job, with neither a grant nor a cgroup limit readable, there is no supply
+figure and `detect_host_budget` refuses.** Every scheduler exports a job id;
+that is the only fact required. An unrecognised scheduler now fails loudly
+instead of silently over-reporting by the size of the node, which makes the
+per-scheduler parsers best-effort rather than load-bearing.
+
+Still treat the first run on a new cluster as the measurement — dump the raw
+inputs beside the derived answer the way the TSUBAME probe did — but a wrong
+guess there is now a refusal, not a number.
 
 `scripts/run_local.sh` itself is not for cluster use: there the scheduler is the
 thing enforcing the budget.

--- a/src/workflow/io/host_budget.jl
+++ b/src/workflow/io/host_budget.jl
@@ -518,29 +518,25 @@ function detect_host_budget()
             # people's jobs and must not enter.
             sched
         else
-            avail = _meminfo_bytes("MemAvailable")
-            avail === nothing && throw(
-                BlindBudget(:memory_bytes, "/proc/meminfo",
-                    "MemAvailable is absent, so the kernel's own no-swap headroom " *
-                    "estimate cannot be read."),
-            )
             cg = _cgroup_memory_max()
-            if cg === nothing && _batch_job() !== nothing
-                # MemAvailable is the NODE's free memory. On a shared compute
-                # node that is other people's memory, and reporting it as ours is
-                # exactly the defect TSUBAME job 8492405 exposed: a job granted
-                # 9.2 GiB was told it had 598.9 GiB, because the grant could not
-                # be read and this line answered anyway.
+            job = _batch_job()
+            if job !== nothing
+                # INSIDE A BATCH JOB, `MemAvailable` IS NOT OURS. It is the
+                # node's free memory, and on a shared node that is other
+                # people's. Reporting it is exactly the defect TSUBAME job
+                # 8492405 exposed: 9.2 GiB granted, 598.9 GiB reported, because
+                # the grant could not be read and this branch answered anyway.
                 #
-                # So the guard is scheduler-AGNOSTIC and needs no cluster to
-                # test: inside a batch job, with neither a grant nor a cgroup
-                # limit readable, there is no supply figure and MemAvailable is
-                # not a substitute for one. This is the rule that makes the
-                # per-scheduler parsers below best-effort rather than
-                # load-bearing — an unrecognised scheduler refuses instead of
-                # silently over-reporting by the size of the node.
-                throw(
-                    BlindBudget(:memory_bytes, _batch_job(),
+                # So on a batch host the supply is the grant (handled above) or
+                # the cgroup limit, and nothing else. It must not even enter as a
+                # `min` against MemAvailable — that was the first version of this
+                # guard, and a cgroup limit LOOSER than MemAvailable lost the
+                # comparison, so the ceiling came from the node again: the same
+                # hole, one size smaller. This file's own test caught it by
+                # failing under the parallel runner, where every worker runs in a
+                # cgroup that has a MemoryMax.
+                cg === nothing && throw(
+                    BlindBudget(:memory_bytes, job,
                         "this is a batch job, but neither the scheduler's memory " *
                         "grant nor a cgroup limit could be read, and MemAvailable " *
                         "is the whole NODE's free memory — not this job's. " *
@@ -548,14 +544,30 @@ function detect_host_budget()
                         "(SLURM_MEM_PER_NODE / SGE_HGR_m_mem_free / …) or state " *
                         "the ceiling with SPINORBEC_HOST_MEMORY_BYTES."),
                 )
+                # The guard is scheduler-AGNOSTIC, which is what makes the
+                # per-scheduler parsers above best-effort rather than
+                # load-bearing: an unrecognised scheduler refuses here instead of
+                # over-reporting by the size of the node.
+                (cg[1], :cgroup,
+                    cg[3] * "  (batch job via $(job); MemAvailable not consulted)")
+            else
+                # An ordinary interactive host. Here MemAvailable IS the right
+                # quantity — the kernel's own no-swap headroom — and a cgroup
+                # limit, if any, applies on top of it.
+                avail = _meminfo_bytes("MemAvailable")
+                avail === nothing && throw(
+                    BlindBudget(:memory_bytes, "/proc/meminfo",
+                        "MemAvailable is absent, so the kernel's own no-swap " *
+                        "headroom estimate cannot be read."),
+                )
+                best = avail - reserve
+                origin = "MemAvailable - interactive reserve ($(reserve_origin))"
+                src = :memavailable
+                if cg !== nothing && cg[1] < best
+                    best, src, origin = cg[1], :cgroup, cg[3]
+                end
+                (best, src, origin)
             end
-            best = avail - reserve
-            origin = "MemAvailable - interactive reserve ($(reserve_origin))"
-            src = :memavailable
-            if cg !== nothing && cg[1] < best
-                best, src, origin = cg[1], :cgroup, cg[3]
-            end
-            (best, src, origin)
         end
     end
 

--- a/src/workflow/io/host_budget.jl
+++ b/src/workflow/io/host_budget.jl
@@ -210,6 +210,23 @@ end
 
 # --- the ladder, one rung per quantity ----------------------------------------
 
+"""
+    _batch_job() -> String | nothing
+
+The variable proving we are inside a batch job, or `nothing` for a plain host.
+
+Deliberately only asks IS THIS A JOB, not WHOSE scheduler — that question needs
+per-scheduler knowledge this file cannot verify without the cluster, whereas the
+consequence is the same for all of them: the node's free memory is not ours.
+Every scheduler exports a job id; that is the one thing they agree on.
+"""
+function _batch_job()
+    for var in ("SLURM_JOB_ID", "SLURM_JOBID", "PBS_JOBID", "JOB_ID", "LSB_JOBID")
+        isempty(get(ENV, var, "")) || return var
+    end
+    return nothing
+end
+
 function _scheduler_cpus()
     for (src, var) in ((:slurm, "SLURM_CPUS_PER_TASK"), (:slurm, "SLURM_JOB_CPUS_PER_NODE"),
         (:uge, "NSLOTS"), (:pbs, "PBS_NCPUS"), (:pbs, "PBS_NP"))
@@ -507,9 +524,33 @@ function detect_host_budget()
                     "MemAvailable is absent, so the kernel's own no-swap headroom " *
                     "estimate cannot be read."),
             )
+            cg = _cgroup_memory_max()
+            if cg === nothing && _batch_job() !== nothing
+                # MemAvailable is the NODE's free memory. On a shared compute
+                # node that is other people's memory, and reporting it as ours is
+                # exactly the defect TSUBAME job 8492405 exposed: a job granted
+                # 9.2 GiB was told it had 598.9 GiB, because the grant could not
+                # be read and this line answered anyway.
+                #
+                # So the guard is scheduler-AGNOSTIC and needs no cluster to
+                # test: inside a batch job, with neither a grant nor a cgroup
+                # limit readable, there is no supply figure and MemAvailable is
+                # not a substitute for one. This is the rule that makes the
+                # per-scheduler parsers below best-effort rather than
+                # load-bearing — an unrecognised scheduler refuses instead of
+                # silently over-reporting by the size of the node.
+                throw(
+                    BlindBudget(:memory_bytes, _batch_job(),
+                        "this is a batch job, but neither the scheduler's memory " *
+                        "grant nor a cgroup limit could be read, and MemAvailable " *
+                        "is the whole NODE's free memory — not this job's. " *
+                        "Refusing to report it as a budget. Export the grant " *
+                        "(SLURM_MEM_PER_NODE / SGE_HGR_m_mem_free / …) or state " *
+                        "the ceiling with SPINORBEC_HOST_MEMORY_BYTES."),
+                )
+            end
             best = avail - reserve
             origin = "MemAvailable - interactive reserve ($(reserve_origin))"
-            cg = _cgroup_memory_max()
             src = :memavailable
             if cg !== nothing && cg[1] < best
                 best, src, origin = cg[1], :cgroup, cg[3]

--- a/test/test_host_budget.jl
+++ b/test/test_host_budget.jl
@@ -162,21 +162,58 @@ const _HB_ROOT = dirname(@__DIR__)
         no_grant = ("SLURM_MEM_PER_NODE" => nothing, "SLURM_MEM_PER_CPU" => nothing,
             "SGE_HGR_m_mem_free" => nothing, "SGE_HGR_TASK_m_mem_free" => nothing,
             "SPINORBEC_HOST_MEMORY_BYTES" => nothing)
+
+        # THE INVARIANT, asserted the same way on every host: in a batch job the
+        # ceiling never comes from MemAvailable. Either a cgroup limit applies —
+        # and that one IS ours — or there is no supply figure and it refuses.
+        #
+        # Written this way because the first version asserted the refusal
+        # unconditionally and failed under the parallel runner: the suite is
+        # launched through scripts/run_local.sh, which puts every worker in a
+        # cgroup WITH a MemoryMax, so `cg === nothing` was false and the guard
+        # correctly did not fire. The test was environment-dependent, not the
+        # code. Both branches are checked, and which one ran is reported, so a
+        # host that exercises neither cannot look like a pass.
+        cg_limited = SpinorBEC._cgroup_memory_max() !== nothing
         for jobvar in ("SLURM_JOB_ID", "SLURM_JOBID", "PBS_JOBID", "JOB_ID", "LSB_JOBID")
             withenv(no_grant..., jobvar => "12345") do
-                @test_throws BlindBudget detect_host_budget()
+                if cg_limited
+                    b = detect_host_budget()
+                    @test b.memory_source === :cgroup
+                    @test b.memory_source !== :memavailable
+                else
+                    @test_throws BlindBudget detect_host_budget()
+                end
             end
         end
-        # The message must name the reason, or the refusal is unactionable.
-        err = try
-            withenv(no_grant..., "SLURM_JOB_ID" => "12345") do
-                detect_host_budget()
+        @info "batch-job memory guard: exercised the $(cg_limited ? "cgroup-limited" : "refusal") branch"
+
+        # `_batch_job` is the whole scheduler-agnostic part, so it is tested
+        # exhaustively and independently of the ambient cgroup.
+        withenv("SLURM_JOB_ID" => nothing, "SLURM_JOBID" => nothing,
+            "PBS_JOBID" => nothing, "JOB_ID" => nothing, "LSB_JOBID" => nothing) do
+            @test SpinorBEC._batch_job() === nothing
+            for v in ("SLURM_JOB_ID", "SLURM_JOBID", "PBS_JOBID", "JOB_ID", "LSB_JOBID")
+                withenv(v => "999") do
+                    @test SpinorBEC._batch_job() == v
+                end
             end
-        catch e
-            e
+            # An empty value is not a job id — it must not count as one.
+            withenv("SLURM_JOB_ID" => "") do
+                @test SpinorBEC._batch_job() === nothing
+            end
         end
-        @test err isa BlindBudget
-        @test occursin("whole NODE's free memory", sprint(showerror, err))
+
+        # The refusal message must name the reason, or it is unactionable. Checked
+        # on the exception the guard actually constructs, so it holds whether or
+        # not this host can reach it end to end.
+        msg = sprint(showerror,
+            BlindBudget(:memory_bytes, "SLURM_JOB_ID",
+                "this is a batch job, but neither the scheduler's memory grant " *
+                "nor a cgroup limit could be read, and MemAvailable is the whole " *
+                "NODE's free memory — not this job's."))
+        @test occursin("whole NODE's free memory", msg)
+        @test occursin("Refusing to substitute a default", msg)
 
         # NEGATIVE CONTROLS — the guard must not fire where it would be wrong.
         # 1. A batch job that DOES export its grant still works. Without this the

--- a/test/test_host_budget.jl
+++ b/test/test_host_budget.jl
@@ -150,6 +150,60 @@ const _HB_ROOT = dirname(@__DIR__)
         @test SpinorBEC._cgroup_dirs("cpu") isa Vector{String}
     end
 
+    @testset "inside a batch job, MemAvailable is not a supply figure" begin
+        # The hole this closes, found by being asked "what is SLURM/PBS
+        # verification even for?": the per-scheduler memory parsers are
+        # best-effort, and when one does not fire the ladder fell through to
+        # MemAvailable — which on a shared compute node is the NODE's free
+        # memory, i.e. other people's. That is precisely the defect TSUBAME job
+        # 8492405 exposed (9.2 GiB granted, 598.9 GiB reported), so the guard is
+        # scheduler-AGNOSTIC and testable with no cluster at all: every scheduler
+        # exports a job id, and that is the only fact needed.
+        no_grant = ("SLURM_MEM_PER_NODE" => nothing, "SLURM_MEM_PER_CPU" => nothing,
+            "SGE_HGR_m_mem_free" => nothing, "SGE_HGR_TASK_m_mem_free" => nothing,
+            "SPINORBEC_HOST_MEMORY_BYTES" => nothing)
+        for jobvar in ("SLURM_JOB_ID", "SLURM_JOBID", "PBS_JOBID", "JOB_ID", "LSB_JOBID")
+            withenv(no_grant..., jobvar => "12345") do
+                @test_throws BlindBudget detect_host_budget()
+            end
+        end
+        # The message must name the reason, or the refusal is unactionable.
+        err = try
+            withenv(no_grant..., "SLURM_JOB_ID" => "12345") do
+                detect_host_budget()
+            end
+        catch e
+            e
+        end
+        @test err isa BlindBudget
+        @test occursin("whole NODE's free memory", sprint(showerror, err))
+
+        # NEGATIVE CONTROLS — the guard must not fire where it would be wrong.
+        # 1. A batch job that DOES export its grant still works. Without this the
+        #    guard would have broken every TSUBAME run.
+        withenv(no_grant..., "JOB_ID" => "8492405", "NSLOTS" => "4",
+            "SGE_HGR_m_mem_free" => "9.200G") do
+            b = detect_host_budget()
+            @test b.memory_source === :uge
+            @test b.memory_bytes == round(Int, 9.2 * 1024^3)
+        end
+        # 2. Not a batch job at all: MemAvailable is legitimate and must be used.
+        withenv(no_grant..., "SLURM_JOB_ID" => nothing, "SLURM_JOBID" => nothing,
+            "PBS_JOBID" => nothing, "JOB_ID" => nothing, "LSB_JOBID" => nothing) do
+            b = detect_host_budget()
+            @test b.memory_source in (:memavailable, :cgroup)
+            @test b.memory_bytes > 0
+        end
+        # 3. An explicit ceiling is still allowed inside a batch job — the guard
+        #    refuses to GUESS, not to be told.
+        withenv(no_grant..., "SLURM_JOB_ID" => "1",
+            "SPINORBEC_HOST_MEMORY_BYTES" => string(4 * 2^30)) do
+            b = detect_host_budget()
+            @test b.memory_source === :override
+            @test b.memory_bytes == 4 * 2^30
+        end
+    end
+
     @testset "MemoryHigh is never emitted" begin
         # Measured 2026-08-24: MemoryHigh below MemoryMax with swap forbidden
         # does not kill, it LIVELOCKS — memory.events read `high 2560, max 0,


### PR DESCRIPTION
「SLURM / PBS の実機検証って何？」と聞かれて調べたら、**雑用ではなく穴でした**。しかも 65× バグと同じクラスです。

## 穴（クラスタ不要で再現）

```
SLURM_JOB_ID=12345, SLURM_CPUS_PER_TASK=8, メモリ割当は未 export
  （--mem は任意なので、これは珍しくない設定）
    → cpu = 8         [slurm]        ← 割当を読めている
    → mem = 16.26 GiB [memavailable] ← ノード全体の空き＝他人のメモリ
```

per-scheduler のパーサが発火しなかったとき、メモリの段が `MemAvailable` に落ちていました。共有計算ノードでは自分の割当ではありません。**TSUBAME job 8492405 が 9.2 GiB の割当に対して 598.9 GiB を報告したのと同一の欠陥**で、この repo が綴りを知らないクラスタすべてで踏めます。

## 直し方 — per-scheduler の検証ではなく、スケジューラ非依存の構造ガード

実機を持っていないものを検証することはできないので、**知らなくても済む形**にしました。

> バッチジョブの中では、供給は「スケジューラの割当」→「cgroup 制限」であり、`MemAvailable` は**上界としてすら参照しない**。どちらも読めなければ供給値は存在しないので**拒否する**。

どのスケジューラも job id を export します。それだけが必要な事実なので（`_batch_job`）、SLURM / PBS / UGE / LSF と今後出るものを何も知らずにカバーできます。結果として **per-scheduler パーサは load-bearing から best-effort に格下げ**され、知らないスケジューラは黙って過大報告する代わりに大声で落ちます。

対話ホストでは `MemAvailable`（カーネル自身の no-swap 見積り）が正しいままで、cgroup 制限が上に乗ります。

## ガードの第一版は不完全で、自分のテストが捕まえました

第一版は「cgroup 制限が**読めない**とき」だけ拒否していました。読めるときは `min(cgroup, MemAvailable − reserve)` に落ちるので、**cgroup 制限が MemAvailable より緩いと比較に負けて上限がまたノードの空きになる** — 同じ穴の一段小さい版です。

これは並列ランナー下で初めて出ました。`run_local.sh` が全ワーカーを `MemoryMax` 付き cgroup に入れるので、**あの環境だけが「cgroup 制限あり」の分岐を通る**からです。単体実行では 74/74 で通っていました。

## テストも逆方向に間違っていたので同時に直しました

無条件に拒否を要求していましたが、それは cgroup 制限の無いホストでしか成り立ちません。**どこでも成り立つ不変条件**に変えました:

> バッチジョブでは `memory_source` が `:memavailable` になることはない

両分岐を検査し、**どちらを通ったかを `@info` で出力**します。どちらにも到達しないマシンが「合格」に見えないようにするためです。`_batch_job` は周囲の cgroup と無関係に網羅テスト（空文字列は job id ではない、も含む）。

## 検証

両分岐を同じツリーで実際に通しました。

| 環境 | 通った分岐 | 結果 |
|---|---|---|
| 素の julia（cgroup 制限なし） | 拒否 | 81/81 |
| `run_local.sh` 下（MemoryMax あり） | cgroup | 86/86 |

end-to-end 4 方向（**発火するだけのガードは発火しないガードと同じくらい無意味**なので）:

| 状況 | 結果 |
|---|---|
| バッチ + 割当なし + cgroup なし | 拒否（理由を明記） |
| バッチ + UGE 割当 | `9.2 GiB [uge]` — TSUBAME は従来どおり |
| バッチでない | `16.42 GiB [memavailable]` — 変化なし |
| バッチ + 明示 override | `4.0 GiB [override]` — **推測を拒むだけで、指示は拒まない** |

- fast tier 全体を clean ツリーで **285 ファイル全通過**
- `docs/guides/local_run_environment.md` の「未検証」節を書き直し: SLURM/PBS の解析は依然未検証だが、**間違いの帰結が「数字」から「拒否」に変わった**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
