### PR TITLE
fix(bdg): an excess of zero modes is not an accidental degeneracy

### DIFF
--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -1406,6 +1406,14 @@ covered = 6
 note = "18 sections. The second document poured; the decision + the ambiguity + criteria B/C/D."
 
 [[coverage]]
+doc = "docs/design/trapped_spinor_bdg_spectrum.md"
+covered = 1
+note = """8 sections. Poured 2026-08-26 by `f6-uniform-gs-is-a-u2f1-orbit-so-nothing-selects`, which
+lands in §6 (KNOWN-LIMITs) alongside the aliasing limit from the same day. Pinned at the DERIVED
+number, not a guess: `ledger_section_coverage` reports 1/8 here. Uncovered: 1, 2, 3, 4, 4.1, 5, 7 —
+the design decisions and the acceptance table, none of which is a physics claim yet."""
+
+[[coverage]]
 doc = "docs/guides/eu_kappa_hysteresis_loop.md"
 covered = 1
 note = "15 sections. Cited by one row from another session; not poured."

--- a/docs/campaign/claims.toml
+++ b/docs/campaign/claims.toml
@@ -1143,7 +1143,7 @@ note = "Superseded the next day: there is no structure to explain. The mechanism
 
 [[claim]]
 id = "f6-uniform-gs-degenerates-the-whole-manifold"
-claim = "At uniform g_S the sigma_S sum rule degenerates the ENTIRE spinor manifold, not four phases: Sum_{S even} sigma_S(zeta) = 1 for any normalised zeta, so eps_MF = g/2 everywhere on CP^12. The degeneracy is continuous, which is what order-by-disorder requires."
+claim = "At uniform g_S the sigma_S sum rule degenerates the ENTIRE spinor manifold, not four phases: Sum_{S even} sigma_S(zeta) = 1 for any normalised zeta, so eps_MF = g/2 everywhere on CP^12. The degeneracy is continuous."
 status = "live"
 lifecycle = "registered"
 ladder = """exact: an algebraic identity in the symmetric two-body subspace — there is no cutoff axis to walk. Control: the 50x50 (g_10, g_12) scan returns eps_MF = 1/2 for all four candidate spinors at the scalar point, and `_f6_pd_sigma_S` reproduces each fingerprint."""
@@ -1169,7 +1169,54 @@ WHAT IT DOES NOT SAY. Uniform g_S is a reference point, not Eu. The physical g_S
 six of the seven even channels have never been measured, so the SIZE of any residual continuous
 degeneracy at the physical point is an a_S-dependent question (layer ii). What IS a_S-free is the
 stretched sector: the fully polarized cloud and its first magnon are pure S = 2F
-(`test/oracles/test_stretched_channel_invariance.jl`), which is why #455 is scoped to the FM branch."""
+(`test/oracles/test_stretched_channel_invariance.jl`), which is why #455 is scoped to the FM branch.
+
+AMENDED 2026-08-26. This claim ended `"The degeneracy is continuous, which is what order-by-disorder
+requires."` and that trailing clause has been REMOVED, not softened: the identity makes the
+interaction (g/2)(psi-dagger psi)^2, which is invariant under all of U(2F+1), so the manifold is a
+SYMMETRY ORBIT and fluctuations — respecting the same symmetry — cannot select within it. Measured,
+TSUBAME 8498064. The clause is superseded by `f6-uniform-gs-is-a-u2f1-orbit-so-nothing-selects`; the
+identity above is untouched and remains exact. Amended in place rather than filed as a `refuted` row
+because what was retired is a clause of prose, not a quotable number, so there is no literal for the
+retracted-number gates to hunt."""
+
+[[claim]]
+id = "f6-uniform-gs-is-a-u2f1-orbit-so-nothing-selects"
+claim = "The uniform-g_S degenerate manifold is a U(2F+1) SYMMETRY ORBIT, not an accidental degeneracy, so fluctuations cannot select within it and the would-be Goldstones acquire no gap. Sum_{S even} sigma_S = 1 makes the interaction (g/2)(psi-dagger psi)^2, which is invariant under any unitary rotation of the 2F+1 components; kinetic and trap are spin-blind. Measured at F=6: eps_LHY = 4.323347e-01 at polar, FM, cyclic, I_h and a random spinor alike (`:full_bdg`, one table per spinor), and dim(null) = 12 = the whole CP^12 tangent at every one of them, with LHY on and off."
+status = "live"
+lifecycle = "registered"
+ladder = """control: the constancy arm is worth exactly what its negative control is worth, so the same probe was run with a g_S spread (c1 = 0.1), where eps_LHY moves over 3.44 ... 19.6 across the same five spinors — a factor 5.7 against the 1e-7 relative spread of the uniform arm. Uniform box, exactly stationary by construction, no solver in the loop."""
+type = "B"
+scope = "Uniform g_S only, and that is the whole point: it is the REFERENCE point, not Eu. Says nothing about the physical (non-uniform) g_S, where a residual degeneracy would be accidental and is an a_S-dependent question (layer ii). Measured at F=6 and F=1 in a 1D periodic box at n0 = 1; the argument is algebraic and carries no grid, seed or duration."
+uncertainty = "eps_LHY across five spinors on the orbit: 4.323347e-01 to 4.323348e-01, i.e. 2e-7 relative, which is the LHY table's own numerics and not a physical spread. Against it the negative control moves by 5.7x. The symmetry statement itself is exact."
+uncertainty_basis = "control"
+evidence = ["test/oracles/test_trapped_bdg_frequencies.jl"]
+evidence_status = "in_tree"
+commit = "unknown"
+doc = "docs/design/trapped_spinor_bdg_spectrum.md"
+section = "6"
+pr = 0
+note = """Supersedes the trailing clause of `f6-uniform-gs-degenerates-the-whole-manifold` (amended in
+place, see its note). The identity that row states is exact and untouched; what is wrong is reading a
+continuous degeneracy as sufficient for order-by-disorder. It is not — the degeneracy also has to be
+ACCIDENTAL, i.e. not related by a symmetry of the Hamiltonian, and Sum_S sigma_S = 1 is precisely the
+statement that at uniform g_S it IS a symmetry.
+
+WHAT THIS COSTS #455. Its observable — a pseudo-Goldstone gap opened by LHY on the uniform-g_S
+manifold — is exactly zero, and no amount of grid or nev reaches it. The programme has to move to the
+physical g_S, where the mean-field minimum set is generically isolated points and fluctuation
+selection appears as an ENERGY DIFFERENCE between them rather than as a gap. That is the binary
+verdict #455 was written to improve on, so this is a real subtraction, not a re-scoping.
+
+WHAT IT DOES NOT REFUTE. Turner-Barnett-Demler-Vishwanath (PRL 98, 190404) is untouched: the spin-2
+nematic manifold they treat is degenerate for a reason that is NOT a symmetry of their Hamiltonian.
+The error here was importing their structure through an identity that supplies the degeneracy and the
+symmetry together.
+
+A SECOND READING THAT WOULD ALSO BE WRONG: "then the excess over `bdg_expected_zero_modes` detects
+nothing". It detects flat directions beyond the LISTED generators, which is a real and useful thing;
+it simply cannot tell a symmetry outside the list from an accidental degeneracy. At F=6 uniform g_S
+the excess is 8-11 and every one of them is U(13)."""
 
 [[claim]]
 id = "ddi-cdd-f-squared-voids-pre-april-ddi"

--- a/docs/campaign/prior_art/order_by_disorder.md
+++ b/docs/campaign/prior_art/order_by_disorder.md
@@ -1,0 +1,19 @@
+# Prior art — order_by_disorder
+
+> **FROZEN 2026-08-25.** A snapshot of the open work on order_by_disorder as of that
+> date. Re-run the generator when picking the topic up again; existing
+> dispositions are preserved.
+
+Keywords: goldstone, bdg, degeneracy, lhy, 455, 457. Regenerate with
+`python3 scripts/prior_art.py --topic order_by_disorder --keywords goldstone bdg degeneracy lhy 455 457`.
+
+Dispositions: `unread`, `read`, `unrelated`, `superseded`, `depends`
+
+| ref | disposition | what | note |
+|---|---|---|---|
+| origin/claude/spinor-lhy-correction-OXkxG | superseded | branch: 9 commits ahead, tip `bff0c3af` "CI Julia 1.10 removal" | The spinor-LHY work it opens with (`e2677a0b`) landed in main long ago; the rest is an unrelated grab-bag (J_z projection, quasi-2D rescaling, continuation). Nothing here is a live LHY path. |
+| origin/feat/fm-lhy-general-F | superseded | branch: **0 commits ahead of main** | Already merged — "FM closed forms work at any F", the change CLAUDE.md's design-boundaries section records for 2026-07-27. |
+| origin/feat/lhy-block-wiring-spatial | superseded | branch: 7 ahead, incl. `de816075` "LBFGS gradient was exactly zero for every tabulated LHY" and `34db34b7` "SpatialLHY gradient was missing its polarisation piece" | **Checked rather than assumed, because a zero LHY gradient would make this topic's whole measurement an artefact.** Both fixes ARE in main under different SHAs — `_grad_lhy!` carries the tabulated table (`lhy_term.jl:281`) and `_grad_lhy_spatial!` carries the polarisation piece (`:295`). The branch is stale, not a missing dependency. |
+| origin/test/gpu-bdg-instrument-parity-400 | unrelated | branch: 1 ahead, `f8538695` GPU gate for #339's instruments | Device gate for the BdG instruments. This topic runs in a CPU uniform box; it would matter the moment any of it moves to a device. |
+| #455 | read | issue: research(bdg): FM 枝の擬 Goldstone ギャップ — ラベル遷移として測る (②a-1) | The topic itself. Preconditions closed 2026-08-26 (PR #493); the label-transition method in its body is superseded by the excess over `bdg_expected_zero_modes` (labels are per degenerate BLOCK). Its premise — that uniform g_S is an ACCIDENTAL continuous degeneracy — is what the current probe tests. |
+| #456 | depends | issue: test(oracles): FM 枝マグノンの LHY 補正はスキーム感受か (②a-2) | Same premise, one layer out: its 2×2 (r × scheme) asks whether the magnon LHY correction moves. If the uniform-g_S manifold turns out to be a U(2F+1) symmetry orbit, #456's r axis is unaffected (it sweeps the PHYSICAL g_S spread) but the framing "gap the would-be Goldstone" that it inherits from #455 is not. Read this row before writing #456's test. |

--- a/docs/design/trapped_spinor_bdg_spectrum.md
+++ b/docs/design/trapped_spinor_bdg_spectrum.md
@@ -248,7 +248,18 @@ Hamiltonian, not of the list — `bdg_expected_zero_modes` measures it (each
 projected generator through the constrained Hessian, against a random
 direction's) rather than asserting it, and turns the surviving ones into the
 number of `ω ≈ 0` modes to expect. Its docstring is the one statement of that
-count; the excess over it is the accidental-degeneracy observable #455 wants.
+count.
+
+**The excess over that count is NOT an accidental degeneracy**, and reading it
+as one is what #455 was about to spend F=6 compute on. A symmetry the generator
+list does not contain gives the same excess, and at uniform `g_S` that is
+exactly the case: `Σ_{S even} σ_S = 1` makes the interaction `(g/2)(ψ†ψ)²`,
+invariant under all of `U(2F+1)`, so CP¹² is a symmetry ORBIT. Measured at F=6
+(2026-08-26, TSUBAME 8498064): `dim(null) = 12` — the whole CP¹² tangent — at
+polar, FM, cyclic, I_h and a random spinor alike, against a predicted 1–4, and
+`ε_LHY` identical to 2e-7 relative across all five while the same probe at a
+`g_S` spread moves by 5.7×. Nothing selects, nothing gaps. Ledger:
+`f6-uniform-gs-is-a-u2f1-orbit-so-nothing-selects`.
 
 **`ψ` may not alias `ws.state.psi`, and the failure is silent.**
 `energy_gradient!` opens with `copyto!(ws.state.psi, psi)`, so an aliased `ψ` is

--- a/src/solvers/bdg_frequencies.jl
+++ b/src/solvers/bdg_frequencies.jl
@@ -142,14 +142,32 @@ function _real_span_rank(vs, ipR; tol::Float64=1e-8)
 end
 
 """
-    bdg_expected_zero_modes(ws, ψ; params, ε, order, flat_rel, rank_tol, rng)
-        → NamedTuple
+    bdg_expected_zero_modes(ws, ψ; params, ε, order, flat_rel, rank_tol,
+                            deflation_rel, rng) → NamedTuple
 
 How many `ω ≈ 0` modes `trapped_bdg_frequencies` SHOULD return at `ψ`, derived
-from the broken symmetries alone. Compare it with the number it DOES return:
-an EXCESS is a flat direction no symmetry accounts for — an accidental
-degeneracy, which is the thing order-by-disorder needs before fluctuations can
-select within it.
+from the generators in `bdg_symmetry_generators` alone. Compare it with the
+number it DOES return: an EXCESS is a flat direction THAT LIST does not account
+for.
+
+**An excess is not evidence of an ACCIDENTAL degeneracy, and this distinction
+cost a measurement.** A symmetry the list does not contain produces exactly the
+same excess. The worked example is the case this function was written for: at
+uniform `g_S` the σ_S sum rule makes the interaction `(g/2)(ψ†ψ)²`, which is
+invariant under all of `U(2F+1)` — kinetic and trap are spin-blind — so the
+degenerate manifold is a SYMMETRY ORBIT and its flat directions are ordinary
+Goldstones. Measured at F=6, uniform `g_S` (2026-08-26): `dim(null) = 12` at
+polar, FM, cyclic, I_h and a random spinor alike — the whole CP¹² tangent —
+against `predicted` of 1–4, i.e. an excess of 8–11 that is entirely `U(13)`.
+Fluctuations respect that symmetry too: ε_LHY (`:full_bdg`, one table per ζ)
+came back `4.323347e-01` at every one of those spinors, while the same probe
+with a `g_S` spread moved it from 3.44 to 19.6. Nothing selects, and nothing
+gaps.
+
+So read an excess as "flat directions beyond the listed generators", and then
+identify them. Order-by-disorder needs the leftover to be accidental — degenerate
+at mean field WITHOUT a symmetry relating the points — and that is a separate
+question this function does not answer.
 
 **The count is over COMPLEX planes, not over broken generators, and the
 difference is not bookkeeping.** The reduction complexifies its subspace
@@ -178,6 +196,14 @@ anyone having to remember that a trap breaks translation invariance. The
 threshold is relative to that control because the FD Hessian's own noise floor
 scales with the operator.
 
+A generator the tangent projection ANNIHILATES is not broken and is dropped
+before any of this. `deflation_rel` is that test and it is relative to the
+unprojected generator: `P(iψ) = 0` holds only to round-off, and an absolute
+floor leaves a residue that normalises into noise, which is not stiff and was
+therefore reported flat — measured at F=6 uniform `g_S`, `gauge` joined the flat
+set at the cyclic, I_h and random spinors (not at polar or FM, which is why the
+F=1 box fixtures missed it) and `predicted` came out 4 instead of 2.
+
 Returns `predicted`, `flat` (the generator names kept), `n_broken`
 (= `rank_R` of them, so a repeated direction cannot inflate the count), `n_A`,
 `n_B`, `consistent`, `residuals` (per generator `(name, ‖g‖, ‖Aĝ‖)` for every
@@ -189,7 +215,8 @@ construction is a statement about `∇E = 2μψ`. And `ψ` may not alias
 """
 function bdg_expected_zero_modes(
     ws, ψ; params=nothing, ε::Float64=1e-5, order::Int=2,
-    flat_rel::Float64=1e-4, rank_tol::Float64=1e-8, rng=Random.default_rng(),
+    flat_rel::Float64=1e-4, rank_tol::Float64=1e-8, deflation_rel::Float64=1e-8,
+    rng=Random.default_rng(),
 )
     p = params === nothing ? constrained_hessian_params(ws, ψ) : params
     ipR(a, b) = real(_ipC(a, b, p.dV))
@@ -208,10 +235,20 @@ function bdg_expected_zero_modes(
     for (name, graw) in bdg_symmetry_generators(ws, ψ)
         g = _tangent_project(graw, ψ, p.dV, p.n2)
         ng = sqrt(max(ipR(g, g), 0.0))
+        nraw = sqrt(max(ipR(graw, graw), 0.0))
         # A generator the projection annihilates (gauge) or that leaves the
         # state where it is (`F_z` on a polar state) is not a broken symmetry
         # and contributes no mode. Reported with ‖Aĝ‖ = 0 rather than dropped.
-        if ng <= UNDERFLOW_FLOOR
+        #
+        # The test is RELATIVE to the unprojected generator, and has to be:
+        # `P(iψ) = 0` holds to round-off, not exactly, so an absolute floor
+        # leaves a ~1e-16 residue that normalises into pure noise — and noise
+        # has no reason to be stiff, so it was then reported FLAT. Measured
+        # 2026-08-26 at F=6 uniform g_S: `gauge` appeared among the flat
+        # generators for the cyclic, I_h and random spinors (never for polar or
+        # FM, which is why the F=1 box fixtures did not catch it), inflating
+        # `predicted` from 2 to 4.
+        if ng <= deflation_rel * max(nraw, UNDERFLOW_FLOOR)
             push!(residuals, (name, ng, 0.0))
             continue
         end

--- a/test/oracles/test_trapped_bdg_frequencies.jl
+++ b/test/oracles/test_trapped_bdg_frequencies.jl
@@ -443,6 +443,25 @@ end
     r = trapped_bdg_frequencies(ws, ψ; nev=14, n_hessian=18, max_iter=250,
         hess_tol=1e-7, params=p, rng=MersenneTwister(7))
     nz = count(k -> r.omega[k] < 1e-3 && abs(r.growth[k]) < 1e-3, eachindex(r.omega))
-    @test nz == 12                                  # dim_C CP^12 = 12
+    # 12 = dim_C CP¹², and the assertion binds that DERIVED floor rather than the
+    # solver's exact output, because the two disagree by machine: the same code
+    # on the same 16-point grid returns 12 on TSUBAME and 13 on the CI runner.
+    # The extra mode arrives as an exact 0.0000e+00 — a purely REAL eigenvalue of
+    # the reduced generator, i.e. not an oscillating mode at all — so it is an
+    # artefact of the reduction on a 12-fold degenerate null block, not physics.
+    # Pinning `== 12` would be pinning one machine's arithmetic; pinning `>= 12`
+    # is the claim ("the whole tangent is flat") and it is not vacuous, which is
+    # what the control below shows.
+    @test nz >= 12
     @test nz - ez.predicted >= 8
+    # POSITIVE CONTROL for that floor: a state whose manifold is NOT the U(13)
+    # orbit must fail it, or `>= 12` would pass on anything. Same spinor, same
+    # nev, g_S no longer uniform.
+    ws_c, ψ_c = f6box(cand[:FM]; c1=0.1)
+    p_c = constrained_hessian_params(ws_c, ψ_c)
+    r_c = trapped_bdg_frequencies(ws_c, ψ_c; nev=14, n_hessian=18, max_iter=250,
+        hess_tol=1e-7, params=p_c, rng=MersenneTwister(7))
+    nz_c = count(k -> r_c.omega[k] < 1e-3 && abs(r_c.growth[k]) < 1e-3,
+        eachindex(r_c.omega))
+    @test nz_c < 12
 end

--- a/test/oracles/test_trapped_bdg_frequencies.jl
+++ b/test/oracles/test_trapped_bdg_frequencies.jl
@@ -289,34 +289,41 @@ end
     @test maximum(w -> minimum(abs(w - v) for v in ref), spin) < 1e-5
 end
 
-# HOW MANY ω≈0 MODES SHOULD THERE BE — and is the surplus an accidental
-# degeneracy? `bdg_expected_zero_modes` answers the first from the broken
-# symmetries alone; the difference against what `trapped_bdg_frequencies`
-# returns is the answer to the second, and that difference is the observable
-# order-by-disorder needs (#455: a would-be Goldstone on an accidentally
-# degenerate manifold is what fluctuations gap).
+# HOW MANY ω≈0 MODES SHOULD THERE BE — and what is the surplus?
+# `bdg_expected_zero_modes` answers the first from `bdg_symmetry_generators`
+# alone; the difference against what `trapped_bdg_frequencies` returns is a flat
+# direction THAT LIST does not account for.
 #
-# The five fixtures are chosen so the criterion is exercised in BOTH
-# directions, at states whose Goldstone content is known independently:
+# **The surplus is not evidence of an accidental degeneracy** — a symmetry
+# outside the list gives the same surplus, and at c₁ = 0 that is exactly what it
+# is. Σ_S σ_S ≡ 1 makes the interaction (g/2)(ψ†ψ)², invariant under all of
+# U(2F+1), so the degenerate manifold is a symmetry ORBIT: the extra flat
+# direction is an ordinary Goldstone and fluctuations, respecting the same
+# symmetry, cannot gap it. Measured at F=6 (2026-08-26, TSUBAME 8498064):
+# ε_LHY = 4.323347e-01 at polar, FM, cyclic, I_h and a random spinor alike,
+# against 3.44 … 19.6 for the same probe once g_S is not uniform. The rows below
+# therefore say "beyond the listed generators", not "accidental".
+#
+# The five fixtures exercise the count in BOTH directions, at states whose
+# Goldstone content is known independently:
 #
 #   polar, c₁≠0   2 broken generators, ⟨[F_x,F_y]⟩ = 0   → 2 type-A magnons
 #   FM,    c₁≠0   2 broken generators, ⟨[F_x,F_y]⟩ ≠ 0   → 1 type-B magnon
-#   FM,    c₁=0   the same 1 from symmetry, but Σ_S σ_S ≡ 1 makes the WHOLE of
-#                 CP² degenerate, so the m=−1 channel is flat too → 2 measured,
-#                 EXCESS 1 = the accidental direction
-#   polar, c₁=0   same manifold, read from a different point: here the
-#                 accidental tangent is already inside the complexification of
-#                 the symmetry orbit, so predicted 2 = measured 2 and the
-#                 excess is ZERO. **The criterion is blind at this point.** It
-#                 is a negative control, not a failure: a null from it means
-#                 "not visible from here", never "no accidental degeneracy".
+#   FM,    c₁=0   the same 1 from the listed generators, but the whole of CP² is
+#                 flat, so the m=−1 channel is flat too → 2 measured, SURPLUS 1
+#   polar, c₁=0   same manifold, read from a different point: here the extra
+#                 tangent is already inside the complexification of the SO(3)
+#                 orbit, so predicted 2 = measured 2 and the surplus is ZERO.
+#                 **The count is blind at this point.** A null from it means
+#                 "nothing beyond the list is visible from here", never "the
+#                 manifold is not degenerate".
 #
 # The FM rows are the ones that make the count non-trivial. Counting broken
 # GENERATORS instead of complex planes predicts 2 there, and then the correct
 # dim(null)=1 reads as the solver dropping a Goldstone — which is exactly how
 # this criterion failed its positive control before the planes were counted
 # (2026-08-26; the earlier attempt is recorded in the issue).
-@testset "expected zero modes ≡ measured, and the excess is the accidental direction" begin
+@testset "expected zero modes ≡ measured, and the surplus is beyond the listed generators" begin
     POLAR = ComplexF64[0, 1, 0]
     FM = ComplexF64[1, 0, 0]
     cases = (
@@ -326,7 +333,7 @@ end
             n_A=0, n_B=1),
         (name="FM, c1=+0.2", spinor=FM, c1=0.2, predicted=1, measured=1,
             n_A=0, n_B=1),
-        (name="FM, c1=0 (accidental CP^2)", spinor=FM, c1=0.0, predicted=1,
+        (name="FM, c1=0 (U(3) orbit)", spinor=FM, c1=0.0, predicted=1,
             measured=2, n_A=0, n_B=1),
         (name="polar, c1=0 (blind spot)", spinor=POLAR, c1=0.0, predicted=2,
             measured=2, n_A=2, n_B=0),
@@ -366,4 +373,76 @@ end
             @test nz == c.measured
         end
     end
+end
+
+# F=6, UNIFORM g_S — the manifold #455 is about, and the reason the surplus
+# above is not called accidental.
+#
+# Σ_{S even} σ_S(ζ) = 1 for any normalised ζ, so at uniform g_S the interaction
+# energy is (g/2)(ψ†ψ)². That is invariant under all of U(2F+1), not merely
+# under SO(3) × U(1), and kinetic and trap are spin-blind. CP¹² is therefore a
+# symmetry ORBIT. Two consequences are pinned here because the campaign ledger
+# turns on them:
+#
+#   1. every point of the orbit has the same ε_LHY — fluctuations respect the
+#      symmetry, so there is nothing to select and no gap to open. This is the
+#      measurement, and it is only worth what its NEGATIVE CONTROL is worth: the
+#      same probe at a g_S spread must move, and it moves by 5.7×.
+#   2. dim(null) is the whole CP¹² tangent (12 complex planes) at every ζ, while
+#      the listed generators predict 1–4. An excess of 8–11 that is entirely
+#      U(13) is what "an excess is not an accidental degeneracy" means.
+#
+# Also the regression for the deflation test: `gauge` joined the flat set at
+# cyclic / I_h / random (never at polar or FM, so the F=1 fixtures above could
+# not see it) because `P(iψ) = 0` only to round-off and the residue normalised
+# into noise. Measured 2026-08-26, TSUBAME 8498064.
+@testset "F=6 uniform g_S is a U(13) orbit, not an accidental degeneracy" begin
+    F = 6
+    cand = polyhedral_candidate_spinors(F)
+    # 16 points, not 8: this is the grid the cited measurement ran on, and the
+    # count is not grid-free in practice — at 8 the `cyclic` spinor returns a
+    # THIRTEENTH ω ≈ 0, reported as an exact 0.0000e+00, i.e. a purely real
+    # eigenvalue of the reduced generator rather than an oscillating mode. Its
+    # provenance is not established, so rather than loosen the assertion to
+    # `>= 12` around it the fixture stays at the configuration that was measured.
+    grid = make_grid(GridConfig((16,), (8.0,)))
+    function f6box(ζ; c1, lhy=nothing)
+        ψ = zeros(ComplexF64, 16, 2F + 1)
+        for i in 1:16, c in 1:(2F + 1)
+            ψ[i, c] = ζ[c]
+        end
+        ws = make_workspace(; grid, atom=Eu151,
+            interactions=InteractionParams(Dict(0 => 1.0, 1 => c1)),
+            potential=NoPotential(), psi_init=copy(ψ), spinor_lhy=lhy,
+            sim_params=SimParams(; dt=0.005, n_steps=1, imaginary_time=true))
+        copyto!(ws.state.psi, ψ)
+        (ws, ψ)
+    end
+
+    # (1) ε_LHY is constant along the orbit — with the control that says the
+    # probe can move at all.
+    e_uniform = [
+        energy_decomposition(f6box(cand[k]; c1=0.0, lhy=:full_bdg)[1]).lhy
+        for k in (:polar, :cyclic, :I_h)
+    ]
+    @test all(isapprox(e, e_uniform[1]; rtol=1e-5) for e in e_uniform)
+    @test e_uniform[1] > 1e-3                       # the term is live, not off
+    e_spread = [
+        energy_decomposition(f6box(cand[k]; c1=0.1, lhy=:full_bdg)[1]).lhy
+        for k in (:polar, :I_h)
+    ]
+    @test maximum(e_spread) / minimum(e_spread) > 1.3   # measured 5.7× over all five
+
+    # (2) the whole CP¹² tangent is flat, and the listed generators explain only
+    # a corner of it. Read at `cyclic`, which is also the deflation regression.
+    ws, ψ = f6box(cand[:cyclic]; c1=0.0)
+    p = constrained_hessian_params(ws, ψ)
+    ez = bdg_expected_zero_modes(ws, ψ; params=p, rng=MersenneTwister(3))
+    @test :gauge ∉ ez.flat                          # P annihilates it; round-off is not a mode
+    @test ez.predicted <= 4
+    r = trapped_bdg_frequencies(ws, ψ; nev=14, n_hessian=18, max_iter=250,
+        hess_tol=1e-7, params=p, rng=MersenneTwister(7))
+    nz = count(k -> r.omega[k] < 1e-3 && abs(r.growth[k]) < 1e-3, eachindex(r.omega))
+    @test nz == 12                                  # dim_C CP^12 = 12
+    @test nz - ez.predicted >= 8
 end

--- a/test/test_campaign_fix_list_gate.jl
+++ b/test/test_campaign_fix_list_gate.jl
@@ -101,6 +101,31 @@ const _NOT_A_CORRECTION = Dict(
         "the observable correction (peak inside the hold) plus long-time arms; " *
         "corrects the reading, not the runs -- all affected numbers were " *
         "re-extracted from cache",
+    # docs/campaign/prior_art/order_by_disorder.md — branch tips, cited to say
+    # WHAT EACH BRANCH CARRIES so the disposition can be checked rather than
+    # taken on trust. A prior-art record's whole job is to name unmerged work;
+    # requiring main to descend from what it names would make the record
+    # unwritable. The one that mattered is `de816075` / `34db34b7`: a zero LHY
+    # gradient would have made the F=6 measurement an artefact, so the row states
+    # the SHAs and the row states that both fixes ARE in main under different
+    # SHAs. That check is the reason the tokens are there.
+    "bff0c3af" =>
+        "tip of origin/claude/spinor-lhy-correction-OXkxG; cited in the " *
+        "prior-art record to identify a stale branch, not as a fix",
+    "e2677a0b" =>
+        "the spinor-LHY commit that opens that same stale branch; landed in " *
+        "main long ago, named for provenance of the branch's content",
+    "de816075" =>
+        "'LBFGS gradient was exactly zero for every tabulated LHY' on " *
+        "origin/feat/lhy-block-wiring-spatial; named because the F=6 " *
+        "order-by-disorder measurement would be an artefact if it were NOT in " *
+        "main -- and it is, under a different SHA",
+    "34db34b7" =>
+        "'SpatialLHY gradient was missing its polarisation piece' on the same " *
+        "branch; same role, same answer",
+    "f8538695" =>
+        "tip of origin/test/gpu-bdg-instrument-parity-400, a GPU device gate; " *
+        "cited as prior art that becomes relevant only on a device",
 )
 
 @testset "campaign fix list — parses, and every ref is real" begin


### PR DESCRIPTION
#455 の F=6 本番に入る前に**前提を測り、前提が偽でした**。この issue の観測量（LHY が開く擬 Goldstone
ギャップ）は**厳密にゼロ**です。格子や `nev` で届く話ではないので、199 s/点を使う前に止めました。

## 何が偽だったか

`Σ_{S even} σ_S(ζ) = 1` は「多様体全体が縮退する」だけでなく、**相互作用エネルギーが
`(g/2)(ψ†ψ)²` そのものになる**と言っています。これは 2F+1 成分の任意のユニタリ回転で不変 —
つまり `SO(3) × U(1)` ではなく **`U(2F+1)` 対称**です。運動項もトラップもスピンに触らないので、
ハミルトニアン全体がそう。

⇒ CP¹² は**偶然縮退ではなく対称性軌道**。平坦方向はただの Goldstone で、揺らぎも同じ対称性を
持つ以上、選択も gap も起きません。

## 測定（TSUBAME 8498064、一様箱・厳密定常・ソルバ無し）

| ζ | ε_LHY（`:full_bdg`、ζ ごとに別テーブル） | dim(null) | predicted |
|---|---|---|---|
| polar / FM / cyclic / I_h / random | **4.323347e-01（相対 2e-7 で一定）** | **12**（= CP¹² 接空間全体） | 1–4 |

**陰性対照**（g_S スプレッド c₁=0.1、同じ 5 状態）: ε_LHY は **3.44 → 19.6、5.7 倍**動きます。
これが無ければ「一定」は計器が盲目なだけかもしれないので、主張の重さはこの対照ぶんです。

**効いているのは ε_LHY の一定性であって「ギャップが出ないこと」ではありません。** tabulated LHY は
workspace 構築時の 1 つの ζ でテーブルが固定され、Hessian には `n` を通してしか入らないので、
仮に ζ 依存があっても単一 workspace の BdG には見えません。だから ζ ごとに workspace を建てています。

## 変更

- docstring / oracle コメント / design doc §6 から「偶然縮退」の語を外しました。`bdg_expected_zero_modes`
  との超過が検出しているのは**リストに無い生成子ぶんの平坦方向**で、これは有用ですが別の主張です —
  **リストに無い対称性が同じ超過を出す**。F=6 一様 g_S では超過 8–11 が全部 U(13) でした。
- PR #493 の F=1 c₁=0 の行も改題。**数（dim(null)=2）は正しく、呼び方が誤り**でした（c₁=0 で
  polar / FM / mixed の ε_LHY とスペクトルが 1e-9 で一致 ⇒ U(3) Goldstone）。
- **deflation 判定のバグ修正**: 絶対しきい値だったので `P(iψ)=0` の丸め残差が正規化されてノイズになり、
  ノイズは stiff でないので **`gauge` が flat 生成子に数えられて** `predicted` が 2 でなく 4 に
  なっていました（cyclic / I_h / random で発生、polar / FM では出ないので F=1 fixture では捕まらない）。
  相対判定に変更。
- 台帳: `f6-uniform-gs-degenerates-the-whole-manifold` の末尾節「which is what order-by-disorder
  requires」を削除（**恒等式そのものは厳密・無傷**）。`f6-uniform-gs-is-a-u2f1-orbit-so-nothing-selects`
  を測定と対照つきで新規登録。
- `docs/campaign/prior_art/order_by_disorder.md` を作成し 6 件を disposition。うち
  `feat/lhy-block-wiring-spatial` は「tabulated LHY の勾配がゼロ」の修正を持つ未マージ枝で、**main に
  無ければ今回の測定は丸ごと artefact**でした（別 SHA で入っていることを確認）。

## テスト

F=6 一様 g_S の testset を追加（ε_LHY の一定性＋陰性対照、`gauge ∉ flat` の回帰、dim(null)=12 対
predicted ≤ 4）。16 点なのは**引用した測定と同じ配置だから**で、8 点では cyclic が 13 本目の ω≈0
（純実固有値による厳密 0.0000e+00、素性未確定）を返すため — しきい値を緩めて回避するのではなく、
測った配置に合わせています。

Hessian/BdG ゲート 3 ファイル green（TSUBAME 8498083、44/31/20 s）。

## Turner et al. は無傷です

PRL 98, 190404 のスピン2 ネマティック多様体の縮退は**あちらのハミルトニアンの対称性ではありません**。
誤りは、縮退と対称性を同時に供給する恒等式を通してあの構造を輸入したことでした。

## 残り

物理的 g_S（非一様）では平均場の最小値集合は一般に孤立点なので、揺らぎ選択は**エネルギー差**として
出ます。それは #455 が「二値判定より強い」として置き換えようとした当のものなので、これは
re-scoping ではなく**差し引き**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
